### PR TITLE
Don't show custom context menu on right-click in Monaco editor

### DIFF
--- a/packages/components/src/context-actions/ContextActions.tsx
+++ b/packages/components/src/context-actions/ContextActions.tsx
@@ -149,8 +149,13 @@ class ContextActions extends Component<
       let el = e.target as Element | null;
       while (el != null) {
         const { classList } = el;
-        if (ignoreClassNames.some(className => classList.contains(className))) {
-          log.debug2('Contextmenu event ignored based on the target className');
+        const ignoredClassName = ignoreClassNames.find(className =>
+          classList.contains(className)
+        );
+        if (ignoredClassName !== undefined) {
+          log.debug2(
+            `Contextmenu event ignored based on the target className "${ignoredClassName}"`
+          );
           return;
         }
         el = el.parentElement;

--- a/packages/components/src/context-actions/ContextActions.tsx
+++ b/packages/components/src/context-actions/ContextActions.tsx
@@ -150,6 +150,7 @@ class ContextActions extends Component<
       while (el != null) {
         const { classList } = el;
         if (ignoreClassNames.some(className => classList.contains(className))) {
+          log.debug2('Contextmenu event ignored based on the target className');
           return;
         }
         el = el.parentElement;

--- a/packages/components/src/context-actions/ContextActions.tsx
+++ b/packages/components/src/context-actions/ContextActions.tsx
@@ -12,6 +12,7 @@ const log = Log.module('ContextActions');
 
 interface ContextActionsProps {
   actions: ContextAction[] | (() => ContextAction[]);
+  ignoreClassNames?: string[];
 }
 
 interface ContextActionsState {
@@ -143,6 +144,17 @@ class ContextActions extends Component<
   container: React.RefObject<HTMLDivElement>;
 
   handleContextMenu(e: MouseEvent): void {
+    const { ignoreClassNames = [] } = this.props;
+    if (ignoreClassNames.length > 0) {
+      let el = e.target as Element | null;
+      while (el != null) {
+        const { classList } = el;
+        if (ignoreClassNames.some(className => classList.contains(className))) {
+          return;
+        }
+        el = el.parentElement;
+      }
+    }
     if (!ContextActionUtils.isContextActionEvent(e)) {
       (e as ContextActionEvent).contextActions = [];
     }

--- a/packages/components/src/context-actions/ContextMenuRoot.tsx
+++ b/packages/components/src/context-actions/ContextMenuRoot.tsx
@@ -3,9 +3,7 @@ import classNames from 'classnames';
 import ContextMenu from './ContextMenu';
 import ContextActionUtils, { MenuItem } from './ContextActionUtils';
 
-type ContextMenuRootProps = {
-  ignoreClassNames?: string[];
-};
+type ContextMenuRootProps = Record<string, never>;
 
 interface ContextMenuRootState {
   actions: MenuItem[] | null;
@@ -58,18 +56,6 @@ class ContextMenuRoot extends Component<
   openMenu: React.RefObject<ContextMenu>;
 
   handleContextMenu(e: MouseEvent): void {
-    const { ignoreClassNames = [] } = this.props;
-    if (ignoreClassNames.length > 0) {
-      let el = e.target as Element | null;
-      while (el != null) {
-        const { classList } = el;
-        if (ignoreClassNames.some(className => classList.contains(className))) {
-          return;
-        }
-        el = el.parentElement;
-      }
-    }
-
     if (!ContextActionUtils.isContextActionEvent(e)) {
       return;
     }

--- a/packages/components/src/context-actions/ContextMenuRoot.tsx
+++ b/packages/components/src/context-actions/ContextMenuRoot.tsx
@@ -56,6 +56,14 @@ class ContextMenuRoot extends Component<
   openMenu: React.RefObject<ContextMenu>;
 
   handleContextMenu(e: MouseEvent): void {
+    let el = e.target as Element | null;
+    while (el != null) {
+      if (el.classList.contains('monaco-editor')) {
+        return;
+      }
+      el = el.parentElement;
+    }
+
     if (!ContextActionUtils.isContextActionEvent(e)) {
       return;
     }

--- a/packages/components/src/context-actions/ContextMenuRoot.tsx
+++ b/packages/components/src/context-actions/ContextMenuRoot.tsx
@@ -3,7 +3,9 @@ import classNames from 'classnames';
 import ContextMenu from './ContextMenu';
 import ContextActionUtils, { MenuItem } from './ContextActionUtils';
 
-type ContextMenuRootProps = Record<string, never>;
+type ContextMenuRootProps = {
+  ignoreClassNames?: string[];
+};
 
 interface ContextMenuRootState {
   actions: MenuItem[] | null;
@@ -56,12 +58,16 @@ class ContextMenuRoot extends Component<
   openMenu: React.RefObject<ContextMenu>;
 
   handleContextMenu(e: MouseEvent): void {
-    let el = e.target as Element | null;
-    while (el != null) {
-      if (el.classList.contains('monaco-editor')) {
-        return;
+    const { ignoreClassNames = [] } = this.props;
+    if (ignoreClassNames.length > 0) {
+      let el = e.target as Element | null;
+      while (el != null) {
+        const { classList } = el;
+        if (ignoreClassNames.some(className => classList.contains(className))) {
+          return;
+        }
+        el = el.parentElement;
       }
-      el = el.parentElement;
     }
 
     if (!ContextActionUtils.isContextActionEvent(e)) {

--- a/packages/console/src/Console.jsx
+++ b/packages/console/src/Console.jsx
@@ -883,7 +883,10 @@ export class Console extends PureComponent {
             />
           )}
         </div>
-        <ContextActions actions={contextActions} />
+        <ContextActions
+          actions={contextActions}
+          ignoreClassNames={[ConsoleInput.INPUT_CLASS_NAME]}
+        />
       </div>
     );
   }

--- a/packages/console/src/ConsoleInput.jsx
+++ b/packages/console/src/ConsoleInput.jsx
@@ -22,6 +22,8 @@ const BUFFER_SIZE = 100;
  * Component for input in a console session. Handles loading the recent command history
  */
 export class ConsoleInput extends PureComponent {
+  static INPUT_CLASS_NAME = 'console-input';
+
   constructor(props) {
     super(props);
 
@@ -388,7 +390,7 @@ export class ConsoleInput extends PureComponent {
           })}
         >
           <div
-            className="console-input"
+            className={ConsoleInput.INPUT_CLASS_NAME}
             ref={this.commandContainer}
             style={{ height: commandEditorHeight }}
           />


### PR DESCRIPTION
Fix the issue with an unusable Monaco context menu when Monaco is nested in a component having its own `ContextMenu` with a non-empty `actions` list.