### PR TITLE
Remove default formatting rules

### DIFF
--- a/packages/code-studio/src/dashboard/LocalWorkspaceStorage.ts
+++ b/packages/code-studio/src/dashboard/LocalWorkspaceStorage.ts
@@ -1,5 +1,4 @@
 import Log from '@deephaven/log';
-import { Formatter } from '@deephaven/iris-grid';
 import { DateTimeColumnFormatter } from '@deephaven/iris-grid/dist/formatters';
 import WorkspaceStorage, { Workspace, WorkspaceData } from './WorkspaceStorage';
 
@@ -16,7 +15,7 @@ export class LocalWorkspaceStorage implements WorkspaceStorage {
       settings: {
         defaultDateTimeFormat:
           DateTimeColumnFormatter.DEFAULT_DATETIME_FORMAT_STRING,
-        formatter: Formatter.getDefaultFormattingRules(),
+        formatter: [],
         timeZone: DateTimeColumnFormatter.DEFAULT_TIME_ZONE_ID,
         showTimeZone: false,
         showTSeparator: true,

--- a/packages/iris-grid/src/Formatter.js
+++ b/packages/iris-grid/src/Formatter.js
@@ -44,54 +44,6 @@ class Formatter {
   }
 
   /**
-   * Creates default column formatting rules
-   * @returns Column formatting rules array
-   */
-  static getDefaultFormattingRules() {
-    const globalFormatsArray = [
-      Formatter.makeColumnFormattingRule(
-        TableUtils.dataType.DATETIME,
-        'Expiry',
-        DateTimeColumnFormatter.makeFormat(
-          '',
-          'yyyy-MM-dd',
-          DateTimeColumnFormatter.TYPE_GLOBAL
-        )
-      ),
-      Formatter.makeColumnFormattingRule(
-        TableUtils.dataType.DATETIME,
-        'Timestamp',
-        DateTimeColumnFormatter.makeFormat(
-          '',
-          'HH:mm:ss.SSS',
-          DateTimeColumnFormatter.TYPE_GLOBAL
-        )
-      ),
-      Formatter.makeColumnFormattingRule(
-        TableUtils.dataType.DECIMAL,
-        'Bid',
-        DecimalColumnFormatter.makeFormat(
-          '',
-          '###,##0.00###',
-          null,
-          DecimalColumnFormatter.TYPE_GLOBAL
-        )
-      ),
-      Formatter.makeColumnFormattingRule(
-        TableUtils.dataType.DECIMAL,
-        'Ask',
-        DecimalColumnFormatter.makeFormat(
-          '',
-          '###,##0.00###',
-          null,
-          DecimalColumnFormatter.TYPE_GLOBAL
-        )
-      ),
-    ];
-    return globalFormatsArray;
-  }
-
-  /**
    * @param {Array} columnFormattingRules Optional array of column formatting rules
    * @param {Object} dateTimeOptions Optional object with DateTime configuration
    * @param {string} dateTimeOptions.timeZone Time zone

--- a/packages/iris-grid/src/Formatter.test.js
+++ b/packages/iris-grid/src/Formatter.test.js
@@ -14,14 +14,6 @@ function makeFormatter(...settings) {
 }
 
 const TYPE_DATETIME = 'io.deephaven.db.tables.utils.DBDateTime';
-const TYPE_FLOAT = 'float';
-
-const columnsWithDefaultFormats = [
-  { type: TYPE_DATETIME, name: 'Timestamp' },
-  { type: TYPE_DATETIME, name: 'Expiry' },
-  { type: TYPE_FLOAT, name: 'Ask' },
-  { type: TYPE_FLOAT, name: 'Bid' },
-];
 
 describe('makeColumnFormatMap', () => {
   const conflictingColumnName = 'Conflicting name';
@@ -92,17 +84,6 @@ it('uses default formatter for types that have no custom formatter', () => {
   expect(
     makeFormatter().getColumnTypeFormatter('randomTypeWithNoCustomFormatter')
   ).toBeInstanceOf(DefaultColumnFormatter);
-});
-
-describe('getDefaultFormattingRules', () => {
-  it('returns default rules for a given list of columns', () => {
-    const defaultFormattingRules = Formatter.getDefaultFormattingRules();
-    const formatter = makeFormatter(defaultFormattingRules);
-    columnsWithDefaultFormats.forEach(column => {
-      const columnFormat = formatter.getColumnFormat(column.type, column.name);
-      expect(columnFormat).toBeDefined();
-    });
-  });
 });
 
 describe('getColumnFormat', () => {


### PR DESCRIPTION
- Default formatting rules were legacy from Enterprise days. Remove these rules, as they are unexpected in Community.
- Fixes #197
- Breaking Change: Formatter no longer has getDefaultFormattingRules
