### PR TITLE
Remove all versions of IE from browserlist

### DIFF
--- a/packages/code-studio/package.json
+++ b/packages/code-studio/package.json
@@ -120,7 +120,7 @@
   "browserslist": [
     ">0.2%",
     "not dead",
-    "not ie <= 10",
+    "not ie >= 0",
     "not op_mini all"
   ],
   "publishConfig": {


### PR DESCRIPTION
We've never supported IE, but it was still allowed in our browserlist. Officially remove it.