### PR TITLE
Add a label check action

### DIFF
--- a/.github/scripts/label-check-one-of.sh
+++ b/.github/scripts/label-check-one-of.sh
@@ -21,3 +21,4 @@ if [ $COUNT_TRUE -eq 1 ] ; then
 fi
 
 >&2 echo "Expected only one of the following labels, instead found ${COUNT_TRUE}:${ALL_LABELS}"
+exit 1

--- a/.github/scripts/label-check-one-of.sh
+++ b/.github/scripts/label-check-one-of.sh
@@ -16,9 +16,7 @@ for label in ${!LABEL_*}; do
   fi
 done
 
-if [ $COUNT_TRUE -eq 1 ] ; then
-  exit 0
+if [ $COUNT_TRUE -ne 1 ] ; then
+  >&2 echo "Expected only one of the following labels, instead found ${COUNT_TRUE}: ${ALL_LABELS:2}"
+  exit 1
 fi
-
->&2 echo "Expected only one of the following labels, instead found ${COUNT_TRUE}: ${ALL_LABELS:2}"
-exit 1

--- a/.github/scripts/label-check-one-of.sh
+++ b/.github/scripts/label-check-one-of.sh
@@ -10,7 +10,7 @@ COUNT_TRUE=0
 ALL_LABELS=""
 
 for label in ${!LABEL_*}; do
-  ALL_LABELS+=" ${label#*_}"
+  ALL_LABELS+=", ${label#*_}"
   if [ "${!label}" == "true" ] ; then
     COUNT_TRUE=$((COUNT_TRUE + 1))
   fi
@@ -20,5 +20,5 @@ if [ $COUNT_TRUE -eq 1 ] ; then
   exit 0
 fi
 
->&2 echo "Expected only one of the following labels, instead found ${COUNT_TRUE}:${ALL_LABELS}"
+>&2 echo "Expected only one of the following labels, instead found ${COUNT_TRUE}: ${ALL_LABELS:2}"
 exit 1

--- a/.github/scripts/label-check-one-of.sh
+++ b/.github/scripts/label-check-one-of.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Checks that exactly one of the provided arguments is true
+# Iterates through all environment variables with the prefix LABEL_, expecting only one to be true
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+COUNT_TRUE=0
+ALL_LABELS=""
+
+for label in ${!LABEL_*}; do
+  ALL_LABELS+=" ${label#*_}"
+  if [ "${!label}" == "true" ] ; then
+    COUNT_TRUE=$((COUNT_TRUE + 1))
+  fi
+done
+
+if [ $COUNT_TRUE -eq 1 ] ; then
+  exit 0
+fi
+
+>&2 echo "Expected only one of the following labels, instead found ${COUNT_TRUE}:${ALL_LABELS}"

--- a/.github/workflows/label-check-ci.yml
+++ b/.github/workflows/label-check-ci.yml
@@ -1,0 +1,27 @@
+name: Label Check CI
+
+on:
+  pull_request:
+    # The default pull_request trigger only happens on opened, synchronize, and reopened types.
+    # We are adding labeled and unlabeled here, so that changes to labels will cause this action to
+    # be re-run.
+    #
+    # Note: we need to rerun this action on new commits (synchronize events) even though it doesn't
+    # effect the labels because the merge requirements need checks to pass against the most recent
+    # commit.
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+    branches: [main]
+
+jobs:
+  doc-labels:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Check Change Labels
+        uses: agilepathway/label-checker@v1
+        with:
+          # Make sure we have at least one of the lerna-changelog labels
+          # https://github.com/lerna/lerna-changelog#usage
+          one_of: bug,enhancement,internal,documentation

--- a/.github/workflows/label-check-ci.yml
+++ b/.github/workflows/label-check-ci.yml
@@ -25,3 +25,4 @@ jobs:
           # Make sure we have at least one of the lerna-changelog labels
           # https://github.com/lerna/lerna-changelog#usage
           one_of: bug,enhancement,internal,documentation
+          repo_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/label-check-ci.yml
+++ b/.github/workflows/label-check-ci.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Check Change Labels
-        uses: agilepathway/label-checker@v1
+        uses: agilepathway/label-checker@v1.0.103
         with:
           # Make sure we have at least one of the lerna-changelog labels
           # https://github.com/lerna/lerna-changelog#usage

--- a/.github/workflows/label-check-ci.yml
+++ b/.github/workflows/label-check-ci.yml
@@ -19,10 +19,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Check Change Labels
-        uses: agilepathway/label-checker@v1.0.103
-        with:
-          # Make sure we have at least one of the lerna-changelog labels
-          # https://github.com/lerna/lerna-changelog#usage
-          one_of: bug,enhancement,internal,documentation
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Check Documentation Labels
+        env:
+          LABEL_bug: ${{ contains(github.event.pull_request.labels.*.name, 'bug') }}
+          LABEL_enhancement: ${{ contains(github.event.pull_request.labels.*.name, 'enhancement') }}
+          LABEL_internal: ${{ contains(github.event.pull_request.labels.*.name, 'internal') }}
+          LABEL_documentation: ${{ contains(github.event.pull_request.labels.*.name, 'documentation') }}
+        run: .github/scripts/label-check-one-of.sh


### PR DESCRIPTION
- Checks if one of the lerna-changelog tags is present

You can see a failed check here: https://github.com/deephaven/web-client-ui/runs/4081157392?check_suite_focus=true

I like how it tells you how to correct the problem:
> Error: Label check failed: required 1 of bug, enhancement, internal, documentation, but found 0.

We should consider adding that to `check-doc-labels.sh` in `deephaven-core` as well, as the current error "No documentation requirements found" and "Conflicting documentation requirements" is vague/requires prior knowledge of which labels satisfy that condition.