### PR TITLE
Command history actions styling improvements

### DIFF
--- a/packages/console/src/command-history/CommandHistory.jsx
+++ b/packages/console/src/command-history/CommandHistory.jsx
@@ -267,7 +267,8 @@ class CommandHistory extends Component {
   }
 
   handleSearchChange(e) {
-    this.setState({ searchText: e.target.value });
+    // clear selected range, as old selection could be filtered from list
+    this.setState({ searchText: e.target.value, selectedRanges: [] });
   }
 
   handleViewportUpdate({ items, offset }) {
@@ -327,6 +328,7 @@ class CommandHistory extends Component {
             itemCount={itemCount}
             items={items}
             offset={offset}
+            selectedRanges={selectedRanges}
             onSelect={this.handleSelect}
             onSelectionChange={this.handleSelectionChange}
             onViewportChange={this.handleViewportChange}

--- a/packages/console/src/command-history/CommandHistory.scss
+++ b/packages/console/src/command-history/CommandHistory.scss
@@ -30,13 +30,16 @@ $command-history-search-toolbar-bg: $content-bg;
   background: $command-history-search-toolbar-bg;
   border-bottom: 2px solid $background;
   width: 100%;
-  padding: $spacer-1;
+  padding: $spacer-1 $spacer-1 0 $spacer-1;
   display: flex;
-  flex-grow: 0;
   flex-wrap: wrap;
+  flex-shrink: 0;
+  overflow: hidden;
 
   .search-group {
     flex-grow: 1;
+    margin-right: $spacer-1;
+    margin-bottom: $spacer-1;
     input {
       background-color: $command-history-search-bg;
     }

--- a/packages/console/src/command-history/CommandHistoryActions.jsx
+++ b/packages/console/src/command-history/CommandHistoryActions.jsx
@@ -2,8 +2,8 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { Tooltip } from '@deephaven/components';
-import { vsArrowLeft } from '@deephaven/icons';
+import { Button } from '@deephaven/components';
+import { vsArrowLeft, vsCircleLargeFilled } from '@deephaven/icons';
 import './CommandHistoryActions.scss';
 
 class CommandHistoryActions extends Component {
@@ -15,10 +15,14 @@ class CommandHistoryActions extends Component {
     if (item.selectionRequired && item.icon) {
       return (
         <div className="fa-md fa-layers">
-          <FontAwesomeIcon icon={item.icon} />
+          <FontAwesomeIcon
+            icon={vsCircleLargeFilled}
+            mask={item.icon}
+            transform="right-5 down-5 shrink-4"
+          />
           <FontAwesomeIcon
             icon={vsArrowLeft}
-            transform="shrink-3 right-12 up-9"
+            transform="shrink-3 right-7 down-6"
           />
         </div>
       );
@@ -37,18 +41,15 @@ class CommandHistoryActions extends Component {
     return (
       <div className="command-history-actions">
         {actions.map((item, index) => (
-          <button
-            className={classNames('btn btn-inline ml-1', item.className)}
+          <Button
+            kind="inline"
+            className={classNames(item.className)}
             key={CommandHistoryActions.itemKey(index, item)}
             onClick={item.action}
-            type="button"
+            tooltip={item.description}
             disabled={item.selectionRequired && !hasSelection}
-          >
-            {CommandHistoryActions.renderContent(item)}
-            <Tooltip options={{ placement: 'bottom' }}>
-              {item.description}
-            </Tooltip>
-          </button>
+            icon={CommandHistoryActions.renderContent(item)}
+          />
         ))}
       </div>
     );

--- a/packages/console/src/command-history/CommandHistoryActions.scss
+++ b/packages/console/src/command-history/CommandHistoryActions.scss
@@ -2,4 +2,9 @@
 
 .command-history-actions {
   flex-shrink: 0;
+  margin-bottom: $spacer-1;
+
+  > *:first-child {
+    margin: 0 $spacer-1 0 0;
+  }
 }


### PR DESCRIPTION
- improved spacing when wrapped
- clear selection on filter, as old selected range could be invalid
- Actually use parent state for selection range, as a controlled component
- use Button component for inline buttons (makes tooltips work when button disabled)
- adjust icons on buttons to have mask, and arrow be above it

Before:
![image](https://user-images.githubusercontent.com/1576283/138911951-2e37e797-e0f8-4983-9d77-1714c5b5dee6.png)

After:
![image](https://user-images.githubusercontent.com/1576283/138911900-bbab4827-b39d-49d1-8b9a-294f835b4ed6.png)
