### PR TITLE
Enable Scala syntax highlighting

### DIFF
--- a/packages/code-studio/.env
+++ b/packages/code-studio/.env
@@ -18,7 +18,7 @@ BUILD_PATH=./build
 # Define the language key and display name that are available on the server.
 # Omit the display name to use the key as the display name.
 # Defaults to the first language, or the value of `REACT_APP_SESSION_LANGUAGE` if defined.
-REACT_APP_SESSION_LANGUAGES=python=Python,groovy=Groovy
+REACT_APP_SESSION_LANGUAGES=python=Python,groovy=Groovy,scala=Scala
 
 # We run our own eslint configuration as part of jest tests in src/test/eslint.test.js
 # We don't need to run it as part of react-scripts, we don't need it running on npm build or npm start

--- a/packages/code-studio/src/dashboard/panels/NotebookPanel.jsx
+++ b/packages/code-studio/src/dashboard/panels/NotebookPanel.jsx
@@ -60,6 +60,8 @@ class NotebookPanel extends Component {
         return 'python';
       case 'groovy':
         return 'groovy';
+      case 'scala':
+        return 'scala';
       default:
         return null;
     }

--- a/packages/console/src/monaco/MonacoUtils.js
+++ b/packages/console/src/monaco/MonacoUtils.js
@@ -60,6 +60,7 @@ import Log from '@deephaven/log';
 import MonacoTheme from './MonacoTheme.module.scss';
 import PyLang from './lang/python';
 import GroovyLang from './lang/groovy';
+import ScalaLang from './lang/scala';
 import DbLang from './lang/db';
 import LogLang from './lang/log';
 
@@ -179,7 +180,7 @@ class MonacoUtils {
     log.debug2('monaco theme: ', MonacoTheme);
     monaco.editor.setTheme('dh-dark');
 
-    registerLanguages([DbLang, PyLang, GroovyLang, LogLang]);
+    registerLanguages([DbLang, PyLang, GroovyLang, LogLang, ScalaLang]);
 
     log.debug('Monaco initialized.');
   }

--- a/packages/console/src/monaco/lang/scala.js
+++ b/packages/console/src/monaco/lang/scala.js
@@ -1,0 +1,485 @@
+/*---------------------------------------------------------------------------------------------
+ *  The MIT License (MIT)
+ *
+ * Copyright (c) Microsoft Corporation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *
+ * The base version of this file is licensed under the MIT License (as above)
+ * and was sourced from microsoft's monaco languages repository:
+ *  - https://github.com/microsoft/monaco-languages/blob/main/src/scala/scala.ts
+ *--------------------------------------------------------------------------------------------*/
+
+const id = 'scala';
+
+const conf = {
+  /*
+   * `...` is allowed as an identifier.
+   * $ is allowed in identifiers.
+   * unary_<op> is allowed as an identifier.
+   * <name>_= is allowed as an identifier.
+   */
+  wordPattern: /(unary_[@~!#%^&*()\-=+\\|:<>/?]+)|([a-zA-Z_$][\w$]*?_=)|(`[^`]+`)|([a-zA-Z_$][\w$]*)/g,
+  comments: {
+    lineComment: '//',
+    blockComment: ['/*', '*/'],
+  },
+  brackets: [
+    ['{', '}'],
+    ['[', ']'],
+    ['(', ')'],
+  ],
+  autoClosingPairs: [
+    { open: '{', close: '}' },
+    { open: '[', close: ']' },
+    { open: '(', close: ')' },
+    { open: '"', close: '"' },
+    { open: "'", close: "'" },
+  ],
+  surroundingPairs: [
+    { open: '{', close: '}' },
+    { open: '[', close: ']' },
+    { open: '(', close: ')' },
+    { open: '"', close: '"' },
+    { open: "'", close: "'" },
+  ],
+  folding: {
+    markers: {
+      start: new RegExp('^\\s*//\\s*(?:(?:#?region\\b)|(?:<editor-fold\\b))'),
+      end: new RegExp('^\\s*//\\s*(?:(?:#?endregion\\b)|(?:</editor-fold>))'),
+    },
+  },
+};
+
+const language = {
+  // tokenPostfix: '.scala',
+
+  // We can't easily add everything from Dotty, but we can at least add some of its keywords
+  keywords: [
+    'asInstanceOf',
+    'catch',
+    'class',
+    'classOf',
+    'def',
+    'do',
+    'else',
+    'extends',
+    'finally',
+    'for',
+    'foreach',
+    'forSome',
+    'if',
+    'import',
+    'isInstanceOf',
+    'macro',
+    'match',
+    'new',
+    'object',
+    'package',
+    'return',
+    'throw',
+    'trait',
+    'try',
+    'type',
+    'until',
+    'val',
+    'var',
+    'while',
+    'with',
+    'yield',
+
+    // Dotty-specific:
+    'given',
+    'enum',
+    'then',
+  ],
+
+  // Dotty-specific:
+  softKeywords: ['as', 'export', 'extension', 'end', 'derives', 'on'],
+
+  constants: ['true', 'false', 'null', 'this', 'super'],
+
+  modifiers: [
+    'abstract',
+    'final',
+    'implicit',
+    'lazy',
+    'override',
+    'private',
+    'protected',
+    'sealed',
+  ],
+
+  // Dotty-specific:
+  softModifiers: ['inline', 'opaque', 'open', 'transparent', 'using'],
+
+  name: /(?:[a-z_$][\w$]*|`[^`]+`)/,
+  type: /(?:[A-Z][\w$]*)/,
+
+  // we include these common regular expressions
+  symbols: /[=><!~?:&|+\-*/^\\%@#]+/,
+  digits: /\d+(_+\d+)*/,
+  hexdigits: /[[0-9a-fA-F]+(_+[0-9a-fA-F]+)*/,
+
+  // C# style strings
+  escapes: /\\(?:[btnfr\\"']|x[0-9A-Fa-f]{1,4}|u[0-9A-Fa-f]{4}|U[0-9A-Fa-f]{8})/,
+
+  fstring_conv: /[bBhHsScCdoxXeEfgGaAt]|[Tn](?:[HIklMSLNpzZsQ]|[BbhAaCYyjmde]|[RTrDFC])/,
+
+  // The main tokenizer for our languages
+  tokenizer: {
+    root: [
+      // strings
+      [
+        /\braw"""/,
+        { token: 'string.quote', bracket: '@open', next: '@rawstringt' },
+      ],
+      [
+        /\braw"/,
+        { token: 'string.quote', bracket: '@open', next: '@rawstring' },
+      ],
+
+      [
+        /\bs"""/,
+        { token: 'string.quote', bracket: '@open', next: '@sstringt' },
+      ],
+      [/\bs"/, { token: 'string.quote', bracket: '@open', next: '@sstring' }],
+      [
+        /\bf""""/,
+        { token: 'string.quote', bracket: '@open', next: '@fstringt' },
+      ],
+      [/\bf"/, { token: 'string.quote', bracket: '@open', next: '@fstring' }],
+      [/"""/, { token: 'string.quote', bracket: '@open', next: '@stringt' }],
+      [/"/, { token: 'string.quote', bracket: '@open', next: '@string' }],
+
+      // numbers
+      [/(@digits)[eE]([-+]?(@digits))?[fFdD]?/, 'number.float', '@allowMethod'],
+      [
+        /(@digits)\.(@digits)([eE][-+]?(@digits))?[fFdD]?/,
+        'number.float',
+        '@allowMethod',
+      ],
+      [/0[xX](@hexdigits)[Ll]?/, 'number.hex', '@allowMethod'],
+      [/(@digits)[fFdD]/, 'number.float', '@allowMethod'],
+      [/(@digits)[lL]?/, 'number', '@allowMethod'],
+      [/\b_\*/, 'key'],
+      [/\b(_)\b/, 'keyword', '@allowMethod'],
+
+      // identifiers and keywords
+      [/\bimport\b/, 'keyword', '@import'],
+      [/\b(case)([ \t]+)(class)\b/, ['keyword.modifier', 'white', 'keyword']],
+      [/\bcase\b/, 'keyword', '@case'],
+      [/\bva[lr]\b/, 'keyword', '@vardef'],
+      [
+        /\b(def)([ \t]+)((?:unary_)?@symbols|@name(?:_=)|@name)/,
+        ['keyword', 'white', 'identifier'],
+      ],
+      [/@name(?=[ \t]*:(?!:))/, 'variable'],
+      [
+        /(\.)(@name|@symbols)/,
+        [
+          'operator',
+          {
+            token: '@rematch',
+            next: '@allowMethod',
+          },
+        ],
+      ],
+      [/([{(])(\s*)(@name(?=\s*=>))/, ['@brackets', 'white', 'variable']],
+      [
+        /@name/,
+        {
+          cases: {
+            '@keywords': 'keyword',
+            '@softKeywords': 'keyword',
+            '@modifiers': 'keyword.modifier',
+            '@softModifiers': 'keyword.modifier',
+            '@constants': {
+              token: 'constant',
+              next: '@allowMethod',
+            },
+            '@default': {
+              token: 'identifier',
+              next: '@allowMethod',
+            },
+          },
+        },
+      ],
+      [/@type/, 'type', '@allowMethod'],
+
+      // whitespace
+      { include: '@whitespace' },
+
+      // @ annotations.
+      [/@[a-zA-Z_$][\w$]*(?:\.[a-zA-Z_$][\w$]*)*/, 'annotation'],
+
+      // delimiters and operators
+      [/[{(]/, '@brackets'],
+      [/[})]/, '@brackets', '@allowMethod'],
+      [/\[/, 'operator.square'],
+      [/](?!\s*(?:va[rl]|def|type)\b)/, 'operator.square', '@allowMethod'],
+      [/]/, 'operator.square'],
+      [/([=-]>|<-|>:|<:|:>|<%)(?=[\s\w()[\]{},."'`])/, 'keyword'],
+      [/@symbols/, 'operator'],
+
+      // delimiter: after number because of .\d floats
+      [/[;,.]/, 'delimiter'],
+
+      // symbols
+      [/'[a-zA-Z$][\w$]*(?!')/, 'attribute.name'],
+
+      // characters
+      [/'[^\\']'/, 'string', '@allowMethod'],
+      [
+        /(')(@escapes)(')/,
+        [
+          'string',
+          'string.escape',
+          {
+            token: 'string',
+            next: '@allowMethod',
+          },
+        ],
+      ],
+      [/'/, 'string.invalid'],
+    ],
+
+    import: [
+      [/;/, 'delimiter', '@pop'],
+      [/^|$/, '', '@pop'],
+      [/[ \t]+/, 'white'],
+      [/[\n\r]+/, 'white', '@pop'],
+      [/\/\*/, 'comment', '@comment'],
+      [/@name|@type/, 'type'],
+      [/[(){}]/, '@brackets'],
+      [/[[\]]/, 'operator.square'],
+      [/[.,]/, 'delimiter'],
+    ],
+
+    allowMethod: [
+      [/^|$/, '', '@pop'],
+      [/[ \t]+/, 'white'],
+      [/[\n\r]+/, 'white', '@pop'],
+      [/\/\*/, 'comment', '@comment'],
+      [/(?==>[\s\w([{])/, 'keyword', '@pop'],
+      [
+        /(@name|@symbols)(?=[ \t]*[[({"'`]|[ \t]+(?:[+-]?\.?\d|\w))/,
+        {
+          cases: {
+            '@keywords': { token: 'keyword', next: '@pop' },
+            '->|<-|>:|<:|<%': { token: 'keyword', next: '@pop' },
+            '@default': { token: '@rematch', next: '@pop' },
+          },
+        },
+      ],
+      ['', '', '@pop'],
+    ],
+
+    comment: [
+      [/[^/*]+/, 'comment'],
+      [/\/\*/, 'comment', '@push'], // nested comment
+      [/\*\//, 'comment', '@pop'],
+      [/[/*]/, 'comment'],
+    ],
+
+    case: [
+      [/\b_\*/, 'key'],
+      [/\b(_|true|false|null|this|super)\b/, 'keyword', '@allowMethod'],
+      [/\bif\b|=>/, 'keyword', '@pop'],
+      [/`[^`]+`/, 'identifier', '@allowMethod'],
+      [/@name/, 'variable', '@allowMethod'],
+      [/:::?|\||@(?![a-z_$])/, 'keyword'],
+      { include: '@root' },
+    ],
+
+    vardef: [
+      [/\b_\*/, 'key'],
+      [/\b(_|true|false|null|this|super)\b/, 'keyword'],
+      [/@name/, 'variable'],
+      [/:::?|\||@(?![a-z_$])/, 'keyword'],
+      [/=|:(?!:)/, 'operator', '@pop'],
+      [/$/, 'white', '@pop'],
+      { include: '@root' },
+    ],
+
+    string: [
+      [/[^\\"\n\r]+/, 'string'],
+      [/@escapes/, 'string.escape'],
+      [/\\./, 'string.escape.invalid'],
+      [
+        /"/,
+        {
+          token: 'string.quote',
+          bracket: '@close',
+          switchTo: '@allowMethod',
+        },
+      ],
+    ],
+
+    stringt: [
+      [/[^\\"\n\r]+/, 'string'],
+      [/@escapes/, 'string.escape'],
+      [/\\./, 'string.escape.invalid'],
+      [/"(?=""")/, 'string'],
+      [
+        /"""/,
+        {
+          token: 'string.quote',
+          bracket: '@close',
+          switchTo: '@allowMethod',
+        },
+      ],
+      [/"/, 'string'],
+    ],
+
+    fstring: [
+      [/@escapes/, 'string.escape'],
+      [
+        /"/,
+        {
+          token: 'string.quote',
+          bracket: '@close',
+          switchTo: '@allowMethod',
+        },
+      ],
+      [/\$\$/, 'string'],
+      [/(\$)([a-z_]\w*)/, ['operator', 'identifier']],
+      [/\$\{/, 'operator', '@interp'],
+      [/%%/, 'string'],
+      [
+        /(%)([-#+ 0,(])(\d+|\.\d+|\d+\.\d+)(@fstring_conv)/,
+        ['metatag', 'keyword.modifier', 'number', 'metatag'],
+      ],
+      [
+        /(%)(\d+|\.\d+|\d+\.\d+)(@fstring_conv)/,
+        ['metatag', 'number', 'metatag'],
+      ],
+      [
+        /(%)([-#+ 0,(])(@fstring_conv)/,
+        ['metatag', 'keyword.modifier', 'metatag'],
+      ],
+      [/(%)(@fstring_conv)/, ['metatag', 'metatag']],
+      [/./, 'string'],
+    ],
+
+    fstringt: [
+      [/@escapes/, 'string.escape'],
+      [/"(?=""")/, 'string'],
+      [
+        /"""/,
+        {
+          token: 'string.quote',
+          bracket: '@close',
+          switchTo: '@allowMethod',
+        },
+      ],
+      [/\$\$/, 'string'],
+      [/(\$)([a-z_]\w*)/, ['operator', 'identifier']],
+      [/\$\{/, 'operator', '@interp'],
+      [/%%/, 'string'],
+      [
+        /(%)([-#+ 0,(])(\d+|\.\d+|\d+\.\d+)(@fstring_conv)/,
+        ['metatag', 'keyword.modifier', 'number', 'metatag'],
+      ],
+      [
+        /(%)(\d+|\.\d+|\d+\.\d+)(@fstring_conv)/,
+        ['metatag', 'number', 'metatag'],
+      ],
+      [
+        /(%)([-#+ 0,(])(@fstring_conv)/,
+        ['metatag', 'keyword.modifier', 'metatag'],
+      ],
+      [/(%)(@fstring_conv)/, ['metatag', 'metatag']],
+      [/./, 'string'],
+    ],
+
+    sstring: [
+      [/@escapes/, 'string.escape'],
+      [
+        /"/,
+        {
+          token: 'string.quote',
+          bracket: '@close',
+          switchTo: '@allowMethod',
+        },
+      ],
+      [/\$\$/, 'string'],
+      [/(\$)([a-z_]\w*)/, ['operator', 'identifier']],
+      [/\$\{/, 'operator', '@interp'],
+      [/./, 'string'],
+    ],
+
+    sstringt: [
+      [/@escapes/, 'string.escape'],
+      [/"(?=""")/, 'string'],
+      [
+        /"""/,
+        {
+          token: 'string.quote',
+          bracket: '@close',
+          switchTo: '@allowMethod',
+        },
+      ],
+      [/\$\$/, 'string'],
+      [/(\$)([a-z_]\w*)/, ['operator', 'identifier']],
+      [/\$\{/, 'operator', '@interp'],
+      [/./, 'string'],
+    ],
+
+    interp: [
+      [/{/, 'operator', '@push'],
+      [/}/, 'operator', '@pop'],
+      { include: '@root' },
+    ],
+
+    rawstring: [
+      [/[^"]/, 'string'],
+      [
+        /"/,
+        {
+          token: 'string.quote',
+          bracket: '@close',
+          switchTo: '@allowMethod',
+        },
+      ],
+    ],
+
+    rawstringt: [
+      [/[^"]/, 'string'],
+      [/"(?=""")/, 'string'],
+      [
+        /"""/,
+        {
+          token: 'string.quote',
+          bracket: '@close',
+          switchTo: '@allowMethod',
+        },
+      ],
+      [/"/, 'string'],
+    ],
+
+    whitespace: [
+      [/[ \t\r\n]+/, 'white'],
+      [/\/\*/, 'comment', '@comment'],
+      [/\/\/.*$/, 'comment'],
+    ],
+  },
+};
+
+export default { id, conf, language };

--- a/packages/console/src/notebook/ScriptEditorUtils.js
+++ b/packages/console/src/notebook/ScriptEditorUtils.js
@@ -1,4 +1,4 @@
-const LANGUAGES = { groovy: 'Groovy', python: 'Python' };
+const LANGUAGES = { groovy: 'Groovy', python: 'Python', scala: 'Scala' };
 
 class ScriptEditorUtils {
   /** Get PQ script language from Monaco language

--- a/packages/file-explorer/src/FileUtils.ts
+++ b/packages/file-explorer/src/FileUtils.ts
@@ -8,6 +8,7 @@ export enum MIME_TYPE {
   PLAIN_TEXT = 'text/plain',
   PYTHON = 'text/x-python',
   PYTHON_COMPILED = 'application/x-python-code',
+  SCALA = 'text/x-scala',
   UNKNOWN = '',
 }
 
@@ -93,6 +94,8 @@ export class FileUtils {
         return MIME_TYPE.PYTHON;
       case 'pyc':
         return MIME_TYPE.PYTHON_COMPILED;
+      case 'scala':
+        return MIME_TYPE.SCALA;
       case 'txt':
         return MIME_TYPE.PLAIN_TEXT;
       default:


### PR DESCRIPTION
Although this is not yet available via the DHC server, the change-set itself is valid and mergeable.

I did notice that the python implementation both is similar and dissimilar to the official monaco-languages python definition. We appear to be missing a handful of keywords. Also, I suspect that the python implementation needs to properly reference the original MIT license.

I wasn't sure of exactly how to make it clear the scala implementation was sourced from a piece of work under the MIT license. I took a first stab at it, but suspect it is inadequate.

I'd be happy to give a demo with or without notice. Looking forward to hearing how to proceed. 