### PR TITLE
Fix Some Shortcut Problems

### DIFF
--- a/packages/code-studio/src/main/AppControlsMenu.jsx
+++ b/packages/code-studio/src/main/AppControlsMenu.jsx
@@ -169,7 +169,7 @@ const AppControlsMenu = props => {
           onClearFilter();
         },
         order: 60,
-        shortcut: GRID_SHORTCUTS.TABLE.CLEAR_FILTERS,
+        shortcut: GRID_SHORTCUTS.TABLE.CLEAR_ALL_FILTERS,
       },
     ],
     [handleControlSelect, handleToolSelect, onClearFilter]

--- a/packages/code-studio/src/main/AppControlsMenu.jsx
+++ b/packages/code-studio/src/main/AppControlsMenu.jsx
@@ -7,7 +7,7 @@ import React, {
 } from 'react';
 import classNames from 'classnames';
 import { DropdownMenu, GLOBAL_SHORTCUTS } from '@deephaven/components';
-import { SHORTCUTS as GRID_SHORTCUTS } from '@deephaven/iris-grid';
+import { SHORTCUTS as IRIS_GRID_SHORTCUTS } from '@deephaven/iris-grid';
 import {
   dhInput,
   dhFilterSlash,
@@ -169,7 +169,7 @@ const AppControlsMenu = props => {
           onClearFilter();
         },
         order: 60,
-        shortcut: GRID_SHORTCUTS.TABLE.CLEAR_ALL_FILTERS,
+        shortcut: IRIS_GRID_SHORTCUTS.TABLE.CLEAR_ALL_FILTERS,
       },
     ],
     [handleControlSelect, handleToolSelect, onClearFilter]

--- a/packages/code-studio/src/main/AppMainContainer.jsx
+++ b/packages/code-studio/src/main/AppMainContainer.jsx
@@ -11,6 +11,7 @@ import {
   ThemeExport,
   GLOBAL_SHORTCUTS,
 } from '@deephaven/components';
+import { SHORTCUTS as IRIS_GRID_SHORTCUTS } from '@deephaven/iris-grid';
 import Log from '@deephaven/log';
 import {
   getActiveTool,
@@ -258,7 +259,7 @@ export class AppMainContainer extends Component {
           this.sendClearFilter();
         },
         order: 50,
-        shortcut: GLOBAL_SHORTCUTS.CLEAR_ALL_FILTERS,
+        shortcut: IRIS_GRID_SHORTCUTS.TABLE.CLEAR_ALL_FILTERS,
       },
       {
         action: () => {

--- a/packages/components/src/context-actions/GlobalContextAction.tsx
+++ b/packages/components/src/context-actions/GlobalContextAction.tsx
@@ -18,17 +18,13 @@ class GlobalContextAction extends Component<GlobalContextActionProps> {
   }
 
   componentDidMount(): void {
-    document.body.addEventListener('contextmenu', this.handleContextMenu, true);
-    document.body.addEventListener('keydown', this.handleKeyDown, true);
+    document.body.addEventListener('contextmenu', this.handleContextMenu);
+    document.body.addEventListener('keydown', this.handleKeyDown);
   }
 
   componentWillUnmount(): void {
-    document.body.removeEventListener(
-      'contextmenu',
-      this.handleContextMenu,
-      true
-    );
-    document.body.removeEventListener('keydown', this.handleKeyDown, true);
+    document.body.removeEventListener('contextmenu', this.handleContextMenu);
+    document.body.removeEventListener('keydown', this.handleKeyDown);
   }
 
   handleContextMenu(evt: MouseEvent): void {

--- a/packages/console/src/monaco/MonacoUtils.js
+++ b/packages/console/src/monaco/MonacoUtils.js
@@ -352,6 +352,10 @@ class MonacoUtils {
       {
         windows: 'ctrl+H',
       },
+      {
+        windows: 'ctrl+L',
+        mac: 'meta+L',
+      },
     ];
 
     try {

--- a/packages/console/src/monaco/MonacoUtils.js
+++ b/packages/console/src/monaco/MonacoUtils.js
@@ -352,10 +352,6 @@ class MonacoUtils {
       {
         windows: 'ctrl+H',
       },
-      {
-        windows: 'ctrl+L',
-        mac: 'meta+L',
-      },
     ];
 
     try {

--- a/packages/iris-grid/src/IrisGridShortcuts.ts
+++ b/packages/iris-grid/src/IrisGridShortcuts.ts
@@ -7,9 +7,15 @@ const TABLE = {
     shortcut: [MODIFIER.CTRL, KEY.F],
     macShortcut: [MODIFIER.CMD, KEY.F],
   }),
+  CLEAR_ALL_FILTERS: ShortcutRegistry.createAndAdd({
+    id: 'TABLE.CLEAR_ALL_FILTERS',
+    name: 'Clear All Table Filters',
+    shortcut: [MODIFIER.CTRL, KEY.E],
+    macShortcut: [MODIFIER.CMD, KEY.E],
+  }),
   CLEAR_FILTERS: ShortcutRegistry.createAndAdd({
     id: 'TABLE.CLEAR_FILTERS',
-    name: 'Clear Filters',
+    name: 'Clear Active Table Filters',
     shortcut: [MODIFIER.CTRL, MODIFIER.SHIFT, KEY.E],
     macShortcut: [MODIFIER.CMD, MODIFIER.SHIFT, KEY.E],
   }),
@@ -22,8 +28,8 @@ const TABLE = {
   TOGGLE_SEARCH: ShortcutRegistry.createAndAdd({
     id: 'TABLE.TOGGLE_SEARCH',
     name: 'Toggle Search',
-    shortcut: [MODIFIER.CTRL, KEY.S],
-    macShortcut: [MODIFIER.CMD, KEY.S],
+    shortcut: [MODIFIER.CTRL, MODIFIER.SHIFT, KEY.F],
+    macShortcut: [MODIFIER.CMD, MODIFIER.SHIFT, KEY.F],
   }),
 };
 

--- a/packages/iris-grid/src/key-handlers/ClearFilterKeyHandler.ts
+++ b/packages/iris-grid/src/key-handlers/ClearFilterKeyHandler.ts
@@ -1,7 +1,6 @@
-/* eslint class-methods-use-this: "off" */
-import { ContextActionUtils } from '@deephaven/components';
 import { KeyHandler } from '@deephaven/grid';
 import { IrisGrid } from '../IrisGrid';
+import { SHORTCUTS } from '..';
 
 class ClearFilterKeyHandler extends KeyHandler {
   private irisGrid: IrisGrid;
@@ -13,11 +12,7 @@ class ClearFilterKeyHandler extends KeyHandler {
   }
 
   onDown(e: KeyboardEvent): boolean {
-    if (
-      e.key.toLowerCase() === 'e' &&
-      ContextActionUtils.isModifierKeyDown(e) &&
-      e.shiftKey
-    ) {
+    if (SHORTCUTS.TABLE.CLEAR_FILTERS.matchesEvent(e)) {
       this.irisGrid.clearAllFilters();
       return true;
     }

--- a/packages/iris-grid/src/key-handlers/ReverseKeyHandler.ts
+++ b/packages/iris-grid/src/key-handlers/ReverseKeyHandler.ts
@@ -1,8 +1,7 @@
-/* eslint class-methods-use-this: "off" */
-import { ContextActionUtils } from '@deephaven/components';
 import { KeyHandler } from '@deephaven/grid';
 import { IrisGrid } from '../IrisGrid';
 import TableUtils from '../TableUtils';
+import { SHORTCUTS } from '..';
 
 class ReverseKeyHandler extends KeyHandler {
   private irisGrid: IrisGrid;
@@ -14,7 +13,7 @@ class ReverseKeyHandler extends KeyHandler {
   }
 
   onDown(e: KeyboardEvent): boolean {
-    if (e.key === 'i' && ContextActionUtils.isModifierKeyDown(e)) {
+    if (SHORTCUTS.TABLE.REVERSE.matchesEvent(e)) {
       if (!this.irisGrid.isReversible()) {
         return false;
       }


### PR DESCRIPTION
Fixes #142 (mostly). See #151 which will address remaining shortcut problems.

Removes the global shortcut handlers from being attached to the capture phase instead of bubble phase. This makes local shortcuts take precedence over global shortcuts. Also means linker won't trigger when inside of monaco, but monaco has its own shortcuts and Don said we should just leave monaco shortcuts alone instead of removing them so our shortcuts work globally (really it's only linker)