### PR TITLE
Don't trigger console csv upload overlay if dragging text

### DIFF
--- a/packages/components/src/Button.tsx
+++ b/packages/components/src/Button.tsx
@@ -29,7 +29,7 @@ interface BaseButtonProps {
   icon?: IconDefinition | JSX.Element;
   disabled?: boolean;
   active?: boolean;
-  onClick: React.MouseEventHandler<HTMLButtonElement>;
+  onClick?: React.MouseEventHandler<HTMLButtonElement>;
   children?: React.ReactNode;
   className?: string;
   style?: React.CSSProperties;
@@ -180,7 +180,16 @@ Button.propTypes = {
   },
   disabled: PropTypes.bool,
   active: PropTypes.bool,
-  onClick: PropTypes.func.isRequired,
+  onClick(props) {
+    const { onClick, type } = props;
+    if (type === 'button' && typeof onClick !== 'function') {
+      return new Error('type button requires an onClick function');
+    }
+    if (onClick !== undefined && typeof onClick !== 'function') {
+      return new Error('onClick must be a function');
+    }
+    return null;
+  },
   children: PropTypes.node,
   className: PropTypes.string,
   style: PropTypes.object,
@@ -188,6 +197,7 @@ Button.propTypes = {
 
 Button.defaultProps = {
   type: 'button',
+  onClick: undefined,
   variant: undefined,
   tooltip: undefined,
   icon: undefined,

--- a/packages/components/src/Button.tsx
+++ b/packages/components/src/Button.tsx
@@ -21,32 +21,22 @@ const VARIANT_KINDS = ['group-end'] as const;
 type VariantTuple = typeof VARIANT_KINDS;
 type VariantKind = VariantTuple[number];
 
-type BaseButtonProps = {
+type ButtonTypes = 'submit' | 'reset' | 'button';
+
+interface BaseButtonProps extends React.ComponentPropsWithRef<'button'> {
   kind: ButtonKind;
+  type?: ButtonTypes;
   variant?: VariantKind;
-  type?: 'button' | 'reset' | 'submit';
   tooltip?: string | JSX.Element;
   icon?: IconDefinition | JSX.Element;
-  disabled?: boolean;
   active?: boolean;
-  onClick?: React.MouseEventHandler<HTMLButtonElement>;
-  children?: React.ReactNode;
-  className?: string;
-  style?: React.CSSProperties;
-};
+}
 
-type ButtonButtonProps = BaseButtonProps & {
-  type?: 'button';
-  onClick: React.MouseEventHandler<HTMLButtonElement>;
-};
-
-type ButtonWithTypeProps = ButtonButtonProps | BaseButtonProps;
-
-type ButtonWithChildren = ButtonWithTypeProps & {
+type ButtonWithChildren = BaseButtonProps & {
   children: React.ReactNode;
 };
 
-type IconOnlyButton = ButtonWithTypeProps & {
+type IconOnlyButton = BaseButtonProps & {
   tooltip: string | JSX.Element;
   icon: IconDefinition | JSX.Element;
   children?: undefined;
@@ -94,9 +84,9 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       disabled,
       active,
       onClick,
-      children,
       className,
       style,
+      children,
     } = props;
 
     const iconOnly = (icon && !children) as boolean;
@@ -163,7 +153,7 @@ Button.displayName = 'Button';
 Button.propTypes = {
   kind: PropTypes.oneOf(BUTTON_KINDS).isRequired,
   variant: PropTypes.oneOf(VARIANT_KINDS),
-  type: PropTypes.oneOf(['button', 'reset', 'submit']),
+  type: PropTypes.oneOf<ButtonTypes>(['submit', 'reset', 'button']),
   tooltip(props) {
     const { tooltip, icon, children } = props;
     if (!tooltip && icon && !children) {

--- a/packages/components/src/Button.tsx
+++ b/packages/components/src/Button.tsx
@@ -21,7 +21,7 @@ const VARIANT_KINDS = ['group-end'] as const;
 type VariantTuple = typeof VARIANT_KINDS;
 type VariantKind = VariantTuple[number];
 
-interface BaseButtonProps {
+type BaseButtonProps = {
   kind: ButtonKind;
   variant?: VariantKind;
   type?: 'button' | 'reset' | 'submit';
@@ -33,17 +33,24 @@ interface BaseButtonProps {
   children?: React.ReactNode;
   className?: string;
   style?: React.CSSProperties;
-}
+};
 
-interface ButtonWithChildren extends BaseButtonProps {
+type ButtonButtonProps = BaseButtonProps & {
+  type?: 'button';
+  onClick: React.MouseEventHandler<HTMLButtonElement>;
+};
+
+type ButtonWithTypeProps = ButtonButtonProps | BaseButtonProps;
+
+type ButtonWithChildren = ButtonWithTypeProps & {
   children: React.ReactNode;
-}
+};
 
-interface IconOnlyButton extends BaseButtonProps {
+type IconOnlyButton = ButtonWithTypeProps & {
   tooltip: string | JSX.Element;
   icon: IconDefinition | JSX.Element;
   children?: undefined;
-}
+};
 
 type ButtonProps = IconOnlyButton | ButtonWithChildren;
 

--- a/packages/console/src/Console.jsx
+++ b/packages/console/src/Console.jsx
@@ -554,7 +554,8 @@ export class Console extends PureComponent {
     if (
       !e.dataTransfer ||
       !e.dataTransfer.items ||
-      e.dataTransfer.items.length === 0
+      e.dataTransfer.items.length === 0 ||
+      e.dataTransfer.items[0].kind === 'string'
     ) {
       return;
     }
@@ -565,6 +566,7 @@ export class Console extends PureComponent {
     const { items } = e.dataTransfer;
     if (items.length > 1) {
       this.setState({ dragError: CsvOverlay.MULTIPLE_FILE_ERROR });
+      return;
     }
 
     const item = items[0];

--- a/packages/console/src/csv/CsvOverlay.jsx
+++ b/packages/console/src/csv/CsvOverlay.jsx
@@ -21,7 +21,7 @@ const INVALID_MIME_TYPES = [/^audio.*/, /^font.*/, /^image.*/, /^video.*/];
  * Overlay that is displayed when uploading a CSV file.
  */
 class CsvOverlay extends Component {
-  static MULTIPLE_FILE_ERROR = 'Please select one file';
+  static MULTIPLE_FILE_ERROR = 'Please select only one file';
 
   static FILE_TYPE_ERROR = 'Filetype not supported.';
 


### PR DESCRIPTION
- You can select text and drag it in a browser (kind == "string"), this shouldn't trigger the csv overlay
- Fix Button component proptype error with "type" other than button requiring an onClick function ex. (csv overlay bar, type=submit)
- Multiple file error should return, as filetype error can replace it