### PR TITLE
Enable code coverage tests, add thresholds

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -20,7 +20,16 @@ module.exports = {
     'jest-watch-typeahead/testname',
     'jest-watch-select-projects',
   ],
-  collectCoverage: false,
+  collectCoverage: true,
   coverageDirectory: '<rootDir>/coverage/', // This is relative to monorepo root
   collectCoverageFrom: ['./src/**/*.{js,ts,jsx,tsx}'], // This is relative to individual project root due to how Jest handles it
+  coverageThreshold: {
+    // These global thresholds were taken as the baseline when code coverage initiative began. Should be increased over time.
+    global: {
+      statements: 40,
+      branches: 30,
+      functions: 30,
+      lines: 40,
+    },
+  },
 };

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -27,7 +27,7 @@ module.exports = {
     // These global thresholds were taken as the baseline when code coverage initiative began. Should be increased over time.
     global: {
       statements: 40,
-      branches: 30,
+      branches: 80,
       functions: 30,
       lines: 40,
     },

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -21,13 +21,16 @@ module.exports = {
     'jest-watch-select-projects',
   ],
   collectCoverage: true,
-  coverageDirectory: '<rootDir>/coverage/', // This is relative to monorepo root
   collectCoverageFrom: ['./src/**/*.{js,ts,jsx,tsx}'], // This is relative to individual project root due to how Jest handles it
+  coverageReporters: ['text'],
   coverageThreshold: {
-    // These global thresholds were taken as the baseline when code coverage initiative began. Should be increased over time.
+    // These global thresholds were taken as the baseline of the overall project when code coverage initiative began.
+    // In CI, these thresholds will be measures against only the files you have changed.
+    // We may want to increase/decrease the thresholds for specific projects, and we can do that:
+    // https://jestjs.io/docs/configuration#coveragethreshold-object
     global: {
       statements: 40,
-      branches: 80,
+      branches: 30,
       functions: 30,
       lines: 40,
     },

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -22,7 +22,6 @@ module.exports = {
   ],
   collectCoverage: true,
   collectCoverageFrom: ['./src/**/*.{js,ts,jsx,tsx}'], // This is relative to individual project root due to how Jest handles it
-  coverageReporters: ['text'],
   coverageThreshold: {
     // These global thresholds were taken as the baseline of the overall project when code coverage initiative began.
     // In CI, these thresholds will be measures against only the files you have changed.


### PR DESCRIPTION
Started with a baseline threshold just below existing levels for the whole project.
However, since the coverage report only runs on existing changes, it will check your diff and fail if they fall below those levels.
Only using the 'text' type reporter as that will be output in our console or in CI log output and we can see the failures from there.