### PR TITLE
Update publish actions

### DIFF
--- a/.github/workflows/publish-alpha.yml
+++ b/.github/workflows/publish-alpha.yml
@@ -11,7 +11,7 @@ on:
         required: false
         default: ''
 jobs:
-  build:
+  build-alpha:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -20,13 +20,11 @@ jobs:
       - uses: actions/checkout@v2
         with:
           ref: ${{ github.event.inputs.ref }}
-      # Setup .npmrc file to publish to GitHub Packages
       - uses: actions/setup-node@v2
         with:
           node-version: '12.x'
-          registry-url: 'https://npm.pkg.github.com'
       - run: npm install
       - run: npm run build
       - run: ./node_modules/.bin/lerna publish --canary --preid ${{ github.event.inputs.preid }} --registry https://npm.pkg.github.com --yes
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN_MOFOJED }}

--- a/.github/workflows/publish-nightly.yml
+++ b/.github/workflows/publish-nightly.yml
@@ -21,7 +21,7 @@ jobs:
         name: check latest commit is less than a day
         if: ${{ github.event_name == 'schedule' }}
         run: test -z $(git rev-list  --after="24 hours"  ${{ github.sha }}) && echo "::set-output name=should_run::false"
-  build:
+  build-nightly:
     needs: check_date
     if: ${{ needs.check_date.outputs.should_run != 'false' }}
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-nightly.yml
+++ b/.github/workflows/publish-nightly.yml
@@ -30,13 +30,11 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@v2
-      # Setup .npmrc file to publish to GitHub Packages
       - uses: actions/setup-node@v2
         with:
           node-version: '12.x'
-          registry-url: 'https://npm.pkg.github.com'
       - run: npm install
       - run: npm run build
       - run: ./node_modules/.bin/lerna publish --canary --preid beta --dist-tag nightly --registry https://npm.pkg.github.com --yes
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN_MOFOJED }}

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -1,0 +1,20 @@
+name: Node.js Publish Packages
+on: workflow_dispatch
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.inputs.ref }}
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '12.x'
+      - run: npm install
+      - run: npm run build
+      - run: ./node_modules/.bin/lerna publish --yes
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN_MOFOJED }}


### PR DESCRIPTION
- Instead of publishing to GitHub packages, publish to the default registry (npmjs).
- Uses my deploy token as a secret.
- Add publish-packages action to publish release packages. Will be triggered manually.