### PR TITLE
Improve console error message handling

### DIFF
--- a/packages/console/src/Console.jsx
+++ b/packages/console/src/Console.jsx
@@ -68,7 +68,6 @@ export class Console extends PureComponent {
     this.handleLogMessage = this.handleLogMessage.bind(this);
     this.handleOverflowActions = this.handleOverflowActions.bind(this);
     this.handleScrollPaneScroll = this.handleScrollPaneScroll.bind(this);
-    this.handleScrollPaneClick = this.handleScrollPaneClick.bind(this);
     this.handleToggleAutoLaunchPanels = this.handleToggleAutoLaunchPanels.bind(
       this
     );
@@ -507,12 +506,6 @@ export class Console extends PureComponent {
     }
   }
 
-  handleScrollPaneClick(e) {
-    if (e.target === e.currentTarget && this.consoleInput.current != null) {
-      this.consoleInput.current.focus();
-    }
-  }
-
   handleToggleAutoLaunchPanels() {
     this.setState(state => ({
       isAutoLaunchPanelsEnabled: !state.isAutoLaunchPanelsEnabled,
@@ -854,7 +847,6 @@ export class Console extends PureComponent {
               className={classNames('scroll-pane no-scroll-x', {
                 'scroll-decoration': isScrollDecorationShown,
               })}
-              onClick={this.handleScrollPaneClick}
               onScroll={this.handleScrollPaneScroll}
               ref={this.consoleHistoryScrollPane}
             >

--- a/packages/console/src/console-history/ConsoleHistoryResultErrorMessage.jsx
+++ b/packages/console/src/console-history/ConsoleHistoryResultErrorMessage.jsx
@@ -21,7 +21,7 @@ class ConsoleHistoryResultErrorMessage extends PureComponent {
 
     this.mouseX = null;
     this.mouseY = null;
-    this.isDragging = false;
+    this.isClicking = false;
 
     this.state = {
       isExpanded: false,
@@ -45,7 +45,7 @@ class ConsoleHistoryResultErrorMessage extends PureComponent {
   handleMouseDown(event) {
     this.mouseX = event.clientX;
     this.mouseY = event.clientY;
-    this.isDragging = false;
+    this.isClicking = true;
   }
 
   handleMouseMove(event) {
@@ -56,18 +56,23 @@ class ConsoleHistoryResultErrorMessage extends PureComponent {
         Math.abs(event.clientY - this.mouseY) >=
           ConsoleHistoryResultErrorMessage.mouseDragThreshold
       ) {
-        this.isDragging = true;
+        this.isClicking = false;
       }
+    } else if (this.isClicking) {
+      // Rare case - could happen if you mouse down, switch window focus, release the mouse, then come back, mouse down outside of the error, drag into the error, then release the mouse
+      this.isClicking = false;
     }
   }
 
-  handleMouseUp() {
-    if (!this.isDragging) {
+  handleMouseUp(event) {
+    // We don't want to expand/collapse the error if user is holding shift or an alt key
+    // They may be trying to adjust their selection
+    if (this.isClicking && !event.shiftKey && !event.metaKey && !event.altKey) {
       this.handleToggleError();
     }
     this.mouseX = null;
     this.mouseY = null;
-    this.isDragging = false;
+    this.isClicking = false;
   }
 
   handleToggleError() {


### PR DESCRIPTION
Before, it would collapse the error message often while you were trying to select text. A couple of fixes:
- Sets `isClicking` on mouse down to start the click. Prevents cases where you drag into the error message from outside collapsing the error message
- Don't register the click if the user is holding Shift - they could be trying to update the selection

Fixes #149
