### PR TITLE
Change some utils to use columns array instead of entire model

### DIFF
--- a/packages/dashboard-core-plugins/src/panels/IrisGridPanel.jsx
+++ b/packages/dashboard-core-plugins/src/panels/IrisGridPanel.jsx
@@ -614,7 +614,6 @@ export class IrisGridPanel extends PureComponent {
   }
 
   loadPanelState(model) {
-    const { table } = model;
     const { panelState } = this.props;
     if (panelState == null) {
       return;
@@ -626,7 +625,7 @@ export class IrisGridPanel extends PureComponent {
         isSelectingPartition,
         partition,
         partitionColumn,
-      } = IrisGridUtils.hydrateIrisGridPanelState(table, irisGridPanelState);
+      } = IrisGridUtils.hydrateIrisGridPanelState(model, irisGridPanelState);
       const {
         advancedFilters,
         advancedSettings,
@@ -646,9 +645,9 @@ export class IrisGridPanel extends PureComponent {
         selectedSearchColumns,
         invertSearchColumns,
         pendingDataMap,
-      } = IrisGridUtils.hydrateIrisGridState(table, irisGridState);
+      } = IrisGridUtils.hydrateIrisGridState(model, irisGridState);
       const { movedColumns, movedRows } = IrisGridUtils.hydrateGridState(
-        table,
+        model,
         gridState,
         irisGridState.customColumns
       );

--- a/packages/iris-grid/src/IrisGridUtils.test.js
+++ b/packages/iris-grid/src/IrisGridUtils.test.js
@@ -25,11 +25,11 @@ describe('quickfilters tests', () => {
   it('exports/imports empty list', () => {
     const table = makeTable();
     const filters = new Map();
-    const exportedFilters = IrisGridUtils.dehydrateQuickFilters(table, filters);
+    const exportedFilters = IrisGridUtils.dehydrateQuickFilters(filters);
     expect(exportedFilters).toEqual([]);
 
     const importedFilters = IrisGridUtils.hydrateQuickFilters(
-      table,
+      table.columns,
       exportedFilters
     );
     expect(importedFilters).toEqual(filters);
@@ -42,16 +42,13 @@ describe('quickfilters tests', () => {
     const filter = makeFilter();
     const quickFilters = new Map([[column, { text, filter }]]);
 
-    const exportedFilters = IrisGridUtils.dehydrateQuickFilters(
-      table,
-      quickFilters
-    );
+    const exportedFilters = IrisGridUtils.dehydrateQuickFilters(quickFilters);
     expect(exportedFilters).toEqual([
       [column, expect.objectContaining({ text })],
     ]);
 
     const importedFilters = IrisGridUtils.hydrateQuickFilters(
-      table,
+      table.columns,
       exportedFilters
     );
     expect(importedFilters).toEqual(
@@ -73,13 +70,13 @@ describe('advanced filter tests', () => {
     const table = makeTable();
     const filters = new Map();
     const exportedFilters = IrisGridUtils.dehydrateAdvancedFilters(
-      table,
+      table.columns,
       filters
     );
     expect(exportedFilters).toEqual([]);
 
     const importedFilters = IrisGridUtils.hydrateAdvancedFilters(
-      table,
+      table.columns,
       exportedFilters
     );
     expect(importedFilters).toEqual(filters);
@@ -98,7 +95,7 @@ describe('advanced filter tests', () => {
     const filters = new Map([[column, { filter, options }]]);
 
     const exportedFilters = IrisGridUtils.dehydrateAdvancedFilters(
-      table,
+      table.columns,
       filters
     );
     expect(exportedFilters).toEqual([
@@ -106,7 +103,7 @@ describe('advanced filter tests', () => {
     ]);
 
     const importedFilters = IrisGridUtils.hydrateAdvancedFilters(
-      table,
+      table.columns,
       exportedFilters
     );
     expect(importedFilters).toEqual(
@@ -130,7 +127,7 @@ describe('sort exporting/importing', () => {
     const exportedSort = IrisGridUtils.dehydrateSort(sort);
     expect(exportedSort).toEqual([]);
 
-    const importedSort = IrisGridUtils.hydrateSort(table, exportedSort);
+    const importedSort = IrisGridUtils.hydrateSort(table.columns, exportedSort);
     expect(importedSort).toEqual(sort);
   });
 
@@ -144,7 +141,7 @@ describe('sort exporting/importing', () => {
       { column: 7, isAbs: true, direction: 'DESC' },
     ]);
 
-    const importedSort = IrisGridUtils.hydrateSort(table, exportedSort);
+    const importedSort = IrisGridUtils.hydrateSort(table.columns, exportedSort);
     expect(importedSort).toEqual([
       expect.objectContaining({
         column: columns[3],


### PR DESCRIPTION
Related to #208 and tangentially #229 

This changes specific utils to not take the entire model since they don't really need the whole model. For things that hydrate/dehydrate the entire grid or panel, the model is still passed even though it is only used for its columns as those methods might make use of the model in the future.

Also reverts `applySettingsToTable` to use a table because the only place it is called has a table that does not have a model associated with it. The table is then used to create a chart.