### PR TITLE
Add caching of node_modules and eslintcache to Github Actions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -64,8 +64,8 @@ jobs:
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: npm ci
 
-      - name: Test
-        run: npm run test:ci
-
       - name: Build
         run: npm run build
+
+      - name: Test
+        run: npm run test:ci

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -52,8 +52,8 @@ jobs:
         uses: actions/cache@v2
         with:
           path: |
-            '**/.eslintcache'
-            '**/.stylelintcache'
+            **/.eslintcache
+            **/.stylelintcache
           key: ${{ runner.os }}-lintcache-${{ github.head_ref }}
           restore-keys: |
             ${{ runner.os }}-lintcache-

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -54,7 +54,7 @@ jobs:
           key: ${{ runner.os }}-eslintcache-${{ github.head_ref }}
           restore-keys: |
             ${{ runner.os }}-eslintcache-
-            ${{ runner.os}}-
+            ${{ runner.os }}-
 
       # Only need to install and bootstrap deps if package-locks changed
       - name: Install dependencies

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -25,14 +25,6 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
-      - name: Cache node_modules
-        id: cache-node-modules
-        uses: actions/cache@v2
-        with:
-          # If no package-locks have changed, it should be safe to restore all node_modules as they were
-          path: '**/node_modules'
-          key: ${{ runner.os }}-modules-${{ hashFiles('**/package-lock.json') }}
-
       - name: Cache npm cache
         uses: actions/cache@v2
         env:
@@ -56,9 +48,7 @@ jobs:
             ${{ runner.os }}-eslintcache-
             ${{ runner.os }}-
 
-      # Only need to install and bootstrap deps if package-locks changed
       - name: Install dependencies
-        if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: npm ci
 
       - name: Test

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -25,6 +25,15 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
+      - name: Cache node_modules
+        id: cache-node-modules
+        uses: actions/cache@v2
+        with:
+          # If no package-locks or the main package.json have changed, it should be safe to restore all node_modules as they were
+          # Changing the main package.json may change the postinstall scripts, so it should be unchanged to cache install results
+          path: '**/node_modules'
+          key: ${{ runner.os }}-modules-${{ hashFiles('**/package-lock.json', 'package.json') }}
+
       - name: Cache npm cache
         uses: actions/cache@v2
         env:
@@ -39,16 +48,20 @@ jobs:
             ${{ runner.os }}-build-
             ${{ runner.os }}-
 
-      - name: Cache eslint cache
+      - name: Cache linter caches
         uses: actions/cache@v2
         with:
-          path: '**/.eslintcache'
-          key: ${{ runner.os }}-eslintcache-${{ github.head_ref }}
+          path: |
+            '**/.eslintcache'
+            '**/.stylelintcache'
+          key: ${{ runner.os }}-lintcache-${{ github.head_ref }}
           restore-keys: |
-            ${{ runner.os }}-eslintcache-
+            ${{ runner.os }}-lintcache-
             ${{ runner.os }}-
 
+      # Only need to install and bootstrap deps if package-locks changed
       - name: Install dependencies
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: npm ci
 
       - name: Test

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -31,8 +31,10 @@ jobs:
         with:
           # If no package-locks or the main package.json have changed, it should be safe to restore all node_modules as they were
           # Changing the main package.json may change the postinstall scripts, so it should be unchanged to cache install results
-          path: '**/node_modules'
-          key: ${{ runner.os }}-modules-${{ hashFiles('**/package-lock.json', 'package.json') }}
+          path: |
+            node_modules
+            packages/*/node_modules
+          key: ${{ runner.os }}-modules-${{ hashFiles('package.json', 'package-lock.json', 'packages/*/package-lock.json') }}
 
       - name: Cache npm cache
         uses: actions/cache@v2
@@ -41,7 +43,7 @@ jobs:
         with:
           # npm cache files are stored in `~/.npm` on Linux/macOS
           path: ~/.npm
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ matrix.node-version }}-${{ hashFiles('**/package-lock.json') }}
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ matrix.node-version }}-${{ hashFiles('package-lock.json', 'packages/*/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-build-${{ env.cache-name }}-${{ matrix.node-version }}
             ${{ runner.os }}-build-${{ env.cache-name }}-
@@ -52,8 +54,10 @@ jobs:
         uses: actions/cache@v2
         with:
           path: |
-            **/.eslintcache
-            **/.stylelintcache
+            .eslintcache
+            packages/*/.eslintcache
+            .stylelintcache
+            packages/*/.stylelintcache
           key: ${{ runner.os }}-lintcache-${{ github.head_ref }}
           restore-keys: |
             ${{ runner.os }}-lintcache-

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -19,14 +19,24 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Cache node modules
+
+      - name: Cache node_modules
+        id: cache-node-modules
+        uses: actions/cache@v2
+        with:
+          # If no package-locks have changed, it should be safe to restore all node_modules as they were
+          path: '**/node_modules'
+          key: ${{ runner.os }}-modules-${{ hashFiles('**/package-lock.json') }}
+
+      - name: Cache npm cache
         uses: actions/cache@v2
         env:
-          cache-name: cache-node-modules
+          cache-name: cache-npm-cache
         with:
           # npm cache files are stored in `~/.npm` on Linux/macOS
           path: ~/.npm
@@ -36,9 +46,23 @@ jobs:
             ${{ runner.os }}-build-${{ env.cache-name }}-
             ${{ runner.os }}-build-
             ${{ runner.os }}-
+
+      - name: Cache eslint cache
+        uses: actions/cache@v2
+        with:
+          path: '**/.eslintcache'
+          key: ${{ runner.os }}-eslintcache-${{ github.head_ref }}
+          restore-keys: |
+            ${{ runner.os }}-eslintcache-
+            ${{ runner.os}}-
+
+      # Only need to install and bootstrap deps if package-locks changed
       - name: Install dependencies
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: npm ci
+
       - name: Test
         run: npm run test:ci
+
       - name: Build
         run: npm run build

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -29,12 +29,11 @@ jobs:
         id: cache-node-modules
         uses: actions/cache@v2
         with:
-          # If no package-locks or the main package.json have changed, it should be safe to restore all node_modules as they were
-          # Changing the main package.json may change the postinstall scripts, so it should be unchanged to cache install results
+          # If no package-lock.json or package.json files have changed, it should be safe to restore all node_modules as they were
           path: |
             node_modules
             packages/*/node_modules
-          key: ${{ runner.os }}-modules-${{ hashFiles('package.json', 'package-lock.json', 'packages/*/package-lock.json') }}
+          key: ${{ runner.os }}-modules-${{ hashFiles('package.json', 'packages/*/package.json', 'package-lock.json', 'packages/*/package-lock.json') }}
 
       - name: Cache npm cache
         uses: actions/cache@v2

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "start:app": "lerna run start --scope=@deephaven/code-studio --stream",
     "start:packages": "lerna run watch --ignore=@deephaven/code-studio --stream --parallel",
     "prestart": "lerna run prestart --stream",
-    "pretest:ci": "npm run build:packages",
     "test": "lerna run test --stream --parallel",
     "test:ci": "lerna run test:ci --stream",
     "sync-version": "lerna version ${DEEPHAVEN_VERSION:-error} --no-git-tag-version --yes",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "prestart": "lerna run prestart --stream",
     "pretest:ci": "npm run build:packages",
     "test": "lerna run test --stream --parallel",
-    "test:ci": "lerna run test:ci --stream",
+    "test:ci": "lerna run test:ci --stream -- -- --maxWorkers=2",
     "sync-version": "lerna version ${DEEPHAVEN_VERSION:-error} --no-git-tag-version --yes",
     "publish": "lerna publish"
   },

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "clean:build": "lerna run clean --stream",
     "clean:modules": "lerna clean --yes",
     "clean": "npm run clean:build && npm run clean:modules",
-    "bootstrap": "lerna bootstrap --hoist",
+    "bootstrap": "lerna bootstrap",
     "build": "lerna run build --stream",
     "build:app": "lerna run --scope=@deephaven/code-studio build",
     "build:packages": "lerna run --ignore=@deephaven/code-studio build --stream",
@@ -21,7 +21,7 @@
     "prestart": "lerna run prestart --stream",
     "pretest:ci": "npm run build:packages",
     "test": "lerna run test --stream --parallel",
-    "test:ci": "lerna run test:ci --stream --parallel",
+    "test:ci": "lerna run test:ci --stream",
     "sync-version": "lerna version ${DEEPHAVEN_VERSION:-error} --no-git-tag-version --yes",
     "publish": "lerna publish"
   },

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "prestart": "lerna run prestart --stream",
     "pretest:ci": "npm run build:packages",
     "test": "lerna run test --stream --parallel",
-    "test:ci": "lerna run test:ci --stream -- -- --maxWorkers=2",
+    "test:ci": "lerna run test:ci --stream -- -- --runInBand",
     "sync-version": "lerna version ${DEEPHAVEN_VERSION:-error} --no-git-tag-version --yes",
     "publish": "lerna publish"
   },

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "clean:build": "lerna run clean --stream",
     "clean:modules": "lerna clean --yes",
     "clean": "npm run clean:build && npm run clean:modules",
-    "bootstrap": "lerna bootstrap",
+    "bootstrap": "lerna bootstrap --hoist -- --no-audit --prefer-offline",
     "build": "lerna run build --stream",
     "build:app": "lerna run --scope=@deephaven/code-studio build",
     "build:packages": "lerna run --ignore=@deephaven/code-studio build --stream",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "start:packages": "lerna run watch --ignore=@deephaven/code-studio --stream --parallel",
     "prestart": "lerna run prestart --stream",
     "test": "lerna run test --stream --parallel",
-    "test:ci": "lerna run test:ci --stream",
+    "test:ci": "lerna run test:ci --stream -- -- --maxWorkers=2",
     "sync-version": "lerna version ${DEEPHAVEN_VERSION:-error} --no-git-tag-version --yes",
     "publish": "lerna publish"
   },

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "prestart": "lerna run prestart --stream",
     "pretest:ci": "npm run build:packages",
     "test": "lerna run test --stream --parallel",
-    "test:ci": "lerna run test:ci --stream -- -- --runInBand",
+    "test:ci": "lerna run test:ci --stream",
     "sync-version": "lerna version ${DEEPHAVEN_VERSION:-error} --no-git-tag-version --yes",
     "publish": "lerna publish"
   },

--- a/packages/code-studio/src/test/eslint.test.js
+++ b/packages/code-studio/src/test/eslint.test.js
@@ -7,6 +7,7 @@ it('eslint', async () => {
   const eslint = new ESLint({
     extensions: ['js', 'jsx', 'ts', 'tsx'],
     cache: true,
+    cacheStrategy: 'content',
   });
   const results = await eslint.lintFiles('./src');
   const formatter = await eslint.loadFormatter();

--- a/packages/components/src/test/eslint.test.js
+++ b/packages/components/src/test/eslint.test.js
@@ -7,6 +7,7 @@ it('eslint', async () => {
   const eslint = new ESLint({
     extensions: ['js', 'jsx', 'ts', 'tsx'],
     cache: true,
+    cacheStrategy: 'content',
   });
   const results = await eslint.lintFiles('./src');
   const formatter = await eslint.loadFormatter();

--- a/packages/jsapi-shim/src/test/eslint.test.js
+++ b/packages/jsapi-shim/src/test/eslint.test.js
@@ -7,6 +7,7 @@ it('eslint', async () => {
   const eslint = new ESLint({
     extensions: ['js', 'jsx', 'ts', 'tsx'],
     cache: true,
+    cacheStrategy: 'content',
   });
   const results = await eslint.lintFiles('./src');
   const formatter = await eslint.loadFormatter();

--- a/packages/log/src/test/eslint.test.js
+++ b/packages/log/src/test/eslint.test.js
@@ -7,6 +7,7 @@ it('eslint', async () => {
   const eslint = new ESLint({
     extensions: ['js', 'jsx', 'ts', 'tsx'],
     cache: true,
+    cacheStrategy: 'content',
   });
   const results = await eslint.lintFiles('./src');
   const formatter = await eslint.loadFormatter();

--- a/packages/react-hooks/src/test/eslint.test.js
+++ b/packages/react-hooks/src/test/eslint.test.js
@@ -7,6 +7,7 @@ it('eslint', async () => {
   const eslint = new ESLint({
     extensions: ['js', 'jsx', 'ts', 'tsx'],
     cache: true,
+    cacheStrategy: 'content',
   });
   const results = await eslint.lintFiles('./src');
   const formatter = await eslint.loadFormatter();

--- a/packages/utils/src/test/eslint.test.js
+++ b/packages/utils/src/test/eslint.test.js
@@ -7,6 +7,7 @@ it('eslint', async () => {
   const eslint = new ESLint({
     extensions: ['js', 'jsx', 'ts', 'tsx'],
     cache: true,
+    cacheStrategy: 'content',
   });
   const results = await eslint.lintFiles('./src');
   const formatter = await eslint.loadFormatter();


### PR DESCRIPTION
Cache all node_modules folders. If any package-lock changes the cache will miss and trigger `npm ci`. Most of the time this should let us skip `npm ci` which also calls `lerna bootstrap` saving ~2min per run.

Also cache the `.eslintcache` files generated in each package. Currently those will rarely miss, if ever, but cache for each branch will be preferred. This should greatly speed up the eslint Jest test we have in each package. Locally `npm run test:ci` took ~54s w/o eslintcache and ~30s w/ eslintcache on a rerun without changing files. 