### PR TITLE
Fix a couple of imports

### DIFF
--- a/packages/components/src/context-actions/ContextActions.test.tsx
+++ b/packages/components/src/context-actions/ContextActions.test.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import TestRenderer from 'react-test-renderer';
 import { TestUtils } from '@deephaven/utils';
-import { ContextMenuRoot, ContextActionUtils } from '.';
+import ContextActionUtils from './ContextActionUtils';
+import ContextMenuRoot from './ContextMenuRoot';
 
 type ContextMenuMock = {
   addEventListener: jest.Mock<void>;

--- a/packages/dashboard/src/PanelManager.ts
+++ b/packages/dashboard/src/PanelManager.ts
@@ -3,8 +3,12 @@ import GoldenLayout, { ReactComponentConfig } from '@deephaven/golden-layout';
 import Log from '@deephaven/log';
 import PanelEvent from './PanelEvent';
 import LayoutUtils from './layout/LayoutUtils';
-import { PanelComponent, PanelProps } from './DashboardPlugin';
-import { isWrappedComponent, PanelComponentType } from '.';
+import {
+  isWrappedComponent,
+  PanelComponent,
+  PanelComponentType,
+  PanelProps,
+} from './DashboardPlugin';
 
 const log = Log.module('PanelManager');
 


### PR DESCRIPTION
- VSCode likes to default to importing from the local index.ts file, which causes a circular import. This in turn breaks some mocks that `requireActual`. Fix up the imports to import directly from the file rather than from the index.
