### PR TITLE
Maintain temporary edits to console history items until execution

### DIFF
--- a/packages/console/src/ConsoleInput.jsx
+++ b/packages/console/src/ConsoleInput.jsx
@@ -83,8 +83,10 @@ export class ConsoleInput extends PureComponent {
 
     log.debug('Command received: ', text);
 
-    this.commandEditor.setValue(text);
+    // Need to set commandHistoryIndex before value
+    // On value change, modified commands map updates
     this.commandHistoryIndex = null;
+    this.commandEditor.setValue(text);
 
     if (focus) {
       this.focusEnd();


### PR DESCRIPTION
Fixes #374 

Sending an item from history to console (or notebook to console) should overwrite the new command. Executing a previous command will erase the new command just like all other edits

Example
1. Type something
2. Arrow up to last item in history
3. Double click a different item in history (the "something" from earlier is now gone)
4. Arrow up should go to last item in history again. Arrow down should go nowhere