### PR TITLE
Using the http-proxy-middleware to proxy

### DIFF
--- a/packages/code-studio/.env.development
+++ b/packages/code-studio/.env.development
@@ -1,7 +1,6 @@
 REACT_APP_ENABLE_LOG_PROXY=false
-REACT_APP_CORE_API_URL=http://localhost:10000/jsapi
 
-# Proxy set in package.json to handle CORS for other URLs
+# Proxy set in src/setupProxy.js to handle CORS for other URLs
 # https://create-react-app.dev/docs/proxying-api-requests-in-development/
 
 REACT_APP_ROUTER_BASE_NAME=/

--- a/packages/code-studio/.env.development
+++ b/packages/code-studio/.env.development
@@ -1,5 +1,5 @@
 REACT_APP_ENABLE_LOG_PROXY=false
-REACT_APP_CORE_API_URL=http://localhost:10000/
+REACT_APP_CORE_API_URL=http://localhost:10000/jsapi
 
 # Proxy set in package.json to handle 4000 to solve CORS
 # https://create-react-app.dev/docs/proxying-api-requests-in-development/

--- a/packages/code-studio/.env.development
+++ b/packages/code-studio/.env.development
@@ -1,10 +1,8 @@
 REACT_APP_ENABLE_LOG_PROXY=false
 REACT_APP_CORE_API_URL=http://localhost:10000/jsapi
 
-# Proxy set in package.json to handle 4000 to solve CORS
+# Proxy set in package.json to handle CORS for other URLs
 # https://create-react-app.dev/docs/proxying-api-requests-in-development/
-REACT_APP_NOTEBOOKS_URL=http://localhost:4000/notebooks
-REACT_APP_LAYOUTS_URL=http://localhost:4000/layouts
 
 REACT_APP_ROUTER_BASE_NAME=/
 REACT_APP_INTERNAL_PLUGINS=ExamplePlugin

--- a/packages/code-studio/.env.development
+++ b/packages/code-studio/.env.development
@@ -1,7 +1,11 @@
 REACT_APP_ENABLE_LOG_PROXY=false
-REACT_APP_CORE_API_URL=http://localhost:10000/jsapi
-REACT_APP_NOTEBOOKS_URL=http://localhost:10000/notebooks
-REACT_APP_LAYOUTS_URL=http://localhost:10000/layouts
+REACT_APP_CORE_API_URL=http://localhost:10000/
+
+# Proxy set in package.json to handle 4000 to solve CORS
+# https://create-react-app.dev/docs/proxying-api-requests-in-development/
+REACT_APP_NOTEBOOKS_URL=http://localhost:4000/notebooks
+REACT_APP_LAYOUTS_URL=http://localhost:4000/layouts
+
 REACT_APP_ROUTER_BASE_NAME=/
 REACT_APP_INTERNAL_PLUGINS=ExamplePlugin
 PORT=4000

--- a/packages/code-studio/package.json
+++ b/packages/code-studio/package.json
@@ -32,6 +32,7 @@
     "cross-env": "^7.0.2",
     "deep-equal": "^2.0.4",
     "fira": "github:mozilla/fira#4.202",
+    "http-proxy-middleware": "^2.0.1",
     "jquery": "^3.5.1",
     "jszip": "3.2.2",
     "lodash.clamp": "^4.0.3",
@@ -110,7 +111,6 @@
     "@types/react-beautiful-dnd": "^13.0.0",
     "@types/react-dom": "^16.9.13",
     "@types/react-transition-group": "^4.4.0",
-    "http-proxy-middleware": "^2.0.1",
     "react-is": "^16.13.1",
     "sass": "1.32.13",
     "webpack": "4.44.2"

--- a/packages/code-studio/package.json
+++ b/packages/code-studio/package.json
@@ -122,5 +122,6 @@
   ],
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "proxy": "http://localhost:10000"
 }

--- a/packages/code-studio/package.json
+++ b/packages/code-studio/package.json
@@ -32,6 +32,7 @@
     "cross-env": "^7.0.2",
     "deep-equal": "^2.0.4",
     "fira": "github:mozilla/fira#4.202",
+    "http-proxy-middleware": "^2.0.1",
     "jquery": "^3.5.1",
     "jszip": "3.2.2",
     "lodash.clamp": "^4.0.3",
@@ -122,6 +123,5 @@
   ],
   "publishConfig": {
     "access": "public"
-  },
-  "proxy": "http://localhost:10000"
+  }
 }

--- a/packages/code-studio/package.json
+++ b/packages/code-studio/package.json
@@ -32,7 +32,6 @@
     "cross-env": "^7.0.2",
     "deep-equal": "^2.0.4",
     "fira": "github:mozilla/fira#4.202",
-    "http-proxy-middleware": "^2.0.1",
     "jquery": "^3.5.1",
     "jszip": "3.2.2",
     "lodash.clamp": "^4.0.3",
@@ -111,6 +110,7 @@
     "@types/react-beautiful-dnd": "^13.0.0",
     "@types/react-dom": "^16.9.13",
     "@types/react-transition-group": "^4.4.0",
+    "http-proxy-middleware": "^2.0.1",
     "react-is": "^16.13.1",
     "sass": "1.32.13",
     "webpack": "4.44.2"

--- a/packages/code-studio/src/setupProxy.js
+++ b/packages/code-studio/src/setupProxy.js
@@ -1,0 +1,10 @@
+const { createProxyMiddleware } = require('http-proxy-middleware');
+
+module.exports = app => {
+  app.use(
+    createProxyMiddleware({
+      target: 'http://localhost:10000',
+      ws: true,
+    })
+  );
+};


### PR DESCRIPTION
Alternative to Don's PR #172 . Needed to add the `ws: true` bit so websockets worked for the api as well.