### PR TITLE
DH-12099 IrisGrid canToggleSearch should allow override by layoutHints

### DIFF
--- a/__mocks__/dh-core.js
+++ b/__mocks__/dh-core.js
@@ -1357,6 +1357,12 @@ const VariableType = Object.freeze({
   PANDAS: 'Pandas',
 });
 
+const SearchDisplayMode = Object.freeze({
+  SEARCH_DISPLAY_HIDE: 'Hide',
+  SEARCH_DISPLAY_SHOW: 'Show',
+  SEARCH_DISPLAY_DEFAULT: 'Default',
+});
+
 //
 // CONSOLE END
 //
@@ -1780,6 +1786,7 @@ const dh = {
   DateWrapper: DateWrapper,
   ViewportData,
   VariableType,
+  SearchDisplayMode,
 };
 
 // The actual library just sets a global window object, we do the same

--- a/packages/iris-grid/src/IrisGrid.jsx
+++ b/packages/iris-grid/src/IrisGrid.jsx
@@ -1679,7 +1679,7 @@ export class IrisGrid extends Component {
 
   toggleSearchBar() {
     const { showSearchBar } = this.state;
-    if (!this.isToggleSearchAvailable()) {
+    if (!this.isTableSearchAvailable()) {
       return;
     }
 

--- a/packages/iris-grid/src/IrisGrid.jsx
+++ b/packages/iris-grid/src/IrisGrid.jsx
@@ -2830,7 +2830,7 @@ export class IrisGrid extends Component {
       isFilterBarShown,
       showSearchBar,
       canDownloadCsv,
-      this.isToggleSearchAvailable()
+      this.isTableSearchAvailable()
     );
 
     const openOptionsStack = openOptions.map(option => {

--- a/packages/iris-grid/src/IrisGrid.jsx
+++ b/packages/iris-grid/src/IrisGrid.jsx
@@ -1665,13 +1665,11 @@ export class IrisGrid extends Component {
     const { model, canToggleSearch } = this.props;
     const searchDisplayMode = model?.layoutHints?.searchDisplayMode;
 
-    if (searchDisplayMode) {
-      if (searchDisplayMode === dh.SearchDisplayMode.SEARCH_DISPLAY_HIDE) {
-        return false;
-      }
-      if (searchDisplayMode === dh.SearchDisplayMode.SEARCH_DISPLAY_SHOW) {
-        return true;
-      }
+    if (searchDisplayMode === dh.SearchDisplayMode.SEARCH_DISPLAY_HIDE) {
+      return false;
+    }
+    if (searchDisplayMode === dh.SearchDisplayMode.SEARCH_DISPLAY_SHOW) {
+      return true;
     }
 
     return canToggleSearch;

--- a/packages/iris-grid/src/IrisGrid.jsx
+++ b/packages/iris-grid/src/IrisGrid.jsx
@@ -1661,10 +1661,27 @@ export class IrisGrid extends Component {
     }
   }
 
+  isTableSearchAvailable() {
+    const { model, canToggleSearch } = this.props;
+    const searchDisplayMode = model?.layoutHints?.searchDisplayMode;
+
+    if (searchDisplayMode) {
+      if (searchDisplayMode === dh.SearchDisplayMode.SEARCH_DISPLAY_HIDE) {
+        return false;
+      }
+      if (searchDisplayMode === dh.SearchDisplayMode.SEARCH_DISPLAY_SHOW) {
+        return true;
+      }
+    }
+
+    return canToggleSearch;
+  }
+
   toggleSearchBar() {
     const { showSearchBar } = this.state;
-    const { canToggleSearch } = this.props;
-    if (!canToggleSearch) return;
+    if (!this.isToggleSearchAvailable()) {
+      return;
+    }
 
     const update = !showSearchBar;
     this.setState(
@@ -2351,7 +2368,6 @@ export class IrisGrid extends Component {
       advancedSettings,
       onAdvancedSettingsChange,
       canDownloadCsv,
-      canToggleSearch,
     } = this.props;
     const {
       metricCalculator,
@@ -2814,7 +2830,7 @@ export class IrisGrid extends Component {
       isFilterBarShown,
       showSearchBar,
       canDownloadCsv,
-      canToggleSearch
+      this.isToggleSearchAvailable()
     );
 
     const openOptionsStack = openOptions.map(option => {


### PR DESCRIPTION
I'll explain the whole flow for reference.

From enterprise IrisGridPanel we are passed `canToggleSearch` which considers the boolean server config setting `ui.show.search`. Tables can have this overridden however via Layout Hints. This PR handles the override case where if a LH is found we simply ignore the server config and use the LH value.

The API support for this work is deployed on the BHS, `davor-searchbar-api` if you wish to test it in action.