### PR TITLE
Create a publish nightly action

### DIFF
--- a/packages/code-studio/src/main/publish-nightly.yml
+++ b/packages/code-studio/src/main/publish-nightly.yml
@@ -1,0 +1,25 @@
+name: Publish nightly packages
+on:
+  # https://docs.github.com/en/actions/reference/events-that-trigger-workflows#schedule
+  # Note: this will set GITHUB_SHA to the latest commit on the default branch.
+  schedule:
+    # 2AM EST == 6AM UTC
+    - cron:  '0 6 * * *'
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v2
+      # Setup .npmrc file to publish to GitHub Packages
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '12.x'
+          registry-url: 'https://npm.pkg.github.com'
+      - run: npm install
+      - run: npm run build
+      - run: ./node_modules/.bin/lerna publish --preid beta --dist-tag nightly --registry https://npm.pkg.github.com --yes
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Right now it's publishing to GitHub packages. Once we've verified it's working there, then I'll update to publish to npmjs
