### PR TITLE
DH-11788: Enable count aggregations for non-rollups

### DIFF
--- a/packages/iris-grid/src/sidebar/aggregations/AggregationUtils.ts
+++ b/packages/iris-grid/src/sidebar/aggregations/AggregationUtils.ts
@@ -8,8 +8,7 @@ import AggregationOperation from './AggregationOperation';
  */
 export const isRollupOperation = (type: AggregationOperation): boolean => {
   switch (type) {
-    case AggregationOperation.COUNT:
-      return true;
+    // currently no rollup only operations, but there has been in the past
     default:
       return false;
   }


### PR DESCRIPTION
Count now works as an aggregation for non-rollups. There are no longer any that are rollup exclusively. Leaving code to allow it in future in case any new rollup only aggregation method gets added.