### PR TITLE
Fix irisgrid tooltip state tracking

### DIFF
--- a/packages/components/src/popper/Tooltip.tsx
+++ b/packages/components/src/popper/Tooltip.tsx
@@ -13,6 +13,7 @@ interface TooltipProps {
   children: React.ReactNode;
   popperClassName: string;
   referenceObject: ReferenceObject;
+  onExited: () => void;
 }
 
 interface TooltipState {
@@ -49,6 +50,9 @@ class Tooltip extends Component<TooltipProps, TooltipState> {
     reshowTimeout: Tooltip.defaultReshowTimeout,
     timeout: Tooltip.defaultTimeout,
     referenceObject: null,
+    onExited(): void {
+      // no-op
+    },
   };
 
   static handleHidden(): void {
@@ -271,6 +275,8 @@ class Tooltip extends Component<TooltipProps, TooltipState> {
 
   handleExited(): void {
     this.setState({ isShown: false });
+    const { onExited } = this.props;
+    onExited();
   }
 
   stopShowingTooltip(): void {

--- a/packages/iris-grid/src/IrisGrid.jsx
+++ b/packages/iris-grid/src/IrisGrid.jsx
@@ -2638,6 +2638,9 @@ export class IrisGrid extends Component {
               options={popperOptions}
               ref={this.handleTooltipRef}
               referenceObject={virtualReference}
+              onExited={() => {
+                this.setState({ shownColumnTooltip: null });
+              }}
             >
               <ColumnStatistics
                 model={model}


### PR DESCRIPTION
- Resolves Grid column tooltips don't work when mouse enters from above #412
- tooltips now have onExited callback, irisgrid updates it's internal state now tooltip exit
- Caused by fix for pr #306, introduced this new edge case
- Remove this.isExiting from popper, doesn't appear to ever have been used