### PR TITLE
Deep linking notebooks

### DIFF
--- a/packages/code-studio/.env
+++ b/packages/code-studio/.env
@@ -3,7 +3,7 @@
 REACT_APP_CORE_API_URL=/jsapi
 REACT_APP_CORE_API_NAME=dh-core.js
 REACT_APP_OPEN_API_NAME=dh-internal.js
-REACT_APP_ROUTER_BASE_NAME=/ide/
+PUBLIC_URL=/ide/
 REACT_APP_VERSION=$npm_package_version
 REACT_APP_NAME=$npm_package_name
 REACT_APP_PLUGIN_URL=/ide/plugins/

--- a/packages/code-studio/.env.development
+++ b/packages/code-studio/.env.development
@@ -5,7 +5,7 @@ REACT_APP_ENABLE_LOG_PROXY=false
 # https://github.com/facebook/create-react-app/issues/5280
 REACT_APP_CORE_API_URL=http://localhost:10000/jsapi
 
-REACT_APP_ROUTER_BASE_NAME=/
+PUBLIC_URL=/
 REACT_APP_INTERNAL_PLUGINS=ExamplePlugin
 PORT=4000
 

--- a/packages/code-studio/package.json
+++ b/packages/code-studio/package.json
@@ -92,6 +92,7 @@
     "@types/react": "^16.14.8",
     "@types/react-beautiful-dnd": "^13.0.0",
     "@types/react-dom": "^16.9.13",
+    "@types/react-router-dom": "^5.1.2",
     "@types/react-transition-group": "^4.4.0",
     "cross-env": "^7.0.2",
     "npm-license": "^0.3.3",

--- a/packages/code-studio/src/DownloadServiceWorkerUtils.js
+++ b/packages/code-studio/src/DownloadServiceWorkerUtils.js
@@ -18,9 +18,7 @@ class DownloadServiceWorkerUtils {
       window.addEventListener('load', () => {
         const swUrl = new URL(
           `${
-            process.env.REACT_APP_ROUTER_BASE_NAME
-              ? `${process.env.REACT_APP_ROUTER_BASE_NAME}`
-              : ''
+            process.env.PUBLIC_URL ? `${process.env.PUBLIC_URL}` : ''
           }download/serviceWorker.js`,
           window.location.href
         );

--- a/packages/code-studio/src/main/AppMainContainer.jsx
+++ b/packages/code-studio/src/main/AppMainContainer.jsx
@@ -245,11 +245,16 @@ export class AppMainContainer extends Component {
         );
       } else {
         // Focus the notebook within its stack if it is already open
+        // Can't use SELECT_NOTEBOOK event
+        // At this stage, the openFileMap in ConsolePlugin is not initialized yet
+        // This causes the file open check to fail since the notebooks haven't initialized
+        // Emitting SELECT_NOTEBOOK will open a 2nd copy of the notebook
         const notebookPanel = LayoutUtils.getContentItemInStack(
           notebookStack,
           panelConfig
         );
-        LayoutUtils.openComponentInStack(notebookStack, notebookPanel.config);
+        notebookPanel.config.props.panelState.isPreview = false;
+        LayoutUtils.activateTab(this.goldenLayout.root, notebookPanel.config);
       }
     }
   }

--- a/packages/code-studio/src/main/AppMainContainer.jsx
+++ b/packages/code-studio/src/main/AppMainContainer.jsx
@@ -17,7 +17,6 @@ import Dashboard, {
   DEFAULT_DASHBOARD_ID,
   getDashboardData,
   updateDashboardData as updateDashboardDataAction,
-  LayoutUtils,
 } from '@deephaven/dashboard';
 import {
   ChartEvent,
@@ -224,38 +223,14 @@ export class AppMainContainer extends Component {
         language,
       };
 
-      const panelConfig = {
-        props: { panelState: { fileMetadata } },
-      };
-
-      const notebookStack = LayoutUtils.getStackForConfig(
-        this.goldenLayout.root,
-        panelConfig
+      this.emitLayoutEvent(
+        NotebookEvent.SELECT_NOTEBOOK,
+        session,
+        language,
+        notebookSettings,
+        fileMetadata,
+        true
       );
-
-      if (!notebookStack) {
-        // Open the notebook if it isn't open anywhere
-        this.emitLayoutEvent(
-          NotebookEvent.SELECT_NOTEBOOK,
-          session,
-          language,
-          notebookSettings,
-          fileMetadata,
-          true
-        );
-      } else {
-        // Focus the notebook within its stack if it is already open
-        // Can't use SELECT_NOTEBOOK event
-        // At this stage, the openFileMap in ConsolePlugin is not initialized yet
-        // This causes the file open check to fail since the notebooks haven't initialized
-        // Emitting SELECT_NOTEBOOK will open a 2nd copy of the notebook
-        const notebookPanel = LayoutUtils.getContentItemInStack(
-          notebookStack,
-          panelConfig
-        );
-        notebookPanel.config.props.panelState.isPreview = false;
-        LayoutUtils.activateTab(this.goldenLayout.root, notebookPanel.config);
-      }
     }
   }
 

--- a/packages/code-studio/src/main/AppRouter.jsx
+++ b/packages/code-studio/src/main/AppRouter.jsx
@@ -12,6 +12,7 @@ const AppRouter = () => (
   <Router basename={process.env.REACT_APP_ROUTER_BASE_NAME}>
     <Switch>
       <Route exact path="/" component={AppInit} />
+      <Route path="/notebook/:notebookPath+" component={AppInit} />
       <Route path="/styleguide" component={StyleGuideInit} />
       <Redirect from="*" to="/" />
     </Switch>

--- a/packages/code-studio/src/main/AppRouter.jsx
+++ b/packages/code-studio/src/main/AppRouter.jsx
@@ -9,7 +9,7 @@ import AppInit from './AppInit';
 import StyleGuideInit from '../styleguide/StyleGuideInit';
 
 const AppRouter = () => (
-  <Router basename={process.env.REACT_APP_ROUTER_BASE_NAME}>
+  <Router basename={process.env.PUBLIC_URL}>
     <Switch>
       <Route exact path="/" component={AppInit} />
       <Route path="/notebook/:notebookPath+" component={AppInit} />

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -38,6 +38,7 @@
     "@deephaven/react-hooks": "^0.9.0",
     "deep-equal": "^2.0.4",
     "jquery": "^3.5.1",
+    "lodash.ismatch": "^4.1.1",
     "lodash.throttle": "^4.1.1",
     "prop-types": "^15.7.2",
     "shortid": "^2.2.15"

--- a/packages/dashboard/src/Dashboard.tsx
+++ b/packages/dashboard/src/Dashboard.tsx
@@ -28,6 +28,7 @@ export type DashboardProps = {
   layoutSettings?: Record<string, unknown>;
   onLayoutConfigChange?: () => void;
   onGoldenLayoutChange?: (goldenLayout: GoldenLayout) => void;
+  onLayoutInitialized?: () => void;
   fallbackComponent?: ForwardRefExoticComponent<RefAttributes<unknown>>;
 };
 
@@ -39,6 +40,7 @@ export const Dashboard = ({
   layoutSettings = EMPTY_OBJECT,
   onLayoutConfigChange = DEFAULT_CALLBACK,
   onGoldenLayoutChange = DEFAULT_CALLBACK,
+  onLayoutInitialized = DEFAULT_CALLBACK,
   fallbackComponent = PanelPlaceholder,
 }: DashboardProps): JSX.Element => {
   const layoutElement = useRef<HTMLDivElement>(null);
@@ -111,6 +113,7 @@ export const Dashboard = ({
           layout={layout}
           layoutConfig={layoutConfig}
           onLayoutChange={onLayoutConfigChange}
+          onLayoutInitialized={onLayoutInitialized}
         >
           {children}
         </DashboardLayout>

--- a/packages/dashboard/src/DashboardLayout.tsx
+++ b/packages/dashboard/src/DashboardLayout.tsx
@@ -70,6 +70,7 @@ export const DashboardLayout = ({
   const [isItemDragging, setIsItemDragging] = useState(false);
   const [lastConfig, setLastConfig] = useState<DashboardLayoutConfig>();
   const [initialClosedPanels] = useState(data?.closed ?? []);
+  const [isDashboardInitialized, setIsDashboardInitialized] = useState(false);
 
   const hydrateMap = useMemo(() => new Map(), []);
   const dehydrateMap = useMemo(() => new Map(), []);
@@ -151,6 +152,11 @@ export const DashboardLayout = ({
     // we risk the last saved state being one without that panel in the layout entirely
     if (isItemDragging) return;
 
+    if (!isDashboardInitialized) {
+      onLayoutInitialized();
+      setIsDashboardInitialized(true);
+    }
+
     const glConfig = layout.toConfig();
     const contentConfig = glConfig.content;
     const dehydratedLayoutConfig = LayoutUtils.dehydrateLayoutConfig(
@@ -175,7 +181,15 @@ export const DashboardLayout = ({
 
       onLayoutChange(dehydratedLayoutConfig);
     }
-  }, [dehydrateComponent, isItemDragging, lastConfig, layout, onLayoutChange]);
+  }, [
+    dehydrateComponent,
+    isDashboardInitialized,
+    isItemDragging,
+    lastConfig,
+    layout,
+    onLayoutChange,
+    onLayoutInitialized,
+  ]);
 
   const handleLayoutItemPickedUp = useCallback(() => {
     setIsItemDragging(true);
@@ -228,7 +242,6 @@ export const DashboardLayout = ({
       }
 
       setIsDashboardEmpty(layout.root.contentItems.length === 0);
-      onLayoutInitialized();
     }
   }, [
     hydrateComponent,
@@ -237,7 +250,6 @@ export const DashboardLayout = ({
     lastConfig,
     panelManager,
     previousLayoutConfig,
-    onLayoutInitialized,
   ]);
 
   return (

--- a/packages/dashboard/src/DashboardLayout.tsx
+++ b/packages/dashboard/src/DashboardLayout.tsx
@@ -44,6 +44,7 @@ interface DashboardLayoutProps {
   layout: GoldenLayout;
   layoutConfig?: DashboardLayoutConfig;
   onLayoutChange?: (dehydratedLayout: DashboardLayoutConfig) => void;
+  onLayoutInitialized?: () => void;
   data?: DashboardData;
   children?: React.ReactNode | React.ReactNode[];
   emptyDashboard?: React.ReactNode;
@@ -59,6 +60,7 @@ export const DashboardLayout = ({
   layout,
   layoutConfig = DEFAULT_LAYOUT_CONFIG,
   onLayoutChange = DEFAULT_CALLBACK,
+  onLayoutInitialized = DEFAULT_CALLBACK,
 }: DashboardLayoutProps): JSX.Element => {
   const dispatch = useDispatch();
   const data =
@@ -226,6 +228,7 @@ export const DashboardLayout = ({
       }
 
       setIsDashboardEmpty(layout.root.contentItems.length === 0);
+      onLayoutInitialized();
     }
   }, [
     hydrateComponent,
@@ -234,6 +237,7 @@ export const DashboardLayout = ({
     lastConfig,
     panelManager,
     previousLayoutConfig,
+    onLayoutInitialized,
   ]);
 
   return (
@@ -261,6 +265,7 @@ DashboardLayout.propTypes = {
   layout: GLPropTypes.Layout.isRequired,
   layoutConfig: PropTypes.arrayOf(PropTypes.shape({})),
   onLayoutChange: PropTypes.func,
+  onLayoutInitialized: PropTypes.func,
 };
 
 export default DashboardLayout;

--- a/packages/dashboard/src/layout/LayoutUtils.js
+++ b/packages/dashboard/src/layout/LayoutUtils.js
@@ -1,5 +1,6 @@
 import deepEqual from 'deep-equal';
 import shortid from 'shortid';
+import isMatch from 'lodash.ismatch';
 import Log from '@deephaven/log';
 import GoldenLayoutThemeExport from './GoldenLayoutThemeExport';
 
@@ -84,6 +85,7 @@ class LayoutUtils {
   }
 
   /**
+   * Gets the first stack which contains a contentItem with the given config values
    * @param {ContentItem} item Golden layout content item to search for the stack
    * @param {Config} config The item properties to match
    */
@@ -99,16 +101,7 @@ class LayoutUtils {
     for (let i = 0; i < item.contentItems.length; i += 1) {
       const contentItem = item.contentItems[i];
       if (contentItem.isComponent && contentItem.config) {
-        let isMatch = true;
-        const keys = Object.keys(config);
-        for (let k = 0; k < keys.length; k += 1) {
-          const key = keys[k];
-          if (config[key] !== contentItem.config[key]) {
-            isMatch = false;
-            break;
-          }
-        }
-        if (isMatch) {
+        if (isMatch(contentItem.config, config)) {
           return item;
         }
       }
@@ -189,7 +182,7 @@ class LayoutUtils {
   }
 
   /**
-   * Gets content item with the specified config in stack.
+   * Gets first content item with the specified config in stack.
    * @param {ContentItem} stack The stack to search for the item
    * @param {Config} config The item config type to match, eg. { component: 'IrisGridPanel', title: 'Table Name' }
    * @returns {ContentItem} Returns the found content item, null if not found.
@@ -198,16 +191,7 @@ class LayoutUtils {
     for (let i = 0; i < stack.contentItems.length; i += 1) {
       const contentItem = stack.contentItems[i];
       if (contentItem.isComponent && contentItem.config) {
-        let isMatch = true;
-        const keys = Object.keys(config);
-        for (let k = 0; k < keys.length; k += 1) {
-          const key = keys[k];
-          if (config[key] !== contentItem.config[key]) {
-            isMatch = false;
-            break;
-          }
-        }
-        if (isMatch) {
+        if (isMatch(contentItem.config, config)) {
           return contentItem;
         }
       }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,10 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
+      // Specifically try mapping to the TS file first in case the file is a TS src
+      "@deephaven/iris-grid/dist/*.js": [
+        "./packages/iris-grid/src/*.ts"
+      ],
       "@deephaven/iris-grid/dist/*": [
         "./packages/iris-grid/src/*"
       ],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
-      // Specifically try mapping to the TS file first in case the file is a TS src
       "@deephaven/iris-grid/dist/*.js": [
         "./packages/iris-grid/src/*.ts"
       ],


### PR DESCRIPTION
Resolves #269 

Adds routes `/notebook/:notebookPath` which will open the provided notebook path if it is not open in the workspace and focus it within its stack if it is open in the workspace. The paths can contain slashes to denote directories so `/notebook/myFolder/myFile.py` would open `/myFolder/myFile.py` from the file explorer

If the file does not exist, it will open a panel which will then fail to load the file and give an error in the panel about the file not existing/unable to be loaded.

Tested locally setting `REACT_APP_ROUTER_BASE_NAME=/ide/` in my `.env.development.local`
