### PR TITLE
Properly register console actions and console disconnected messages

### DIFF
--- a/packages/code-studio/src/dashboard/panels/ConsolePanel.jsx
+++ b/packages/code-studio/src/dashboard/panels/ConsolePanel.jsx
@@ -409,7 +409,12 @@ class ConsolePanel extends PureComponent {
                 commandHistoryStorage={commandHistoryStorage}
                 onSettingsChange={this.handleSettingsChange}
                 language={language}
-                name={name}
+                statusBarChildren={
+                  <>
+                    <div>&nbsp;</div>
+                    <div>{name}</div>
+                  </>
+                }
                 scope={sessionId}
                 actions={actions}
               />

--- a/packages/console/src/Console.jsx
+++ b/packages/console/src/Console.jsx
@@ -729,18 +729,6 @@ export class Console extends PureComponent {
 
   getObjects = memoize(objectMap => [...objectMap.values()]);
 
-  getContextActions = memoize(actions => [
-    ...actions,
-    {
-      action: this.handleClearShortcut,
-      shortcut: SHORTCUTS.CONSOLE.CLEAR,
-    },
-    {
-      action: this.handleFocusHistory,
-      shortcut: SHORTCUTS.CONSOLE.FOCUS_HISTORY,
-    },
-  ]);
-
   addCommand(command, focus = true, execute = false) {
     if (!this.consoleInput.current) {
       return;

--- a/packages/console/src/Console.jsx
+++ b/packages/console/src/Console.jsx
@@ -729,6 +729,18 @@ export class Console extends PureComponent {
 
   getObjects = memoize(objectMap => [...objectMap.values()]);
 
+  getContextActions = memoize(actions => [
+    ...actions,
+    {
+      action: this.handleClearShortcut,
+      shortcut: SHORTCUTS.CONSOLE.CLEAR,
+    },
+    {
+      action: this.handleFocusHistory,
+      shortcut: SHORTCUTS.CONSOLE.FOCUS_HISTORY,
+    },
+  ]);
+
   addCommand(command, focus = true, execute = false) {
     if (!this.consoleInput.current) {
       return;
@@ -777,9 +789,9 @@ export class Console extends PureComponent {
 
   render() {
     const {
+      actions,
       disconnectedChildren,
       language,
-      name,
       statusBarChildren,
       openObject,
       session,
@@ -799,6 +811,7 @@ export class Console extends PureComponent {
     const consoleMenuObjects = this.getObjects(objectMap);
     const inputMaxHeight = Math.round(consoleHeight * 0.7);
     const isDisconnected = disconnectedChildren != null;
+    const contextActions = this.getContextActions(actions);
 
     return (
       <div
@@ -809,13 +822,13 @@ export class Console extends PureComponent {
       >
         <div className="console-pane" ref={this.consolePane}>
           <ConsoleStatusBar
-            name={name}
-            statusBarChildren={statusBarChildren}
             session={session}
             overflowActions={this.handleOverflowActions}
             openObject={openObject}
             objects={consoleMenuObjects}
-          />
+          >
+            {statusBarChildren}
+          </ConsoleStatusBar>
           <div
             className="console-csv-container"
             onDragOver={CsvOverlay.handleDragOver}
@@ -872,13 +885,13 @@ export class Console extends PureComponent {
             />
           )}
         </div>
+        <ContextActions actions={contextActions} />
       </div>
     );
   }
 }
 
 Console.propTypes = {
-  name: PropTypes.string,
   statusBarChildren: PropTypes.node,
   settings: PropTypes.shape({}),
   focusCommandHistory: PropTypes.func.isRequired,
@@ -891,12 +904,11 @@ Console.propTypes = {
   scope: PropTypes.string,
   actions: PropTypes.arrayOf(PropTypes.shape({})),
 
-  // Message shown when the session has disconnected
+  // Message shown when the session has disconnected. Setting this value removes the input bar and disables old tables
   disconnectedChildren: PropTypes.node,
 };
 
 Console.defaultProps = {
-  name: 'Default',
   statusBarChildren: null,
   settings: {},
   onSettingsChange: () => {},

--- a/packages/console/src/ConsoleStatusBar.jsx
+++ b/packages/console/src/ConsoleStatusBar.jsx
@@ -74,7 +74,7 @@ export class ConsoleStatusBar extends PureComponent {
   }
 
   render() {
-    const { children, name, openObject, overflowActions, objects } = this.props;
+    const { children, openObject, overflowActions, objects } = this.props;
     const { isDisconnected, isCommandRunning } = this.state;
 
     let statusIconClass = null;
@@ -97,8 +97,6 @@ export class ConsoleStatusBar extends PureComponent {
       <div className="console-pane-status-bar">
         <div>
           <div className={classNames('console-status-icon', statusIconClass)} />
-          <div>&nbsp;</div>
-          <div>{name}</div>
           <Tooltip>{tooltipText}</Tooltip>
         </div>
         {children}
@@ -114,7 +112,6 @@ export class ConsoleStatusBar extends PureComponent {
 
 ConsoleStatusBar.propTypes = {
   children: PropTypes.node,
-  name: PropTypes.string,
   session: APIPropTypes.IdeSession.isRequired,
   openObject: PropTypes.func.isRequired,
   objects: PropTypes.arrayOf(APIPropTypes.VariableDefinition).isRequired,
@@ -126,7 +123,6 @@ ConsoleStatusBar.propTypes = {
 
 ConsoleStatusBar.defaultProps = {
   children: null,
-  name: 'Default',
 };
 
 export default ConsoleStatusBar;

--- a/packages/console/src/command-history/index.jsx
+++ b/packages/console/src/command-history/index.jsx
@@ -1,0 +1,5 @@
+export { default as CommandHistory } from './CommandHistory';
+export { default as CommandHistoryActions } from './CommandHistoryActions';
+export { default as CommandHistoryItem } from './CommandHistoryItem';
+export { default as CommandHistoryItemTooltip } from './CommandHistoryItemTooltip';
+export * from './CommandHistoryStorage';

--- a/packages/console/src/console-history/index.jsx
+++ b/packages/console/src/console-history/index.jsx
@@ -1,0 +1,5 @@
+export { default as ConsoleHistory } from './ConsoleHistory';
+export { default as ConsoleHistoryItem } from './ConsoleHistoryItem';
+export { default as ConsoleHistoryItemResult } from './ConsoleHistoryItemResult';
+export { default as ConsoleHistoryResultErrorMessage } from './ConsoleHistoryResultErrorMessage';
+export { default as ConsoleHistoryResultInProgress } from './ConsoleHistoryResultInProgress';

--- a/packages/console/src/index.js
+++ b/packages/console/src/index.js
@@ -10,13 +10,8 @@ export { default as MonacoUtils } from './monaco/MonacoUtils';
 export { default as Editor } from './notebook/Editor';
 export { default as ScriptEditor } from './notebook/ScriptEditor';
 export { default as ScriptEditorUtils } from './notebook/ScriptEditorUtils';
-export { default as CommandHistory } from './command-history/CommandHistory';
-export {
-  CommandHistoryStorage,
-  CommandHistoryStorageData,
-  CommandHistoryStorageItem,
-  CommandHistoryTable,
-} from './command-history/CommandHistoryStorage';
+export * from './command-history';
+export * from './console-history';
 export { default as LogView } from './log/LogView';
 
 export { default } from './Console';


### PR DESCRIPTION
- ContextActions can now be registered by the parent container instead of passed in
- Overflow actions are passed in and shown
- Pass in a node for displaying when console is disconnected unexpectedly

Fixes #112 