### PR TITLE
Add UI version to support log data

### DIFF
--- a/packages/code-studio/src/log/LogExport.ts
+++ b/packages/code-studio/src/log/LogExport.ts
@@ -86,7 +86,7 @@ export async function exportLogs(
   const folder = zip.folder(fileNamePrefix) as JSZip;
   folder.file('console.txt', logHistory.getFormattedHistory());
   folder.file('redux.json', getReduxDataString());
-  folder.file('metadata.json', JSON.stringify(metadata));
+  folder.file('metadata.json', JSON.stringify(metadata, null, 2));
 
   const blob = await zip.generateAsync({ type: 'blob' });
   const link = document.createElement('a');

--- a/packages/code-studio/src/log/LogExport.ts
+++ b/packages/code-studio/src/log/LogExport.ts
@@ -61,7 +61,7 @@ function makeSafeToStringify(
   return output;
 }
 
-function getReduxDataString() {
+function getReduxDataString(): string {
   const reduxData = store.getState();
   return JSON.stringify(
     makeSafeToStringify(reduxData),
@@ -72,9 +72,11 @@ function getReduxDataString() {
 
 /**
  * Export support logs with the given name.
+ * @param metadata Any extra metadata to be written to a metadata file
  * @param fileNamePrefix The zip file name without the .zip extension. Ex: test will be saved as test.zip
  */
 export async function exportLogs(
+  metadata = {},
   fileNamePrefix = `${dh.i18n.DateTimeFormat.format(
     FILENAME_DATE_FORMAT,
     new Date()
@@ -84,6 +86,7 @@ export async function exportLogs(
   const folder = zip.folder(fileNamePrefix) as JSZip;
   folder.file('console.txt', logHistory.getFormattedHistory());
   folder.file('redux.json', getReduxDataString());
+  folder.file('metadata', JSON.stringify(metadata));
 
   const blob = await zip.generateAsync({ type: 'blob' });
   const link = document.createElement('a');

--- a/packages/code-studio/src/log/LogExport.ts
+++ b/packages/code-studio/src/log/LogExport.ts
@@ -70,13 +70,21 @@ function getReduxDataString(): string {
   );
 }
 
+function getMetadata(): string {
+  const metadata = {
+    uiVersion: process.env.REACT_APP_VERSION,
+    userAgent: navigator.userAgent,
+  };
+
+  return JSON.stringify(metadata, null, 2);
+}
+
 /**
  * Export support logs with the given name.
  * @param metadata Any extra metadata to be written to a metadata file
  * @param fileNamePrefix The zip file name without the .zip extension. Ex: test will be saved as test.zip
  */
 export async function exportLogs(
-  metadata = {},
   fileNamePrefix = `${dh.i18n.DateTimeFormat.format(
     FILENAME_DATE_FORMAT,
     new Date()
@@ -86,7 +94,7 @@ export async function exportLogs(
   const folder = zip.folder(fileNamePrefix) as JSZip;
   folder.file('console.txt', logHistory.getFormattedHistory());
   folder.file('redux.json', getReduxDataString());
-  folder.file('metadata.json', JSON.stringify(metadata, null, 2));
+  folder.file('metadata.json', getMetadata());
 
   const blob = await zip.generateAsync({ type: 'blob' });
   const link = document.createElement('a');

--- a/packages/code-studio/src/log/LogExport.ts
+++ b/packages/code-studio/src/log/LogExport.ts
@@ -81,7 +81,6 @@ function getMetadata(): string {
 
 /**
  * Export support logs with the given name.
- * @param metadata Any extra metadata to be written to a metadata file
  * @param fileNamePrefix The zip file name without the .zip extension. Ex: test will be saved as test.zip
  */
 export async function exportLogs(

--- a/packages/code-studio/src/log/LogExport.ts
+++ b/packages/code-studio/src/log/LogExport.ts
@@ -86,7 +86,7 @@ export async function exportLogs(
   const folder = zip.folder(fileNamePrefix) as JSZip;
   folder.file('console.txt', logHistory.getFormattedHistory());
   folder.file('redux.json', getReduxDataString());
-  folder.file('metadata', JSON.stringify(metadata));
+  folder.file('metadata.json', JSON.stringify(metadata));
 
   const blob = await zip.generateAsync({ type: 'blob' });
   const link = document.createElement('a');

--- a/packages/code-studio/src/settings/SettingsMenu.jsx
+++ b/packages/code-studio/src/settings/SettingsMenu.jsx
@@ -24,16 +24,8 @@ export class SettingsMenu extends Component {
     }
   }
 
-  static getVersion() {
-    return process.env.REACT_APP_VERSION;
-  }
-
   static handleExportSupportLogs() {
-    const metadata = {
-      uiVersion: SettingsMenu.getVersion(),
-      userAgent: navigator.userAgent,
-    };
-    exportLogs(metadata);
+    exportLogs();
   }
 
   constructor(props) {
@@ -76,7 +68,7 @@ export class SettingsMenu extends Component {
   }
 
   render() {
-    const version = SettingsMenu.getVersion();
+    const version = process.env.REACT_APP_VERSION;
     const supportLink = process.env.REACT_APP_SUPPORT_LINK;
     const docsLink = process.env.REACT_APP_DOCS_LINK;
 

--- a/packages/code-studio/src/settings/SettingsMenu.jsx
+++ b/packages/code-studio/src/settings/SettingsMenu.jsx
@@ -24,8 +24,15 @@ export class SettingsMenu extends Component {
     }
   }
 
+  static getVersion() {
+    return process.env.REACT_APP_VERSION;
+  }
+
   static handleExportSupportLogs() {
-    exportLogs();
+    const metadata = {
+      uiVersion: SettingsMenu.getVersion(),
+    };
+    exportLogs(metadata);
   }
 
   constructor(props) {
@@ -68,7 +75,7 @@ export class SettingsMenu extends Component {
   }
 
   render() {
-    const version = process.env.REACT_APP_VERSION;
+    const version = SettingsMenu.getVersion();
     const supportLink = process.env.REACT_APP_SUPPORT_LINK;
     const docsLink = process.env.REACT_APP_DOCS_LINK;
 

--- a/packages/code-studio/src/settings/SettingsMenu.jsx
+++ b/packages/code-studio/src/settings/SettingsMenu.jsx
@@ -31,6 +31,7 @@ export class SettingsMenu extends Component {
   static handleExportSupportLogs() {
     const metadata = {
       uiVersion: SettingsMenu.getVersion(),
+      userAgent: navigator.userAgent,
     };
     exportLogs(metadata);
   }


### PR DESCRIPTION
Fixes #196 

Adds a file `metadata.json` to the support log zip which currently just contains `uiVersion`