### PR TITLE
Fix babel public class fields plugin

### DIFF
--- a/packages/babel-preset/index.js
+++ b/packages/babel-preset/index.js
@@ -11,13 +11,13 @@ module.exports = api => ({
           : {
               esmodules: true,
             },
+        include: ['@babel/plugin-proposal-class-properties'],
       },
     ],
     '@babel/preset-react',
-    '@babel/preset-typescript',
+    ['@babel/preset-typescript', { allowDeclareFields: true }],
   ],
   plugins: [
-    '@babel/plugin-proposal-class-properties',
     api.env('test') ? false : ['babel-plugin-add-import-extension'],
     [
       'transform-rename-import',

--- a/packages/utils/src/EventTargetShimUtils.ts
+++ b/packages/utils/src/EventTargetShimUtils.ts
@@ -2,20 +2,25 @@ import type { Event, EventTarget } from 'event-target-shim';
 
 /**
  * A CustomEvent extension which combines the browser CustomEvent and event-target-shim's Event types for type safety
- * CustomEvent does not
+ * CustomEvent does not have a generic type and augmenting the dom types seemed like not the best idea
  */
 export class EventShimCustomEvent<T extends string, D = unknown>
   extends CustomEvent<D>
   implements Event<T> {
-  type!: T;
+  // The fields declared are so TS plays nicely w/ event-target-shim and the browser CustomEvent
+  // They don't actually do anything other than tell TS to not complain that they aren't set in the constructor
+  // If declare is removed, then the properties are initialized to undefined which breaks this class
+  // This will be the default for tsc and babel at some point
+  // https://github.com/babel/babel/issues/12128#issuecomment-702119272
+  declare type: T;
 
-  target!: EventTarget | null;
+  declare target: EventTarget | null;
 
-  srcElement!: EventTarget | null;
+  declare srcElement: EventTarget | null;
 
-  currentTarget!: EventTarget | null;
+  declare currentTarget: EventTarget | null;
 
-  composedPath!: () => EventTarget[];
+  declare composedPath: () => EventTarget[];
 
   // eslint-disable-next-line @typescript-eslint/no-useless-constructor
   constructor(typeArg: T, eventInitDict?: CustomEventInit<D>) {


### PR DESCRIPTION
This was causing an issue w/ redefined shortcuts in Monaco. Specifically in EventTargetShimUtils

The class which needs to declare to TS that fields will exist (because the event-target-shim Event type and CustomEvent don't play very nicely together) was having those fields initialized to undefined even though they will be defined by the super constructor.

```ts
class A {
  field: string;
}
```

Previous to #370 the types would be stripped before babel got the file, but TS will likely change this behavior in the future to not remove fields like above. Instead you have to use `declare field: string` to have TS remove it.

Reference: https://github.com/babel/babel/issues/12128#issuecomment-702119272