### PR TITLE
Add fetch-depth flag in alpha publish

### DIFF
--- a/.github/workflows/publish-alpha.yml
+++ b/.github/workflows/publish-alpha.yml
@@ -19,6 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
+          fetch-depth: '0' # Need the history to properly select the canary version number
           ref: ${{ github.event.inputs.ref }}
       - uses: actions/setup-node@v2
         with:


### PR DESCRIPTION
It wasn't getting the proper version number because it didn't have a git history to view.