### PR TITLE
Hide the suggestion widget when it's showing a status message

### DIFF
--- a/packages/components/src/BaseStyleSheet.scss
+++ b/packages/components/src/BaseStyleSheet.scss
@@ -651,12 +651,10 @@ input[type='number']::-webkit-inner-spin-button {
   display: none;
 }
 
-//hide the "Loading..." and "No suggestions" message in the suggest widget in monaco to make it feel faster
 .monaco-editor {
-  .editor-widget.suggest-widget {
-    .message {
-      display: none;
-    }
+  // Hide the "Loading..." and "No suggestions" message in the suggest widget in monaco to make it feel faster
+  .editor-widget.suggest-widget.message {
+    display: none;
   }
 
   .find-widget {


### PR DESCRIPTION
We were already supposed to be doing this, but we weren't hiding the right element so it was showing an empty box.
Update it to hide the correct element.

Fixes #144 