### PR TITLE
Fix up issues printed out when running tests

### DIFF
--- a/packages/components/src/MaskedInput.tsx
+++ b/packages/components/src/MaskedInput.tsx
@@ -452,6 +452,7 @@ const MaskedInput = React.forwardRef<HTMLInputElement, MaskedInputProps>(
         type="text"
         pattern={pattern}
         value={value}
+        onChange={() => undefined}
         onKeyDown={handleKeyDown}
         onSelect={handleSelect}
         onSelectCapture={handleSelectCapture}

--- a/packages/components/src/context-actions/ContextActions.test.jsx
+++ b/packages/components/src/context-actions/ContextActions.test.jsx
@@ -151,7 +151,7 @@ it('renders an empty menu for a rejected promise', () => {
 
 it('renders a menu from a promise returned from a function', () => {
   const mock = DEFAULT_MOCK();
-  const promise = Promise.resolve();
+  const promise = Promise.resolve([]);
   const fn = () => promise;
 
   const tree = TestRenderer.create(


### PR DESCRIPTION
- Fix warning in MaskedInput about input not having an onChange handler - add a basic one, we just use handleKeyDown anyway
- Fix ContextMenu not resolving to an item

Fixes #99 