### PR TITLE
Handle null session in some panels

### DIFF
--- a/packages/dashboard-core-plugins/src/panels/CommandHistoryPanel.jsx
+++ b/packages/dashboard-core-plugins/src/panels/CommandHistoryPanel.jsx
@@ -196,8 +196,8 @@ const mapStateToProps = (state, ownProps) => {
     state,
     ownProps.localDashboardId
   );
-  const { session, config: sessionConfig } = sessionWrapper;
-  const { type: language, id: sessionId } = sessionConfig;
+  const { session, config: sessionConfig } = sessionWrapper ?? {};
+  const { type: language, id: sessionId } = sessionConfig ?? {};
 
   return {
     commandHistoryStorage,

--- a/packages/dashboard-core-plugins/src/panels/FileExplorerPanel.tsx
+++ b/packages/dashboard-core-plugins/src/panels/FileExplorerPanel.tsx
@@ -231,8 +231,8 @@ const mapStateToProps = (
     state,
     ownProps.localDashboardId
   );
-  const { session, config: sessionConfig } = sessionWrapper;
-  const language = sessionConfig.type;
+  const { session, config: sessionConfig } = sessionWrapper ?? {};
+  const language = sessionConfig?.type;
 
   return {
     fileStorage,

--- a/packages/dashboard-core-plugins/src/panels/LogPanel.jsx
+++ b/packages/dashboard-core-plugins/src/panels/LogPanel.jsx
@@ -115,7 +115,8 @@ LogPanel.defaultProps = {
 };
 
 const mapStateToProps = (state, ownProps) => ({
-  session: getDashboardSessionWrapper(state, ownProps.localDashboardId).session,
+  session: getDashboardSessionWrapper(state, ownProps.localDashboardId)
+    ?.session,
 });
 
 export default connect(mapStateToProps, null, null, { forwardRef: true })(

--- a/packages/dashboard-core-plugins/src/panels/NotebookPanel.jsx
+++ b/packages/dashboard-core-plugins/src/panels/NotebookPanel.jsx
@@ -932,8 +932,8 @@ const mapStateToProps = (state, ownProps) => {
     state,
     ownProps.localDashboardId
   );
-  const { session, config: sessionConfig } = sessionWrapper;
-  const { type: sessionLanguage } = sessionConfig;
+  const { session, config: sessionConfig } = sessionWrapper ?? {};
+  const { type: sessionLanguage } = sessionConfig ?? {};
   return {
     fileStorage,
     session,


### PR DESCRIPTION
Null session wasn't being handled properly in some panels. The session was optional in these panels so it should handle it.
