### PR TITLE
Chart fixes for docs snapshots

### DIFF
--- a/packages/chart/src/ChartModelFactory.js
+++ b/packages/chart/src/ChartModelFactory.js
@@ -1,6 +1,7 @@
 import dh from '@deephaven/jsapi-shim';
 import ChartUtils from './ChartUtils';
 import FigureChartModel from './FigureChartModel';
+import ChartTheme from './ChartTheme';
 
 class ChartModelFactory {
   /**
@@ -14,9 +15,10 @@ class ChartModelFactory {
    * @param {string} settings.xAxis The column name to use for the x-axis
    * @param {string[]} settings.hiddenSeries Array of hidden series names
    * @param {dh.Table} table The table to build the model for
+   * @param {Object} theme The theme for the figure. Defaults to ChartTheme
    * @returns {Promise<FigureChartModel>} The FigureChartModel representing the figure
    */
-  static async makeModelFromSettings(settings, table) {
+  static async makeModelFromSettings(settings, table, theme = ChartTheme) {
     // Copy the table first and then re-apply the filters from the original table
     // When we add table linking we'll want to listen to the original table and update
     // the copied table with any changes that occur.
@@ -28,7 +30,7 @@ class ChartModelFactory {
 
       return dh.plot.Figure.create(
         ChartUtils.makeFigureSettings(settings, tableCopy)
-      ).then(figure => new FigureChartModel(figure, settings));
+      ).then(figure => new FigureChartModel(figure, settings, theme));
     });
   }
 
@@ -43,10 +45,11 @@ class ChartModelFactory {
    * @param {string} settings.xAxis The column name to use for the x-axis
    * @param {string[]} settings.hiddenSeries Array of hidden series names
    * @param {dh.Figure} figure The figure to build the model for
+   * @param {Object} theme The theme for the figure. Defaults to ChartTheme
    * @returns {Promise<FigureChartModel>} The FigureChartModel representing the figure
    */
-  static async makeModel(settings, figure) {
-    return new FigureChartModel(figure, settings);
+  static async makeModel(settings, figure, theme = ChartTheme) {
+    return new FigureChartModel(figure, settings, theme);
   }
 }
 

--- a/packages/chart/src/ChartUtils.js
+++ b/packages/chart/src/ChartUtils.js
@@ -1225,7 +1225,13 @@ class ChartUtils {
     return axis;
   }
 
-  static makeDefaultLayout(theme = {}) {
+  /**
+   * Parses the colorway property of a theme and returns an array of colors
+   * Theme could have a single string with space separated colors or an array of strings representing the colorway
+   * @param {ChartTheme} theme The theme to get colorway from
+   * @returns {string[]} Colorway array for the theme
+   */
+  static getColorwayFromTheme(theme) {
     let colorway = [];
     if (theme.colorway) {
       if (Array.isArray(theme.colorway)) {
@@ -1237,10 +1243,14 @@ class ChartUtils {
       }
     }
 
+    return colorway;
+  }
+
+  static makeDefaultLayout(theme = {}) {
     const layout = {
       ...theme,
       autosize: true,
-      colorway,
+      colorway: ChartUtils.getColorwayFromTheme(theme),
       font: {
         family: "'Fira Sans', sans-serif",
       },

--- a/packages/chart/src/ChartUtils.test.js
+++ b/packages/chart/src/ChartUtils.test.js
@@ -2,6 +2,7 @@ import dh from '@deephaven/jsapi-shim';
 import { Formatter } from '@deephaven/iris-grid';
 import ChartUtils from './ChartUtils';
 import ChartTestUtils from './ChartTestUtils';
+import ChartTheme from './ChartTheme';
 
 function makeFormatter() {
   return new Formatter();
@@ -32,8 +33,8 @@ it('groups the axes by type properly', () => {
 });
 
 it('returns a newly composed layout object each time', () => {
-  const layout1 = ChartUtils.makeDefaultLayout();
-  const layout2 = ChartUtils.makeDefaultLayout();
+  const layout1 = ChartUtils.makeDefaultLayout(ChartTheme);
+  const layout2 = ChartUtils.makeDefaultLayout(ChartTheme);
 
   expect(layout1).not.toBe(layout2);
   expect(layout1.xaxis).not.toBe(layout2.xaxis);
@@ -287,7 +288,7 @@ describe('updating layout axes', () => {
 describe('returns the axis layout ranges properly', () => {
   function makeLayout(layout) {
     return {
-      ...ChartUtils.makeDefaultLayout(),
+      ...ChartUtils.makeDefaultLayout(ChartTheme),
       ...layout,
     };
   }

--- a/packages/chart/src/FigureChartModel.js
+++ b/packages/chart/src/FigureChartModel.js
@@ -18,7 +18,7 @@ class FigureChartModel extends ChartModel {
    * @param {dh.plot.Figure} figure The figure object created by the API
    * @param {Object} settings Chart settings
    */
-  constructor(figure, settings = {}) {
+  constructor(figure, settings = {}, theme = {}) {
     super();
 
     this.handleFigureUpdated = this.handleFigureUpdated.bind(this);
@@ -40,8 +40,9 @@ class FigureChartModel extends ChartModel {
 
     this.figure = figure;
     this.settings = settings;
+    this.theme = theme;
     this.data = [];
-    this.layout = ChartUtils.makeDefaultLayout();
+    this.layout = ChartUtils.makeDefaultLayout(theme);
     this.seriesDataMap = new Map();
     this.pendingSeries = [];
     this.oneClicks = [];
@@ -111,7 +112,8 @@ class FigureChartModel extends ChartModel {
     const seriesData = ChartUtils.makeSeriesDataFromSeries(
       series,
       axisTypeMap,
-      ChartUtils.getSeriesVisibility(series.name, this.settings)
+      ChartUtils.getSeriesVisibility(series.name, this.settings),
+      this.theme
     );
 
     this.seriesDataMap.set(series.name, seriesData);
@@ -494,7 +496,8 @@ class FigureChartModel extends ChartModel {
         chart.axes,
         plotWidth,
         plotHeight,
-        axisRangeParser
+        axisRangeParser,
+        this.theme
       );
     }
   }

--- a/packages/chart/src/MockChartModel.js
+++ b/packages/chart/src/MockChartModel.js
@@ -152,7 +152,7 @@ class MockChartModel extends ChartModel {
   }
 
   static makeDefaultLayout() {
-    const layout = ChartUtils.makeDefaultLayout();
+    const layout = ChartUtils.makeDefaultLayout(ChartTheme);
     layout.title = 'Chart';
     layout.xaxis.title = 'Datestamp';
     layout.yaxis.title = 'Price';

--- a/packages/chart/src/index.ts
+++ b/packages/chart/src/index.ts
@@ -4,3 +4,4 @@ export { default as ChartModel } from './ChartModel';
 export { default as ChartUtils } from './ChartUtils';
 export { default as FigureChartModel } from './FigureChartModel';
 export { default as MockChartModel } from './MockChartModel';
+export { default as Plot } from './plotly/Plot';

--- a/packages/chart/src/plotly/Plot.js
+++ b/packages/chart/src/plotly/Plot.js
@@ -4,4 +4,9 @@
 import createPlotlyComponent from 'react-plotly.js/factory.js';
 import Plotly from './Plotly';
 
-export default createPlotlyComponent(Plotly);
+// Webpack 4 (used in CRA) handles this import such that createPlotlyComponent is a function
+// Webpack 5 (used in docusaurus) gives an object w/ a default key
+// This is probably something on react-plotly.js's side
+export default typeof createPlotlyComponent === 'function'
+  ? createPlotlyComponent(Plotly)
+  : createPlotlyComponent.default(Plotly);

--- a/packages/chart/src/plotly/Plotly.js
+++ b/packages/chart/src/plotly/Plotly.js
@@ -3,14 +3,13 @@
 // https://github.com/plotly/plotly.js/#modules
 
 import Plotly from 'plotly.js/lib/core.js';
+import bar from 'plotly.js/lib/bar.js';
+import histogram from 'plotly.js/lib/histogram.js';
+import pie from 'plotly.js/lib/pie.js';
+import ohlc from 'plotly.js/lib/ohlc.js';
+import scattergl from 'plotly.js/lib/scattergl.js';
 
 // Load in the trace types we need/support
-Plotly.register([
-  require('plotly.js/lib/bar'),
-  require('plotly.js/lib/histogram'),
-  require('plotly.js/lib/pie'),
-  require('plotly.js/lib/ohlc'),
-  require('plotly.js/lib/scattergl'),
-]);
+Plotly.register([bar, histogram, pie, ohlc, scattergl]);
 
 export default Plotly;

--- a/packages/dashboard-core-plugins/src/panels/ConsolePanel.jsx
+++ b/packages/dashboard-core-plugins/src/panels/ConsolePanel.jsx
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import shortid from 'shortid';
 import debounce from 'lodash.debounce';
 import { connect } from 'react-redux';
-import { FigureChartModel } from '@deephaven/chart';
+import { ChartModelFactory } from '@deephaven/chart';
 import { ThemeExport } from '@deephaven/components';
 import { Console, ConsoleConstants, ConsoleUtils } from '@deephaven/console';
 import { GLPropTypes, PanelEvent } from '@deephaven/dashboard';
@@ -206,7 +206,9 @@ class ConsolePanel extends PureComponent {
     const id = this.getItemId(name);
     const metadata = { figure: name };
     const makeModel = () =>
-      session.getObject(object).then(result => new FigureChartModel(result));
+      session
+        .getObject(object)
+        .then(result => ChartModelFactory.makeModel(undefined, result));
 
     const { glEventHub } = this.props;
     glEventHub.emit(ChartEvent.OPEN, name, makeModel, metadata, id);


### PR DESCRIPTION
Fixes some issues for charts in the docs snapshot tool. Mainly moving the theme out of ChartUtils so the snapshot tool (in Node) can import ChartUtils and not crash from being unable to handle the css import