### PR TITLE
Fix issue where tables would not reload after refreshing the page

### DIFF
--- a/packages/code-studio/src/main/WidgetUtils.ts
+++ b/packages/code-studio/src/main/WidgetUtils.ts
@@ -51,13 +51,13 @@ export const createChartModel = async (
   }
 
   if (figureName) {
-    const definition = { id: figureName, type: dh.VariableType.FIGURE };
+    const definition = { name: figureName, type: dh.VariableType.FIGURE };
     const figure = await session.getObject(definition);
 
     return ChartModelFactory.makeModel(settings, figure);
   }
 
-  const definition = { id: tableName, type: dh.VariableType.TABLE };
+  const definition = { name: tableName, type: dh.VariableType.TABLE };
   const table = await session.getObject(definition);
 
   IrisGridUtils.applyTableSettings(
@@ -74,7 +74,7 @@ export const createGridModel = async (
   metadata: GridPanelMetadata
 ): Promise<IrisGridModel> => {
   const { table: tableName } = metadata;
-  const definition = { id: tableName, type: dh.VariableType.TABLE };
+  const definition = { name: tableName, type: dh.VariableType.TABLE };
   const table = await session.getObject(definition);
   return IrisGridModelFactory.makeModel(table, false);
 };

--- a/packages/dashboard-core-plugins/src/events/ControlEvent.js
+++ b/packages/dashboard-core-plugins/src/events/ControlEvent.js
@@ -1,5 +1,0 @@
-class ControlEvent {
-  static CLOSE = 'ControlEvent.CLOSE';
-}
-
-export default ControlEvent;

--- a/packages/dashboard-core-plugins/src/events/index.js
+++ b/packages/dashboard-core-plugins/src/events/index.js
@@ -1,6 +1,5 @@
 export { default as ChartEvent } from './ChartEvent';
 export { default as ConsoleEvent } from './ConsoleEvent';
-export { default as ControlEvent } from './ControlEvent';
 export { default as InputFilterEvent } from './InputFilterEvent';
 export { default as IrisGridEvent } from './IrisGridEvent';
 export { default as MarkdownEvent } from './MarkdownEvent';

--- a/packages/dashboard-core-plugins/src/panels/ConsolePanel.jsx
+++ b/packages/dashboard-core-plugins/src/panels/ConsolePanel.jsx
@@ -17,7 +17,6 @@ import { getCommandHistoryStorage, getTimeZone } from '@deephaven/redux';
 import {
   ChartEvent,
   ConsoleEvent,
-  ControlEvent,
   IrisGridEvent,
   PandasEvent,
 } from '../events';
@@ -175,7 +174,7 @@ class ConsolePanel extends PureComponent {
     const { name } = object;
     const id = this.getItemId(name, false);
     const { glEventHub } = this.props;
-    glEventHub.emit(ControlEvent.CLOSE, id);
+    glEventHub.emit(PanelEvent.CLOSE, id);
   }
 
   handleSettingsChange(consoleSettings) {
@@ -246,7 +245,7 @@ class ConsolePanel extends PureComponent {
     const panelIdsToClose = [...itemIds.values()];
     const { glEventHub } = this.props;
     panelIdsToClose.forEach(panelId => {
-      glEventHub.emit(ControlEvent.CLOSE, panelId);
+      glEventHub.emit(PanelEvent.CLOSE, panelId);
     });
 
     this.setState({ itemIds: new Map() });


### PR DESCRIPTION
Two fixes:
- The "Close Panels on Disconnect" option wasn't working. This is because I was emitting the incorrect event (nothing listened to `ControlEvent.CLOSE` anymore)
- If the "Close Panels on Disconnect" option was not selected, the tables would not re-open on browser refresh. This is because I was passing the table name in the `id` field, instead of the `name` field.

Fixes #286 