### PR TITLE
Cross column search does not restrict to selected columns

### DIFF
--- a/packages/iris-grid/src/CrossColumnSearch.jsx
+++ b/packages/iris-grid/src/CrossColumnSearch.jsx
@@ -22,7 +22,9 @@ class CrossColumnSearch extends PureComponent {
     invertSelection
   ) {
     const filterColumns = invertSelection
-      ? columns.filter(column => !selectedColumns.includes(column.name))
+      ? columns
+          .filter(column => !selectedColumns.includes(column.name))
+          .map(column => column.name)
       : selectedColumns;
     if (searchValue && filterColumns.length > 0) {
       const filterValue = dh.FilterValue.ofString(searchValue);


### PR DESCRIPTION
Fix the issue with cross-column search where it doesn't properly restrict to selected columns. Tested manually, unit tests pass.