### PR TITLE
Fix DBDateTime formatting on Enterprise side

### DIFF
--- a/packages/iris-grid/src/TableUtils.js
+++ b/packages/iris-grid/src/TableUtils.js
@@ -275,6 +275,7 @@ class TableUtils {
       case TableUtils.dataType.STRING:
         return TableUtils.dataType.STRING;
       case 'io.deephaven.db.tables.utils.DBDateTime':
+      case 'com.illumon.iris.db.tables.utils.DBDateTime':
       case TableUtils.dataType.DATETIME:
         return TableUtils.dataType.DATETIME;
       case 'double':
@@ -311,6 +312,7 @@ class TableUtils {
   static isDateType(columnType) {
     switch (columnType) {
       case 'io.deephaven.db.tables.utils.DBDateTime':
+      case 'com.illumon.iris.db.tables.utils.DBDateTime':
         return true;
       default:
         return false;


### PR DESCRIPTION
Enterprise has a different class path for the DBDateTime class. Use both.
