### PR TITLE
Update workflow_dispatch action to take a git SHA

### DIFF
--- a/.github/workflows/publish-alpha.yml
+++ b/.github/workflows/publish-alpha.yml
@@ -2,8 +2,12 @@ name: Node.js Package Alpha
 on:
   workflow_dispatch:
     inputs:
+      preid:
+        description: 'Preid used to publish package. Must be unique per branch.'
+        required: true
+        default: 'alpha'
       ref:
-        description: 'Commit to deploy from. Defaults to branch used for workflow_dispatch action'
+        description: 'Commit to deploy from. Defaults to branch used for workflow_dispatch action.'
         required: false
         default: ''
 jobs:
@@ -23,6 +27,6 @@ jobs:
           registry-url: 'https://npm.pkg.github.com'
       - run: npm install
       - run: npm run build
-      - run: ./node_modules/.bin/lerna publish --canary --registry https://npm.pkg.github.com --yes
+      - run: ./node_modules/.bin/lerna publish --canary --preid ${{ github.event.inputs.preid }} --registry https://npm.pkg.github.com --yes
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-alpha.yml
+++ b/.github/workflows/publish-alpha.yml
@@ -1,5 +1,11 @@
 name: Node.js Package Alpha
-on: workflow_dispatch
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Commit to deploy from. Defaults to branch used for workflow_dispatch action'
+        required: false
+        default: ''
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -8,6 +14,8 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.inputs.ref }}
       # Setup .npmrc file to publish to GitHub Packages
       - uses: actions/setup-node@v2
         with:


### PR DESCRIPTION
workflow_dispatch action allows you to select the branch you want to execute the workflow from, however it doesn't let you select a PR that's currently in review if it's created from a fork.

By allowing a SHA to be input, we should be able to input the commit from the PR and it will publish from that.