### PR TITLE
WIP failing code coverage

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -29,7 +29,7 @@ module.exports = {
     // We may want to increase/decrease the thresholds for specific projects, and we can do that:
     // https://jestjs.io/docs/configuration#coveragethreshold-object
     global: {
-      statements: 40,
+      statements: 80,
       branches: 30,
       functions: 30,
       lines: 40,

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -20,7 +20,16 @@ module.exports = {
     'jest-watch-typeahead/testname',
     'jest-watch-select-projects',
   ],
-  collectCoverage: false,
+  collectCoverage: true,
   coverageDirectory: '<rootDir>/coverage/', // This is relative to monorepo root
   collectCoverageFrom: ['./src/**/*.{js,ts,jsx,tsx}'], // This is relative to individual project root due to how Jest handles it
+  coverageThreshold: {
+    // These global thresholds were taken as the baseline when code coverage initiative began. Should be increased over time.
+    global: {
+      statements: 40,
+      branches: 30,
+      functions: 30,
+      lines: 40,
+    },
+  },
 };

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -27,7 +27,7 @@ module.exports = {
     // These global thresholds were taken as the baseline when code coverage initiative began. Should be increased over time.
     global: {
       statements: 40,
-      branches: 30,
+      branches: 80,
       functions: 30,
       lines: 40,
     },

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -21,13 +21,16 @@ module.exports = {
     'jest-watch-select-projects',
   ],
   collectCoverage: true,
-  coverageDirectory: '<rootDir>/coverage/', // This is relative to monorepo root
   collectCoverageFrom: ['./src/**/*.{js,ts,jsx,tsx}'], // This is relative to individual project root due to how Jest handles it
+  coverageReporters: ['text'],
   coverageThreshold: {
-    // These global thresholds were taken as the baseline when code coverage initiative began. Should be increased over time.
+    // These global thresholds were taken as the baseline of the overall project when code coverage initiative began.
+    // In CI, these thresholds will be measures against only the files you have changed.
+    // We may want to increase/decrease the thresholds for specific projects, and we can do that:
+    // https://jestjs.io/docs/configuration#coveragethreshold-object
     global: {
       statements: 40,
-      branches: 80,
+      branches: 30,
       functions: 30,
       lines: 40,
     },

--- a/packages/grid/src/Grid.jsx
+++ b/packages/grid/src/Grid.jsx
@@ -1222,7 +1222,7 @@ class Grid extends PureComponent {
   }
 
   /**
-   * Notify all of the mouse handlers for this grid of a mouse event.
+   * Notify all of the mouse handlers for this grid of a mouse event
    * @param {String} functionName The name of the function in the mouse handler to call
    * @param {MouseEvent} event The mouse event to notify
    * @param {Boolean} updateCoordinates Whether to update the mouse coordinates

--- a/packages/grid/src/GridUtils.js
+++ b/packages/grid/src/GridUtils.js
@@ -257,7 +257,7 @@ class GridUtils {
     if (
       columnHeaderHeight < y ||
       !allowColumnResize ||
-      headerSeparatorHandleSize <= 0
+      headerSeparatorHandleSize <= 5
     ) {
       return null;
     }


### PR DESCRIPTION
- Enable code coverage tests, add thresholds
- Set the threshold too high so the first run fails
- Change threshold, only report in text
- WIP check in failing code coverage so we can see
