### PR TITLE
Fix double box-shadow focus ring on iconOnly ghost buttons

### DIFF
--- a/packages/components/src/BaseStyleSheet.scss
+++ b/packages/components/src/BaseStyleSheet.scss
@@ -215,6 +215,7 @@ span.btn-disabled-wrapper {
   &:focus {
     outline: none;
     text-decoration: none;
+    box-shadow: none;
     &::after {
       background: rgba($primary, $focus-bg-transparency);
       border: $input-border-width solid $primary;

--- a/packages/embed-grid/package.json
+++ b/packages/embed-grid/package.json
@@ -33,7 +33,7 @@
     "@types/node": "^12.20.24",
     "@types/react": "^16.14.15",
     "@types/react-dom": "^17.0.9",
-    "bootstrap": "^4.6.0",
+    "bootstrap": "4.4.1",
     "classnames": "^2.3.1",
     "deep-equal": "^2.0.5",
     "fira": "mozilla/fira#4.202",


### PR DESCRIPTION
After element has the focus ring, box-shadow should be removed on actual element

Fixes the inner focus circle showing up:
![image](https://user-images.githubusercontent.com/1576283/152237017-84acf2e5-aa49-4140-a697-aac65772b1ef.png)

