### PR TITLE
Fix disconnect status not resetting history items in Console

### DIFF
--- a/packages/console/src/Console.jsx
+++ b/packages/console/src/Console.jsx
@@ -140,12 +140,12 @@ export class Console extends PureComponent {
   }
 
   componentDidUpdate(prevProps, prevState) {
-    const { state } = this;
+    const { props, state } = this;
     this.sendSettingsChange(prevState, state);
 
     if (
-      state.disconnectedChildren != null &&
-      prevState.disconnectedChildren == null
+      props.disconnectedChildren != null &&
+      prevProps.disconnectedChildren == null
     ) {
       this.disconnect();
     }


### PR DESCRIPTION
- Was looking in state instead of props
