### PR TITLE
DH-11632 handle LH frozen columns in the UI

### DIFF
--- a/packages/code-studio/src/styleguide/MockIrisGridTreeModel.js
+++ b/packages/code-studio/src/styleguide/MockIrisGridTreeModel.js
@@ -83,10 +83,6 @@ class MockIrisGridTreeModel extends IrisGridModel {
     return this.model.isRowExpanded(row);
   }
 
-  getColumnIndexByName(name) {
-    return this.model.getColumnIndexByName(name);
-  }
-
   setRowExpanded(row, isExpanded) {
     this.model.setRowExpanded(row, isExpanded);
   }

--- a/packages/grid/src/GridMetricCalculator.js
+++ b/packages/grid/src/GridMetricCalculator.js
@@ -62,7 +62,6 @@ class GridMetricCalculator {
       x -= sizeMap.get(totalCount - i - 1);
       coordinates.set(totalCount - i - 1, x);
     }
-
     return coordinates;
   }
 
@@ -718,10 +717,7 @@ class GridMetricCalculator {
 
     const columnWidths = new Map();
     for (let i = 0; i < floatingLeftColumnCount && i < columnCount; i += 1) {
-      columnWidths.set(
-        i,
-        this.getVisibleColumnWidth(i, state, firstColumn, treePaddingX)
-      );
+      columnWidths.set(i, this.getVisibleColumnWidth(i, state, firstColumn, 0));
     }
 
     for (
@@ -732,7 +728,7 @@ class GridMetricCalculator {
       const column = columnCount - i - 1;
       columnWidths.set(
         column,
-        this.getVisibleColumnWidth(column, state, firstColumn, treePaddingX)
+        this.getVisibleColumnWidth(column, state, firstColumn, 0)
       );
     }
 

--- a/packages/grid/src/GridMetricCalculator.js
+++ b/packages/grid/src/GridMetricCalculator.js
@@ -703,7 +703,11 @@ class GridMetricCalculator {
     return rowHeights;
   }
 
-  getFloatingColumnWidths(state, firstColumn = this.getFirstColumn(state)) {
+  getFloatingColumnWidths(
+    state,
+    firstColumn = this.getFirstColumn(state),
+    treePaddingX = this.calculateTreePaddingX(state)
+  ) {
     const { model } = state;
     const {
       columnCount,
@@ -713,7 +717,10 @@ class GridMetricCalculator {
 
     const columnWidths = new Map();
     for (let i = 0; i < floatingLeftColumnCount && i < columnCount; i += 1) {
-      columnWidths.set(i, this.getVisibleColumnWidth(i, state, firstColumn, 0));
+      columnWidths.set(
+        i,
+        this.getVisibleColumnWidth(i, state, firstColumn, treePaddingX)
+      );
     }
 
     for (
@@ -724,7 +731,7 @@ class GridMetricCalculator {
       const column = columnCount - i - 1;
       columnWidths.set(
         column,
-        this.getVisibleColumnWidth(column, state, firstColumn, 0)
+        this.getVisibleColumnWidth(column, state, firstColumn, treePaddingX)
       );
     }
 
@@ -1190,7 +1197,9 @@ class GridMetricCalculator {
   calculateTreePaddingX(state) {
     const { top, height, model, theme } = state;
     const { rowHeight, treeDepthIndent } = theme;
-
+    if (!model.hasExpandableRows) {
+      return 0;
+    }
     let treePadding = 0;
 
     const rowsPerPage = height / rowHeight;

--- a/packages/grid/src/GridMetricCalculator.js
+++ b/packages/grid/src/GridMetricCalculator.js
@@ -703,11 +703,7 @@ class GridMetricCalculator {
     return rowHeights;
   }
 
-  getFloatingColumnWidths(
-    state,
-    firstColumn = this.getFirstColumn(state),
-    treePaddingX = this.calculateTreePaddingX(state)
-  ) {
+  getFloatingColumnWidths(state, firstColumn = this.getFirstColumn(state)) {
     const { model } = state;
     const {
       columnCount,

--- a/packages/grid/src/GridModel.js
+++ b/packages/grid/src/GridModel.js
@@ -86,6 +86,10 @@ class GridModel extends EventTarget {
     return true;
   }
 
+  isColumnFrozen(column) {
+    return false;
+  }
+
   isRowMovable(row) {
     return true;
   }

--- a/packages/grid/src/GridModel.js
+++ b/packages/grid/src/GridModel.js
@@ -86,10 +86,6 @@ class GridModel extends EventTarget {
     return true;
   }
 
-  isColumnFrozen(column) {
-    return false;
-  }
-
   isRowMovable(row) {
     return true;
   }

--- a/packages/grid/src/GridRenderer.js
+++ b/packages/grid/src/GridRenderer.js
@@ -762,7 +762,20 @@ class GridRenderer {
 
   drawGridLinesForRows(context, state, rows) {
     const { metrics } = state;
-    const { visibleRowYs, maxX } = metrics;
+    const {
+      visibleRowYs,
+      maxX: metricsMaxX,
+      floatingLeftColumnCount,
+      visibleColumnXs,
+      visibleColumnWidths,
+    } = metrics;
+    let maxX = metricsMaxX;
+
+    if (floatingLeftColumnCount) {
+      maxX =
+        visibleColumnXs.get(floatingLeftColumnCount - 1) +
+        visibleColumnWidths.get(floatingLeftColumnCount - 1);
+    }
 
     // Draw row lines
     for (let i = 0; i < rows.length; i += 1) {
@@ -1754,7 +1767,7 @@ class GridRenderer {
       context.fillStyle = theme.selectionColor;
       context.fill();
 
-      /* 
+      /*
       draw an "inner stroke" that's clipped to just inside of the rects
       to act as a casing to the outer stroke. 3px width because 1px is outside
       the rect (but clipped), 1px is "on" the rect (technically this pixel is

--- a/packages/grid/src/GridRenderer.js
+++ b/packages/grid/src/GridRenderer.js
@@ -271,6 +271,8 @@ class GridRenderer {
       visibleColumnXs,
       visibleColumnWidths,
       width,
+      height,
+      columnHeaderHeight,
     } = metrics;
 
     if (floatingColumns.length === 0) {
@@ -300,6 +302,12 @@ class GridRenderer {
       this.drawFloatingMouseRowHover(context, state);
     }
 
+    // Clip floated column grid lines.
+    context.save();
+    context.beginPath();
+    context.rect(0, 0, floatingLeftWidth, height);
+    context.clip();
+
     this.drawGridLinesForItems(
       context,
       state,
@@ -308,6 +316,8 @@ class GridRenderer {
       theme.floatingGridColumnColor,
       theme.floatingGridRowColor
     );
+
+    context.restore();
 
     this.drawCellBackgroundsForItems(
       context,
@@ -761,20 +771,8 @@ class GridRenderer {
 
   drawGridLinesForRows(context, state, rows) {
     const { metrics } = state;
-    const {
-      visibleRowYs,
-      maxX: metricsMaxX,
-      floatingLeftColumnCount,
-      visibleColumnXs,
-      visibleColumnWidths,
-    } = metrics;
-    let maxX = metricsMaxX;
-
-    if (floatingLeftColumnCount) {
-      maxX =
-        visibleColumnXs.get(floatingLeftColumnCount - 1) +
-        visibleColumnWidths.get(floatingLeftColumnCount - 1);
-    }
+    const { visibleRowYs, maxX: metricsMaxX } = metrics;
+    const maxX = metricsMaxX;
 
     // Draw row lines
     for (let i = 0; i < rows.length; i += 1) {

--- a/packages/grid/src/GridRenderer.js
+++ b/packages/grid/src/GridRenderer.js
@@ -1172,7 +1172,7 @@ class GridRenderer {
 
       // Frozen columns' background
       context.fillStyle = headerBackgroundColor;
-      context.fillRect(0, 0, floatingLeftColumnsWidth, columnHeaderHeight);
+      context.fillRect(gridX, 0, floatingLeftColumnsWidth, columnHeaderHeight);
 
       // Frozen columns.
       context.fillStyle = headerColor;

--- a/packages/grid/src/GridRenderer.js
+++ b/packages/grid/src/GridRenderer.js
@@ -272,7 +272,6 @@ class GridRenderer {
       visibleColumnWidths,
       width,
       height,
-      columnHeaderHeight,
     } = metrics;
 
     if (floatingColumns.length === 0) {

--- a/packages/grid/src/GridRenderer.js
+++ b/packages/grid/src/GridRenderer.js
@@ -325,7 +325,6 @@ class GridRenderer {
         state,
         {
           left: 0,
-          right: floatingLeftColumnCount,
           maxX:
             visibleColumnXs.get(floatingLeftColumnCount - 1) +
             visibleColumnWidths.get(floatingLeftColumnCount - 1),
@@ -1184,21 +1183,20 @@ class GridRenderer {
       this.drawColumnHeader(context, state, column, x, columnWidth);
     }
 
-    // Draw the separators
-    // TODO: Refactor this draw separator code so you can draw all the
-    // visibleColumns, then all the floatingColumns
+    // Draw the separators, visible columns then floating columns.
     if (headerSeparatorColor) {
       context.strokeStyle = headerSeparatorColor;
       context.beginPath();
       const hiddenColumns = [];
+
+      // Draw visible column separators.
       let isPreviousColumnHidden = false;
       for (let i = 0; i < visibleColumns.length; i += 1) {
         const column = visibleColumns[i];
         const columnX = visibleColumnXs.get(column);
         const columnWidth = visibleColumnWidths.get(column);
-        const isUnderFloatingColumns = columnX < frozenColumnsWidth;
 
-        if (!isUnderFloatingColumns) {
+        if (!(columnX < frozenColumnsWidth - columnWidth)) {
           if (columnWidth > 0) {
             const x = gridX + columnX + columnWidth + 0.5;
             context.moveTo(x, 0);
@@ -1260,7 +1258,8 @@ class GridRenderer {
           mouseX,
           mouseY,
           metrics,
-          theme
+          theme,
+          frozenColumnsWidth
         );
       }
 

--- a/packages/grid/src/GridUtils.js
+++ b/packages/grid/src/GridUtils.js
@@ -237,14 +237,14 @@ class GridUtils {
    * @param {Number} y Mouse y coordinate
    * @param {GridMetrics} metrics The GridMetricCalculator metrics
    * @param {GridTheme} theme The grid theme with potantial user overrides
+   * @param {Number} floatingColumnsWidth The total width of the frozen columns
    * @returns {Number|null} Column index or null
    */
-  static getColumnSeparatorIndex(x, y, metrics, theme) {
+  static getColumnSeparatorIndex(x, y, metrics, theme, floatingColumnsWidth) {
     const {
       rowHeaderWidth,
       columnHeaderHeight,
       floatingColumns,
-      floatingLeftColumnCount,
       visibleColumns,
       visibleColumnXs,
       visibleColumnWidths,
@@ -262,14 +262,7 @@ class GridUtils {
     const gridX = x - rowHeaderWidth;
     const halfSeparatorSize = headerSeparatorHandleSize * 0.5;
 
-    // TODO: Remove this.
-    // We calculate this in the calling function -> can pass the width as a param.
-    const floatingColumnsWidth =
-      visibleColumnXs.get(floatingLeftColumnCount - 1) +
-      visibleColumnWidths.get(floatingLeftColumnCount - 1);
-
-    // TODO: Iterate through the floatingColumns similar to below, need to
-    // iterate through them first as they're on top
+    // Iterate through the floating columns first since they're on top
     let isPreviousColumnHidden = false;
     for (let i = floatingColumns.length - 1; i >= 0; i -= 1) {
       const column = floatingColumns[i];
@@ -299,14 +292,11 @@ class GridUtils {
     for (let i = visibleColumns.length - 1; i >= 0; i -= 1) {
       const column = visibleColumns[i];
       const columnX = visibleColumnXs.get(column);
-      // TODO: Check if this columnX is <= floatingleft width and ignore it
-      // if so, otherwise could have a separator from below in the middle
-      // of the column header picked up
       const columnWidth = visibleColumnWidths.get(column);
       const isColumnHidden = columnWidth === 0;
 
-      // We're under the floating columns. Terminate early.
-      if (columnX <= floatingColumnsWidth) {
+      // If this column is under the floating columns "layer". Terminate early.
+      if (columnX < floatingColumnsWidth - columnWidth) {
         return null;
       }
 

--- a/packages/grid/src/GridUtils.js
+++ b/packages/grid/src/GridUtils.js
@@ -237,10 +237,9 @@ class GridUtils {
    * @param {Number} y Mouse y coordinate
    * @param {GridMetrics} metrics The GridMetricCalculator metrics
    * @param {GridTheme} theme The grid theme with potantial user overrides
-   * @param {Number} floatingColumnsWidth The total width of the frozen columns
    * @returns {Number|null} Column index or null
    */
-  static getColumnSeparatorIndex(x, y, metrics, theme, floatingColumnsWidth) {
+  static getColumnSeparatorIndex(x, y, metrics, theme) {
     const {
       rowHeaderWidth,
       columnHeaderHeight,
@@ -248,8 +247,12 @@ class GridUtils {
       visibleColumns,
       visibleColumnXs,
       visibleColumnWidths,
+      floatingLeftColumnCount,
     } = metrics;
     const { allowColumnResize, headerSeparatorHandleSize } = theme;
+    const floatingLeftColumnsWidth =
+      visibleColumnXs.get(floatingLeftColumnCount - 1) +
+      visibleColumnWidths.get(floatingLeftColumnCount - 1);
 
     if (
       columnHeaderHeight < y ||
@@ -296,7 +299,7 @@ class GridUtils {
       const isColumnHidden = columnWidth === 0;
 
       // If this column is under the floating columns "layer". Terminate early.
-      if (columnX < floatingColumnsWidth - columnWidth) {
+      if (columnX < floatingLeftColumnsWidth - columnWidth) {
         return null;
       }
 

--- a/packages/iris-grid/src/ColumnStatistics.jsx
+++ b/packages/iris-grid/src/ColumnStatistics.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { LoadingSpinner } from '@deephaven/components';
-import { dhRefresh, vsLock } from '@deephaven/icons';
+import { dhFreeze, dhRefresh, vsLock } from '@deephaven/icons';
 import { PropTypes as APIPropTypes } from '@deephaven/jsapi-shim';
 import Log from '@deephaven/log';
 import { PromiseUtils } from '@deephaven/utils';
@@ -160,9 +160,7 @@ class ColumnStatistics extends Component {
       ? 'Expanded Rows'
       : 'Number of Rows';
     const formattedRowCount = model.displayString(numRows, 'long');
-    const columnIndex = model.columns.findIndex(
-      col => col.name === column.name
-    );
+    const columnIndex = model.getColumnIndexByName(column.name);
     return (
       <div className="column-statistics">
         <div className="column-statistics-title">
@@ -174,8 +172,11 @@ class ColumnStatistics extends Component {
         )}
         {!model.isColumnMovable(columnIndex) && (
           <div className="column-statistics-status">
-            <FontAwesomeIcon icon={vsLock} className="mr-1" />
-            Not movable
+            <FontAwesomeIcon
+              icon={model.isColumnFrozen(columnIndex) ? dhFreeze : vsLock}
+              className="mr-1"
+            />
+            {model.isColumnFrozen(columnIndex) ? 'Frozen' : 'Not movable'}
           </div>
         )}
         <div className="column-statistics-grid">

--- a/packages/iris-grid/src/IrisGrid.jsx
+++ b/packages/iris-grid/src/IrisGrid.jsx
@@ -1024,17 +1024,37 @@ export class IrisGrid extends Component {
     }
   }
 
-  getAlwaysFetchColumns = memoize((alwaysFetchColumns, model) => {
-    const columnSet = new Set(alwaysFetchColumns);
+  getAlwaysFetchColumns = memoize(
+    (
+      alwaysFetchColumns,
+      columns,
+      floatingLeftColumnCount,
+      floatingRightColumnCount
+    ) => {
+      let floatingLeftColumns = [];
+      let floatingRightColumns = [];
 
-    model.columns.forEach(({ name }) => {
-      if (model.isColumnFrozen(model.getColumnIndexByName(name))) {
-        columnSet.add(name);
+      if (floatingLeftColumnCount) {
+        floatingLeftColumns = columns
+          .slice(0, floatingLeftColumnCount)
+          .map(col => col.name);
       }
-    });
 
-    return [...columnSet];
-  });
+      if (floatingRightColumnCount) {
+        floatingRightColumns = columns
+          .slice(-floatingRightColumnCount)
+          .map(col => col.name);
+      }
+
+      const columnSet = new Set([
+        ...alwaysFetchColumns,
+        ...floatingLeftColumns,
+        ...floatingRightColumns,
+      ]);
+
+      return [...columnSet];
+    }
+  );
 
   updateFormatter(updatedFormats, forceUpdate = true) {
     const { customColumnFormatMap } = this.state;
@@ -2810,7 +2830,9 @@ export class IrisGrid extends Component {
                 hiddenColumns={hiddenColumns}
                 alwaysFetchColumns={this.getAlwaysFetchColumns(
                   alwaysFetchColumns,
-                  model
+                  model.columns,
+                  model.floatingLeftColumnCount,
+                  model.floatingRightColumnCount
                 )}
                 rollupConfig={this.getModelRollupConfig(
                   model.originalColumns,

--- a/packages/iris-grid/src/IrisGrid.jsx
+++ b/packages/iris-grid/src/IrisGrid.jsx
@@ -1024,6 +1024,18 @@ export class IrisGrid extends Component {
     }
   }
 
+  getAlwaysFetchColumns = memoize((alwaysFetchColumns, model) => {
+    const columnSet = new Set(alwaysFetchColumns);
+
+    model.columns.forEach(({ name }) => {
+      if (model.isColumnFrozen(model.getColumnIndexByName(name))) {
+        columnSet.add(name);
+      }
+    });
+
+    return [...columnSet];
+  });
+
   updateFormatter(updatedFormats, forceUpdate = true) {
     const { customColumnFormatMap } = this.state;
     const update = {
@@ -2796,7 +2808,10 @@ export class IrisGrid extends Component {
                 movedColumns={movedColumns}
                 customColumns={customColumns}
                 hiddenColumns={hiddenColumns}
-                alwaysFetchColumns={alwaysFetchColumns}
+                alwaysFetchColumns={this.getAlwaysFetchColumns(
+                  alwaysFetchColumns,
+                  model
+                )}
                 rollupConfig={this.getModelRollupConfig(
                   model.originalColumns,
                   rollupConfig,

--- a/packages/iris-grid/src/IrisGridModel.js
+++ b/packages/iris-grid/src/IrisGridModel.js
@@ -216,6 +216,14 @@ class IrisGridModel extends GridModel {
   }
 
   /**
+   * @param {Number} index The column index to check
+   * @returns {Boolean} Whether the column is one of LayoutHints' frozen columns
+   */
+  isColumnFrozen(index) {
+    return false;
+  }
+
+  /**
    * @returns {boolean} True if this model requires a filter to be set
    */
   get isFilterRequired() {

--- a/packages/iris-grid/src/IrisGridProxyModel.js
+++ b/packages/iris-grid/src/IrisGridProxyModel.js
@@ -203,6 +203,10 @@ class IrisGridProxyModel extends IrisGridModel {
     return this.model.isColumnMovable(...args);
   }
 
+  isColumnFrozen(...args) {
+    return this.model.isColumnFrozen(...args);
+  }
+
   get hasExpandableRows() {
     return this.model.hasExpandableRows;
   }

--- a/packages/iris-grid/src/IrisGridTableModel.js
+++ b/packages/iris-grid/src/IrisGridTableModel.js
@@ -1142,10 +1142,9 @@ class IrisGridTableModel extends IrisGridModel {
   }
 
   isColumnFrozen(x) {
-    if (this.layoutHints?.frozenColumns?.includes(this.columns[x].name)) {
-      return true;
-    }
-    return false;
+    return (
+      this.layoutHints?.frozenColumns?.includes(this.columns[x].name) ?? false
+    );
   }
 
   isKeyColumn(x) {


### PR DESCRIPTION
There is some possible refactoring optimization to be had in `drawColumnHeaders` but it looked quite ugly locally since the loops contents relied on too many scoped+calculated vars. Still open to suggestions in either case.