### PR TITLE
DH-10241: Persist grid isStuckToBottom state

### DIFF
--- a/packages/dashboard-core-plugins/src/panels/IrisGridPanel.jsx
+++ b/packages/dashboard-core-plugins/src/panels/IrisGridPanel.jsx
@@ -272,8 +272,14 @@ export class IrisGridPanel extends PureComponent {
       })
   );
 
-  getDehydratedGridState = memoize((model, movedColumns, movedRows) =>
-    IrisGridUtils.dehydrateGridState(model, { movedColumns, movedRows })
+  getDehydratedGridState = memoize(
+    (model, movedColumns, movedRows, isStuckToBottom, isStuckToRight) =>
+      IrisGridUtils.dehydrateGridState(model, {
+        isStuckToBottom,
+        isStuckToRight,
+        movedColumns,
+        movedRows,
+      })
   );
 
   getCachedPanelState = memoize(
@@ -700,7 +706,12 @@ export class IrisGridPanel extends PureComponent {
         pendingDataMap,
         frozenColumns,
       } = IrisGridUtils.hydrateIrisGridState(model, irisGridState);
-      const { movedColumns, movedRows } = IrisGridUtils.hydrateGridState(
+      const {
+        isStuckToBottom,
+        isStuckToRight,
+        movedColumns,
+        movedRows,
+      } = IrisGridUtils.hydrateGridState(
         model,
         gridState,
         irisGridState.customColumns
@@ -730,6 +741,8 @@ export class IrisGridPanel extends PureComponent {
         invertSearchColumns,
         pendingDataMap,
         frozenColumns,
+        isStuckToBottom,
+        isStuckToRight,
       });
     } catch (error) {
       log.error('loadPanelState failed to load panelState', panelState, error);
@@ -767,7 +780,12 @@ export class IrisGridPanel extends PureComponent {
       frozenColumns,
     } = irisGridState;
     const { userColumnWidths, userRowHeights } = metrics;
-    const { movedColumns, movedRows } = gridState;
+    const {
+      isStuckToBottom,
+      isStuckToRight,
+      movedColumns,
+      movedRows,
+    } = gridState;
 
     const panelState = this.getCachedPanelState(
       this.getDehydratedIrisGridPanelState(
@@ -798,7 +816,13 @@ export class IrisGridPanel extends PureComponent {
         pendingDataMap,
         frozenColumns
       ),
-      this.getDehydratedGridState(model, movedColumns, movedRows),
+      this.getDehydratedGridState(
+        model,
+        movedColumns,
+        movedRows,
+        isStuckToBottom,
+        isStuckToRight
+      ),
       pluginState
     );
 
@@ -844,6 +868,8 @@ export class IrisGridPanel extends PureComponent {
       isDisconnected,
       isFilterBarShown,
       isSelectingPartition,
+      isStuckToBottom,
+      isStuckToRight,
       isLoaded,
       isLoading,
       isModelReady,
@@ -919,6 +945,8 @@ export class IrisGridPanel extends PureComponent {
             isFilterBarShown={isFilterBarShown}
             isSelectingColumn={columnSelectionValidator != null}
             isSelectingPartition={isSelectingPartition}
+            isStuckToBottom={isStuckToBottom}
+            isStuckToRight={isStuckToRight}
             movedColumns={movedColumns}
             movedRows={movedRows}
             partition={partition}

--- a/packages/iris-grid/src/IrisGrid.jsx
+++ b/packages/iris-grid/src/IrisGrid.jsx
@@ -2344,6 +2344,8 @@ export class IrisGrid extends Component {
       customFilters,
       getDownloadWorker,
       isSelectingColumn,
+      isStuckToBottom,
+      isStuckToRight,
       model,
       name,
       onlyFetchVisibleColumns,
@@ -2980,6 +2982,8 @@ export class IrisGrid extends Component {
                 this.grid = grid;
               }}
               isStickyBottom={!model.isEditable}
+              isStuckToBottom={isStuckToBottom}
+              isStuckToRight={isStuckToRight}
               metricCalculator={metricCalculator}
               model={model}
               keyHandlers={keyHandlers}
@@ -3199,6 +3203,8 @@ IrisGrid.propTypes = {
 
   isSelectingColumn: PropTypes.bool,
   isSelectingPartition: PropTypes.bool,
+  isStuckToBottom: PropTypes.bool,
+  isStuckToRight: PropTypes.bool,
 
   // eslint-disable-next-line react/no-unused-prop-types
   columnSelectionValidator: PropTypes.func,
@@ -3263,6 +3269,8 @@ IrisGrid.defaultProps = {
   onSelectionChanged: () => {},
   isSelectingColumn: false,
   isSelectingPartition: false,
+  isStuckToBottom: false,
+  isStuckToRight: false,
   columnSelectionValidator: null,
   columnAllowedCursor: null,
   columnNotAllowedCursor: null,

--- a/packages/iris-grid/src/IrisGridUtils.js
+++ b/packages/iris-grid/src/IrisGridUtils.js
@@ -17,10 +17,17 @@ class IrisGridUtils {
    * @returns {Object} An object that can be stringified and imported with {{@link hydrateGridState}}
    */
   static dehydrateGridState(model, gridState) {
-    const { movedColumns, movedRows } = gridState;
+    const {
+      isStuckToBottom,
+      isStuckToRight,
+      movedColumns,
+      movedRows,
+    } = gridState;
 
     const { columns } = model;
     return {
+      isStuckToBottom,
+      isStuckToRight,
       movedColumns: [...movedColumns]
         .filter(
           ({ to, from }) =>
@@ -41,7 +48,12 @@ class IrisGridUtils {
    * @returns {Object} The gridState props to set on the Grid
    */
   static hydrateGridState(model, gridState, customColumns = []) {
-    const { movedColumns, movedRows } = gridState;
+    const {
+      isStuckToBottom,
+      isStuckToRight,
+      movedColumns,
+      movedRows,
+    } = gridState;
 
     const { columns } = model;
     const customColumnNames = IrisGridUtils.parseCustomColumnNames(
@@ -52,6 +64,8 @@ class IrisGridUtils {
       .concat(customColumnNames);
 
     return {
+      isStuckToBottom,
+      isStuckToRight,
       movedColumns: [...movedColumns]
         .map(({ to, from }) => {
           if (


### PR DESCRIPTION
- Persist isStuckToBottom state from grid
- Moved from a property on grid to the state

Tested with the following snippet:
```
from deephaven.TableTools import emptyTable
t = emptyTable(100).update("A=i")
```

Scrolled to the bottom and refreshed the page. Table stayed and was stuck to bottom.