### PR TITLE
DH-11661 refresh viewport on IrisGridTableMode.handleTotalsUpdate

### DIFF
--- a/packages/iris-grid/src/IrisGridTableModel.js
+++ b/packages/iris-grid/src/IrisGridTableModel.js
@@ -178,7 +178,6 @@ class IrisGridTableModel extends IrisGridModel {
 
   handleTotalsUpdate(event) {
     this.copyTotalsData(event.detail);
-    this.applyViewport();
 
     this.dispatchEvent(new CustomEvent(IrisGridModel.EVENT.UPDATED));
   }
@@ -664,6 +663,7 @@ class IrisGridTableModel extends IrisGridModel {
     log.debug2('copyTotalsData', dataMap);
 
     this.totalsDataMap = dataMap;
+    this.formattedStringData = [];
   }
 
   /**

--- a/packages/iris-grid/src/IrisGridTableModel.js
+++ b/packages/iris-grid/src/IrisGridTableModel.js
@@ -178,6 +178,7 @@ class IrisGridTableModel extends IrisGridModel {
 
   handleTotalsUpdate(event) {
     this.copyTotalsData(event.detail);
+    this.applyViewport();
 
     this.dispatchEvent(new CustomEvent(IrisGridModel.EVENT.UPDATED));
   }


### PR DESCRIPTION
Not sure if this is the ideal path but the event detail and copyTotalsData were doing the right thing yet the aggs table wasn't updating until a viewport change happened. Easy review though!