### PR TITLE
Add registry-url back, add release action

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,0 +1,34 @@
+name: Create Release
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version number for this release (eg. v0.1.2)'
+        required: true
+jobs:
+  create-release:
+    runs-on: ubuntu-latest
+    name: Create Release
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        env:
+          # lerna-changelog uses the env var GITHUB_AUTH for authentication
+          GITHUB_AUTH: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          node-version: '12.x'
+        # Get the changelog and write it out to a file so it can be used by the create-release step later
+      - run: npx lerna-changelog --next-version=${{ github.event.inputs.version }} > /tmp/changelog.md
+        # lerna version will bump the version, tag it and push the branch
+      - run: npx lerna version ${{ github.event.inputs.version }} --yes
+      - name: Create Release
+        id: create_release
+        uses: actions/checkout@v2
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # With a tag_name specified, it creates a release pointing to that commit
+          tag_name: ${{ github.event.inputs.version }}
+          release_name: ${{ github.event.inputs.version }}
+          body_path: /tmp/changelog.md

--- a/.github/workflows/publish-alpha.yml
+++ b/.github/workflows/publish-alpha.yml
@@ -1,4 +1,4 @@
-name: Node.js Package Alpha
+name: Package Alpha
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/publish-alpha.yml
+++ b/.github/workflows/publish-alpha.yml
@@ -11,7 +11,7 @@ on:
         required: false
         default: ''
 jobs:
-  build-alpha:
+  publish-alpha:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -23,6 +23,7 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: '12.x'
+          registry-url: 'https://registry.npmjs.org'
       - run: npm install
       - run: npm run build
       - run: ./node_modules/.bin/lerna publish --canary --preid ${{ github.event.inputs.preid }} --yes

--- a/.github/workflows/publish-nightly.yml
+++ b/.github/workflows/publish-nightly.yml
@@ -21,7 +21,7 @@ jobs:
         name: check latest commit is less than a day
         if: ${{ github.event_name == 'schedule' }}
         run: test -z $(git rev-list  --after="24 hours"  ${{ github.sha }}) && echo "::set-output name=should_run::false"
-  build-nightly:
+  publish-nightly:
     needs: check_date
     if: ${{ needs.check_date.outputs.should_run != 'false' }}
     runs-on: ubuntu-latest
@@ -33,6 +33,7 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: '12.x'
+          registry-url: 'https://registry.npmjs.org'
       - run: npm install
       - run: npm run build
       - run: ./node_modules/.bin/lerna publish --canary --preid beta --dist-tag nightly --yes

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -1,4 +1,4 @@
-name: Node.js Publish Packages
+name: Publish Packages
 on: workflow_dispatch
 jobs:
   publish-packages:

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -1,7 +1,7 @@
 name: Node.js Publish Packages
 on: workflow_dispatch
 jobs:
-  build:
+  publish-packages:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -13,6 +13,7 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: '12.x'
+          registry-url: 'https://registry.npmjs.org'
       - run: npm install
       - run: npm run build
       - run: ./node_modules/.bin/lerna publish --yes


### PR DESCRIPTION
Even though it defaults to registry.npmjs.org, it doesn't use auth unless you specify the registry: https://github.com/actions/setup-node/blob/25316bbc1f10ac9d8798711f44914b1cf3c4e954/src/main.ts#L46
Also updated a couple action names to be publish instead of build

Add a create-release action, that bumps the version and adds the release to GitHub. Note that the publish step still needs to be triggered after this.
