### PR TITLE
Fix Send to Active Notebook functionality

### DIFF
--- a/packages/dashboard-core-plugins/src/ChartPlugin.tsx
+++ b/packages/dashboard-core-plugins/src/ChartPlugin.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentType, DragEvent, useCallback, useEffect } from 'react';
+import React, { DragEvent, useCallback, useEffect } from 'react';
 import { ChartModel } from '@deephaven/chart';
 import {
   DashboardPluginComponentProps,
@@ -59,11 +59,7 @@ export const ChartPlugin = ({
 
   useEffect(() => {
     const cleanups = [
-      registerComponent(
-        ChartPanel.COMPONENT,
-        (ChartPanel as unknown) as ComponentType,
-        hydrate
-      ),
+      registerComponent(ChartPanel.COMPONENT, ChartPanel, hydrate),
     ];
     return () => {
       cleanups.forEach(cleanup => cleanup());

--- a/packages/dashboard-core-plugins/src/ConsolePlugin.tsx
+++ b/packages/dashboard-core-plugins/src/ConsolePlugin.tsx
@@ -3,17 +3,12 @@ import {
   DashboardPluginComponentProps,
   LayoutUtils,
   PanelComponent,
+  PanelComponentType,
   useListener,
 } from '@deephaven/dashboard';
 import { FileUtils } from '@deephaven/file-explorer';
 import Log from '@deephaven/log';
-import React, {
-  ComponentType,
-  useCallback,
-  useEffect,
-  useRef,
-  useState,
-} from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import shortid from 'shortid';
 import { ConsoleEvent, NotebookEvent } from './events';
@@ -442,26 +437,14 @@ export const ConsolePlugin = ({
 
   useEffect(() => {
     const cleanups = [
-      registerComponent(
-        ConsolePanel.COMPONENT,
-        (ConsolePanel as unknown) as ComponentType
-      ),
-      registerComponent(
-        CommandHistoryPanel.COMPONENT,
-        (CommandHistoryPanel as unknown) as ComponentType
-      ),
+      registerComponent(ConsolePanel.COMPONENT, ConsolePanel),
+      registerComponent(CommandHistoryPanel.COMPONENT, CommandHistoryPanel),
       registerComponent(
         FileExplorerPanel.COMPONENT,
-        (FileExplorerPanel as unknown) as ComponentType
+        (FileExplorerPanel as unknown) as PanelComponentType
       ),
-      registerComponent(
-        LogPanel.COMPONENT,
-        (LogPanel as unknown) as ComponentType
-      ),
-      registerComponent(
-        NotebookPanel.COMPONENT,
-        (NotebookPanel as unknown) as ComponentType
-      ),
+      registerComponent(LogPanel.COMPONENT, LogPanel),
+      registerComponent(NotebookPanel.COMPONENT, NotebookPanel),
     ];
 
     return () => {

--- a/packages/dashboard-core-plugins/src/ConsolePlugin.tsx
+++ b/packages/dashboard-core-plugins/src/ConsolePlugin.tsx
@@ -3,7 +3,6 @@ import {
   DashboardPluginComponentProps,
   LayoutUtils,
   PanelComponent,
-  PanelComponentType,
   useListener,
 } from '@deephaven/dashboard';
 import { FileUtils } from '@deephaven/file-explorer';
@@ -48,7 +47,7 @@ export const ConsolePlugin = ({
   const dispatch = useDispatch();
 
   const getConsolePanel = useCallback(
-    () => panelManager.getLastUsedPanelOfType(ConsolePanel.WrappedComponent),
+    () => panelManager.getLastUsedPanelOfType(ConsolePanel),
     [panelManager]
   );
 
@@ -421,9 +420,7 @@ export const ConsolePlugin = ({
   /** Attempts to send the text to a notebook matching the passed in settings */
   const sendToNotebook = useCallback(
     (session, sessionLanguage, settings = {}, createIfNecessary = true) => {
-      const notebookPanel = panelManager.getLastUsedPanelOfType(
-        NotebookPanel.WrappedComponent
-      );
+      const notebookPanel = panelManager.getLastUsedPanelOfType(NotebookPanel);
       if (notebookPanel && isNotebookPanel(notebookPanel)) {
         if (settings && settings.value && notebookPanel.notebook) {
           notebookPanel.notebook.append(settings.value);
@@ -439,10 +436,7 @@ export const ConsolePlugin = ({
     const cleanups = [
       registerComponent(ConsolePanel.COMPONENT, ConsolePanel),
       registerComponent(CommandHistoryPanel.COMPONENT, CommandHistoryPanel),
-      registerComponent(
-        FileExplorerPanel.COMPONENT,
-        (FileExplorerPanel as unknown) as PanelComponentType
-      ),
+      registerComponent(FileExplorerPanel.COMPONENT, FileExplorerPanel),
       registerComponent(LogPanel.COMPONENT, LogPanel),
       registerComponent(NotebookPanel.COMPONENT, NotebookPanel),
     ];

--- a/packages/dashboard-core-plugins/src/FilterPlugin.tsx
+++ b/packages/dashboard-core-plugins/src/FilterPlugin.tsx
@@ -1,10 +1,4 @@
-import React, {
-  Component,
-  ComponentType,
-  useCallback,
-  useEffect,
-  useState,
-} from 'react';
+import React, { Component, useCallback, useEffect, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import shortid from 'shortid';
 import {
@@ -235,18 +229,9 @@ export const FilterPlugin = ({
 
   useEffect(() => {
     const cleanups = [
-      registerComponent(
-        DropdownFilterPanel.COMPONENT,
-        (DropdownFilterPanel as unknown) as ComponentType
-      ),
-      registerComponent(
-        InputFilterPanel.COMPONENT,
-        (InputFilterPanel as unknown) as ComponentType
-      ),
-      registerComponent(
-        FilterSetManagerPanel.COMPONENT,
-        (FilterSetManagerPanel as unknown) as ComponentType
-      ),
+      registerComponent(DropdownFilterPanel.COMPONENT, DropdownFilterPanel),
+      registerComponent(InputFilterPanel.COMPONENT, InputFilterPanel),
+      registerComponent(FilterSetManagerPanel.COMPONENT, FilterSetManagerPanel),
     ];
 
     return () => {

--- a/packages/dashboard-core-plugins/src/GridPlugin.tsx
+++ b/packages/dashboard-core-plugins/src/GridPlugin.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentType, DragEvent, useCallback, useEffect } from 'react';
+import React, { DragEvent, useCallback, useEffect } from 'react';
 import {
   DashboardPluginComponentProps,
   DashboardUtils,
@@ -65,11 +65,7 @@ export const GridPlugin = ({
 
   useEffect(() => {
     const cleanups = [
-      registerComponent(
-        IrisGridPanel.COMPONENT,
-        (IrisGridPanel as unknown) as ComponentType,
-        hydrate
-      ),
+      registerComponent(IrisGridPanel.COMPONENT, IrisGridPanel, hydrate),
     ];
     return () => {
       cleanups.forEach(cleanup => cleanup());

--- a/packages/dashboard-core-plugins/src/MarkdownPlugin.tsx
+++ b/packages/dashboard-core-plugins/src/MarkdownPlugin.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentType, useCallback, useEffect } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import shortid from 'shortid';
 import {
   DashboardPluginComponentProps,
@@ -88,7 +88,7 @@ export const MarkdownPlugin = ({
     const cleanups = [
       registerComponent(
         MarkdownPanel.COMPONENT,
-        (MarkdownPanel as unknown) as ComponentType,
+        MarkdownPanel,
         hydrate,
         dehydrateMarkdown
       ),

--- a/packages/dashboard-core-plugins/src/panels/FileExplorerPanel.tsx
+++ b/packages/dashboard-core-plugins/src/panels/FileExplorerPanel.tsx
@@ -1,3 +1,4 @@
+import { PanelProps } from '@deephaven/dashboard';
 import Log from '@deephaven/log';
 import { getFileStorage, RootState } from '@deephaven/redux';
 import FileExplorer, {
@@ -6,7 +7,6 @@ import FileExplorer, {
   FileStorageItem,
   NewItemModal,
 } from '@deephaven/file-explorer';
-import GoldenLayout from '@deephaven/golden-layout';
 import React, { ReactNode } from 'react';
 import { connect } from 'react-redux';
 import Panel from './Panel';
@@ -21,13 +21,11 @@ type DhSession = {
 };
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface FileExplorerPanelProps {
+export type FileExplorerPanelProps = {
   fileStorage: FileStorage;
-  glContainer: GoldenLayout.Container;
-  glEventHub: GoldenLayout.EventEmitter;
   language: string;
   session?: DhSession;
-}
+} & PanelProps;
 
 export interface FileExplorerPanelState {
   isShown: boolean;

--- a/packages/dashboard/src/DashboardLayout.tsx
+++ b/packages/dashboard/src/DashboardLayout.tsx
@@ -1,5 +1,4 @@
 import React, {
-  ComponentType,
   ReactElement,
   useCallback,
   useEffect,
@@ -21,6 +20,7 @@ import {
 import PanelEvent from './PanelEvent';
 import { GLPropTypes, useListener } from './layout';
 import { getDashboardData, updateDashboardData } from './redux';
+import { PanelComponentType } from './DashboardPlugin';
 
 export type DashboardLayoutConfig = ItemConfigType[];
 
@@ -75,7 +75,7 @@ export const DashboardLayout = ({
   const registerComponent = useCallback(
     (
       name: string,
-      componentType: ComponentType,
+      componentType: PanelComponentType,
       hydrate = hydrateDefault,
       dehydrate = dehydrateDefault
     ) => {

--- a/packages/dashboard/src/DashboardPlugin.ts
+++ b/packages/dashboard/src/DashboardPlugin.ts
@@ -1,6 +1,24 @@
-import { Component, ComponentType } from 'react';
+import { Component, ComponentClass, ComponentType } from 'react';
+import { ConnectedComponent } from 'react-redux';
 import GoldenLayout, { ReactComponentConfig } from '@deephaven/golden-layout';
 import PanelManager from './PanelManager';
+
+export type WrappedComponentType<
+  C extends ComponentClass,
+  P extends PanelProps
+> = ConnectedComponent<C, P>;
+
+export type PanelComponentType<
+  C extends ComponentClass = ComponentClass,
+  P extends PanelProps = PanelProps
+> = ComponentType | WrappedComponentType<C, P>;
+
+export function isWrappedComponent<
+  C extends ComponentClass,
+  P extends PanelProps
+>(type: PanelComponentType<C, P>): type is WrappedComponentType<C, P> {
+  return (type as WrappedComponentType<C, P>)?.WrappedComponent !== undefined;
+}
 
 export type PanelProps = {
   glContainer: GoldenLayout.Container;
@@ -40,9 +58,9 @@ export type DashboardPluginComponentProps = {
   id: string;
   layout: GoldenLayout;
   panelManager: PanelManager;
-  registerComponent: (
+  registerComponent: <C extends ComponentClass, P extends PanelProps>(
     name: string,
-    ComponentType: ComponentType,
+    ComponentType: PanelComponentType<C, P>,
     hydrate?: PanelHydrateFunction,
     dehydrate?: PanelDehydrateFunction
   ) => DeregisterComponentFunction;

--- a/packages/dashboard/src/DashboardPlugin.ts
+++ b/packages/dashboard/src/DashboardPlugin.ts
@@ -1,23 +1,23 @@
-import { Component, ComponentClass, ComponentType } from 'react';
+import { Component, ComponentType } from 'react';
 import { ConnectedComponent } from 'react-redux';
 import GoldenLayout, { ReactComponentConfig } from '@deephaven/golden-layout';
 import PanelManager from './PanelManager';
 
 export type WrappedComponentType<
-  C extends ComponentClass,
-  P extends PanelProps
+  P extends PanelProps,
+  C extends ComponentType<P>
 > = ConnectedComponent<C, P>;
 
 export type PanelComponentType<
-  C extends ComponentClass = ComponentClass,
-  P extends PanelProps = PanelProps
-> = ComponentType | WrappedComponentType<C, P>;
+  P extends PanelProps = PanelProps,
+  C extends ComponentType<P> = ComponentType<P>
+> = ComponentType<P> | WrappedComponentType<P, C>;
 
 export function isWrappedComponent<
-  C extends ComponentClass,
-  P extends PanelProps
->(type: PanelComponentType<C, P>): type is WrappedComponentType<C, P> {
-  return (type as WrappedComponentType<C, P>)?.WrappedComponent !== undefined;
+  P extends PanelProps,
+  C extends ComponentType<P>
+>(type: PanelComponentType<P, C>): type is WrappedComponentType<P, C> {
+  return (type as WrappedComponentType<P, C>)?.WrappedComponent !== undefined;
 }
 
 export type PanelProps = {
@@ -58,9 +58,9 @@ export type DashboardPluginComponentProps = {
   id: string;
   layout: GoldenLayout;
   panelManager: PanelManager;
-  registerComponent: <C extends ComponentClass, P extends PanelProps>(
+  registerComponent: <P extends PanelProps, C extends ComponentType<P>>(
     name: string,
-    ComponentType: PanelComponentType<C, P>,
+    ComponentType: PanelComponentType<P, C>,
     hydrate?: PanelHydrateFunction,
     dehydrate?: PanelDehydrateFunction
   ) => DeregisterComponentFunction;

--- a/packages/dashboard/src/PanelManager.test.ts
+++ b/packages/dashboard/src/PanelManager.test.ts
@@ -72,3 +72,24 @@ it('gets last used panel of type properly', () => {
   layout.eventHub.emit(PanelEvent.UNMOUNT, panelA);
   layout.eventHub.emit(PanelEvent.UNMOUNT, panelB);
 });
+
+it('get last used panel for multiple types', () => {
+  const layout = makeLayout();
+  const panelManager = new PanelManager(layout);
+
+  const panelA = new TestComponentA();
+  const panelB = new TestComponentB();
+  layout.eventHub.emit(PanelEvent.MOUNT, panelA);
+  layout.eventHub.emit(PanelEvent.MOUNT, panelB);
+
+  expect(panelManager.getLastUsedPanelOfTypes([TestComponentA])).toBe(panelA);
+  expect(
+    panelManager.getLastUsedPanelOfTypes([TestComponentA, TestComponentB])
+  ).toBe(panelB);
+  expect(
+    panelManager.getLastUsedPanelOfTypes([TestComponentB, TestComponentB])
+  ).toBe(panelB);
+
+  layout.eventHub.emit(PanelEvent.UNMOUNT, panelA);
+  layout.eventHub.emit(PanelEvent.UNMOUNT, panelB);
+});

--- a/packages/dashboard/src/PanelManager.test.ts
+++ b/packages/dashboard/src/PanelManager.test.ts
@@ -1,37 +1,53 @@
+/* eslint-disable react/prop-types */
 /* eslint react/prefer-stateless-function: "off" */
 /* eslint react/no-multi-comp: "off" */
 /* eslint max-classes-per-file: "off" */
 
 import { Component } from 'react';
-import GoldenLayout from '@deephaven/golden-layout';
+import GoldenLayout, { ContentItem, Tab } from '@deephaven/golden-layout';
 import './layout/jquery';
 import PanelManager from './PanelManager';
 import PanelEvent from './PanelEvent';
+import { PanelProps } from './DashboardPlugin';
 
-type TestComponentProps = { id?: string };
+type TestComponentProps = { id: string } & PanelProps;
 
-class TestComponentA extends Component {
-  constructor({ id = 'A' }: TestComponentProps = {}) {
-    super({ glContainer: { tab: { contentItem: { config: { id } } } } });
-  }
+class TestComponentA extends Component<TestComponentProps> {}
 
-  render() {
-    return null;
-  }
+class TestComponentB extends Component<TestComponentProps> {}
+
+function makeContainer(id: string): GoldenLayout.Container {
+  return {
+    tab: {
+      contentItem: {
+        config: { id, component: 'TestComponentA', type: 'TestComponentA' },
+      } as ContentItem,
+    } as Tab,
+  } as GoldenLayout.Container;
 }
 
-class TestComponentB extends Component {
-  constructor({ id = 'B' }: TestComponentProps = {}) {
-    super({ glContainer: { tab: { contentItem: { config: { id } } } } });
-  }
-
-  render() {
-    return null;
-  }
+function makeEventHub(): GoldenLayout.EventEmitter {
+  return {} as GoldenLayout.EventEmitter;
 }
 
 function makeLayout() {
   return new GoldenLayout({});
+}
+
+function makeProps(id: string): TestComponentProps {
+  return {
+    id,
+    glContainer: makeContainer(id),
+    glEventHub: makeEventHub(),
+  };
+}
+
+function makeComponentA(id = 'A'): TestComponentA {
+  return new TestComponentA(makeProps(id));
+}
+
+function makeComponentB(id = 'B'): TestComponentB {
+  return new TestComponentB(makeProps(id));
 }
 
 it('creates without crashing', () => {
@@ -44,7 +60,7 @@ it('handles panels mounting and unmounting', () => {
   const layout = makeLayout();
   const panelManager = new PanelManager(layout);
 
-  const panel = new TestComponentA();
+  const panel = makeComponentA();
   layout.eventHub.emit(PanelEvent.MOUNT, panel);
 
   let opened = panelManager.getOpenedPanels();
@@ -61,8 +77,8 @@ it('gets last used panel of type properly', () => {
   const layout = makeLayout();
   const panelManager = new PanelManager(layout);
 
-  const panelA = new TestComponentA();
-  const panelB = new TestComponentB();
+  const panelA = makeComponentA();
+  const panelB = makeComponentB();
   layout.eventHub.emit(PanelEvent.MOUNT, panelA);
   layout.eventHub.emit(PanelEvent.MOUNT, panelB);
 
@@ -77,8 +93,8 @@ it('get last used panel for multiple types', () => {
   const layout = makeLayout();
   const panelManager = new PanelManager(layout);
 
-  const panelA = new TestComponentA();
-  const panelB = new TestComponentB();
+  const panelA = makeComponentA();
+  const panelB = makeComponentB();
   layout.eventHub.emit(PanelEvent.MOUNT, panelA);
   layout.eventHub.emit(PanelEvent.MOUNT, panelB);
 
@@ -87,7 +103,7 @@ it('get last used panel for multiple types', () => {
     panelManager.getLastUsedPanelOfTypes([TestComponentA, TestComponentB])
   ).toBe(panelB);
   expect(
-    panelManager.getLastUsedPanelOfTypes([TestComponentB, TestComponentB])
+    panelManager.getLastUsedPanelOfTypes([TestComponentB, TestComponentA])
   ).toBe(panelB);
 
   layout.eventHub.emit(PanelEvent.UNMOUNT, panelA);

--- a/packages/dashboard/src/PanelManager.ts
+++ b/packages/dashboard/src/PanelManager.ts
@@ -1,3 +1,4 @@
+import { ComponentType } from 'react';
 import GoldenLayout, { ReactComponentConfig } from '@deephaven/golden-layout';
 import Log from '@deephaven/log';
 import PanelEvent from './PanelEvent';
@@ -162,13 +163,17 @@ class PanelManager {
     return undefined;
   }
 
-  getLastUsedPanelOfType(type: PanelComponentType): PanelComponent | undefined {
+  getLastUsedPanelOfType<
+    P extends PanelProps = PanelProps,
+    C extends ComponentType<P> = ComponentType<P>
+  >(type: PanelComponentType<P, C>): PanelComponent<P> | undefined {
     return this.getLastUsedPanelOfTypes([type]);
   }
 
-  getLastUsedPanelOfTypes(
-    types: PanelComponentType[]
-  ): PanelComponent | undefined {
+  getLastUsedPanelOfTypes<
+    P extends PanelProps = PanelProps,
+    C extends ComponentType<P> = ComponentType<P>
+  >(types: PanelComponentType<P, C>[]): PanelComponent<P> | undefined {
     return this.getLastUsedPanel(panel =>
       types.some(
         type =>

--- a/packages/dashboard/src/PanelManager.ts
+++ b/packages/dashboard/src/PanelManager.ts
@@ -1,9 +1,9 @@
-import { ComponentType } from 'react';
 import GoldenLayout, { ReactComponentConfig } from '@deephaven/golden-layout';
 import Log from '@deephaven/log';
 import PanelEvent from './PanelEvent';
 import LayoutUtils from './layout/LayoutUtils';
 import { PanelComponent, PanelProps } from './DashboardPlugin';
+import { isWrappedComponent, PanelComponentType } from '.';
 
 const log = Log.module('PanelManager');
 
@@ -162,8 +162,22 @@ class PanelManager {
     return undefined;
   }
 
-  getLastUsedPanelOfType(type: ComponentType): PanelComponent | undefined {
-    return this.getLastUsedPanel(panel => panel instanceof type);
+  getLastUsedPanelOfType(type: PanelComponentType): PanelComponent | undefined {
+    return this.getLastUsedPanelOfTypes([type]);
+  }
+
+  getLastUsedPanelOfTypes(
+    types: PanelComponentType[]
+  ): PanelComponent | undefined {
+    return this.getLastUsedPanel(panel =>
+      types.some(
+        type =>
+          panel instanceof type ||
+          (isWrappedComponent(type) &&
+            type.WrappedComponent &&
+            panel instanceof type.WrappedComponent)
+      )
+    );
   }
 
   updatePanel(panel: PanelComponent): void {


### PR DESCRIPTION
- Added `getLastUsedPanelOfTypes` to PanelManager (will be needed for Enterprise)
- Clean up some of the TypeScript types
