### PR TITLE
Add `from-package` flag to publish step

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -16,6 +16,6 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
       - run: npm install
       - run: npm run build
-      - run: ./node_modules/.bin/lerna publish --yes
+      - run: ./node_modules/.bin/lerna publish from-package --yes
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN_MOFOJED }}


### PR DESCRIPTION
I forgot to include this flag. We have the version bump as a separate step, so this should publish whatever version is already commited.
