### PR TITLE
Make jsapi-shim more robust

### DIFF
--- a/packages/jsapi-shim/src/dh.js
+++ b/packages/jsapi-shim/src/dh.js
@@ -1,6 +1,17 @@
 // The Deephaven API script isn't packaged as a module (yet), and is just included in index.html, exported to the global namespace
 // This include file is simply a wrapper so that it behaves like a module, and can be mocked easily for unit tests.
 // https://github.com/facebook/create-react-app/blob/master/packages/react-scripts/template/README.md#using-global-variables
-const { dh } = window;
+
+/* eslint-disable no-console */
+// eslint-disable-next-line import/no-mutable-exports
+let dh;
+try {
+  dh = window.dh;
+  if (!dh) {
+    console.error('dh API not defined on the window');
+  }
+} catch {
+  console.error('window is not defined');
+}
 
 export default dh;

--- a/packages/jsapi-shim/src/dh.ts
+++ b/packages/jsapi-shim/src/dh.ts
@@ -1,24 +1,12 @@
 // The Deephaven API script isn't packaged as a module (yet), and is just included in index.html, exported to the global namespace
 // This include file is simply a wrapper so that it behaves like a module, and can be mocked easily for unit tests.
 // https://github.com/facebook/create-react-app/blob/master/packages/react-scripts/template/README.md#using-global-variables
-/* eslint-disable @typescript-eslint/no-explicit-any */
-/* eslint-disable no-console */
 
 declare global {
-  interface Window {
-    dh: any;
-  }
+  // eslint-disable-next-line vars-on-top,no-var,@typescript-eslint/no-explicit-any
+  var dh: any;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any, import/no-mutable-exports
-let dh: any;
-try {
-  dh = window.dh;
-  if (!dh) {
-    console.error('dh API not defined on the window');
-  }
-} catch {
-  console.error('window is not defined');
-}
+const { dh } = globalThis;
 
 export default dh;

--- a/packages/jsapi-shim/src/dh.ts
+++ b/packages/jsapi-shim/src/dh.ts
@@ -1,10 +1,17 @@
 // The Deephaven API script isn't packaged as a module (yet), and is just included in index.html, exported to the global namespace
 // This include file is simply a wrapper so that it behaves like a module, and can be mocked easily for unit tests.
 // https://github.com/facebook/create-react-app/blob/master/packages/react-scripts/template/README.md#using-global-variables
-
+/* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable no-console */
-// eslint-disable-next-line import/no-mutable-exports
-let dh;
+
+declare global {
+  interface Window {
+    dh: any;
+  }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any, import/no-mutable-exports
+let dh: any;
 try {
   dh = window.dh;
   if (!dh) {


### PR DESCRIPTION
This is getting very annoying to work around in docs since SSR has no window object and can't be defined globally it seems due to module scope/whatever environment the SSR on docs runs in. The global workaround I've used for Node in other places doesn't work w/ the docs SSR.

This shouldn't affect anything for our app and just make the shim function in docs SSR. The API isn't actually used in SSR, but the utils import the shim which then errors out since window is undefined