### PR TITLE
Fix theme for input tables

### DIFF
--- a/packages/iris-grid/src/IrisGridTheme.module.scss
+++ b/packages/iris-grid/src/IrisGridTheme.module.scss
@@ -37,6 +37,8 @@ $selection-outline-casing-color: $gray-900;
   negative-number-color: $red;
   zero-number-color: $yellow;
   date-color: $yellow;
+  pending-text-color: lighten($yellow, 10%);
+  error-text-color: $danger;
 
   $filter-color: $primary; // local to just the following
   filter-bar-active-bg: scale-color(


### PR DESCRIPTION
There were a couple of theme values missing for input tables. Add them back.
Looks like these were the only values missing (checking the theme in a previous Enterprise branch)
