### PR TITLE
Fix autoresizetextarea default height in Firefox

### DIFF
--- a/packages/components/src/AutoResizeTextarea.tsx
+++ b/packages/components/src/AutoResizeTextarea.tsx
@@ -62,7 +62,7 @@ const AutoResizeTextarea = ({
     if (!element.current) {
       return;
     }
-    element.current.style.height = 'auto'; // needed to allow component to shrink
+    element.current.style.height = '0'; // shrink component to get scrollHeight
     const resizedHeight =
       element.current.scrollHeight +
       (element.current.offsetHeight - element.current.clientHeight);


### PR DESCRIPTION
Fixes difference in default size in FF, chrome was fine with either.

Firefox calculates scrollHeight differently then chrome with height auto. Setting height 0 instead makes them both behave the same. Component is setting height to 0, getting the scrollHeight, then setting component to that height.
![image](https://user-images.githubusercontent.com/1576283/145595283-b1faf488-baaa-4d9d-948e-7d3376edc1d4.png)

Screenshot shows chrome left/firefox right. After this change they both behave like chrome screenshot.
