### PR TITLE
Fast refresh fix

### DIFF
--- a/packages/code-studio/package.json
+++ b/packages/code-studio/package.json
@@ -46,6 +46,7 @@
     "react-redux": "^7.2.4",
     "react-router-dom": "^5.1.2",
     "react-scripts": "4.0.3",
+    "react-error-overlay": "6.0.9",
     "react-transition-group": "^2.3.1",
     "reactstrap": "^8.4.1",
     "redux": "^4.0.5",


### PR DESCRIPTION
If you save w/ react hot reload/fast refresh then the React error iframe tries to pop up/initialize and fails. This freezes the page requiring a reload.

The fix is to specify a version of `react-error-overlay` according to the create react app ticket below. Should be fixed in CRA v5

https://github.com/facebook/create-react-app/issues/11773#issuecomment-995933869