### PR TITLE
Handle invalid layout files from the server correctly

### DIFF
--- a/packages/code-studio/src/main/UserLayoutUtils.ts
+++ b/packages/code-studio/src/main/UserLayoutUtils.ts
@@ -1,10 +1,13 @@
 import { ItemConfigType } from '@deephaven/golden-layout';
+import Log from '@deephaven/log';
 import LayoutStorage from './LayoutStorage';
 import {
   CommandHistoryPanel,
   ConsolePanel,
   FileExplorerPanel,
 } from '../dashboard/panels';
+
+const log = Log.module('UserLayoutUtils');
 
 export const DEFAULT_LAYOUT_CONFIG = [
   {
@@ -68,8 +71,14 @@ export const getDefaultLayout = async (
 ): Promise<ItemConfigType[]> => {
   const layouts = await layoutStorage.getLayouts();
   if (layouts.length > 0) {
-    // We found a layout on the server, use it. It could be an empty layout if they want user to build their own
-    return layoutStorage.getLayout(layouts[0]);
+    try {
+      // We found a layout on the server, use it. It could be an empty layout if they want user to build their own
+      const layout = await layoutStorage.getLayout(layouts[0]);
+      return layout;
+    } catch (err) {
+      log.error('Unable to load layout', layouts[0], ':', err);
+      log.warn('No valid layouts found, falling back to default layout');
+    }
   }
   // Otherwise, do the default layout
   return DEFAULT_LAYOUT_CONFIG;

--- a/packages/code-studio/src/main/WebdavLayoutStorage.ts
+++ b/packages/code-studio/src/main/WebdavLayoutStorage.ts
@@ -18,9 +18,9 @@ export class WebdavLayoutStorage implements LayoutStorage {
   }
 
   async getLayouts(): Promise<string[]> {
-    const files = (await this.client.getDirectoryContents(
-      this.root
-    )) as FileStat[];
+    const files = (await this.client.getDirectoryContents(this.root, {
+      glob: '*.json',
+    })) as FileStat[];
 
     return files.map(file => file.basename);
   }


### PR DESCRIPTION
- Only check `.json` files to avoid reading from an incorrect file
- If the .json file is corrupted for some reason (not valid json), fallback to the default layout
- Fixes #221
