### PR TITLE
Fix log and console crashes if process is undefined

### DIFF
--- a/packages/console/src/common/ConsoleConstants.ts
+++ b/packages/console/src/common/ConsoleConstants.ts
@@ -2,11 +2,17 @@ class ConsoleConstants {
   /**
    * Map of language keys to their display names
    */
-  static LANGUAGE_MAP = new Map(
-    process.env.REACT_APP_SESSION_LANGUAGES?.split(',')
-      .map(str => str.split('='))
-      .map(([language, displayName]) => [language, displayName ?? language])
-  );
+  static get LANGUAGE_MAP(): Map<string, string> {
+    try {
+      return new Map(
+        process.env.REACT_APP_SESSION_LANGUAGES?.split(',')
+          .map(str => str.split('='))
+          .map(([language, displayName]) => [language, displayName ?? language])
+      );
+    } catch {
+      return new Map<never, never>();
+    }
+  }
 }
 
 export default ConsoleConstants;

--- a/packages/log/src/DefaultLogger.js
+++ b/packages/log/src/DefaultLogger.js
@@ -10,7 +10,12 @@ import LoggerLevel, { DEBUG2, INFO, SILENT } from './LoggerLevel';
  * @returns {number} The default log level to use
  */
 function getDefaultLevel() {
-  const envValue = process.env.DEEPHAVEN_LOG_LEVEL;
+  let envValue = '';
+  try {
+    envValue = process.env.DEEPHAVEN_LOG_LEVEL;
+  } catch {
+    // no-op. Environment without process defined
+  }
   if (envValue && LoggerLevel[envValue]) {
     return LoggerLevel[envValue];
   }
@@ -18,11 +23,16 @@ function getDefaultLevel() {
   if (!Number.isNaN(envLevel)) {
     return envLevel;
   }
-  if (process.env.NODE_ENV === 'test') {
-    return SILENT;
-  }
-  if (process.env.NODE_ENV === 'development') {
-    return DEBUG2;
+
+  try {
+    if (process.env.NODE_ENV === 'test') {
+      return SILENT;
+    }
+    if (process.env.NODE_ENV === 'development') {
+      return DEBUG2;
+    }
+  } catch {
+    // no-op. Environment without process defined
   }
 
   return INFO;


### PR DESCRIPTION
Fixes #189 

Must use try/catch instead of `typeof process === 'undefined'` because CRA injects the values at build time. `process` will be undefined in a browser even w/ CRA.

Needed for docs plotting as docusaurus doesn't inject `process.env` variables like CRA does