### PR TITLE
Fix table options styling

### DIFF
--- a/packages/code-studio/src/index.jsx
+++ b/packages/code-studio/src/index.jsx
@@ -3,9 +3,11 @@ import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
 import 'bootstrap';
 import 'fira';
+// This must be before MonacoUtils so MenuItem styling is correct
+// Best guess is something to do with webpack/CRA order of resolution/deduping
+import './index.scss';
 import { MonacoUtils } from '@deephaven/console';
 import { store } from '@deephaven/redux';
-import './index.scss';
 import AppRouter from './main/AppRouter';
 import DownloadServiceWorkerUtils from './DownloadServiceWorkerUtils';
 import logInit from './log/LogInit.ts';


### PR DESCRIPTION
Fixes #42 

Not 100% sure why this fix works. Best guess is something to do with how CRA/webpack is deduping CSS imports. As far as I can tell they are deduped because adding the same sass import multiple times doesn't result in multiple copies of the rules showing up in dev tools