### PR TITLE
Export links and filterSets with layout

### DIFF
--- a/packages/code-studio/src/main/AppMainContainer.test.jsx
+++ b/packages/code-studio/src/main/AppMainContainer.test.jsx
@@ -23,6 +23,7 @@ function makeAppMainContainer({
   user = TestUtils.REGULAR_USER,
   dashboardData = {},
   saveWorkspace = jest.fn(() => Promise.resolve()),
+  updateDashboardData = jest.fn(() => Promise.resolve()),
   updateWorkspaceData = jest.fn(() => Promise.resolve()),
   workspace = { data: {} },
   workspaceStorage = new LocalWorkspaceStorage(),
@@ -39,6 +40,7 @@ function makeAppMainContainer({
       dashboardData={dashboardData}
       layoutStorage={layoutStorage}
       saveWorkspace={saveWorkspace}
+      updateDashboardData={updateDashboardData}
       updateWorkspaceData={updateWorkspaceData}
       user={user}
       workspace={workspace}


### PR DESCRIPTION
- Export links and filterSets in addition to the layoutConfig
- Add a version to the exported layout
- Add support for importing legacy version of layout
- Fixes #314
