### PR TITLE
DH-11923: Fix column tooltip when above the table

### DIFF
--- a/packages/code-studio/src/styleguide/MockIrisGridTreeModel.js
+++ b/packages/code-studio/src/styleguide/MockIrisGridTreeModel.js
@@ -54,7 +54,7 @@ class MockIrisGridTreeModel extends IrisGridModel {
   set pendingDataMap(value) {}
 
   getColumnIndexByName(name) {
-    return 3;
+    return Number(name);
   }
 
   textForCell(column, row) {

--- a/packages/code-studio/src/styleguide/MockIrisGridTreeModel.js
+++ b/packages/code-studio/src/styleguide/MockIrisGridTreeModel.js
@@ -53,6 +53,10 @@ class MockIrisGridTreeModel extends IrisGridModel {
 
   set pendingDataMap(value) {}
 
+  getColumnIndexByName(name) {
+    return 3;
+  }
+
   textForCell(column, row) {
     return (
       this.editedData[column]?.[row] ?? this.model.textForCell(column, row)

--- a/packages/components/src/popper/Popper.tsx
+++ b/packages/components/src/popper/Popper.tsx
@@ -19,7 +19,7 @@ import React, { Component } from 'react';
 import ReactDOM from 'react-dom';
 import classNames from 'classnames';
 import { CSSTransition } from 'react-transition-group';
-import PopperJs, { PopperOptions } from 'popper.js';
+import PopperJs, { PopperOptions, ReferenceObject } from 'popper.js';
 import PropTypes from 'prop-types';
 import ThemeExport from '../ThemeExport';
 import './Popper.scss';
@@ -33,6 +33,7 @@ interface PopperProps {
   isShown: boolean;
   closeOnBlur: boolean;
   interactive: boolean;
+  referenceObject: ReferenceObject;
 }
 
 interface PopperState {
@@ -51,6 +52,7 @@ class Popper extends Component<PopperProps, PopperState> {
     isShown: PropTypes.bool,
     closeOnBlur: PropTypes.bool,
     interactive: PropTypes.bool,
+    referenceObject: PropTypes.shape({}),
   };
 
   static defaultProps = {
@@ -66,6 +68,7 @@ class Popper extends Component<PopperProps, PopperState> {
     isShown: false,
     interactive: false,
     closeOnBlur: false,
+    referenceObject: null,
   };
 
   constructor(props: PopperProps) {
@@ -136,7 +139,7 @@ class Popper extends Component<PopperProps, PopperState> {
 
   initPopper(): void {
     let { popper } = this.state;
-    const { closeOnBlur } = this.props;
+    const { closeOnBlur, referenceObject } = this.props;
 
     if (popper) {
       return;
@@ -158,7 +161,7 @@ class Popper extends Component<PopperProps, PopperState> {
       parent = this.container.current;
     }
 
-    popper = new PopperJs(parent, this.element, options);
+    popper = new PopperJs(referenceObject || parent, this.element, options);
     popper.scheduleUpdate();
 
     // delayed due to scheduleUpdate
@@ -293,4 +296,4 @@ class Popper extends Component<PopperProps, PopperState> {
 }
 
 export default Popper;
-export type { PopperOptions };
+export type { PopperOptions, ReferenceObject };

--- a/packages/components/src/popper/Tooltip.tsx
+++ b/packages/components/src/popper/Tooltip.tsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import classNames from 'classnames';
 import Log from '@deephaven/log';
-import Popper, { PopperOptions } from './Popper';
+import Popper, { PopperOptions, ReferenceObject } from './Popper';
 
 const log = Log.module('Tooltip');
 
@@ -12,6 +12,7 @@ interface TooltipProps {
   reshowTimeout: number;
   children: React.ReactNode;
   popperClassName: string;
+  referenceObject: ReferenceObject;
 }
 
 interface TooltipState {
@@ -47,6 +48,7 @@ class Tooltip extends Component<TooltipProps, TooltipState> {
     popperClassName: '',
     reshowTimeout: Tooltip.defaultReshowTimeout,
     timeout: Tooltip.defaultTimeout,
+    referenceObject: null,
   };
 
   static handleHidden(): void {
@@ -280,7 +282,13 @@ class Tooltip extends Component<TooltipProps, TooltipState> {
   }
 
   render(): JSX.Element {
-    const { interactive, children, options, popperClassName } = this.props;
+    const {
+      interactive,
+      children,
+      options,
+      referenceObject,
+      popperClassName,
+    } = this.props;
     const { isShown } = this.state;
     return (
       <div ref={this.container} style={{ display: 'none' }}>
@@ -290,6 +298,7 @@ class Tooltip extends Component<TooltipProps, TooltipState> {
           ref={this.popper}
           onExited={this.handleExited}
           interactive={interactive}
+          referenceObject={referenceObject}
         >
           <div className="tooltip-content"> {isShown && children}</div>
         </Popper>

--- a/packages/iris-grid/package.json
+++ b/packages/iris-grid/package.json
@@ -42,6 +42,7 @@
     "@fortawesome/react-fontawesome": "^0.1.12",
     "classnames": "^2.3.1",
     "deep-equal": "^2.0.4",
+    "lodash.clamp": "^4.0.3",
     "lodash.debounce": "^4.0.8",
     "lodash.throttle": "^4.1.1",
     "memoize-one": "^5.1.1",

--- a/packages/iris-grid/src/IrisGrid.jsx
+++ b/packages/iris-grid/src/IrisGrid.jsx
@@ -2426,14 +2426,33 @@ export class IrisGrid extends Component {
         columnHeaderHeight,
         visibleColumnXs,
         visibleColumnWidths,
+        width,
       } = metrics;
       const columnX = visibleColumnXs.get(shownColumnTooltip);
       const columnWidth = visibleColumnWidths.get(shownColumnTooltip);
+
+      /**
+       * Create a wrapper dom element, the size of the column header.
+       * The wrapper acts as tooltip parent, for positioning, and the
+       * tooltip component will trigger hide on mouseleave of wrapper
+       * or tooltip. The wrapper should be bound to within the
+       * grid dimensions, so popper doesn't end up outside the panel.
+       */
+      const boundedLeft = Math.max(0, columnX);
+      let boundedWidth = columnWidth;
+      if (columnX + columnWidth > width) {
+        // column is extending past right edge
+        boundedWidth = width - columnX;
+      } else if (columnX < 0) {
+        // column is extending past left edge
+        boundedWidth = columnWidth - Math.abs(columnX);
+      }
+
       const wrapperStyle = {
         position: 'absolute',
         top: 0,
-        left: columnX,
-        width: columnWidth,
+        left: boundedLeft,
+        width: boundedWidth,
         height: columnHeaderHeight,
         pointerEvents: 'none',
       };

--- a/packages/iris-grid/src/IrisGrid.jsx
+++ b/packages/iris-grid/src/IrisGrid.jsx
@@ -2464,7 +2464,7 @@ export class IrisGrid extends Component {
        * positioning and keep the popper centered on the label. Creates a
        * 1px x headerHeight virtual object, placed centered on the column
        * label, clamped to 0 + margin to width - margin. We add a margin,
-       * otherwise the arrow wants to esacpe the boundry.
+       * otherwise the arrow wants to escape the boundary.
        */
       const gridRect = this.gridWrapper.getBoundingClientRect();
       const popperMargin = 20;

--- a/packages/iris-grid/src/mousehandlers/IrisGridColumnTooltipMouseHandler.js
+++ b/packages/iris-grid/src/mousehandlers/IrisGridColumnTooltipMouseHandler.js
@@ -36,6 +36,10 @@ class IrisGridColumnTooltipMouseHandler extends GridMouseHandler {
     return false;
   }
 
+  onWheel() {
+    this.destroyColumnTooltip();
+  }
+
   onMove(gridPoint) {
     const { y, column, row } = gridPoint;
     const { shownColumnTooltip } = this.irisGrid.state;

--- a/packages/iris-grid/src/mousehandlers/IrisGridColumnTooltipMouseHandler.js
+++ b/packages/iris-grid/src/mousehandlers/IrisGridColumnTooltipMouseHandler.js
@@ -58,14 +58,6 @@ class IrisGridColumnTooltipMouseHandler extends GridMouseHandler {
 
     return false;
   }
-
-  onLeave(gridPoint) {
-    const { y } = gridPoint;
-    if (y < 0) {
-      this.destroyColumnTooltip();
-    }
-    return false;
-  }
 }
 
 export default IrisGridColumnTooltipMouseHandler;


### PR DESCRIPTION
When column tooltips are displayed above the table, instead of below (due to being to close to the bottom edge of the window) attempting to mouse into them was triggering them to close.

![685c7c7f-549a-44a9-9433-06ceb60769fe](https://user-images.githubusercontent.com/1576283/142664186-805c6470-5368-4ab2-a84b-5eb40ef5c1e6.png)

This was caused by IrisGridColumnTooltipMouseHandler triggering its own onLeave even when y < 0  that dismissed the tooltip.

This handler is actually unnecessary, as the popper has its on move handler on the window, that handles dismissing when the mouse moves outside the bounds of the popper OR **the parent** of the popper. And the parent in this case is a wrapper div that is temporarily created by iris gird, and is sized exactly to the column header.

![image](https://user-images.githubusercontent.com/1576283/142664603-377b25e2-593e-4efc-b463-da7fafc7b00a.png)

Previously, this wrapper was used for positioning as well. However, this wrapper was being sized to the column width, which meant if the column was wider, and extended past the edge of the grid, the popper would be placed outside the grid as well. This change, restricts the wrapper, to be bounded by the grid.

![image](https://user-images.githubusercontent.com/1576283/143058727-ef6526bc-efc5-4e0f-8611-9c1a8719be48.png)

However, this introduced a new problem, where the popper was now centered over the column space, rather than the label of the column. So additionally, we leverage a popper Reference Object, to act as the positioning guide for the popper, that is centered on the text. The wrapper is still the hover area, used for the mouse leave, the reference object is used just for positioning.
