### PR TITLE
Ability to copy column header from ui

### DIFF
--- a/packages/iris-grid/src/ColumnStatistics.jsx
+++ b/packages/iris-grid/src/ColumnStatistics.jsx
@@ -2,8 +2,12 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { LoadingSpinner } from '@deephaven/components';
-import { dhRefresh, vsLock } from '@deephaven/icons';
+import {
+  Button,
+  ContextActionUtils,
+  LoadingSpinner,
+} from '@deephaven/components';
+import { dhRefresh, vsCopy, vsLock, vsPassFilled } from '@deephaven/icons';
 import { PropTypes as APIPropTypes } from '@deephaven/jsapi-shim';
 import Log from '@deephaven/log';
 import { PromiseUtils } from '@deephaven/utils';
@@ -35,6 +39,7 @@ class ColumnStatistics extends Component {
     this.handleError = this.handleError.bind(this);
     this.handleGenerateStatistics = this.handleGenerateStatistics.bind(this);
     this.handleStatistics = this.handleStatistics.bind(this);
+    this.handleCopyHeader = this.handleCopyHeader.bind(this);
 
     this.cancelablePromise = null;
 
@@ -43,6 +48,7 @@ class ColumnStatistics extends Component {
       loading: false,
       statistics: null,
       numRows: 0,
+      copied: false,
     };
   }
 
@@ -54,6 +60,10 @@ class ColumnStatistics extends Component {
     if (this.cancelablePromise) {
       this.cancelablePromise.cancel();
     }
+  }
+
+  handleCopyHeader() {
+    this.setState({ copied: true });
   }
 
   maybeGenerateStatistics() {
@@ -128,7 +138,7 @@ class ColumnStatistics extends Component {
 
   render() {
     const { column, model } = this.props;
-    const { error, loading, statistics, numRows } = this.state;
+    const { error, loading, statistics, numRows, copied } = this.state;
     const showGenerateStatistics =
       !loading &&
       error == null &&
@@ -168,6 +178,17 @@ class ColumnStatistics extends Component {
         <div className="column-statistics-title">
           {column.name}&nbsp;
           <span className="column-statistics-type">({columnType})</span>
+          <Button
+            kind="ghost"
+            className="column-statistics-copy"
+            icon={copied ? vsPassFilled : vsCopy}
+            onClick={() => {
+              ContextActionUtils.copyToClipboard(column.name)
+                .then(() => this.handleCopyHeader())
+                .catch(e => log.error('Unable to column name', e));
+            }}
+            tooltip={copied ? 'Copied text' : 'Copy column name'}
+          />
         </div>
         {description && (
           <div className="column-statistics-description">{description}</div>

--- a/packages/iris-grid/src/ColumnStatistics.jsx
+++ b/packages/iris-grid/src/ColumnStatistics.jsx
@@ -180,15 +180,15 @@ class ColumnStatistics extends Component {
     return (
       <div className="column-statistics">
         <div className="column-statistics-title">
-          {column.name}&nbsp;
-          <span className="column-statistics-type">({columnType})</span>
+          {column.name}
+          <span className="column-statistics-type">&nbsp;({columnType})</span>
           <Button
             kind="ghost"
             className="column-statistics-copy"
             icon={copied ? vsPassFilled : vsCopy}
             onClick={() => {
               ContextActionUtils.copyToClipboard(column.name)
-                .then(() => this.handleCopyHeader())
+                .then(this.handleCopyHeader)
                 .catch(e => log.error('Unable to column name', e));
             }}
             tooltip={copied ? 'Copied text' : 'Copy column name'}

--- a/packages/iris-grid/src/ColumnStatistics.jsx
+++ b/packages/iris-grid/src/ColumnStatistics.jsx
@@ -7,7 +7,13 @@ import {
   ContextActionUtils,
   LoadingSpinner,
 } from '@deephaven/components';
-import { dhFreeze, dhRefresh, vsCopy, vsLock, vsPassFilled } from '@deephaven/icons';
+import {
+  dhFreeze,
+  dhRefresh,
+  vsCopy,
+  vsLock,
+  vsPassFilled,
+} from '@deephaven/icons';
 import { PropTypes as APIPropTypes } from '@deephaven/jsapi-shim';
 import Log from '@deephaven/log';
 import { PromiseUtils } from '@deephaven/utils';

--- a/packages/iris-grid/src/ColumnStatistics.scss
+++ b/packages/iris-grid/src/ColumnStatistics.scss
@@ -10,7 +10,12 @@
 }
 
 .column-statistics-title {
+  padding-top: $spacer-1;
   font-weight: 500;
+  .column-statistics-copy {
+    margin-left: 2px;
+    margin-top: -2px;
+  }
 }
 
 .column-statistics-type {

--- a/packages/iris-grid/src/mousehandlers/IrisGridColumnTooltipMouseHandler.js
+++ b/packages/iris-grid/src/mousehandlers/IrisGridColumnTooltipMouseHandler.js
@@ -42,8 +42,12 @@ class IrisGridColumnTooltipMouseHandler extends GridMouseHandler {
     const theme = this.irisGrid.getTheme();
     let newTooltip = null;
     if (column !== null && row === null) {
-      if (y >= 0 && y <= theme.columnHeaderHeight - 2) {
-        // -2 account for borders
+      /**
+       * one would expect at y == theme.columnHeaderHeight, row == null
+       * however, gridY also == theme.columnHeaderHeight, so row still has a value
+       * so this tooltip won't actually show until row is null at columnHeaderHeight - 1
+       */
+      if (y >= 0 && y <= theme.columnHeaderHeight) {
         newTooltip = column;
       }
     }

--- a/packages/iris-grid/src/mousehandlers/IrisGridContextMenuHandler.jsx
+++ b/packages/iris-grid/src/mousehandlers/IrisGridContextMenuHandler.jsx
@@ -325,6 +325,15 @@ class IrisGridContextMenuHandler extends GridMouseHandler {
             }
           },
         });
+        actions.push({
+          title: 'Copy Column Name',
+          group: IrisGridContextMenuHandler.GROUP_COPY,
+          action: () => {
+            ContextActionUtils.copyToClipboard(
+              model.textForColumnHeader(modelColumn)
+            ).catch(e => log.error('Unable to copy header', e));
+          },
+        });
 
         if (TableUtils.isDateType(column.type)) {
           actions.push({


### PR DESCRIPTION
> This is a small annoyance, but I would love to have "copy header" on the header right click menu.I can get it from the copying a selection with headers, but it would be nice to just copy the header.Just one. I'm copying it and using it a text. Either pasting into some Javascript code or putting it in an Excel Spreadsheet.

fixes [DH-11843](https://deephaven.atlassian.net/browse/DH-11843)

Added to column menu and column tooltip.