### PR TITLE
Fix command history item not vertically centered

### DIFF
--- a/packages/console/src/command-history/CommandHistoryItem.scss
+++ b/packages/console/src/command-history/CommandHistoryItem.scss
@@ -27,7 +27,7 @@ $selection-hover-color: $interfacewhite;
     text-align: left;
     cursor: pointer;
     user-select: none;
-    line-height: 1.75rem;
+    line-height: 27px; // CommandHistory.ITEM_HEIGHT - borders
     transition: $btn-transition;
     border: 1px solid transparent; //we need a spacer border so stuff doesn't move on us when we apply a border-color
   }


### PR DESCRIPTION
Fixes vertical alignment of text within command history item.

Before:
![image](https://user-images.githubusercontent.com/1576283/138125054-cd931444-4146-42ee-81ec-df5086400a90.png)

After:
![image](https://user-images.githubusercontent.com/1576283/138125217-2c100d66-dfde-4d35-80df-b30305db6fa3.png)
