### PR TITLE
Add fetch-depth to fetch changelog properly

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -18,17 +18,17 @@ jobs:
       - name: Get changelog
         env: 
           GITHUB_AUTH: ${{ secrets.GITHUB_TOKEN }}
-        run: npx lerna-changelog --next-version=${{ github.event.inputs.version }} > /tmp/changelog.md
+        run: npx lerna-changelog --next-version=${{ github.event.inputs.version }} # > /tmp/changelog.md
         # lerna version will bump the version, tag it and push the branch
-      - name: Bump version
-        run: npx lerna version ${{ github.event.inputs.version }} --yes
-      - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          # With a tag_name specified, it creates a release pointing to that commit
-          tag_name: ${{ github.event.inputs.version }}
-          release_name: ${{ github.event.inputs.version }}
-          body_path: /tmp/changelog.md
+      # - name: Bump version
+      #   run: npx lerna version ${{ github.event.inputs.version }} --yes
+      # - name: Create Release
+      #   id: create_release
+      #   uses: actions/create-release@v1
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #   with:
+      #     # With a tag_name specified, it creates a release pointing to that commit
+      #     tag_name: ${{ github.event.inputs.version }}
+      #     release_name: ${{ github.event.inputs.version }}
+      #     body_path: /tmp/changelog.md

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -20,17 +20,17 @@ jobs:
       - name: Get changelog
         env: 
           GITHUB_AUTH: ${{ secrets.GITHUB_TOKEN }}
-        run: npx lerna-changelog --next-version=${{ github.event.inputs.version }} # > /tmp/changelog.md
+        run: npx lerna-changelog --next-version=${{ github.event.inputs.version }} > /tmp/changelog.md
         # lerna version will bump the version, tag it and push the branch
-      # - name: Bump version
-      #   run: npx lerna version ${{ github.event.inputs.version }} --yes
-      # - name: Create Release
-      #   id: create_release
-      #   uses: actions/create-release@v1
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #   with:
-      #     # With a tag_name specified, it creates a release pointing to that commit
-      #     tag_name: ${{ github.event.inputs.version }}
-      #     release_name: ${{ github.event.inputs.version }}
-      #     body_path: /tmp/changelog.md
+      - name: Bump version
+        run: npx lerna version ${{ github.event.inputs.version }} --yes
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # With a tag_name specified, it creates a release pointing to that commit
+          tag_name: ${{ github.event.inputs.version }}
+          release_name: ${{ github.event.inputs.version }}
+          body_path: /tmp/changelog.md

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -11,6 +11,8 @@ jobs:
     name: Create Release
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: '0' # This action defaults to only getting the latest commit. Setting to 0 makes it retrieve the full git commit history
       - uses: actions/setup-node@v2
         with:
           node-version: '12.x'


### PR DESCRIPTION
By default, actions/checkout only checks out the latest HEAD. Need to get the full fetch depth to create the proper changelog