### PR TITLE
Get console type from the API, don't allow switching language

### DIFF
--- a/packages/code-studio/src/dashboard/panels/ConsolePanel.jsx
+++ b/packages/code-studio/src/dashboard/panels/ConsolePanel.jsx
@@ -133,6 +133,10 @@ class ConsolePanel extends PureComponent {
 
       log.info('Available types:', types);
 
+      if (types.length === 0) {
+        throw new Error('No console types available');
+      }
+
       const type = types[0];
 
       log.info('Starting session with type', type);

--- a/packages/code-studio/src/dashboard/panels/ConsolePanel.jsx
+++ b/packages/code-studio/src/dashboard/panels/ConsolePanel.jsx
@@ -68,13 +68,9 @@ class ConsolePanel extends PureComponent {
     };
     const { consoleSettings, itemIds } = panelState;
 
-    const language =
-      process.env.REACT_APP_SESSION_LANGUAGE ??
-      Array.from(ConsoleConstants.LANGUAGE_MAP.keys())[0];
-
     this.state = {
       consoleSettings,
-      language,
+      language: null,
       itemIds: new Map(itemIds),
 
       isLoading: true,
@@ -120,8 +116,6 @@ class ConsolePanel extends PureComponent {
 
   async initSession() {
     try {
-      const { language } = this.state;
-
       const baseUrl = new URL(
         process.env.REACT_APP_CORE_API_URL,
         window.location
@@ -151,7 +145,7 @@ class ConsolePanel extends PureComponent {
 
       const { glEventHub } = this.props;
       glEventHub.emit(ConsoleEvent.SESSION_OPENED, session, {
-        language,
+        language: type,
         sessionId,
       });
 
@@ -259,30 +253,6 @@ class ConsolePanel extends PureComponent {
     glEventHub.emit(ConsoleEvent.SETTINGS_CHANGED, consoleSettings);
   }
 
-  switchLanguage(newLanguage) {
-    const { language, session, sessionId } = this.state;
-
-    log.debug('Switching language to', newLanguage);
-
-    session.close();
-    const { glEventHub } = this.props;
-    glEventHub.emit(ConsoleEvent.SESSION_CLOSED, session, {
-      language,
-      sessionId,
-    });
-    this.setState(
-      {
-        language: newLanguage,
-        isLoading: true,
-        session: null,
-        sessionId: null,
-      },
-      () => {
-        this.initSession();
-      }
-    );
-  }
-
   openTable(object, session) {
     const { name } = object;
     const id = this.getItemId(name);
@@ -373,7 +343,6 @@ class ConsolePanel extends PureComponent {
       session,
       sessionId,
     } = this.state;
-    const name = ConsoleConstants.LANGUAGE_MAP.get(language);
     return (
       <Panel
         componentPanel={this}
@@ -409,7 +378,7 @@ class ConsolePanel extends PureComponent {
                 statusBarChildren={
                   <>
                     <div>&nbsp;</div>
-                    <div>{name}</div>
+                    <div>{ConsoleConstants.LANGUAGE_MAP.get(language)}</div>
                   </>
                 }
                 scope={sessionId}

--- a/packages/code-studio/src/dashboard/panels/ConsolePanel.jsx
+++ b/packages/code-studio/src/dashboard/panels/ConsolePanel.jsx
@@ -121,11 +121,11 @@ class ConsolePanel extends PureComponent {
         window.location
       );
 
-      log.info('Starting connection...');
+      const websocketUrl = `${baseUrl.protocol}//${baseUrl.host}`;
 
-      const connection = new dh.IdeConnection({
-        websocketUrl: `${baseUrl.protocol}//${baseUrl.host}`,
-      });
+      log.info(`Starting connection to '${websocketUrl}'...`);
+
+      const connection = new dh.IdeConnection(websocketUrl);
 
       log.info('Getting console types...');
 


### PR DESCRIPTION
Fixes #58

- The server does not support switching languages, remove that functionality
- Get the console types (languages) from the connection, use the first one as default
- Requires server changes https://github.com/deephaven/deephaven-core/pull/863