### PR TITLE
Add dashboard layout/data saving to workspace, notebook copy

### DIFF
--- a/packages/code-studio/src/dashboard/DashboardContainer.jsx
+++ b/packages/code-studio/src/dashboard/DashboardContainer.jsx
@@ -152,6 +152,9 @@ export class DashboardContainer extends Component {
         ...props,
         localDashboardId,
       }),
+      FileExplorerPanel: props => ({
+        ...props,
+      }),
       InputFilterPanel: props => ({
         ...props,
         localDashboardId,
@@ -159,6 +162,9 @@ export class DashboardContainer extends Component {
       IrisGridPanel: props => ({
         ...props,
         localDashboardId,
+        makeModel: async () => {
+          throw new Error('Re-hydration not yet implemented.');
+        },
       }),
       LogPanel: props => ({
         ...props,
@@ -220,7 +226,7 @@ export class DashboardContainer extends Component {
 
   async init() {
     this.initData();
-    const layout = await this.initLayout();
+    const layout = this.initLayout();
     this.initEventHandlers(layout);
     this.isInitialised = true;
   }
@@ -231,7 +237,7 @@ export class DashboardContainer extends Component {
     setDashboardLinks(id, [...links]);
   }
 
-  async initLayout() {
+  initLayout() {
     const { layoutConfig, data, onGoldenLayoutChange } = this.props;
     const { layoutSettings = {} } = data;
     this.setState({
@@ -281,19 +287,6 @@ export class DashboardContainer extends Component {
     this.initPanelManager(layout);
 
     layout.init();
-
-    await new Promise(resolve => {
-      if (layout.isInitialised) {
-        resolve();
-        return;
-      }
-      const onInit = () => {
-        log.debug('layout initialized');
-        layout.off('initialised', onInit);
-        resolve();
-      };
-      layout.on('initialised', onInit);
-    });
 
     window.addEventListener('resize', this.handleResize);
 
@@ -372,6 +365,7 @@ export class DashboardContainer extends Component {
       ConsolePanel: DashboardContainer.dehydratePanelConfig,
       CommandHistoryPanel: DashboardContainer.dehydratePanelConfig,
       DropdownFilterPanel: DashboardContainer.dehydratePanelConfig,
+      FileExplorerPanel: DashboardContainer.dehydratePanelConfig,
       IrisGridPanel: DashboardContainer.dehydratePanelConfig,
       InputFilterPanel: DashboardContainer.dehydratePanelConfig,
       LogPanel: DashboardContainer.dehydratePanelConfig,

--- a/packages/code-studio/src/dashboard/event-handlers/ConsoleEventHandler.js
+++ b/packages/code-studio/src/dashboard/event-handlers/ConsoleEventHandler.js
@@ -3,6 +3,7 @@ import Log from '@deephaven/log';
 import { ConsoleEvent } from '../events';
 import LayoutUtils from '../../layout/LayoutUtils';
 import { CommandHistoryPanel, ConsolePanel, LogPanel } from '../panels';
+import FileExplorerPanel from '../panels/FileExplorerPanel';
 
 const log = Log.module('ConsoleEventHandler');
 
@@ -17,7 +18,14 @@ class ConsoleEventHandler {
     this.handleDisconnectSession = this.handleDisconnectSession.bind(this);
     this.handleRestartSession = this.handleRestartSession.bind(this);
 
+    this.initialize();
+  }
+
+  async initialize() {
     this.startListening();
+
+    await LayoutUtils.onInitialized(this.layout);
+
     this.addMissingPanels();
     this.activateConsolePanel();
   }
@@ -60,7 +68,7 @@ class ConsoleEventHandler {
       return;
     }
 
-    const panels = [CommandHistoryPanel];
+    const panels = [CommandHistoryPanel, FileExplorerPanel];
     const componentTypes = panels.map(panel => panel.COMPONENT);
 
     const stack = LayoutUtils.getStackForComponentTypes(

--- a/packages/code-studio/src/dashboard/event-handlers/LayoutEventHandler.js
+++ b/packages/code-studio/src/dashboard/event-handlers/LayoutEventHandler.js
@@ -69,7 +69,9 @@ class LayoutEventHandler {
     this.onLayoutChange(dehydratedLayoutConfig);
   }
 
-  updateLayoutCss() {
+  async updateLayoutCss() {
+    await LayoutUtils.onInitialized(this.layout);
+
     const items = this.layout.root.getItemsByFilter(item => item.isComponent);
     for (let i = 0; i < items.length; i += 1) {
       LayoutEventHandler.updateComponentCss(items[i]);

--- a/packages/code-studio/src/dashboard/panels/FileExplorerPanel.tsx
+++ b/packages/code-studio/src/dashboard/panels/FileExplorerPanel.tsx
@@ -79,6 +79,12 @@ export class FileExplorerPanel extends React.Component<
     };
   }
 
+  componentDidMount(): void {
+    if (!this.isHidden()) {
+      this.setState({ isShown: true });
+    }
+  }
+
   private fileExplorer = React.createRef<UpdateableComponent>();
 
   handleCreateFile(): void {
@@ -177,6 +183,12 @@ export class FileExplorerPanel extends React.Component<
   handleShow(): void {
     this.setState({ isShown: true });
     this.fileExplorer.current?.updateDimensions();
+  }
+
+  isHidden(): boolean {
+    const { glContainer } = this.props;
+    const { isHidden } = glContainer;
+    return isHidden;
   }
 
   render(): ReactNode {

--- a/packages/code-studio/src/dashboard/panels/NotebookPanel.jsx
+++ b/packages/code-studio/src/dashboard/panels/NotebookPanel.jsx
@@ -609,10 +609,10 @@ class NotebookPanel extends Component {
     this.runCommand(this.notebook.getSelectedCommand());
   }
 
-  handleSessionOpened(config, sessionLanguage, ide, console, session) {
+  handleSessionOpened(session, { language }) {
     this.setState({
       session,
-      sessionLanguage,
+      sessionLanguage: language,
     });
   }
 

--- a/packages/code-studio/src/layout/LayoutUtils.js
+++ b/packages/code-studio/src/layout/LayoutUtils.js
@@ -684,6 +684,25 @@ class LayoutUtils {
     focusElement.focus();
     return focusElement;
   }
+
+  /**
+   * Get a promise that initializes when layout is initialized
+   * @param {GoldenLayout} layout The layout to await initialization on
+   * @returns Promise that resolves when layout is initialized
+   */
+  static onInitialized(layout) {
+    return new Promise(resolve => {
+      if (layout.isInitialised) {
+        resolve();
+        return;
+      }
+      const onInit = () => {
+        layout.off('initialised', onInit);
+        resolve();
+      };
+      layout.on('initialised', onInit);
+    });
+  }
 }
 
 export default LayoutUtils;

--- a/packages/code-studio/src/main/AppInit.jsx
+++ b/packages/code-studio/src/main/AppInit.jsx
@@ -46,8 +46,8 @@ const AppInit = props => {
     setCommandHistoryStorage(COMMAND_HISTORY_STORAGE);
     setFileStorage(FILE_STORAGE);
     setUser(USER);
-    setWorkspace(loadedWorkspace);
     setWorkspaceStorage(WORKSPACE_STORAGE);
+    setWorkspace(loadedWorkspace);
   }, [
     setActiveTool,
     setCommandHistoryStorage,

--- a/packages/code-studio/src/main/AppMainContainer.jsx
+++ b/packages/code-studio/src/main/AppMainContainer.jsx
@@ -9,8 +9,10 @@ import { ContextActions, Tooltip, ThemeExport } from '@deephaven/components';
 import Log from '@deephaven/log';
 import {
   getActiveTool,
+  getWorkspace,
   getUser,
   setActiveTool as setActiveToolAction,
+  updateWorkspaceData as updateWorkspaceDataAction,
 } from '@deephaven/redux';
 import { PromiseUtils } from '@deephaven/utils';
 import SettingsMenu from '../settings/SettingsMenu';
@@ -92,15 +94,14 @@ export class AppMainContainer extends Component {
     this.handleControlSelect = this.handleControlSelect.bind(this);
     this.handleToolSelect = this.handleToolSelect.bind(this);
     this.handleClearFilter = this.handleClearFilter.bind(this);
-    this.handleGoldenLayoutChanged = this.handleGoldenLayoutChanged.bind(this);
+    this.handleDataChange = this.handleDataChange.bind(this);
+    this.handleGoldenLayoutChange = this.handleGoldenLayoutChange.bind(this);
+    this.handleLayoutConfigChange = this.handleLayoutConfigChange.bind(this);
     this.handlePaste = this.handlePaste.bind(this);
 
     this.goldenLayout = null;
 
-    this.state = {
-      showSettingsMenu: false,
-      layoutConfig: DEFAULT_LAYOUT_CONFIG,
-    };
+    this.state = { showSettingsMenu: false };
   }
 
   sendClearFilter() {
@@ -182,8 +183,18 @@ export class AppMainContainer extends Component {
     this.sendClearFilter();
   }
 
-  handleGoldenLayoutChanged(goldenLayout) {
+  handleDataChange(data) {
+    const { updateWorkspaceData } = this.props;
+    updateWorkspaceData({ data });
+  }
+
+  handleGoldenLayoutChange(goldenLayout) {
     this.goldenLayout = goldenLayout;
+  }
+
+  handleLayoutConfigChange(layoutConfig) {
+    const { updateWorkspaceData } = this.props;
+    updateWorkspaceData({ layoutConfig });
   }
 
   // eslint-disable-next-line class-methods-use-this
@@ -213,8 +224,10 @@ export class AppMainContainer extends Component {
   }
 
   render() {
-    const { activeTool, user } = this.props;
-    const { layoutConfig, showSettingsMenu } = this.state;
+    const { activeTool, user, workspace } = this.props;
+    const { data: workspaceData = {} } = workspace;
+    const { data = {}, layoutConfig = DEFAULT_LAYOUT_CONFIG } = workspaceData;
+    const { showSettingsMenu } = this.state;
     const contextActions = [
       {
         action: () => {
@@ -307,9 +320,11 @@ export class AppMainContainer extends Component {
           </div>
         </nav>
         <DashboardContainer
-          data={{}}
+          data={data}
           layoutConfig={layoutConfig}
-          onGoldenLayoutChange={this.handleGoldenLayoutChanged}
+          onDataChange={this.handleDataChange}
+          onGoldenLayoutChange={this.handleGoldenLayoutChange}
+          onLayoutConfigChange={this.handleLayoutConfigChange}
         />
         <CSSTransition
           in={showSettingsMenu}
@@ -329,14 +344,23 @@ export class AppMainContainer extends Component {
 AppMainContainer.propTypes = {
   activeTool: PropTypes.string.isRequired,
   setActiveTool: PropTypes.func.isRequired,
+  updateWorkspaceData: PropTypes.func.isRequired,
   user: IrisPropTypes.User.isRequired,
+  workspace: PropTypes.shape({
+    data: PropTypes.shape({
+      data: PropTypes.shape({}),
+      layoutConfig: PropTypes.arrayOf(PropTypes.shape({})),
+    }),
+  }).isRequired,
 };
 
 const mapStateToProps = state => ({
   activeTool: getActiveTool(state),
   user: getUser(state),
+  workspace: getWorkspace(state),
 });
 
 export default connect(mapStateToProps, {
   setActiveTool: setActiveToolAction,
+  updateWorkspaceData: updateWorkspaceDataAction,
 })(AppMainContainer);

--- a/packages/file-explorer/src/FileUtils.ts
+++ b/packages/file-explorer/src/FileUtils.ts
@@ -58,6 +58,25 @@ export class FileUtils {
   }
 
   /**
+   * Create copy file name, used for copying unsaved files so doesn't have to be unique
+   * @param {string} nameParam File name
+   */
+  static getCopyFileName(originalName: string): string {
+    const extensionPosition = originalName.lastIndexOf('.');
+    let extension = null;
+    let name = null;
+    if (extensionPosition < 0) {
+      // No extension
+      name = originalName;
+    } else {
+      name = originalName.substring(0, extensionPosition);
+      extension = originalName.substring(extensionPosition + 1);
+    }
+    const copyName = name ? `${name}-copy` : 'Copy';
+    return extension !== null ? `${copyName}.${extension}` : copyName;
+  }
+
+  /**
    * Return a MIME type for the provided file
    * @param name The file name to get the type for
    * @returns A known MIME type if recognized

--- a/packages/file-explorer/src/FileUtils.ts
+++ b/packages/file-explorer/src/FileUtils.ts
@@ -59,7 +59,8 @@ export class FileUtils {
 
   /**
    * Create copy file name, used for copying unsaved files so doesn't have to be unique
-   * @param {string} nameParam File name
+   * @param originalName File name
+   * @returns The file name of the copy
    */
   static getCopyFileName(originalName: string): string {
     const extensionPosition = originalName.lastIndexOf('.');

--- a/packages/file-explorer/src/WebdavFileStorage.ts
+++ b/packages/file-explorer/src/WebdavFileStorage.ts
@@ -47,13 +47,14 @@ export class WebdavFileStorage implements FileStorage {
   }
 
   async loadFile(name: string): Promise<File> {
-    const content = (await this.client.getFileContents(name, {
+    const content = await this.client.getFileContents(name, {
       format: 'text',
-    })) as string;
+    });
     return {
       filename: name,
       basename: FileUtils.getBaseName(name),
-      content,
+      // If the file is just a number, it can come back as just a number
+      content: typeof content === 'string' ? content : `${content}`,
     };
   }
 


### PR DESCRIPTION
- Wire up dashboard changes to trigger saving to the workspace.
- The NotebookPanel soft saves to the layout whenever it's changed, which gets reloaded from the users workspace. Fixes #88.
- Prompt is shown when attempting to close a notebook that isn't saved.
- Copy functionality enabled from right clicking on the tab.
