### PR TITLE
JS plugins loading from the server

### DIFF
--- a/packages/chart/package-lock.json
+++ b/packages/chart/package-lock.json
@@ -44,142 +44,12 @@
 				}
 			}
 		},
-		"@babel/runtime": {
-			"version": "7.16.7",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.7.tgz",
-			"integrity": "sha512-9E9FJowqAsytyOY6LG+1KuueckRL+aQW+mKvXRXnuFGyRAyepJPmEo9vgMfXUA6O9u3IeEdv9MAkppFcaQwogQ==",
-			"requires": {
-				"regenerator-runtime": "^0.13.4"
-			}
-		},
 		"@choojs/findup": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/@choojs/findup/-/findup-0.2.1.tgz",
 			"integrity": "sha512-YstAqNb0MCN8PjdLCDfRsBcGVRN41f3vgLvaI0IrIcBp4AqILRSS0DeWNGkicC+f/zRIPJLc+9RURVSepwvfBw==",
 			"requires": {
 				"commander": "^2.15.1"
-			}
-		},
-		"@deephaven/grid": {
-			"version": "0.9.1",
-			"resolved": "https://registry.npmjs.org/@deephaven/grid/-/grid-0.9.1.tgz",
-			"integrity": "sha512-INVZKFo/2bK+FpT5vqN7wfdrW66Xl5fxDOkr8I8PO9LL23RMfdiPvilzO8Ji7fKP3fOZtvCznO7yLMEzVBhFLA==",
-			"requires": {
-				"classnames": "^2.3.1",
-				"color-convert": "^2.0.1",
-				"event-target-shim": "^6.0.2",
-				"lodash.clamp": "^4.0.3",
-				"memoize-one": "^5.1.1",
-				"memoizee": "^0.4.15",
-				"prop-types": "^15.7.2"
-			},
-			"dependencies": {
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				}
-			}
-		},
-		"@deephaven/icons": {
-			"version": "0.9.1",
-			"resolved": "https://registry.npmjs.org/@deephaven/icons/-/icons-0.9.1.tgz",
-			"integrity": "sha512-nLLZez6hNl4Ep6b7IjjIxLTGRa9WxeagNC2BP2IWVXs/ONvHHv0t5SYeCCJ/IaH8Bz2UWnxf09VivVPdIGZYig==",
-			"requires": {
-				"@fortawesome/fontawesome-common-types": "^0.2.35"
-			}
-		},
-		"@deephaven/iris-grid": {
-			"version": "0.9.1",
-			"resolved": "https://registry.npmjs.org/@deephaven/iris-grid/-/iris-grid-0.9.1.tgz",
-			"integrity": "sha512-KHZwBKu/oVZY3GyrEAuMqrV0BKX4SYCBtFc5p11xSMwfduwGm01ppcrv5T4j90P9vNTt2KffLgIya6JS3JMzlQ==",
-			"requires": {
-				"@deephaven/grid": "^0.9.1",
-				"@deephaven/icons": "^0.9.1",
-				"@deephaven/jsapi-shim": "^0.9.1",
-				"@deephaven/react-hooks": "^0.9.1",
-				"@deephaven/utils": "^0.9.1",
-				"@fortawesome/react-fontawesome": "^0.1.12",
-				"classnames": "^2.3.1",
-				"deep-equal": "^2.0.4",
-				"lodash.clamp": "^4.0.3",
-				"lodash.debounce": "^4.0.8",
-				"lodash.throttle": "^4.1.1",
-				"memoize-one": "^5.1.1",
-				"memoizee": "^0.4.15",
-				"monaco-editor": "^0.27.0",
-				"prop-types": "^15.7.2",
-				"react-beautiful-dnd": "^13.0.0",
-				"react-transition-group": "^2.3.1",
-				"shortid": "^2.2.15",
-				"web-streams-polyfill": "^2.1.0"
-			}
-		},
-		"@deephaven/jsapi-shim": {
-			"version": "0.9.1",
-			"resolved": "https://registry.npmjs.org/@deephaven/jsapi-shim/-/jsapi-shim-0.9.1.tgz",
-			"integrity": "sha512-soBU7sU9qZgzDXJyYrU96GiB7UBCdHScUaQjl4ISx2igIdK+Qfe7JOYVxYjJdV8KEVK/l+smSkahAIT5/NJY4Q==",
-			"requires": {
-				"prop-types": "^15.7.2"
-			}
-		},
-		"@deephaven/log": {
-			"version": "0.9.1",
-			"resolved": "https://registry.npmjs.org/@deephaven/log/-/log-0.9.1.tgz",
-			"integrity": "sha512-L/yKtSYOrNZlvyElqpgdrnL3JBaY07szFjhA37XK31+uH/jcPcbMxsn2Uf+++yyFcn6GKO1XXXP44V3xBkBQJg==",
-			"dev": true,
-			"requires": {
-				"event-target-shim": "^6.0.2"
-			}
-		},
-		"@deephaven/mocks": {
-			"version": "0.9.0",
-			"resolved": "https://registry.npmjs.org/@deephaven/mocks/-/mocks-0.9.0.tgz",
-			"integrity": "sha512-PkCZ0UtFemj1wlD+fGmmmkafOsieK/ts1PyRAdBH4EBDg0WEBjCRsD9lltGydXB1LSUDy0G0xtGOjX/BPPviRA==",
-			"dev": true
-		},
-		"@deephaven/react-hooks": {
-			"version": "0.9.1",
-			"resolved": "https://registry.npmjs.org/@deephaven/react-hooks/-/react-hooks-0.9.1.tgz",
-			"integrity": "sha512-v7r2DZoPahHNBspbulCtvUgCqJ+i9WPEA8cK9nEsTVTeuR3mhwLw4E/0g+WlXJ78FsUdA0K9FECJfUg1YTvyLg=="
-		},
-		"@deephaven/tsconfig": {
-			"version": "0.9.0",
-			"resolved": "https://registry.npmjs.org/@deephaven/tsconfig/-/tsconfig-0.9.0.tgz",
-			"integrity": "sha512-zYKPllv+W+UhAuzC2pbsaQynxzsE0bBK/XjfiK0LWiGMkMhp43rwEaCiMODSYaxGmaV5eA+ijm8r1Y8v21pH4w==",
-			"dev": true
-		},
-		"@deephaven/utils": {
-			"version": "0.9.1",
-			"resolved": "https://registry.npmjs.org/@deephaven/utils/-/utils-0.9.1.tgz",
-			"integrity": "sha512-kll4L5bNOOPdtpeSDpIvC8+NnlaToKrsPoJ3kvsZvJVmILdIKAIXcviGPxZO5SCjyzgV/NmfLUmHq0CcMAYnEg=="
-		},
-		"@fortawesome/fontawesome-common-types": {
-			"version": "0.2.36",
-			"resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.36.tgz",
-			"integrity": "sha512-a/7BiSgobHAgBWeN7N0w+lAhInrGxksn13uK7231n2m8EDPE3BMCl9NZLTGrj9ZXfCmC6LM0QLqXidIizVQ6yg=="
-		},
-		"@fortawesome/react-fontawesome": {
-			"version": "0.1.17",
-			"resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.1.17.tgz",
-			"integrity": "sha512-dX43Z5IvMaW7fwzU8farosYjKNGfRb2HB/DgjVBHeJZ/NSnuuaujPPx0YOdcAq+n3mqn70tyCde2HM1mqbhiuw==",
-			"requires": {
-				"prop-types": "^15.8.1"
-			},
-			"dependencies": {
-				"prop-types": {
-					"version": "15.8.1",
-					"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
-					"integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-					"requires": {
-						"loose-envify": "^1.4.0",
-						"object-assign": "^4.1.1",
-						"react-is": "^16.13.1"
-					}
-				}
 			}
 		},
 		"@mapbox/geojson-rewind": {
@@ -324,15 +194,6 @@
 				"@turf/helpers": "^6.5.0"
 			}
 		},
-		"@types/hoist-non-react-statics": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
-			"integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
-			"requires": {
-				"@types/react": "*",
-				"hoist-non-react-statics": "^3.3.0"
-			}
-		},
 		"@types/json-schema": {
 			"version": "7.0.9",
 			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
@@ -342,12 +203,14 @@
 		"@types/prop-types": {
 			"version": "15.7.4",
 			"resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.4.tgz",
-			"integrity": "sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ=="
+			"integrity": "sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ==",
+			"dev": true
 		},
 		"@types/react": {
 			"version": "17.0.39",
 			"resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.39.tgz",
 			"integrity": "sha512-UVavlfAxDd/AgAacMa60Azl7ygyQNRwC/DsHZmKgNvPmRR5p70AJ5Q9EAmL2NWOJmeV+vVUI4IAP7GZrN8h8Ug==",
+			"dev": true,
 			"requires": {
 				"@types/prop-types": "*",
 				"@types/scheduler": "*",
@@ -363,21 +226,11 @@
 				"@types/react": "*"
 			}
 		},
-		"@types/react-redux": {
-			"version": "7.1.22",
-			"resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-7.1.22.tgz",
-			"integrity": "sha512-GxIA1kM7ClU73I6wg9IRTVwSO9GS+SAKZKe0Enj+82HMU6aoESFU2HNAdNi3+J53IaOHPiUfT3kSG4L828joDQ==",
-			"requires": {
-				"@types/hoist-non-react-statics": "^3.3.0",
-				"@types/react": "*",
-				"hoist-non-react-statics": "^3.3.0",
-				"redux": "^4.0.0"
-			}
-		},
 		"@types/scheduler": {
 			"version": "0.16.2",
 			"resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
-			"integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew=="
+			"integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
+			"dev": true
 		},
 		"a-big-triangle": {
 			"version": "1.0.3",
@@ -777,11 +630,6 @@
 			"resolved": "https://registry.npmjs.org/clamp/-/clamp-1.0.1.tgz",
 			"integrity": "sha1-ZqDmQBGBbjcZaCj9yMjBRzEshjQ="
 		},
-		"classnames": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
-			"integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA=="
-		},
 		"clean-pslg": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/clean-pslg/-/clean-pslg-1.1.2.tgz",
@@ -1042,14 +890,6 @@
 				"which": "^2.0.1"
 			}
 		},
-		"css-box-model": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/css-box-model/-/css-box-model-1.2.1.tgz",
-			"integrity": "sha512-a7Vr4Q/kd/aw96bnJG332W9V9LkJO69JRcaCYDUqjp6/z0w6VcZjgAcTbgFxEPfBgdnAwlh3iwu+hLopa+flJw==",
-			"requires": {
-				"tiny-invariant": "^1.0.6"
-			}
-		},
 		"css-font": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/css-font/-/css-font-1.2.0.tgz",
@@ -1104,7 +944,8 @@
 		"csstype": {
 			"version": "3.0.10",
 			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.10.tgz",
-			"integrity": "sha512-2u44ZG2OcNUO9HDp/Jl8C07x6pU/eTR3ncV91SiK3dhG9TWvRVsCoJw14Ckx5DgWkzGA3waZWO3d7pgqpUI/XA=="
+			"integrity": "sha512-2u44ZG2OcNUO9HDp/Jl8C07x6pU/eTR3ncV91SiK3dhG9TWvRVsCoJw14Ckx5DgWkzGA3waZWO3d7pgqpUI/XA==",
+			"dev": true
 		},
 		"cubic-hermite": {
 			"version": "1.0.0",
@@ -1300,14 +1141,6 @@
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/detect-kerning/-/detect-kerning-2.1.2.tgz",
 			"integrity": "sha512-I3JIbrnKPAntNLl1I6TpSQQdQ4AutYzv/sKMFKbepawV/hlH0GmYKhUoOEMd4xqaUHT+Bm0f4127lh5qs1m1tw=="
-		},
-		"dom-helpers": {
-			"version": "3.4.0",
-			"resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.4.0.tgz",
-			"integrity": "sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==",
-			"requires": {
-				"@babel/runtime": "^7.1.2"
-			}
 		},
 		"double-bits": {
 			"version": "1.1.1",
@@ -1565,11 +1398,6 @@
 				"d": "1",
 				"es5-ext": "~0.10.14"
 			}
-		},
-		"event-target-shim": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-6.0.2.tgz",
-			"integrity": "sha512-8q3LsZjRezbFZ2PN+uP+Q7pnHUMmAOziU2vA2OwoFaKIXxlxl38IylhSSgUorWu/rf4er67w0ikBqjBFk/pomA=="
 		},
 		"events": {
 			"version": "3.3.0",
@@ -2472,14 +2300,6 @@
 				"has-symbols": "^1.0.2"
 			}
 		},
-		"hoist-non-react-statics": {
-			"version": "3.3.2",
-			"resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
-			"integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
-			"requires": {
-				"react-is": "^16.7.0"
-			}
-		},
 		"hosted-git-info": {
 			"version": "2.8.9",
 			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
@@ -2855,11 +2675,6 @@
 				"json5": "^2.1.2"
 			}
 		},
-		"lodash.clamp": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/lodash.clamp/-/lodash.clamp-4.0.3.tgz",
-			"integrity": "sha1-XCS+3u7vB1NWDcK0y0Zx+Qpt36o="
-		},
 		"lodash.debounce": {
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -2869,11 +2684,6 @@
 			"version": "4.6.2",
 			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
 			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
-		},
-		"lodash.throttle": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
-			"integrity": "sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ="
 		},
 		"loose-envify": {
 			"version": "1.4.0",
@@ -3052,11 +2862,6 @@
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
 			"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
 		},
-		"monaco-editor": {
-			"version": "0.27.0",
-			"resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.27.0.tgz",
-			"integrity": "sha512-UhwP78Wb8w0ZSYoKXQNTV/0CHObp6NS3nCt51QfKE6sKyBo5PBsvuDOHoI2ooBakc6uIwByRLHVeT7+yXQe2fQ=="
-		},
 		"monotone-convex-hull-2d": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/monotone-convex-hull-2d/-/monotone-convex-hull-2d-1.0.1.tgz",
@@ -3117,11 +2922,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/murmurhash-js/-/murmurhash-js-1.0.0.tgz",
 			"integrity": "sha1-sGJ44h/Gw3+lMTcysEEry2rhX1E="
-		},
-		"nanoid": {
-			"version": "2.1.11",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.1.11.tgz",
-			"integrity": "sha512-s/snB+WGm6uwi0WjsZdaVcuf3KJXlfGl2LcxgwkEwJF0D/BWzVWAZW/XY4bFaiR7s0Jk3FPvlnepg1H1b1UwlA=="
 		},
 		"native-promise-only": {
 			"version": "0.8.1",
@@ -3870,11 +3670,6 @@
 				"performance-now": "^2.1.0"
 			}
 		},
-		"raf-schd": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/raf-schd/-/raf-schd-4.0.3.tgz",
-			"integrity": "sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ=="
-		},
 		"rat-vec": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/rat-vec/-/rat-vec-1.1.1.tgz",
@@ -3893,29 +3688,10 @@
 				"object-assign": "^4.1.1"
 			}
 		},
-		"react-beautiful-dnd": {
-			"version": "13.1.0",
-			"resolved": "https://registry.npmjs.org/react-beautiful-dnd/-/react-beautiful-dnd-13.1.0.tgz",
-			"integrity": "sha512-aGvblPZTJowOWUNiwd6tNfEpgkX5OxmpqxHKNW/4VmvZTNTbeiq7bA3bn5T+QSF2uibXB0D1DmJsb1aC/+3cUA==",
-			"requires": {
-				"@babel/runtime": "^7.9.2",
-				"css-box-model": "^1.2.0",
-				"memoize-one": "^5.1.1",
-				"raf-schd": "^4.0.2",
-				"react-redux": "^7.2.0",
-				"redux": "^4.0.4",
-				"use-memo-one": "^1.1.1"
-			}
-		},
 		"react-is": {
 			"version": "16.13.1",
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
 			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
-		},
-		"react-lifecycles-compat": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
-			"integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
 		},
 		"react-plotly.js": {
 			"version": "2.5.1",
@@ -3923,37 +3699,6 @@
 			"integrity": "sha512-Oya14whSHvPsYXdI0nHOGs1pZhMzV2edV7HAW1xFHD58Y73m/LbG2Encvyz1tztL0vfjph0JNhiwO8cGBJnlhg==",
 			"requires": {
 				"prop-types": "^15.7.2"
-			}
-		},
-		"react-redux": {
-			"version": "7.2.6",
-			"resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.6.tgz",
-			"integrity": "sha512-10RPdsz0UUrRL1NZE0ejTkucnclYSgXp5q+tB5SWx2qeG2ZJQJyymgAhwKy73yiL/13btfB6fPr+rgbMAaZIAQ==",
-			"requires": {
-				"@babel/runtime": "^7.15.4",
-				"@types/react-redux": "^7.1.20",
-				"hoist-non-react-statics": "^3.3.2",
-				"loose-envify": "^1.4.0",
-				"prop-types": "^15.7.2",
-				"react-is": "^17.0.2"
-			},
-			"dependencies": {
-				"react-is": {
-					"version": "17.0.2",
-					"resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-					"integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
-				}
-			}
-		},
-		"react-transition-group": {
-			"version": "2.9.0",
-			"resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.9.0.tgz",
-			"integrity": "sha512-+HzNTCHpeQyl4MJ/bdE0u6XRMe9+XG/+aL4mCxVN4DnPBQ0/5bfHWPDuOZUzYdMj94daZaZdCCc1Dzt9R/xSSg==",
-			"requires": {
-				"dom-helpers": "^3.4.0",
-				"loose-envify": "^1.4.0",
-				"prop-types": "^15.6.2",
-				"react-lifecycles-compat": "^3.0.4"
 			}
 		},
 		"read-pkg": {
@@ -3987,19 +3732,6 @@
 				"compare-cell": "^1.0.0",
 				"compare-oriented-cell": "^1.0.1"
 			}
-		},
-		"redux": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/redux/-/redux-4.1.2.tgz",
-			"integrity": "sha512-SH8PglcebESbd/shgf6mii6EIoRM0zrQyjcuQ+ojmfxjTtE0z9Y8pa62iA/OJ58qjP6j27uyW4kUF4jl/jd6sw==",
-			"requires": {
-				"@babel/runtime": "^7.9.2"
-			}
-		},
-		"regenerator-runtime": {
-			"version": "0.13.9",
-			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-			"integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
 		},
 		"regex-regex": {
 			"version": "1.0.0",
@@ -4300,14 +4032,6 @@
 			"resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.2.tgz",
 			"integrity": "sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==",
 			"dev": true
-		},
-		"shortid": {
-			"version": "2.2.16",
-			"resolved": "https://registry.npmjs.org/shortid/-/shortid-2.2.16.tgz",
-			"integrity": "sha512-Ugt+GIZqvGXCIItnsL+lvFJOiN7RYqlGy7QE41O3YC1xbNSeDGIRO7xg2JJXIAj1cAGnOeC1r7/T9pgrtQbv4g==",
-			"requires": {
-				"nanoid": "^2.1.0"
-			}
 		},
 		"side-channel": {
 			"version": "1.0.4",
@@ -4685,11 +4409,6 @@
 				"next-tick": "1"
 			}
 		},
-		"tiny-invariant": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.2.0.tgz",
-			"integrity": "sha512-1Uhn/aqw5C6RI4KejVeTg6mIS7IqxnLJ8Mv2tV5rTc0qWobay7pDUz6Wi392Cnc8ak1H0F2cjoRzb2/AW4+Fvg=="
-		},
 		"tinycolor2": {
 			"version": "1.4.2",
 			"resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.4.2.tgz",
@@ -4842,11 +4561,6 @@
 			"requires": {
 				"punycode": "^2.1.0"
 			}
-		},
-		"use-memo-one": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/use-memo-one/-/use-memo-one-1.1.2.tgz",
-			"integrity": "sha512-u2qFKtxLsia/r8qG0ZKkbytbztzRb317XCkT7yP8wxL0tZ/CzK2G+WWie5vWvpyeP7+YoPIwbJoIHJ4Ba4k0oQ=="
 		},
 		"util-deprecate": {
 			"version": "1.0.2",
@@ -5015,11 +4729,6 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/weakmap-shim/-/weakmap-shim-1.1.1.tgz",
 			"integrity": "sha1-1lr9eEEJshZuAP9XHDMVDsKkC0k="
-		},
-		"web-streams-polyfill": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-2.1.1.tgz",
-			"integrity": "sha512-dlNpL2aab3g8CKfGz6rl8FNmGaRWLLn2g/DtSc9IjB30mEdE6XxzPfPSig5BwGSzI+oLxHyETrQGKjrVVhbLCg=="
 		},
 		"webgl-context": {
 			"version": "2.2.0",

--- a/packages/chart/src/Chart.jsx
+++ b/packages/chart/src/Chart.jsx
@@ -465,6 +465,7 @@ export class Chart extends Component {
             revision={revision}
             config={config}
             onAfterPlot={this.handleAfterPlot}
+            onError={log.error}
             onRelayout={this.handleRelayout}
             onUpdate={this.handlePlotUpdate}
             onRestyle={this.handleRestyle}

--- a/packages/chart/src/ChartModelFactory.js
+++ b/packages/chart/src/ChartModelFactory.js
@@ -10,10 +10,9 @@ class ChartModelFactory {
    * @param {Object} settings The chart builder settings
    * @param {boolean} settings.isLinked Whether the newly created chart should stay linked with the original table, update when filters are updated
    * @param {string[]} settings.series The column names to use for creating the series of this chart
-   * @param {string} settings.sourcePanelId The panel ID the chart was created from
    * @param {string} settings.type Chart builder type, from ChartBuilder.types
    * @param {string} settings.xAxis The column name to use for the x-axis
-   * @param {string[]} settings.hiddenSeries Array of hidden series names
+   * @param {string[]} [settings.hiddenSeries] Array of hidden series names
    * @param {dh.Table} table The table to build the model for
    * @param {Object} theme The theme for the figure. Defaults to ChartTheme
    * @returns {Promise<ChartModel | FigureChartModel>} The FigureChartModel representing the figure
@@ -21,19 +20,38 @@ class ChartModelFactory {
    * This causes TS issues in 1 or 2 spots. Once this is TS it can be returned to just FigureChartModel
    */
   static async makeModelFromSettings(settings, table, theme = ChartTheme) {
+    const figure = await ChartModelFactory.makeFigureFromSettings(
+      settings,
+      table
+    );
+    return new FigureChartModel(figure, settings, theme);
+  }
+
+  /**
+   * Creates a model from the settings provided.
+   * Tries to create a Figure in the API with it.
+   * @param {Object} settings The chart builder settings
+   * @param {boolean} settings.isLinked Whether the newly created chart should stay linked with the original table, update when filters are updated
+   * @param {string[]} settings.series The column names to use for creating the series of this chart
+   * @param {string} settings.type Chart builder type, from ChartBuilder.types
+   * @param {string} settings.xAxis The column name to use for the x-axis
+   * @param {string[]} [settings.hiddenSeries] Array of hidden series names
+   * @param {dh.Table} table The table to build the model for
+   * @returns {Promise<dh.plot.Figure>} The Figure created with the settings provided
+   */
+  static async makeFigureFromSettings(settings, table) {
     // Copy the table first and then re-apply the filters from the original table
     // When we add table linking we'll want to listen to the original table and update
     // the copied table with any changes that occur.
     // The table gets owned by the Figure that gets created, which closes the table
-    return table.copy().then(tableCopy => {
-      tableCopy.applyCustomColumns(table.customColumns);
-      tableCopy.applyFilter(table.filter);
-      tableCopy.applySort(table.sort);
+    const tableCopy = await table.copy();
+    tableCopy.applyCustomColumns(table.customColumns);
+    tableCopy.applyFilter(table.filter);
+    tableCopy.applySort(table.sort);
 
-      return dh.plot.Figure.create(
-        ChartUtils.makeFigureSettings(settings, tableCopy)
-      ).then(figure => new FigureChartModel(figure, settings, theme));
-    });
+    return dh.plot.Figure.create(
+      ChartUtils.makeFigureSettings(settings, tableCopy)
+    );
   }
 
   /**
@@ -42,10 +60,9 @@ class ChartModelFactory {
    * @param {Object|undefined} settings The chart builder settings
    * @param {boolean} settings.isLinked Whether the newly created chart should stay linked with the original table, update when filters are updated
    * @param {string[]} settings.series The column names to use for creating the series of this chart
-   * @param {string} settings.sourcePanelId The panel ID the chart was created from
    * @param {string} settings.type Chart builder type, from ChartBuilder.types
    * @param {string} settings.xAxis The column name to use for the x-axis
-   * @param {string[]} settings.hiddenSeries Array of hidden series names
+   * @param {string[]} [settings.hiddenSeries] Array of hidden series names
    * @param {dh.Figure} figure The figure to build the model for
    * @param {Object} theme The theme for the figure. Defaults to ChartTheme
    * @returns {Promise<ChartModel | FigureChartModel>} The FigureChartModel representing the figure

--- a/packages/chart/src/ChartModelFactory.js
+++ b/packages/chart/src/ChartModelFactory.js
@@ -39,7 +39,7 @@ class ChartModelFactory {
   /**
    * Creates a model from the settings provided.
    * Tries to create a Figure in the API with it.
-   * @param {Object} settings The chart builder settings
+   * @param {Object|undefined} settings The chart builder settings
    * @param {boolean} settings.isLinked Whether the newly created chart should stay linked with the original table, update when filters are updated
    * @param {string[]} settings.series The column names to use for creating the series of this chart
    * @param {string} settings.sourcePanelId The panel ID the chart was created from

--- a/packages/chart/src/ChartUtils.js
+++ b/packages/chart/src/ChartUtils.js
@@ -1276,17 +1276,6 @@ class ChartUtils {
   }
 
   /**
-   * Dehydrate settings so they can be JSONified
-   * @param {object} settings Chart builder settings
-   */
-  static dehydrateSettings(settings) {
-    return {
-      ...settings,
-      type: `${settings.type}`,
-    };
-  }
-
-  /**
    * Hydrate settings from a JSONable object
    * @param {object} settings Dehydrated settings
    */

--- a/packages/code-studio/.env
+++ b/packages/code-studio/.env
@@ -6,14 +6,24 @@ REACT_APP_OPEN_API_NAME=dh-internal.js
 PUBLIC_URL=/ide/
 REACT_APP_VERSION=$npm_package_version
 REACT_APP_NAME=$npm_package_name
-REACT_APP_PLUGIN_URL=/ide/plugins/
 REACT_APP_NOTEBOOKS_URL=/notebooks
 REACT_APP_LAYOUTS_URL=/layouts
-REACT_APP_INTERNAL_PLUGINS=
 REACT_APP_ENABLE_LOG_PROXY=true
 REACT_APP_SUPPORT_LINK=https://github.com/deephaven/web-client-ui/
 REACT_APP_DOCS_LINK=https://deephaven.io/core/docs/
 BUILD_PATH=./build
+
+# Plugin URLs
+## Path to plugins that load/render as a component (e.g. Table plugins)
+## See https://github.com/deephaven/js-plugin-template/ for templates
+REACT_APP_COMPONENT_PLUGINS_URL=/ide/plugins/
+## Path to component plugins that are loaded locally/internally
+## Mainly used for development purposes
+REACT_APP_INTERNAL_COMPONENT_PLUGINS=
+## Path to plugins that load a module
+## TODO: Create this repo
+## See https://github.com/deephaven/js-module-plugin-template/
+REACT_APP_MODULE_PLUGINS_URL=/js-plugins
 
 # Define the language key and display name that are available on the server.
 # Omit the display name to use the key as the display name.

--- a/packages/code-studio/.env
+++ b/packages/code-studio/.env
@@ -21,8 +21,7 @@ REACT_APP_COMPONENT_PLUGINS_URL=/ide/plugins/
 ## Mainly used for development purposes
 REACT_APP_INTERNAL_COMPONENT_PLUGINS=
 ## Path to plugins that load a module
-## TODO: Create this repo
-## See https://github.com/deephaven/js-module-plugin-template/
+## See https://github.com/deephaven/deephaven-js-plugin-template/
 REACT_APP_MODULE_PLUGINS_URL=/js-plugins
 
 # Define the language key and display name that are available on the server.

--- a/packages/code-studio/.env.development
+++ b/packages/code-studio/.env.development
@@ -6,7 +6,7 @@ REACT_APP_ENABLE_LOG_PROXY=false
 REACT_APP_CORE_API_URL=http://localhost:10000/jsapi
 
 PUBLIC_URL=/
-REACT_APP_INTERNAL_PLUGINS=ExamplePlugin
+REACT_APP_INTERNAL_COMPONENT_PLUGINS=ExamplePlugin
 PORT=4000
 
 # This converts all eslint errors to warnings in dev

--- a/packages/code-studio/package-lock.json
+++ b/packages/code-studio/package-lock.json
@@ -13,6 +13,11 @@
 		"fira": {
 			"version": "github:mozilla/fira#48a8d0a0354e933c0d1cfcf9feb07ccb00eb6fa9",
 			"from": "github:mozilla/fira#4.202"
+		},
+		"regenerator-runtime": {
+			"version": "0.13.9",
+			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
+			"integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
 		}
 	}
 }

--- a/packages/code-studio/package.json
+++ b/packages/code-studio/package.json
@@ -29,6 +29,7 @@
     "@fortawesome/fontawesome-svg-core": "1.2.36",
     "@fortawesome/react-fontawesome": "^0.1.12",
     "@paciolan/remote-component": "2.7.2",
+    "@paciolan/remote-module-loader": "^3.0.2",
     "classnames": "^2.3.1",
     "event-target-shim": "^6.0.2",
     "fira": "github:mozilla/fira#4.202",

--- a/packages/code-studio/package.json
+++ b/packages/code-studio/package.json
@@ -52,6 +52,7 @@
     "reactstrap": "^8.4.1",
     "redux": "^4.0.5",
     "redux-thunk": "^2.3.0",
+    "regenerator-runtime": "^0.13.9",
     "shortid": "^2.2.15",
     "webdav": "^4.6.1"
   },

--- a/packages/code-studio/src/main/App.jsx
+++ b/packages/code-studio/src/main/App.jsx
@@ -9,6 +9,4 @@ const App = () => (
   </div>
 );
 
-App.propTypes = {};
-
 export default App;

--- a/packages/code-studio/src/main/AppInit.jsx
+++ b/packages/code-studio/src/main/AppInit.jsx
@@ -105,8 +105,8 @@ const AppInit = props => {
       log.debug('Plugin manifest loaded:', manifest);
       const pluginPromises = [];
       for (let i = 0; i < manifest.plugins.length; i += 1) {
-        const { main } = manifest.plugins[i];
-        const pluginMainUrl = `${process.env.REACT_APP_MODULE_PLUGINS_URL}/${main}`;
+        const { name, main } = manifest.plugins[i];
+        const pluginMainUrl = `${process.env.REACT_APP_MODULE_PLUGINS_URL}/${name}/${main}`;
         pluginPromises.push(PluginUtils.loadModulePlugin(pluginMainUrl));
       }
       const pluginModules = await Promise.all(pluginPromises);

--- a/packages/code-studio/src/main/AppInit.jsx
+++ b/packages/code-studio/src/main/AppInit.jsx
@@ -121,7 +121,7 @@ const AppInit = props => {
       return pluginMap;
     } catch (e) {
       log.error('Unable to load plugins:', e);
-      return [];
+      return new Map();
     }
   }, []);
 

--- a/packages/code-studio/src/main/AppMainContainer.jsx
+++ b/packages/code-studio/src/main/AppMainContainer.jsx
@@ -85,6 +85,7 @@ export class AppMainContainer extends Component {
     this.handleExportLayoutClick = this.handleExportLayoutClick.bind(this);
     this.handleImportLayoutClick = this.handleImportLayoutClick.bind(this);
     this.handleImportLayoutFiles = this.handleImportLayoutFiles.bind(this);
+    this.handleLoadTablePlugin = this.handleLoadTablePlugin.bind(this);
     this.handleResetLayoutClick = this.handleResetLayoutClick.bind(this);
     this.handleWidgetMenuClick = this.handleWidgetMenuClick.bind(this);
     this.handleWidgetsMenuClose = this.handleWidgetsMenuClose.bind(this);
@@ -479,12 +480,29 @@ export class AppMainContainer extends Component {
     }
   }
 
+  /**
+   * Load a Table plugin specified by a table
+   * @param {string} pluginName The name of the plugin to load
+   * @returns {JSX.Element} An element from the plugin
+   */
+  handleLoadTablePlugin(pluginName) {
+    const { plugins } = this.props;
+
+    // First check if we have any plugin modules loaded that match the TablePlugin.
+    const pluginModule = plugins.get(pluginName);
+    if (pluginModule.TablePlugin) {
+      return pluginModule.TablePlugin;
+    }
+
+    return PluginUtils.loadComponentPlugin(pluginName);
+  }
+
   hydrateGrid(props, id) {
     const { session } = this.props;
     return {
       ...props,
       getDownloadWorker: DownloadServiceWorkerUtils.getServiceWorker,
-      loadPlugin: PluginUtils.loadComponentPlugin,
+      loadPlugin: this.handleLoadTablePlugin,
       localDashboardId: id,
       makeModel: () => createGridModel(session, props.metadata),
     };
@@ -519,9 +537,7 @@ export class AppMainContainer extends Component {
   getDashboardPlugins = memoize(plugins =>
     [...plugins.entries()]
       .filter(([, { DashboardPlugin }]) => DashboardPlugin)
-      .map(([name, { DashboardPlugin }]) =>
-        DashboardPlugin ? <DashboardPlugin key={name} /> : null
-      )
+      .map(([name, { DashboardPlugin }]) => <DashboardPlugin key={name} />)
   );
 
   render() {
@@ -625,7 +641,7 @@ export class AppMainContainer extends Component {
           <GridPlugin
             hydrate={this.hydrateGrid}
             getDownloadWorker={DownloadServiceWorkerUtils.getServiceWorker}
-            loadPlugin={PluginUtils.loadComponentPlugin}
+            loadPlugin={this.handleLoadTablePlugin}
           />
           <ChartPlugin hydrate={this.hydrateChart} />
           <ConsolePlugin />

--- a/packages/code-studio/src/main/AppMainContainer.jsx
+++ b/packages/code-studio/src/main/AppMainContainer.jsx
@@ -500,7 +500,7 @@ export class AppMainContainer extends Component {
     return PluginUtils.loadComponentPlugin(pluginName);
   }
 
-  hydrateDefault(props, id) {
+  hydrateDefault(props = {}, id = '') {
     const { session } = this.props;
     const { metadata } = props;
     if (metadata?.type && (metadata?.id || metadata?.name)) {

--- a/packages/code-studio/src/main/AppMainContainer.jsx
+++ b/packages/code-studio/src/main/AppMainContainer.jsx
@@ -490,7 +490,7 @@ export class AppMainContainer extends Component {
 
     // First check if we have any plugin modules loaded that match the TablePlugin.
     const pluginModule = plugins.get(pluginName);
-    if (pluginModule.TablePlugin) {
+    if (pluginModule?.TablePlugin) {
       return pluginModule.TablePlugin;
     }
 

--- a/packages/code-studio/src/main/AppMainContainer.jsx
+++ b/packages/code-studio/src/main/AppMainContainer.jsx
@@ -14,6 +14,7 @@ import {
   Popper,
 } from '@deephaven/components';
 import Dashboard, {
+  DashboardUtils,
   DEFAULT_DASHBOARD_ID,
   getDashboardData,
   PanelEvent,
@@ -93,6 +94,7 @@ export class AppMainContainer extends Component {
     this.handlePaste = this.handlePaste.bind(this);
     this.hydrateChart = this.hydrateChart.bind(this);
     this.hydrateGrid = this.hydrateGrid.bind(this);
+    this.hydrateDefault = this.hydrateDefault.bind(this);
     this.openNotebookFromURL = this.openNotebookFromURL.bind(this);
 
     this.goldenLayout = null;
@@ -497,6 +499,26 @@ export class AppMainContainer extends Component {
     return PluginUtils.loadComponentPlugin(pluginName);
   }
 
+  hydrateDefault(props, id) {
+    const { session } = this.props;
+    const { metadata } = props;
+    if (metadata?.type && (metadata?.id || metadata?.name)) {
+      // Looks like a widget, hydrate it as such
+      const widget = metadata.id
+        ? {
+            type: metadata.type,
+            id: metadata.id,
+          }
+        : { type: metadata.type, name: metadata.name };
+      return {
+        fetch: () => session.getObject(widget),
+        localDashboardId: id,
+        ...props,
+      };
+    }
+    return DashboardUtils.hydrate(props, id);
+  }
+
   hydrateGrid(props, id) {
     const { session } = this.props;
     return {
@@ -637,6 +659,7 @@ export class AppMainContainer extends Component {
           onGoldenLayoutChange={this.handleGoldenLayoutChange}
           onLayoutConfigChange={this.handleLayoutConfigChange}
           onLayoutInitialized={this.openNotebookFromURL}
+          hydrate={this.hydrateDefault}
         >
           <GridPlugin
             hydrate={this.hydrateGrid}

--- a/packages/code-studio/src/main/AppMainContainer.jsx
+++ b/packages/code-studio/src/main/AppMainContainer.jsx
@@ -35,6 +35,7 @@ import {
   UIPropTypes,
   ControlType,
   ToolType,
+  ChartBuilderPlugin,
 } from '@deephaven/dashboard-core-plugins';
 import { vsGear, dhShapes, dhPanels } from '@deephaven/icons';
 import dh, { PropTypes as APIPropTypes } from '@deephaven/jsapi-shim';
@@ -544,7 +545,7 @@ export class AppMainContainer extends Component {
 
   /**
    * Open a widget up, using a drag event if specified.
-   * @param {VariableDefinition} widget The widget to
+   * @param {VariableDefinition} widget The widget to open
    * @param {DragEvent} dragEvent The mouse drag event that trigger it, undefined if it was not triggered by a drag
    */
   openWidget(widget, dragEvent) {
@@ -667,6 +668,7 @@ export class AppMainContainer extends Component {
             loadPlugin={this.handleLoadTablePlugin}
           />
           <ChartPlugin hydrate={this.hydrateChart} />
+          <ChartBuilderPlugin />
           <ConsolePlugin />
           <FilterPlugin />
           <PandasPlugin />

--- a/packages/code-studio/src/main/AppMainContainer.jsx
+++ b/packages/code-studio/src/main/AppMainContainer.jsx
@@ -5,7 +5,6 @@ import memoize from 'memoize-one';
 import { CSSTransition } from 'react-transition-group';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
-import shortid from 'shortid';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import {
   ContextActions,
@@ -21,13 +20,11 @@ import Dashboard, {
   updateDashboardData as updateDashboardDataAction,
 } from '@deephaven/dashboard';
 import {
-  ChartEvent,
   ChartPlugin,
   ConsolePlugin,
   FilterPlugin,
   GridPlugin,
   InputFilterEvent,
-  IrisGridEvent,
   LinkerPlugin,
   MarkdownEvent,
   NotebookEvent,

--- a/packages/code-studio/src/main/AppMainContainer.jsx
+++ b/packages/code-studio/src/main/AppMainContainer.jsx
@@ -500,7 +500,7 @@ export class AppMainContainer extends Component {
     return PluginUtils.loadComponentPlugin(pluginName);
   }
 
-  hydrateDefault(props = {}, id = '') {
+  hydrateDefault(props, id) {
     const { session } = this.props;
     const { metadata } = props;
     if (metadata?.type && (metadata?.id || metadata?.name)) {

--- a/packages/code-studio/src/main/AppMainContainer.test.jsx
+++ b/packages/code-studio/src/main/AppMainContainer.test.jsx
@@ -18,6 +18,18 @@ function makeSession() {
   };
 }
 
+function makeSessionConfig() {
+  return { type: 'Test' };
+}
+
+function makeMatch() {
+  return {
+    params: {
+      notebookPath: '/test/',
+    },
+  };
+}
+
 function makeAppMainContainer({
   layoutStorage = {},
   user = TestUtils.REGULAR_USER,
@@ -34,8 +46,9 @@ function makeAppMainContainer({
   serverConfigValues = {},
   dashboardOpenedPanelMaps = {},
   session = makeSession(),
-  sessionConfig = {},
-  match = {},
+  sessionConfig = makeSessionConfig(),
+  match = makeMatch(),
+  plugins = new Map(),
 } = {}) {
   return shallow(
     <AppMainContainer
@@ -56,6 +69,7 @@ function makeAppMainContainer({
       session={session}
       sessionConfig={sessionConfig}
       match={match}
+      plugins={plugins}
     />
   );
 }

--- a/packages/code-studio/src/main/WidgetList.tsx
+++ b/packages/code-studio/src/main/WidgetList.tsx
@@ -60,8 +60,8 @@ export const WidgetList = (props: WidgetListProps): JSX.Element => {
    * Send object to be created, if an event is passed object
    * is treated as createDragSourceFromEvent in golden-layout
    * and uses the event as the starting location for the drag.
-   * @param {WidgetDefintion} widget
-   * @param {WindowMouseEvent?} event
+   * @param widget
+   * @param event
    */
   const sendSelect = useCallback(
     (widget: VariableDefinition, event?: WindowMouseEvent) => {

--- a/packages/code-studio/src/main/WidgetList.tsx
+++ b/packages/code-studio/src/main/WidgetList.tsx
@@ -14,6 +14,7 @@ import {
   vsPreview,
   vsRefresh,
 } from '@deephaven/icons';
+import { VariableDefinition } from '@deephaven/jsapi-shim';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import './WidgetList.scss';
 
@@ -23,23 +24,18 @@ const MINIMUM_DRAG_DISTANCE = 10;
 // `WindowMouseEvent` is just a convenience alias
 export type WindowMouseEvent = globalThis.MouseEvent;
 
-export type WidgetDefinition = {
-  name: string;
-  type: string;
-};
-
 export type SelectStartEvent = {
   x: number;
   y: number;
-  widget: WidgetDefinition;
+  widget: VariableDefinition;
 };
 
 export interface WidgetListProps {
-  onSelect: (widget: WidgetDefinition, e?: WindowMouseEvent) => undefined;
+  onSelect: (widget: VariableDefinition, e?: WindowMouseEvent) => undefined;
   onExportLayout: () => undefined;
   onImportLayout: () => undefined;
   onResetLayout: () => undefined;
-  widgets?: WidgetDefinition[];
+  widgets?: VariableDefinition[];
 }
 
 /**
@@ -68,7 +64,7 @@ export const WidgetList = (props: WidgetListProps): JSX.Element => {
    * @param {WindowMouseEvent?} event
    */
   const sendSelect = useCallback(
-    (widget: WidgetDefinition, event?: WindowMouseEvent) => {
+    (widget: VariableDefinition, event?: WindowMouseEvent) => {
       if (widget) onSelect(widget, event);
     },
     [onSelect]
@@ -100,7 +96,7 @@ export const WidgetList = (props: WidgetListProps): JSX.Element => {
   );
 
   const handleMouseDown = useCallback(
-    (e: MouseEvent, widget: WidgetDefinition) => {
+    (e: MouseEvent, widget: VariableDefinition) => {
       selectStartEvent.current = {
         x: e.clientX,
         y: e.clientY,
@@ -112,7 +108,7 @@ export const WidgetList = (props: WidgetListProps): JSX.Element => {
   );
 
   const handleMouseUp = useCallback(
-    (e: MouseEvent, widget: WidgetDefinition) => {
+    (e: MouseEvent, widget: VariableDefinition) => {
       window.removeEventListener('mousemove', handleMouseMove);
 
       // down and up need to occur on same object to constitute a click event
@@ -129,11 +125,11 @@ export const WidgetList = (props: WidgetListProps): JSX.Element => {
     () =>
       widgets.filter(widget =>
         searchText
-          ? widget.name.toLowerCase().includes(searchText.toLowerCase())
+          ? widget.name?.toLowerCase().includes(searchText.toLowerCase())
           : true
       ),
     [searchText, widgets]
-  ).sort((a, b) => a.name.localeCompare(b.name));
+  ).sort((a, b) => a.name?.localeCompare(b.name ?? '') ?? 0);
 
   const widgetElements = useMemo(
     () =>
@@ -142,7 +138,7 @@ export const WidgetList = (props: WidgetListProps): JSX.Element => {
           <button
             type="button"
             className="btn btn-link"
-            data-testid={`panel-list-item-${widget.name}-button`}
+            data-testid={`panel-list-item-${widget.name ?? ''}-button`}
             onMouseDown={event => {
               handleMouseDown(event, widget);
             }}
@@ -156,7 +152,7 @@ export const WidgetList = (props: WidgetListProps): JSX.Element => {
             }}
             disabled={disableDoubleClick}
           >
-            <ObjectIcon type={widget.type} /> {widget.name}
+            <ObjectIcon type={widget.type} /> {widget.name ?? ''}
           </button>
         </li>
       )),

--- a/packages/code-studio/src/main/WidgetUtils.ts
+++ b/packages/code-studio/src/main/WidgetUtils.ts
@@ -78,7 +78,7 @@ export const createGridModel = async (
   const { table: tableName } = metadata;
   const definition = { name: tableName, type: dh.VariableType.TABLE };
   const table = await session.getObject(definition);
-  return IrisGridModelFactory.makeModel(table, false);
+  return IrisGridModelFactory.makeModel(table);
 };
 
 export default { createChartModel, createGridModel };

--- a/packages/code-studio/src/plugins/PluginUtils.jsx
+++ b/packages/code-studio/src/plugins/PluginUtils.jsx
@@ -1,13 +1,21 @@
 import React, { Suspense } from 'react';
 import Log from '@deephaven/log';
 import RemoteComponent from './RemoteComponent';
+import loadRemoteModule from './loadRemoteModule';
 
 const log = Log.module('PluginUtils');
 
 class PluginUtils {
-  static loadPlugin(pluginName) {
+  /**
+   * Load a component plugin either specified in the REACT_APP_COMPONENT_TABLE_PLUGINS environment variable, or from the server if it's not internal.
+   * @param {string} pluginName Name of the table plugin to load
+   * @returns {JSX.Element} A lazily loaded JSX.Element from the plugin
+   */
+  static loadComponentPlugin(pluginName) {
     if (
-      process.env.REACT_APP_INTERNAL_PLUGINS.split(',').includes(pluginName)
+      process.env.REACT_APP_INTERNAL_COMPONENT_PLUGINS.split(',').includes(
+        pluginName
+      )
     ) {
       const LazyPlugin = React.lazy(() => import(`./internal/${pluginName}`));
       const LocalPlugin = React.forwardRef((props, ref) => (
@@ -21,7 +29,10 @@ class PluginUtils {
       return LocalPlugin;
     }
 
-    const baseUrl = new URL(process.env.REACT_APP_PLUGIN_URL, window.location);
+    const baseUrl = new URL(
+      process.env.REACT_APP_COMPONENT_PLUGINS_URL,
+      window.location
+    );
     const pluginUrl = new URL(`${pluginName}.js`, baseUrl);
     const Plugin = React.forwardRef((props, ref) => (
       <RemoteComponent
@@ -40,6 +51,40 @@ class PluginUtils {
     Plugin.pluginName = pluginName;
     Plugin.displayName = 'Plugin';
     return Plugin;
+  }
+
+  /**
+   * Imports a commonjs plugin module from the provided URL
+   * @param {string} pluginUrl The URL of the plugin to load
+   * @returns The loaded module
+   */
+  static async loadModulePlugin(pluginUrl) {
+    const myModule = await loadRemoteModule(pluginUrl);
+    return myModule;
+  }
+
+  /**
+   * Loads a JSON file and returns the JSON object
+   * @param {string} jsonUrl The URL of the JSON file to load
+   * @returns The JSON object of the manifest file
+   */
+  static async loadJson(jsonUrl) {
+    return new Promise((resolve, reject) => {
+      const request = new XMLHttpRequest();
+      request.addEventListener('load', () => {
+        try {
+          const json = JSON.parse(request.responseText);
+          resolve(json);
+        } catch (err) {
+          reject(err);
+        }
+      });
+      request.addEventListener('error', err => {
+        reject(err);
+      });
+      request.open('GET', jsonUrl);
+      request.send();
+    });
   }
 }
 

--- a/packages/code-studio/src/plugins/loadRemoteModule.js
+++ b/packages/code-studio/src/plugins/loadRemoteModule.js
@@ -1,0 +1,10 @@
+import createLoadRemoteModule, {
+  createRequires,
+} from '@paciolan/remote-module-loader';
+
+const dependencies = {
+  react: require('react'),
+};
+
+const requires = createRequires(dependencies);
+export default createLoadRemoteModule({ requires });

--- a/packages/code-studio/src/plugins/loadRemoteModule.js
+++ b/packages/code-studio/src/plugins/loadRemoteModule.js
@@ -3,6 +3,7 @@ import createLoadRemoteModule, {
 } from '@paciolan/remote-module-loader';
 
 const dependencies = {
+  // eslint-disable-next-line global-require
   react: require('react'),
 };
 

--- a/packages/code-studio/src/plugins/loadRemoteModule.js
+++ b/packages/code-studio/src/plugins/loadRemoteModule.js
@@ -1,10 +1,11 @@
+/* eslint-disable global-require */
 import createLoadRemoteModule, {
   createRequires,
 } from '@paciolan/remote-module-loader';
 
 const dependencies = {
-  // eslint-disable-next-line global-require
   react: require('react'),
+  reactstrap: require('reactstrap'),
 };
 
 const requires = createRequires(dependencies);

--- a/packages/code-studio/src/plugins/loadRemoteModule.js
+++ b/packages/code-studio/src/plugins/loadRemoteModule.js
@@ -1,12 +1,10 @@
-/* eslint-disable global-require */
 import createLoadRemoteModule, {
   createRequires,
 } from '@paciolan/remote-module-loader';
+import { resolve } from '../remote-component.config';
 
-const dependencies = {
-  react: require('react'),
-  reactstrap: require('reactstrap'),
-};
+const requires = createRequires(resolve);
 
-const requires = createRequires(dependencies);
-export default createLoadRemoteModule({ requires });
+export const loadRemoteModule = createLoadRemoteModule({ requires });
+
+export default loadRemoteModule;

--- a/packages/code-studio/src/remote-component.config.js
+++ b/packages/code-studio/src/remote-component.config.js
@@ -1,4 +1,4 @@
-/* eslint-disable */
+/* eslint-disable global-require */
 /**
  * remote-component.config.js
  *

--- a/packages/code-studio/src/remote-component.config.js
+++ b/packages/code-studio/src/remote-component.config.js
@@ -7,6 +7,7 @@
 module.exports = {
   resolve: {
     react: require('react'),
-    reactstrap: require(`reactstrap`),
+    reactstrap: require('reactstrap'),
+    regeneratorRuntime: require('regenerator-runtime/runtime'),
   },
 };

--- a/packages/console/package-lock.json
+++ b/packages/console/package-lock.json
@@ -21,167 +21,6 @@
 				"source-map": "^0.5.0"
 			}
 		},
-		"@babel/runtime": {
-			"version": "7.16.7",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.7.tgz",
-			"integrity": "sha512-9E9FJowqAsytyOY6LG+1KuueckRL+aQW+mKvXRXnuFGyRAyepJPmEo9vgMfXUA6O9u3IeEdv9MAkppFcaQwogQ==",
-			"requires": {
-				"regenerator-runtime": "^0.13.4"
-			}
-		},
-		"@deephaven/components": {
-			"version": "0.9.1",
-			"resolved": "https://registry.npmjs.org/@deephaven/components/-/components-0.9.1.tgz",
-			"integrity": "sha512-B96vtZW3NHN27z+pfo7WO0FmZlt/uESaPi0WmQbzxJj3XNZifgfEWZy258udvG27FXy4Md4J/poXaCjdaauQmw==",
-			"dev": true,
-			"requires": {
-				"@deephaven/icons": "^0.9.1",
-				"@deephaven/react-hooks": "^0.9.1",
-				"@deephaven/utils": "^0.9.1",
-				"@fortawesome/fontawesome-svg-core": "^1.2.32",
-				"@fortawesome/react-fontawesome": "^0.1.12",
-				"bootstrap": "4.4.1",
-				"classnames": "^2.3.1",
-				"event-target-shim": "^6.0.2",
-				"jquery": "^3.5.1",
-				"lodash.debounce": "^4.0.8",
-				"lodash.flatten": "^4.4.0",
-				"memoizee": "^0.4.15",
-				"popper.js": "^1.16.1",
-				"prop-types": "^15.7.2",
-				"react-beautiful-dnd": "^13.0.0",
-				"react-transition-group": "^2.3.1",
-				"react-virtualized-auto-sizer": "^1.0.2",
-				"react-window": "^1.8.5",
-				"reactstrap": "^8.4.1",
-				"shortid": "^2.2.15"
-			}
-		},
-		"@deephaven/grid": {
-			"version": "0.9.1",
-			"resolved": "https://registry.npmjs.org/@deephaven/grid/-/grid-0.9.1.tgz",
-			"integrity": "sha512-INVZKFo/2bK+FpT5vqN7wfdrW66Xl5fxDOkr8I8PO9LL23RMfdiPvilzO8Ji7fKP3fOZtvCznO7yLMEzVBhFLA==",
-			"requires": {
-				"classnames": "^2.3.1",
-				"color-convert": "^2.0.1",
-				"event-target-shim": "^6.0.2",
-				"lodash.clamp": "^4.0.3",
-				"memoize-one": "^5.1.1",
-				"memoizee": "^0.4.15",
-				"prop-types": "^15.7.2"
-			},
-			"dependencies": {
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-				}
-			}
-		},
-		"@deephaven/icons": {
-			"version": "0.9.1",
-			"resolved": "https://registry.npmjs.org/@deephaven/icons/-/icons-0.9.1.tgz",
-			"integrity": "sha512-nLLZez6hNl4Ep6b7IjjIxLTGRa9WxeagNC2BP2IWVXs/ONvHHv0t5SYeCCJ/IaH8Bz2UWnxf09VivVPdIGZYig==",
-			"requires": {
-				"@fortawesome/fontawesome-common-types": "^0.2.35"
-			}
-		},
-		"@deephaven/iris-grid": {
-			"version": "0.9.1",
-			"resolved": "https://registry.npmjs.org/@deephaven/iris-grid/-/iris-grid-0.9.1.tgz",
-			"integrity": "sha512-KHZwBKu/oVZY3GyrEAuMqrV0BKX4SYCBtFc5p11xSMwfduwGm01ppcrv5T4j90P9vNTt2KffLgIya6JS3JMzlQ==",
-			"requires": {
-				"@deephaven/grid": "^0.9.1",
-				"@deephaven/icons": "^0.9.1",
-				"@deephaven/jsapi-shim": "^0.9.1",
-				"@deephaven/react-hooks": "^0.9.1",
-				"@deephaven/utils": "^0.9.1",
-				"@fortawesome/react-fontawesome": "^0.1.12",
-				"classnames": "^2.3.1",
-				"deep-equal": "^2.0.4",
-				"lodash.clamp": "^4.0.3",
-				"lodash.debounce": "^4.0.8",
-				"lodash.throttle": "^4.1.1",
-				"memoize-one": "^5.1.1",
-				"memoizee": "^0.4.15",
-				"monaco-editor": "^0.27.0",
-				"prop-types": "^15.7.2",
-				"react-beautiful-dnd": "^13.0.0",
-				"react-transition-group": "^2.3.1",
-				"shortid": "^2.2.15",
-				"web-streams-polyfill": "^2.1.0"
-			}
-		},
-		"@deephaven/jsapi-shim": {
-			"version": "0.9.1",
-			"resolved": "https://registry.npmjs.org/@deephaven/jsapi-shim/-/jsapi-shim-0.9.1.tgz",
-			"integrity": "sha512-soBU7sU9qZgzDXJyYrU96GiB7UBCdHScUaQjl4ISx2igIdK+Qfe7JOYVxYjJdV8KEVK/l+smSkahAIT5/NJY4Q==",
-			"requires": {
-				"prop-types": "^15.7.2"
-			}
-		},
-		"@deephaven/log": {
-			"version": "0.9.1",
-			"resolved": "https://registry.npmjs.org/@deephaven/log/-/log-0.9.1.tgz",
-			"integrity": "sha512-L/yKtSYOrNZlvyElqpgdrnL3JBaY07szFjhA37XK31+uH/jcPcbMxsn2Uf+++yyFcn6GKO1XXXP44V3xBkBQJg==",
-			"dev": true,
-			"requires": {
-				"event-target-shim": "^6.0.2"
-			}
-		},
-		"@deephaven/mocks": {
-			"version": "0.9.0",
-			"resolved": "https://registry.npmjs.org/@deephaven/mocks/-/mocks-0.9.0.tgz",
-			"integrity": "sha512-PkCZ0UtFemj1wlD+fGmmmkafOsieK/ts1PyRAdBH4EBDg0WEBjCRsD9lltGydXB1LSUDy0G0xtGOjX/BPPviRA==",
-			"dev": true
-		},
-		"@deephaven/react-hooks": {
-			"version": "0.9.1",
-			"resolved": "https://registry.npmjs.org/@deephaven/react-hooks/-/react-hooks-0.9.1.tgz",
-			"integrity": "sha512-v7r2DZoPahHNBspbulCtvUgCqJ+i9WPEA8cK9nEsTVTeuR3mhwLw4E/0g+WlXJ78FsUdA0K9FECJfUg1YTvyLg=="
-		},
-		"@deephaven/storage": {
-			"version": "0.9.1",
-			"resolved": "https://registry.npmjs.org/@deephaven/storage/-/storage-0.9.1.tgz",
-			"integrity": "sha512-Bcsuaaib5RLX0IEYfPlLl5CfOb/yNssq+4FbD4h0R8SBmFN7oTmRlWLMDWflFpV9FVwBBKojp5GyvKhxyTkHBQ==",
-			"requires": {
-				"@deephaven/iris-grid": "^0.9.1",
-				"lodash.throttle": "^4.1.1"
-			}
-		},
-		"@deephaven/tsconfig": {
-			"version": "0.9.0",
-			"resolved": "https://registry.npmjs.org/@deephaven/tsconfig/-/tsconfig-0.9.0.tgz",
-			"integrity": "sha512-zYKPllv+W+UhAuzC2pbsaQynxzsE0bBK/XjfiK0LWiGMkMhp43rwEaCiMODSYaxGmaV5eA+ijm8r1Y8v21pH4w==",
-			"dev": true
-		},
-		"@deephaven/utils": {
-			"version": "0.9.1",
-			"resolved": "https://registry.npmjs.org/@deephaven/utils/-/utils-0.9.1.tgz",
-			"integrity": "sha512-kll4L5bNOOPdtpeSDpIvC8+NnlaToKrsPoJ3kvsZvJVmILdIKAIXcviGPxZO5SCjyzgV/NmfLUmHq0CcMAYnEg=="
-		},
-		"@fortawesome/fontawesome-common-types": {
-			"version": "0.2.36",
-			"resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.36.tgz",
-			"integrity": "sha512-a/7BiSgobHAgBWeN7N0w+lAhInrGxksn13uK7231n2m8EDPE3BMCl9NZLTGrj9ZXfCmC6LM0QLqXidIizVQ6yg=="
-		},
-		"@fortawesome/fontawesome-svg-core": {
-			"version": "1.2.36",
-			"resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.36.tgz",
-			"integrity": "sha512-YUcsLQKYb6DmaJjIHdDWpBIGCcyE/W+p/LMGvjQem55Mm2XWVAP5kWTMKWLv9lwpCVjpLxPyOMOyUocP1GxrtA==",
-			"dev": true,
-			"requires": {
-				"@fortawesome/fontawesome-common-types": "^0.2.36"
-			}
-		},
 		"@fortawesome/react-fontawesome": {
 			"version": "0.1.15",
 			"resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.1.15.tgz",
@@ -190,31 +29,12 @@
 				"prop-types": "^15.7.2"
 			}
 		},
-		"@hypnosphi/create-react-context": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/@hypnosphi/create-react-context/-/create-react-context-0.3.1.tgz",
-			"integrity": "sha512-V1klUed202XahrWJLLOT3EXNeCpFHCcJntdFGI15ntCwau+jfT386w7OFTMaCqOgXUH1fa0w/I1oZs+i/Rfr0A==",
-			"dev": true,
-			"requires": {
-				"gud": "^1.0.0",
-				"warning": "^4.0.3"
-			}
-		},
 		"@nicolo-ribaudo/chokidar-2": {
 			"version": "2.1.8-no-fsevents.3",
 			"resolved": "https://registry.npmjs.org/@nicolo-ribaudo/chokidar-2/-/chokidar-2-2.1.8-no-fsevents.3.tgz",
 			"integrity": "sha512-s88O1aVtXftvp5bCPB7WnmXc5IwOZZ7YPuwNPt+GtOOXpPvad1LfbmjYv+qII7zP6RU2QGnqve27dnLycEnyEQ==",
 			"dev": true,
 			"optional": true
-		},
-		"@types/hoist-non-react-statics": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
-			"integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
-			"requires": {
-				"@types/react": "*",
-				"hoist-non-react-statics": "^3.3.0"
-			}
 		},
 		"@types/json-schema": {
 			"version": "7.0.9",
@@ -225,12 +45,14 @@
 		"@types/prop-types": {
 			"version": "15.7.4",
 			"resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.4.tgz",
-			"integrity": "sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ=="
+			"integrity": "sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ==",
+			"dev": true
 		},
 		"@types/react": {
 			"version": "17.0.39",
 			"resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.39.tgz",
 			"integrity": "sha512-UVavlfAxDd/AgAacMa60Azl7ygyQNRwC/DsHZmKgNvPmRR5p70AJ5Q9EAmL2NWOJmeV+vVUI4IAP7GZrN8h8Ug==",
+			"dev": true,
 			"requires": {
 				"@types/prop-types": "*",
 				"@types/scheduler": "*",
@@ -246,21 +68,11 @@
 				"@types/react": "*"
 			}
 		},
-		"@types/react-redux": {
-			"version": "7.1.22",
-			"resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-7.1.22.tgz",
-			"integrity": "sha512-GxIA1kM7ClU73I6wg9IRTVwSO9GS+SAKZKe0Enj+82HMU6aoESFU2HNAdNi3+J53IaOHPiUfT3kSG4L828joDQ==",
-			"requires": {
-				"@types/hoist-non-react-statics": "^3.3.0",
-				"@types/react": "*",
-				"hoist-non-react-statics": "^3.3.0",
-				"redux": "^4.0.0"
-			}
-		},
 		"@types/scheduler": {
 			"version": "0.16.2",
 			"resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
-			"integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew=="
+			"integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
+			"dev": true
 		},
 		"ajv": {
 			"version": "6.12.6",
@@ -289,11 +101,6 @@
 				"color-convert": "^1.9.0"
 			}
 		},
-		"available-typed-arrays": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
-			"integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw=="
-		},
 		"balanced-match": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -304,12 +111,6 @@
 			"version": "5.2.2",
 			"resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
 			"integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
-			"dev": true
-		},
-		"bootstrap": {
-			"version": "4.4.1",
-			"resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.4.1.tgz",
-			"integrity": "sha512-tbx5cHubwE6e2ZG7nqM3g/FZ5PQEDMWmMGNrCUBVRPHXTJaH7CBDdsLeu3eCh3B1tzAxTnAbtmrzvWEvT2NNEA==",
 			"dev": true
 		},
 		"brace-expansion": {
@@ -326,6 +127,7 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
 			"integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+			"dev": true,
 			"requires": {
 				"function-bind": "^1.1.1",
 				"get-intrinsic": "^1.0.2"
@@ -493,18 +295,11 @@
 				"which": "^2.0.1"
 			}
 		},
-		"css-box-model": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/css-box-model/-/css-box-model-1.2.1.tgz",
-			"integrity": "sha512-a7Vr4Q/kd/aw96bnJG332W9V9LkJO69JRcaCYDUqjp6/z0w6VcZjgAcTbgFxEPfBgdnAwlh3iwu+hLopa+flJw==",
-			"requires": {
-				"tiny-invariant": "^1.0.6"
-			}
-		},
 		"csstype": {
 			"version": "3.0.10",
 			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.10.tgz",
-			"integrity": "sha512-2u44ZG2OcNUO9HDp/Jl8C07x6pU/eTR3ncV91SiK3dhG9TWvRVsCoJw14Ckx5DgWkzGA3waZWO3d7pgqpUI/XA=="
+			"integrity": "sha512-2u44ZG2OcNUO9HDp/Jl8C07x6pU/eTR3ncV91SiK3dhG9TWvRVsCoJw14Ckx5DgWkzGA3waZWO3d7pgqpUI/XA==",
+			"dev": true
 		},
 		"d": {
 			"version": "1.0.1",
@@ -515,49 +310,13 @@
 				"type": "^1.0.1"
 			}
 		},
-		"deep-equal": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.0.5.tgz",
-			"integrity": "sha512-nPiRgmbAtm1a3JsnLCf6/SLfXcjyN5v8L1TXzdCmHrXJ4hx+gW/w1YCcn7z8gJtSiDArZCgYtbao3QqLm/N1Sw==",
-			"requires": {
-				"call-bind": "^1.0.0",
-				"es-get-iterator": "^1.1.1",
-				"get-intrinsic": "^1.0.1",
-				"is-arguments": "^1.0.4",
-				"is-date-object": "^1.0.2",
-				"is-regex": "^1.1.1",
-				"isarray": "^2.0.5",
-				"object-is": "^1.1.4",
-				"object-keys": "^1.1.1",
-				"object.assign": "^4.1.2",
-				"regexp.prototype.flags": "^1.3.0",
-				"side-channel": "^1.0.3",
-				"which-boxed-primitive": "^1.0.1",
-				"which-collection": "^1.0.1",
-				"which-typed-array": "^1.1.2"
-			},
-			"dependencies": {
-				"isarray": {
-					"version": "2.0.5",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-					"integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
-				}
-			}
-		},
 		"define-properties": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
 			"integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+			"dev": true,
 			"requires": {
 				"object-keys": "^1.0.12"
-			}
-		},
-		"dom-helpers": {
-			"version": "3.4.0",
-			"resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.4.0.tgz",
-			"integrity": "sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==",
-			"requires": {
-				"@babel/runtime": "^7.1.2"
 			}
 		},
 		"emojis-list": {
@@ -579,6 +338,7 @@
 			"version": "1.18.5",
 			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.5.tgz",
 			"integrity": "sha512-DDggyJLoS91CkJjgauM5c0yZMjiD1uK3KcaCeAmffGwZ+ODWzOkPN4QwRbsK5DOFf06fywmyLci3ZD8jLGhVYA==",
+			"dev": true,
 			"requires": {
 				"call-bind": "^1.0.2",
 				"es-to-primitive": "^1.2.1",
@@ -599,32 +359,11 @@
 				"unbox-primitive": "^1.0.1"
 			}
 		},
-		"es-get-iterator": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.2.tgz",
-			"integrity": "sha512-+DTO8GYwbMCwbywjimwZMHp8AuYXOS2JZFWoi2AlPOS3ebnII9w/NLpNZtA7A0YLaVDw+O7KFCeoIV7OPvM7hQ==",
-			"requires": {
-				"call-bind": "^1.0.2",
-				"get-intrinsic": "^1.1.0",
-				"has-symbols": "^1.0.1",
-				"is-arguments": "^1.1.0",
-				"is-map": "^2.0.2",
-				"is-set": "^2.0.2",
-				"is-string": "^1.0.5",
-				"isarray": "^2.0.5"
-			},
-			"dependencies": {
-				"isarray": {
-					"version": "2.0.5",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-					"integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
-				}
-			}
-		},
 		"es-to-primitive": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
 			"integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+			"dev": true,
 			"requires": {
 				"is-callable": "^1.1.4",
 				"is-date-object": "^1.0.1",
@@ -693,11 +432,6 @@
 				"es5-ext": "~0.10.14"
 			}
 		},
-		"event-target-shim": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-6.0.2.tgz",
-			"integrity": "sha512-8q3LsZjRezbFZ2PN+uP+Q7pnHUMmAOziU2vA2OwoFaKIXxlxl38IylhSSgUorWu/rf4er67w0ikBqjBFk/pomA=="
-		},
 		"ext": {
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/ext/-/ext-1.5.0.tgz",
@@ -725,11 +459,6 @@
 			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
 			"dev": true
 		},
-		"foreach": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
-			"integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
-		},
 		"fs-readdir-recursive": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
@@ -752,12 +481,14 @@
 		"function-bind": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+			"dev": true
 		},
 		"get-intrinsic": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
 			"integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+			"dev": true,
 			"requires": {
 				"function-bind": "^1.1.1",
 				"has": "^1.0.3",
@@ -793,16 +524,11 @@
 			"integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==",
 			"dev": true
 		},
-		"gud": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/gud/-/gud-1.0.0.tgz",
-			"integrity": "sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw==",
-			"dev": true
-		},
 		"has": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
 			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+			"dev": true,
 			"requires": {
 				"function-bind": "^1.1.1"
 			}
@@ -810,7 +536,8 @@
 		"has-bigints": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.1.tgz",
-			"integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA=="
+			"integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==",
+			"dev": true
 		},
 		"has-flag": {
 			"version": "3.0.0",
@@ -821,22 +548,16 @@
 		"has-symbols": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
-			"integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw=="
+			"integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+			"dev": true
 		},
 		"has-tostringtag": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
 			"integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
+			"dev": true,
 			"requires": {
 				"has-symbols": "^1.0.2"
-			}
-		},
-		"hoist-non-react-statics": {
-			"version": "3.3.2",
-			"resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
-			"integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
-			"requires": {
-				"react-is": "^16.7.0"
 			}
 		},
 		"hosted-git-info": {
@@ -869,19 +590,11 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
 			"integrity": "sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==",
+			"dev": true,
 			"requires": {
 				"get-intrinsic": "^1.1.0",
 				"has": "^1.0.3",
 				"side-channel": "^1.0.4"
-			}
-		},
-		"is-arguments": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
-			"integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
-			"requires": {
-				"call-bind": "^1.0.2",
-				"has-tostringtag": "^1.0.0"
 			}
 		},
 		"is-arrayish": {
@@ -894,6 +607,7 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
 			"integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
+			"dev": true,
 			"requires": {
 				"has-bigints": "^1.0.1"
 			}
@@ -902,6 +616,7 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
 			"integrity": "sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==",
+			"dev": true,
 			"requires": {
 				"call-bind": "^1.0.2",
 				"has-tostringtag": "^1.0.0"
@@ -910,7 +625,8 @@
 		"is-callable": {
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
-			"integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w=="
+			"integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==",
+			"dev": true
 		},
 		"is-core-module": {
 			"version": "2.6.0",
@@ -925,6 +641,7 @@
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
 			"integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
+			"dev": true,
 			"requires": {
 				"has-tostringtag": "^1.0.0"
 			}
@@ -944,20 +661,17 @@
 				"is-extglob": "^2.1.1"
 			}
 		},
-		"is-map": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.2.tgz",
-			"integrity": "sha512-cOZFQQozTha1f4MxLFzlgKYPTyj26picdZTx82hbc/Xf4K/tZOOXSCkMvU4pKioRXGDLJRn0GM7Upe7kR721yg=="
-		},
 		"is-negative-zero": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
-			"integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w=="
+			"integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w==",
+			"dev": true
 		},
 		"is-number-object": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.6.tgz",
 			"integrity": "sha512-bEVOqiRcvo3zO1+G2lVMy+gkkEm9Yh7cDMRusKKu5ZJKPUYSJwICTKZrNKHA2EbSP0Tu0+6B/emsYNHZyn6K8g==",
+			"dev": true,
 			"requires": {
 				"has-tostringtag": "^1.0.0"
 			}
@@ -971,20 +685,17 @@
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
 			"integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
+			"dev": true,
 			"requires": {
 				"call-bind": "^1.0.2",
 				"has-tostringtag": "^1.0.0"
 			}
 		},
-		"is-set": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.2.tgz",
-			"integrity": "sha512-+2cnTEZeY5z/iXGbLhPrOAaK/Mau5k5eXq9j14CpRTftq0pAJu2MwVRSZhyZWBzx3o6X795Lz6Bpb6R0GKf37g=="
-		},
 		"is-string": {
 			"version": "1.0.7",
 			"resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
 			"integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
+			"dev": true,
 			"requires": {
 				"has-tostringtag": "^1.0.0"
 			}
@@ -993,34 +704,9 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
 			"integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
+			"dev": true,
 			"requires": {
 				"has-symbols": "^1.0.2"
-			}
-		},
-		"is-typed-array": {
-			"version": "1.1.8",
-			"resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.8.tgz",
-			"integrity": "sha512-HqH41TNZq2fgtGT8WHVFVJhBVGuY3AnP3Q36K8JKXUxSxRgk/d+7NjmwG2vo2mYmXK8UYZKu0qH8bVP5gEisjA==",
-			"requires": {
-				"available-typed-arrays": "^1.0.5",
-				"call-bind": "^1.0.2",
-				"es-abstract": "^1.18.5",
-				"foreach": "^2.0.5",
-				"has-tostringtag": "^1.0.0"
-			}
-		},
-		"is-weakmap": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.1.tgz",
-			"integrity": "sha512-NSBR4kH5oVj1Uwvv970ruUkCV7O1mzgVFO4/rev2cLRda9Tm9HrL70ZPut4rOHgY0FNrUu9BCbXA2sdQ+x0chA=="
-		},
-		"is-weakset": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.2.tgz",
-			"integrity": "sha512-t2yVvttHkQktwnNNmBQ98AhENLdPUTDTE21uPqAQ0ARwQfGeQKRVS0NNurH7bTf7RrvcVn1OOge45CnBeHCSmg==",
-			"requires": {
-				"call-bind": "^1.0.2",
-				"get-intrinsic": "^1.1.1"
 			}
 		},
 		"isarray": {
@@ -1032,12 +718,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
 			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-			"dev": true
-		},
-		"jquery": {
-			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.0.tgz",
-			"integrity": "sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw==",
 			"dev": true
 		},
 		"js-tokens": {
@@ -1116,21 +796,10 @@
 				"json5": "^2.1.2"
 			}
 		},
-		"lodash.clamp": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/lodash.clamp/-/lodash.clamp-4.0.3.tgz",
-			"integrity": "sha1-XCS+3u7vB1NWDcK0y0Zx+Qpt36o="
-		},
 		"lodash.debounce": {
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
 			"integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
-		},
-		"lodash.flatten": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
-			"integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=",
-			"dev": true
 		},
 		"lodash.throttle": {
 			"version": "4.1.1",
@@ -1219,11 +888,6 @@
 			"version": "0.27.0",
 			"resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.27.0.tgz",
 			"integrity": "sha512-UhwP78Wb8w0ZSYoKXQNTV/0CHObp6NS3nCt51QfKE6sKyBo5PBsvuDOHoI2ooBakc6uIwByRLHVeT7+yXQe2fQ=="
-		},
-		"nanoid": {
-			"version": "2.1.11",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.1.11.tgz",
-			"integrity": "sha512-s/snB+WGm6uwi0WjsZdaVcuf3KJXlfGl2LcxgwkEwJF0D/BWzVWAZW/XY4bFaiR7s0Jk3FPvlnepg1H1b1UwlA=="
 		},
 		"next-tick": {
 			"version": "1.1.0",
@@ -1324,26 +988,20 @@
 		"object-inspect": {
 			"version": "1.11.0",
 			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.0.tgz",
-			"integrity": "sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg=="
-		},
-		"object-is": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
-			"integrity": "sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==",
-			"requires": {
-				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.3"
-			}
+			"integrity": "sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg==",
+			"dev": true
 		},
 		"object-keys": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-			"integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
+			"integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+			"dev": true
 		},
 		"object.assign": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
 			"integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+			"dev": true,
 			"requires": {
 				"call-bind": "^1.0.0",
 				"define-properties": "^1.1.3",
@@ -1433,12 +1091,6 @@
 			"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
 			"dev": true
 		},
-		"popper.js": {
-			"version": "1.16.1",
-			"resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
-			"integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==",
-			"dev": true
-		},
 		"process-nextick-args": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -1460,11 +1112,6 @@
 			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
 			"dev": true
 		},
-		"raf-schd": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/raf-schd/-/raf-schd-4.0.3.tgz",
-			"integrity": "sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ=="
-		},
 		"react": {
 			"version": "17.0.2",
 			"resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
@@ -1473,20 +1120,6 @@
 			"requires": {
 				"loose-envify": "^1.1.0",
 				"object-assign": "^4.1.1"
-			}
-		},
-		"react-beautiful-dnd": {
-			"version": "13.1.0",
-			"resolved": "https://registry.npmjs.org/react-beautiful-dnd/-/react-beautiful-dnd-13.1.0.tgz",
-			"integrity": "sha512-aGvblPZTJowOWUNiwd6tNfEpgkX5OxmpqxHKNW/4VmvZTNTbeiq7bA3bn5T+QSF2uibXB0D1DmJsb1aC/+3cUA==",
-			"requires": {
-				"@babel/runtime": "^7.9.2",
-				"css-box-model": "^1.2.0",
-				"memoize-one": "^5.1.1",
-				"raf-schd": "^4.0.2",
-				"react-redux": "^7.2.0",
-				"redux": "^4.0.4",
-				"use-memo-one": "^1.1.1"
 			}
 		},
 		"react-dom": {
@@ -1504,116 +1137,6 @@
 			"version": "16.13.1",
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
 			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
-		},
-		"react-lifecycles-compat": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
-			"integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
-		},
-		"react-popper": {
-			"version": "1.3.11",
-			"resolved": "https://registry.npmjs.org/react-popper/-/react-popper-1.3.11.tgz",
-			"integrity": "sha512-VSA/bS+pSndSF2fiasHK/PTEEAyOpX60+H5EPAjoArr8JGm+oihu4UbrqcEBpQibJxBVCpYyjAX7abJ+7DoYVg==",
-			"dev": true,
-			"requires": {
-				"@babel/runtime": "^7.1.2",
-				"@hypnosphi/create-react-context": "^0.3.1",
-				"deep-equal": "^1.1.1",
-				"popper.js": "^1.14.4",
-				"prop-types": "^15.6.1",
-				"typed-styles": "^0.0.7",
-				"warning": "^4.0.2"
-			},
-			"dependencies": {
-				"deep-equal": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
-					"integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
-					"dev": true,
-					"requires": {
-						"is-arguments": "^1.0.4",
-						"is-date-object": "^1.0.1",
-						"is-regex": "^1.0.4",
-						"object-is": "^1.0.1",
-						"object-keys": "^1.1.1",
-						"regexp.prototype.flags": "^1.2.0"
-					}
-				}
-			}
-		},
-		"react-redux": {
-			"version": "7.2.6",
-			"resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.6.tgz",
-			"integrity": "sha512-10RPdsz0UUrRL1NZE0ejTkucnclYSgXp5q+tB5SWx2qeG2ZJQJyymgAhwKy73yiL/13btfB6fPr+rgbMAaZIAQ==",
-			"requires": {
-				"@babel/runtime": "^7.15.4",
-				"@types/react-redux": "^7.1.20",
-				"hoist-non-react-statics": "^3.3.2",
-				"loose-envify": "^1.4.0",
-				"prop-types": "^15.7.2",
-				"react-is": "^17.0.2"
-			},
-			"dependencies": {
-				"react-is": {
-					"version": "17.0.2",
-					"resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-					"integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
-				}
-			}
-		},
-		"react-transition-group": {
-			"version": "2.9.0",
-			"resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.9.0.tgz",
-			"integrity": "sha512-+HzNTCHpeQyl4MJ/bdE0u6XRMe9+XG/+aL4mCxVN4DnPBQ0/5bfHWPDuOZUzYdMj94daZaZdCCc1Dzt9R/xSSg==",
-			"requires": {
-				"dom-helpers": "^3.4.0",
-				"loose-envify": "^1.4.0",
-				"prop-types": "^15.6.2",
-				"react-lifecycles-compat": "^3.0.4"
-			}
-		},
-		"react-virtualized-auto-sizer": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.6.tgz",
-			"integrity": "sha512-7tQ0BmZqfVF6YYEWcIGuoR3OdYe8I/ZFbNclFlGOC3pMqunkYF/oL30NCjSGl9sMEb17AnzixDz98Kqc3N76HQ==",
-			"dev": true
-		},
-		"react-window": {
-			"version": "1.8.6",
-			"resolved": "https://registry.npmjs.org/react-window/-/react-window-1.8.6.tgz",
-			"integrity": "sha512-8VwEEYyjz6DCnGBsd+MgkD0KJ2/OXFULyDtorIiTz+QzwoP94tBoA7CnbtyXMm+cCeAUER5KJcPtWl9cpKbOBg==",
-			"dev": true,
-			"requires": {
-				"@babel/runtime": "^7.0.0",
-				"memoize-one": ">=3.1.1 <6"
-			}
-		},
-		"reactstrap": {
-			"version": "8.10.1",
-			"resolved": "https://registry.npmjs.org/reactstrap/-/reactstrap-8.10.1.tgz",
-			"integrity": "sha512-StjLADa/12yMNjafrSs+UD7sZAGtKpLO9fZp++2Dj0IzJinqY7eQhXlM3nFf0q40YsIcLvQdFc9pKF8PF4f0Qg==",
-			"dev": true,
-			"requires": {
-				"@babel/runtime": "^7.12.5",
-				"classnames": "^2.2.3",
-				"prop-types": "^15.5.8",
-				"react-popper": "^1.3.6",
-				"react-transition-group": "^3.0.0"
-			},
-			"dependencies": {
-				"react-transition-group": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-3.0.0.tgz",
-					"integrity": "sha512-A9ojB/LWECbFj58SNfjK1X9aaAU+1olLS0DFSikvrr2KfMaiBELemHDa5dKNvcTk2t3gUtDL/PJpFrBKDfMpLg==",
-					"dev": true,
-					"requires": {
-						"dom-helpers": "^3.4.0",
-						"loose-envify": "^1.4.0",
-						"prop-types": "^15.6.2",
-						"react-lifecycles-compat": "^3.0.4"
-					}
-				}
-			}
 		},
 		"read-pkg": {
 			"version": "3.0.0",
@@ -1638,28 +1161,6 @@
 				"safe-buffer": "~5.1.1",
 				"string_decoder": "~1.1.1",
 				"util-deprecate": "~1.0.1"
-			}
-		},
-		"redux": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/redux/-/redux-4.1.2.tgz",
-			"integrity": "sha512-SH8PglcebESbd/shgf6mii6EIoRM0zrQyjcuQ+ojmfxjTtE0z9Y8pa62iA/OJ58qjP6j27uyW4kUF4jl/jd6sw==",
-			"requires": {
-				"@babel/runtime": "^7.9.2"
-			}
-		},
-		"regenerator-runtime": {
-			"version": "0.13.9",
-			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-			"integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
-		},
-		"regexp.prototype.flags": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.1.tgz",
-			"integrity": "sha512-pMR7hBVUUGI7PMA37m2ofIdQCsomVnas+Jn5UPGAHQ+/LlwKm/aTLJHdasmHRzlfeZwHiAOaRSo2rbBDm3nNUQ==",
-			"requires": {
-				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.3"
 			}
 		},
 		"resolve": {
@@ -1747,18 +1248,11 @@
 			"resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.2.tgz",
 			"integrity": "sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg=="
 		},
-		"shortid": {
-			"version": "2.2.16",
-			"resolved": "https://registry.npmjs.org/shortid/-/shortid-2.2.16.tgz",
-			"integrity": "sha512-Ugt+GIZqvGXCIItnsL+lvFJOiN7RYqlGy7QE41O3YC1xbNSeDGIRO7xg2JJXIAj1cAGnOeC1r7/T9pgrtQbv4g==",
-			"requires": {
-				"nanoid": "^2.1.0"
-			}
-		},
 		"side-channel": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
 			"integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+			"dev": true,
 			"requires": {
 				"call-bind": "^1.0.0",
 				"get-intrinsic": "^1.0.2",
@@ -1830,6 +1324,7 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
 			"integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+			"dev": true,
 			"requires": {
 				"call-bind": "^1.0.2",
 				"define-properties": "^1.1.3"
@@ -1839,6 +1334,7 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
 			"integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+			"dev": true,
 			"requires": {
 				"call-bind": "^1.0.2",
 				"define-properties": "^1.1.3"
@@ -1876,26 +1372,16 @@
 				"next-tick": "1"
 			}
 		},
-		"tiny-invariant": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.2.0.tgz",
-			"integrity": "sha512-1Uhn/aqw5C6RI4KejVeTg6mIS7IqxnLJ8Mv2tV5rTc0qWobay7pDUz6Wi392Cnc8ak1H0F2cjoRzb2/AW4+Fvg=="
-		},
 		"type": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
 			"integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg=="
 		},
-		"typed-styles": {
-			"version": "0.0.7",
-			"resolved": "https://registry.npmjs.org/typed-styles/-/typed-styles-0.0.7.tgz",
-			"integrity": "sha512-pzP0PWoZUhsECYjABgCGQlRGL1n7tOHsgwYv3oIiEpJwGhFTuty/YNeduxQYzXXa3Ge5BdT6sHYIQYpl4uJ+5Q==",
-			"dev": true
-		},
 		"unbox-primitive": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
 			"integrity": "sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==",
+			"dev": true,
 			"requires": {
 				"function-bind": "^1.1.1",
 				"has-bigints": "^1.0.1",
@@ -1912,11 +1398,6 @@
 				"punycode": "^2.1.0"
 			}
 		},
-		"use-memo-one": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/use-memo-one/-/use-memo-one-1.1.2.tgz",
-			"integrity": "sha512-u2qFKtxLsia/r8qG0ZKkbytbztzRb317XCkT7yP8wxL0tZ/CzK2G+WWie5vWvpyeP7+YoPIwbJoIHJ4Ba4k0oQ=="
-		},
 		"util-deprecate": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -1931,20 +1412,6 @@
 				"spdx-correct": "^3.0.0",
 				"spdx-expression-parse": "^3.0.0"
 			}
-		},
-		"warning": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
-			"integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
-			"dev": true,
-			"requires": {
-				"loose-envify": "^1.0.0"
-			}
-		},
-		"web-streams-polyfill": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-2.1.1.tgz",
-			"integrity": "sha512-dlNpL2aab3g8CKfGz6rl8FNmGaRWLLn2g/DtSc9IjB30mEdE6XxzPfPSig5BwGSzI+oLxHyETrQGKjrVVhbLCg=="
 		},
 		"webpack-sources": {
 			"version": "1.4.3",
@@ -1977,36 +1444,13 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
 			"integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
+			"dev": true,
 			"requires": {
 				"is-bigint": "^1.0.1",
 				"is-boolean-object": "^1.1.0",
 				"is-number-object": "^1.0.4",
 				"is-string": "^1.0.5",
 				"is-symbol": "^1.0.3"
-			}
-		},
-		"which-collection": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.1.tgz",
-			"integrity": "sha512-W8xeTUwaln8i3K/cY1nGXzdnVZlidBcagyNFtBdD5kxnb4TvGKR7FfSIS3mYpwWS1QUCutfKz8IY8RjftB0+1A==",
-			"requires": {
-				"is-map": "^2.0.1",
-				"is-set": "^2.0.1",
-				"is-weakmap": "^2.0.1",
-				"is-weakset": "^2.0.1"
-			}
-		},
-		"which-typed-array": {
-			"version": "1.1.7",
-			"resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.7.tgz",
-			"integrity": "sha512-vjxaB4nfDqwKI0ws7wZpxIlde1XrLX5uB0ZjpfshgmapJMD7jJWhZI+yToJTqaFByF0eNBcYxbjmCzoRP7CfEw==",
-			"requires": {
-				"available-typed-arrays": "^1.0.5",
-				"call-bind": "^1.0.2",
-				"es-abstract": "^1.18.5",
-				"foreach": "^2.0.5",
-				"has-tostringtag": "^1.0.0",
-				"is-typed-array": "^1.1.7"
 			}
 		},
 		"wrappy": {

--- a/packages/console/src/Console.jsx
+++ b/packages/console/src/Console.jsx
@@ -15,7 +15,6 @@ import ConsoleHistory from './console-history/ConsoleHistory';
 import SHORTCUTS from './ConsoleShortcuts';
 import LogLevel from './log/LogLevel';
 import ConsoleInput from './ConsoleInput';
-import ConsoleUtils from './common/ConsoleUtils';
 import CsvOverlay from './csv/CsvOverlay';
 import CsvInputBar from './csv/CsvInputBar';
 import './Console.scss';
@@ -365,9 +364,9 @@ export class Console extends PureComponent {
     }
 
     const { openObject } = this.props;
-    [...changes.created, ...changes.updated]
-      .filter(object => ConsoleUtils.isOpenableType(object.type))
-      .forEach(object => openObject(object));
+    [...changes.created, ...changes.updated].forEach(object =>
+      openObject(object)
+    );
   }
 
   closeRemovedItems(changes) {
@@ -377,9 +376,7 @@ export class Console extends PureComponent {
 
     const { closeObject } = this.props;
     const { removed } = changes;
-    removed
-      .filter(object => ConsoleUtils.isOpenableType(object.type))
-      .forEach(object => closeObject(object));
+    removed.forEach(object => closeObject(object));
   }
 
   updateHistory(result, historyItemParam) {

--- a/packages/console/src/common/ConsoleUtils.js
+++ b/packages/console/src/common/ConsoleUtils.js
@@ -55,10 +55,6 @@ class ConsoleUtils {
     );
   }
 
-  static isDataStringType(type) {
-    return type === dh.VariableType.DATA_STRING;
-  }
-
   static isOpenableType(type) {
     return ConsoleUtils.isTableType(type) || ConsoleUtils.isWidgetType(type);
   }

--- a/packages/console/src/common/ConsoleUtils.js
+++ b/packages/console/src/common/ConsoleUtils.js
@@ -55,6 +55,10 @@ class ConsoleUtils {
     );
   }
 
+  static isDataStringType(type) {
+    return type === dh.VariableType.DATA_STRING;
+  }
+
   static isOpenableType(type) {
     return ConsoleUtils.isTableType(type) || ConsoleUtils.isWidgetType(type);
   }

--- a/packages/console/src/console-history/ConsoleHistoryItem.jsx
+++ b/packages/console/src/console-history/ConsoleHistoryItem.jsx
@@ -61,24 +61,22 @@ class ConsoleHistoryItem extends PureComponent {
 
       if (changes) {
         const { created, updated } = changes;
-        [...created, ...updated]
-          .filter(({ type }) => ConsoleUtils.isOpenableType(type))
-          .forEach(object => {
-            const { name } = object;
-            const key = `${name}`;
-            const disabled = (disabledObjects ?? []).indexOf(name) >= 0;
-            const element = (
-              <ButtonOld
-                key={key}
-                onClick={() => this.handleObjectClick(object)}
-                className="btn-primary btn-console"
-                disabled={disabled}
-              >
-                <ObjectIcon type={object.type} /> {name}
-              </ButtonOld>
-            );
-            resultElements.push(element);
-          });
+        [...created, ...updated].forEach(object => {
+          const { name } = object;
+          const key = `${name}`;
+          const disabled = (disabledObjects ?? []).indexOf(name) >= 0;
+          const element = (
+            <ButtonOld
+              key={key}
+              onClick={() => this.handleObjectClick(object)}
+              className="btn-primary btn-console"
+              disabled={disabled}
+            >
+              <ObjectIcon type={object.type} /> {name}
+            </ButtonOld>
+          );
+          resultElements.push(element);
+        });
       }
 
       // If the error has an associated command, we'll actually get a separate ERROR item printed out, so only print an error if there isn't an associated command

--- a/packages/console/src/console-history/ConsoleHistoryItem.jsx
+++ b/packages/console/src/console-history/ConsoleHistoryItem.jsx
@@ -10,7 +10,6 @@ import { Code, ObjectIcon } from '../common';
 import ConsoleHistoryItemResult from './ConsoleHistoryItemResult';
 import ConsoleHistoryResultInProgress from './ConsoleHistoryResultInProgress';
 import ConsoleHistoryResultErrorMessage from './ConsoleHistoryResultErrorMessage';
-import ConsoleUtils from '../common/ConsoleUtils';
 import './ConsoleHistoryItem.scss';
 
 const log = Log.module('ConsoleHistoryItem');

--- a/packages/dashboard-core-plugins/package-lock.json
+++ b/packages/dashboard-core-plugins/package-lock.json
@@ -1345,21 +1345,6 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
-    "@choojs/findup": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@choojs/findup/-/findup-0.2.1.tgz",
-      "integrity": "sha512-YstAqNb0MCN8PjdLCDfRsBcGVRN41f3vgLvaI0IrIcBp4AqILRSS0DeWNGkicC+f/zRIPJLc+9RURVSepwvfBw==",
-      "requires": {
-        "commander": "^2.15.1"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "2.20.3",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
-        }
-      }
-    },
     "@cnakazawa/watch": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@cnakazawa/watch/-/watch-1.0.4.tgz",
@@ -1369,234 +1354,6 @@
         "exec-sh": "^0.3.2",
         "minimist": "^1.2.0"
       }
-    },
-    "@deephaven/chart": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@deephaven/chart/-/chart-0.9.1.tgz",
-      "integrity": "sha512-sOTgr4X/iPt6EM7fhbL1S/vRV7rQ+zML8vG1T59ktEndTUFRpTpUeODnQCA9G6RWiWiN6pg9gLKI9sUBQ3X2xQ==",
-      "requires": {
-        "@deephaven/icons": "^0.9.1",
-        "@deephaven/iris-grid": "^0.9.1",
-        "@deephaven/jsapi-shim": "^0.9.1",
-        "deep-equal": "^2.0.4",
-        "lodash.debounce": "^4.0.8",
-        "memoize-one": "^5.1.1",
-        "memoizee": "^0.4.15",
-        "plotly.js": "^2.2.1",
-        "prop-types": "^15.7.2",
-        "react-plotly.js": "^2.4.0"
-      }
-    },
-    "@deephaven/components": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@deephaven/components/-/components-0.9.1.tgz",
-      "integrity": "sha512-B96vtZW3NHN27z+pfo7WO0FmZlt/uESaPi0WmQbzxJj3XNZifgfEWZy258udvG27FXy4Md4J/poXaCjdaauQmw==",
-      "dev": true,
-      "requires": {
-        "@deephaven/icons": "^0.9.1",
-        "@deephaven/react-hooks": "^0.9.1",
-        "@deephaven/utils": "^0.9.1",
-        "@fortawesome/fontawesome-svg-core": "^1.2.32",
-        "@fortawesome/react-fontawesome": "^0.1.12",
-        "bootstrap": "4.4.1",
-        "classnames": "^2.3.1",
-        "event-target-shim": "^6.0.2",
-        "jquery": "^3.5.1",
-        "lodash.debounce": "^4.0.8",
-        "lodash.flatten": "^4.4.0",
-        "memoizee": "^0.4.15",
-        "popper.js": "^1.16.1",
-        "prop-types": "^15.7.2",
-        "react-beautiful-dnd": "^13.0.0",
-        "react-transition-group": "^2.3.1",
-        "react-virtualized-auto-sizer": "^1.0.2",
-        "react-window": "^1.8.5",
-        "reactstrap": "^8.4.1",
-        "shortid": "^2.2.15"
-      }
-    },
-    "@deephaven/console": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@deephaven/console/-/console-0.9.1.tgz",
-      "integrity": "sha512-E1dSc9s2qJO9t9TUhfmB40Mb5TUuYO5EHdaR6KLSUGkI75YrFcs+TpGDuyQS7HbOuKkApcpEUG2KKMJZnFh3aw==",
-      "requires": {
-        "@deephaven/icons": "^0.9.1",
-        "@deephaven/jsapi-shim": "^0.9.1",
-        "@deephaven/storage": "^0.9.1",
-        "@deephaven/utils": "^0.9.1",
-        "@fortawesome/react-fontawesome": "^0.1.12",
-        "classnames": "^2.3.1",
-        "jszip": "3.2.2",
-        "lodash.debounce": "^4.0.8",
-        "lodash.throttle": "^4.1.1",
-        "memoize-one": "^5.1.1",
-        "memoizee": "^0.4.15",
-        "monaco-editor": "^0.27.0",
-        "papaparse": "^5.2.0",
-        "prop-types": "^15.7.2",
-        "shell-quote": "^1.7.2"
-      }
-    },
-    "@deephaven/dashboard": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@deephaven/dashboard/-/dashboard-0.9.1.tgz",
-      "integrity": "sha512-/WfSy3tiQS/AUmfWgFaFww0B8bhzukTsTG0WVKmhIdhyegoDzX2x3Q6hRI/Eh+fYw/9oKZTAlkKv1MUsZ4La+w==",
-      "requires": {
-        "@deephaven/golden-layout": "^0.9.1",
-        "@deephaven/react-hooks": "^0.9.1",
-        "deep-equal": "^2.0.4",
-        "jquery": "^3.5.1",
-        "lodash.ismatch": "^4.1.1",
-        "lodash.throttle": "^4.1.1",
-        "prop-types": "^15.7.2",
-        "shortid": "^2.2.15"
-      }
-    },
-    "@deephaven/file-explorer": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@deephaven/file-explorer/-/file-explorer-0.9.1.tgz",
-      "integrity": "sha512-b66MJOruKBkmo6W06599RM2+5i5fSBR6lIgrmvyGYisiT6bhjzz6BnZC0DkPZropZpK4B0jYH33cLJZ7+32Ftw==",
-      "requires": {
-        "@deephaven/icons": "^0.9.1",
-        "@deephaven/storage": "^0.9.1",
-        "@deephaven/utils": "^0.9.1",
-        "@fortawesome/fontawesome-svg-core": "^1.2.32",
-        "@fortawesome/react-fontawesome": "^0.1.12",
-        "classnames": "^2.3.1",
-        "lodash.throttle": "^4.1.1",
-        "prop-types": "^15.7.2",
-        "reactstrap": "^8.4.1",
-        "webdav": "^4.6.1"
-      }
-    },
-    "@deephaven/golden-layout": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@deephaven/golden-layout/-/golden-layout-0.9.1.tgz",
-      "integrity": "sha512-sQWdxXEv38y79ZlgeI0NyK46T1LAmePGcP67RxjVkq3lgK+bCB78Q2X+0H7bP2YekPLAgZfY3zWXgCNUXFoIeg==",
-      "requires": {
-        "jquery": "^3.5.1"
-      }
-    },
-    "@deephaven/grid": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@deephaven/grid/-/grid-0.9.1.tgz",
-      "integrity": "sha512-INVZKFo/2bK+FpT5vqN7wfdrW66Xl5fxDOkr8I8PO9LL23RMfdiPvilzO8Ji7fKP3fOZtvCznO7yLMEzVBhFLA==",
-      "requires": {
-        "classnames": "^2.3.1",
-        "color-convert": "^2.0.1",
-        "event-target-shim": "^6.0.2",
-        "lodash.clamp": "^4.0.3",
-        "memoize-one": "^5.1.1",
-        "memoizee": "^0.4.15",
-        "prop-types": "^15.7.2"
-      },
-      "dependencies": {
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-        }
-      }
-    },
-    "@deephaven/icons": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@deephaven/icons/-/icons-0.9.1.tgz",
-      "integrity": "sha512-nLLZez6hNl4Ep6b7IjjIxLTGRa9WxeagNC2BP2IWVXs/ONvHHv0t5SYeCCJ/IaH8Bz2UWnxf09VivVPdIGZYig==",
-      "requires": {
-        "@fortawesome/fontawesome-common-types": "^0.2.35"
-      }
-    },
-    "@deephaven/iris-grid": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@deephaven/iris-grid/-/iris-grid-0.9.1.tgz",
-      "integrity": "sha512-KHZwBKu/oVZY3GyrEAuMqrV0BKX4SYCBtFc5p11xSMwfduwGm01ppcrv5T4j90P9vNTt2KffLgIya6JS3JMzlQ==",
-      "requires": {
-        "@deephaven/grid": "^0.9.1",
-        "@deephaven/icons": "^0.9.1",
-        "@deephaven/jsapi-shim": "^0.9.1",
-        "@deephaven/react-hooks": "^0.9.1",
-        "@deephaven/utils": "^0.9.1",
-        "@fortawesome/react-fontawesome": "^0.1.12",
-        "classnames": "^2.3.1",
-        "deep-equal": "^2.0.4",
-        "lodash.clamp": "^4.0.3",
-        "lodash.debounce": "^4.0.8",
-        "lodash.throttle": "^4.1.1",
-        "memoize-one": "^5.1.1",
-        "memoizee": "^0.4.15",
-        "monaco-editor": "^0.27.0",
-        "prop-types": "^15.7.2",
-        "react-beautiful-dnd": "^13.0.0",
-        "react-transition-group": "^2.3.1",
-        "shortid": "^2.2.15",
-        "web-streams-polyfill": "^2.1.0"
-      }
-    },
-    "@deephaven/jsapi-shim": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@deephaven/jsapi-shim/-/jsapi-shim-0.9.1.tgz",
-      "integrity": "sha512-soBU7sU9qZgzDXJyYrU96GiB7UBCdHScUaQjl4ISx2igIdK+Qfe7JOYVxYjJdV8KEVK/l+smSkahAIT5/NJY4Q==",
-      "requires": {
-        "prop-types": "^15.7.2"
-      }
-    },
-    "@deephaven/log": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@deephaven/log/-/log-0.9.1.tgz",
-      "integrity": "sha512-L/yKtSYOrNZlvyElqpgdrnL3JBaY07szFjhA37XK31+uH/jcPcbMxsn2Uf+++yyFcn6GKO1XXXP44V3xBkBQJg==",
-      "dev": true,
-      "requires": {
-        "event-target-shim": "^6.0.2"
-      }
-    },
-    "@deephaven/mocks": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@deephaven/mocks/-/mocks-0.9.0.tgz",
-      "integrity": "sha512-PkCZ0UtFemj1wlD+fGmmmkafOsieK/ts1PyRAdBH4EBDg0WEBjCRsD9lltGydXB1LSUDy0G0xtGOjX/BPPviRA==",
-      "dev": true
-    },
-    "@deephaven/react-hooks": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@deephaven/react-hooks/-/react-hooks-0.9.1.tgz",
-      "integrity": "sha512-v7r2DZoPahHNBspbulCtvUgCqJ+i9WPEA8cK9nEsTVTeuR3mhwLw4E/0g+WlXJ78FsUdA0K9FECJfUg1YTvyLg=="
-    },
-    "@deephaven/redux": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@deephaven/redux/-/redux-0.9.1.tgz",
-      "integrity": "sha512-5wvTVtWgtn3DRdLvUrw7S6ln5GY9Im5Pt6BODotgMXmTJkmecYsPGj8jRLRT08LNVVwz+QTP8XR0Ntda3dofZA==",
-      "dev": true,
-      "requires": {
-        "deep-equal": "^2.0.4",
-        "redux-thunk": "^2.3.0"
-      }
-    },
-    "@deephaven/storage": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@deephaven/storage/-/storage-0.9.1.tgz",
-      "integrity": "sha512-Bcsuaaib5RLX0IEYfPlLl5CfOb/yNssq+4FbD4h0R8SBmFN7oTmRlWLMDWflFpV9FVwBBKojp5GyvKhxyTkHBQ==",
-      "requires": {
-        "@deephaven/iris-grid": "^0.9.1",
-        "lodash.throttle": "^4.1.1"
-      }
-    },
-    "@deephaven/tsconfig": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@deephaven/tsconfig/-/tsconfig-0.9.0.tgz",
-      "integrity": "sha512-zYKPllv+W+UhAuzC2pbsaQynxzsE0bBK/XjfiK0LWiGMkMhp43rwEaCiMODSYaxGmaV5eA+ijm8r1Y8v21pH4w==",
-      "dev": true
-    },
-    "@deephaven/utils": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@deephaven/utils/-/utils-0.9.1.tgz",
-      "integrity": "sha512-kll4L5bNOOPdtpeSDpIvC8+NnlaToKrsPoJ3kvsZvJVmILdIKAIXcviGPxZO5SCjyzgV/NmfLUmHq0CcMAYnEg=="
     },
     "@discoveryjs/json-ext": {
       "version": "0.5.5",
@@ -1734,19 +1491,6 @@
       "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz",
       "integrity": "sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==",
       "dev": true
-    },
-    "@fortawesome/fontawesome-common-types": {
-      "version": "0.2.36",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.36.tgz",
-      "integrity": "sha512-a/7BiSgobHAgBWeN7N0w+lAhInrGxksn13uK7231n2m8EDPE3BMCl9NZLTGrj9ZXfCmC6LM0QLqXidIizVQ6yg=="
-    },
-    "@fortawesome/fontawesome-svg-core": {
-      "version": "1.2.36",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.36.tgz",
-      "integrity": "sha512-YUcsLQKYb6DmaJjIHdDWpBIGCcyE/W+p/LMGvjQem55Mm2XWVAP5kWTMKWLv9lwpCVjpLxPyOMOyUocP1GxrtA==",
-      "requires": {
-        "@fortawesome/fontawesome-common-types": "^0.2.36"
-      }
     },
     "@fortawesome/react-fontawesome": {
       "version": "0.1.15",
@@ -1983,65 +1727,6 @@
         }
       }
     },
-    "@mapbox/geojson-rewind": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@mapbox/geojson-rewind/-/geojson-rewind-0.5.1.tgz",
-      "integrity": "sha512-eL7fMmfTBKjrb+VFHXCGv9Ot0zc3C0U+CwXo1IrP+EPwDczLoXv34Tgq3y+2mPSFNVUXgU42ILWJTC7145KPTA==",
-      "requires": {
-        "get-stream": "^6.0.1",
-        "minimist": "^1.2.5"
-      },
-      "dependencies": {
-        "get-stream": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
-          "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg=="
-        }
-      }
-    },
-    "@mapbox/geojson-types": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@mapbox/geojson-types/-/geojson-types-1.0.2.tgz",
-      "integrity": "sha512-e9EBqHHv3EORHrSfbR9DqecPNn+AmuAoQxV6aL8Xu30bJMJR1o8PZLZzpk1Wq7/NfCbuhmakHTPYRhoqLsXRnw=="
-    },
-    "@mapbox/jsonlint-lines-primitives": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.2.tgz",
-      "integrity": "sha1-zlblOfg1UrWNENZy6k1vya3HsjQ="
-    },
-    "@mapbox/mapbox-gl-supported": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-supported/-/mapbox-gl-supported-1.5.0.tgz",
-      "integrity": "sha512-/PT1P6DNf7vjEEiPkVIRJkvibbqWtqnyGaBz3nfRdcxclNSnSdaLU5tfAgcD7I8Yt5i+L19s406YLl1koLnLbg=="
-    },
-    "@mapbox/point-geometry": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-0.1.0.tgz",
-      "integrity": "sha1-ioP5M1x4YO/6Lu7KJUMyqgru2PI="
-    },
-    "@mapbox/tiny-sdf": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-1.2.5.tgz",
-      "integrity": "sha512-cD8A/zJlm6fdJOk6DqPUV8mcpyJkRz2x2R+/fYcWDYG3oWbG7/L7Yl/WqQ1VZCjnL9OTIMAn6c+BC5Eru4sQEw=="
-    },
-    "@mapbox/unitbezier": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.0.tgz",
-      "integrity": "sha1-FWUb1VOme4WB+zmIEMmK2Go0Uk4="
-    },
-    "@mapbox/vector-tile": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@mapbox/vector-tile/-/vector-tile-1.3.1.tgz",
-      "integrity": "sha512-MCEddb8u44/xfQ3oD+Srl/tNcQoqTw3goGk2oLsrFxOTc3dUp+kAnby3PvAeeBYSMSjSPD1nd1AJA6W49WnoUw==",
-      "requires": {
-        "@mapbox/point-geometry": "~0.1.0"
-      }
-    },
-    "@mapbox/whoots-js": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@mapbox/whoots-js/-/whoots-js-3.1.0.tgz",
-      "integrity": "sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q=="
-    },
     "@mdx-js/loader": {
       "version": "1.6.22",
       "resolved": "https://registry.npmjs.org/@mdx-js/loader/-/loader-1.6.22.tgz",
@@ -2222,49 +1907,6 @@
           "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
           "dev": true
         }
-      }
-    },
-    "@plotly/d3": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@plotly/d3/-/d3-3.8.0.tgz",
-      "integrity": "sha512-L10iHgzvw3uSic/nQpYehlNzxUQvImwms5U7S95pJAEhrllzkrdQNy1Mc5DW9ab881Yr4fh300gJztKXWZDfkQ=="
-    },
-    "@plotly/d3-sankey": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@plotly/d3-sankey/-/d3-sankey-0.7.2.tgz",
-      "integrity": "sha512-2jdVos1N3mMp3QW0k2q1ph7Gd6j5PY1YihBrwpkFnKqO+cqtZq3AdEYUeSGXMeLsBDQYiqTVcihYfk8vr5tqhw==",
-      "requires": {
-        "d3-array": "1",
-        "d3-collection": "1",
-        "d3-shape": "^1.2.0"
-      }
-    },
-    "@plotly/d3-sankey-circular": {
-      "version": "0.33.1",
-      "resolved": "https://registry.npmjs.org/@plotly/d3-sankey-circular/-/d3-sankey-circular-0.33.1.tgz",
-      "integrity": "sha512-FgBV1HEvCr3DV7RHhDsPXyryknucxtfnLwPtCKKxdolKyTFYoLX/ibEfX39iFYIL7DYbVeRtP43dbFcrHNE+KQ==",
-      "requires": {
-        "d3-array": "^1.2.1",
-        "d3-collection": "^1.0.4",
-        "d3-shape": "^1.2.0",
-        "elementary-circuits-directed-graph": "^1.0.4"
-      }
-    },
-    "@plotly/point-cluster": {
-      "version": "3.1.9",
-      "resolved": "https://registry.npmjs.org/@plotly/point-cluster/-/point-cluster-3.1.9.tgz",
-      "integrity": "sha512-MwaI6g9scKf68Orpr1pHZ597pYx9uP8UEFXLPbsCmuw3a84obwz6pnMXGc90VhgDNeNiLEdlmuK7CPo+5PIxXw==",
-      "requires": {
-        "array-bounds": "^1.0.1",
-        "binary-search-bounds": "^2.0.4",
-        "clamp": "^1.0.1",
-        "defined": "^1.0.0",
-        "dtype": "^2.0.0",
-        "flatten-vertex-data": "^1.0.2",
-        "is-obj": "^1.0.1",
-        "math-log2": "^1.0.1",
-        "parse-rect": "^1.2.0",
-        "pick-by-alias": "^1.2.0"
       }
     },
     "@pmmmwh/react-refresh-webpack-plugin": {
@@ -3943,46 +3585,6 @@
         }
       }
     },
-    "@turf/area": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@turf/area/-/area-6.5.0.tgz",
-      "integrity": "sha512-xCZdiuojokLbQ+29qR6qoMD89hv+JAgWjLrwSEWL+3JV8IXKeNFl6XkEJz9HGkVpnXvQKJoRz4/liT+8ZZ5Jyg==",
-      "requires": {
-        "@turf/helpers": "^6.5.0",
-        "@turf/meta": "^6.5.0"
-      }
-    },
-    "@turf/bbox": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@turf/bbox/-/bbox-6.5.0.tgz",
-      "integrity": "sha512-RBbLaao5hXTYyyg577iuMtDB8ehxMlUqHEJiMs8jT1GHkFhr6sYre3lmLsPeYEi/ZKj5TP5tt7fkzNdJ4GIVyw==",
-      "requires": {
-        "@turf/helpers": "^6.5.0",
-        "@turf/meta": "^6.5.0"
-      }
-    },
-    "@turf/centroid": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@turf/centroid/-/centroid-6.5.0.tgz",
-      "integrity": "sha512-MwE1oq5E3isewPprEClbfU5pXljIK/GUOMbn22UM3IFPDJX0KeoyLNwghszkdmFp/qMGL/M13MMWvU+GNLXP/A==",
-      "requires": {
-        "@turf/helpers": "^6.5.0",
-        "@turf/meta": "^6.5.0"
-      }
-    },
-    "@turf/helpers": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.5.0.tgz",
-      "integrity": "sha512-VbI1dV5bLFzohYYdgqwikdMVpe7pJ9X3E+dlr425wa2/sMJqYDhTO++ec38/pcPvPE6oD9WEEeU3Xu3gza+VPw=="
-    },
-    "@turf/meta": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-6.5.0.tgz",
-      "integrity": "sha512-RrArvtsV0vdsCBegoBtOalgdSOfkBrTJ07VkpiCnq/491W67hnMWmDu7e6Ztw0C3WldRYTXkg3SumfdzZxLBHA==",
-      "requires": {
-        "@turf/helpers": "^6.5.0"
-      }
-    },
     "@types/braces": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@types/braces/-/braces-3.0.1.tgz",
@@ -4041,6 +3643,7 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
       "integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
+      "dev": true,
       "requires": {
         "@types/react": "*",
         "hoist-non-react-statics": "^3.3.0"
@@ -4175,7 +3778,8 @@
     "@types/prop-types": {
       "version": "15.7.4",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.4.tgz",
-      "integrity": "sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ=="
+      "integrity": "sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ==",
+      "dev": true
     },
     "@types/qs": {
       "version": "6.9.7",
@@ -4196,6 +3800,7 @@
       "version": "17.0.39",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.39.tgz",
       "integrity": "sha512-UVavlfAxDd/AgAacMa60Azl7ygyQNRwC/DsHZmKgNvPmRR5p70AJ5Q9EAmL2NWOJmeV+vVUI4IAP7GZrN8h8Ug==",
+      "dev": true,
       "requires": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -4206,6 +3811,7 @@
       "version": "7.1.18",
       "resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-7.1.18.tgz",
       "integrity": "sha512-9iwAsPyJ9DLTRH+OFeIrm9cAbIj1i2ANL3sKQFATqnPWRbg+jEFXyZOKHiQK/N86pNRXbb4HRxAxo0SIX1XwzQ==",
+      "dev": true,
       "requires": {
         "@types/hoist-non-react-statics": "^3.3.0",
         "@types/react": "*",
@@ -4225,7 +3831,8 @@
     "@types/scheduler": {
       "version": "0.16.2",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
-      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew=="
+      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
+      "dev": true
     },
     "@types/source-list-map": {
       "version": "0.1.2",
@@ -4520,11 +4127,6 @@
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
       "dev": true
     },
-    "abs-svg-path": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/abs-svg-path/-/abs-svg-path-0.1.1.tgz",
-      "integrity": "sha1-32Acjo0roQ1KdtYl4japo5wnI78="
-    },
     "accepts": {
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
@@ -4538,7 +4140,8 @@
     "acorn": {
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
-      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A=="
+      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+      "dev": true
     },
     "acorn-jsx": {
       "version": "5.3.2",
@@ -4616,11 +4219,6 @@
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
       "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
       "dev": true
-    },
-    "almost-equal": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/almost-equal/-/almost-equal-1.1.0.tgz",
-      "integrity": "sha1-+FHGMROHV5lCdqou++jfowZszN0="
     },
     "ansi-align": {
       "version": "3.0.0",
@@ -4762,23 +4360,14 @@
     "arr-flatten": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
+      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+      "dev": true
     },
     "arr-union": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
       "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
       "dev": true
-    },
-    "array-bounds": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/array-bounds/-/array-bounds-1.0.1.tgz",
-      "integrity": "sha512-8wdW3ZGk6UjMPJx/glyEt0sLzzwAE1bhToPsO1W2pbpR2gULyxe3BjSiuJFheP50T/GgODVPz2fuMUmIywt8cQ=="
-    },
-    "array-find-index": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
-      "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E="
     },
     "array-flatten": {
       "version": "1.1.1",
@@ -4798,24 +4387,6 @@
         "get-intrinsic": "^1.1.1",
         "is-string": "^1.0.5"
       }
-    },
-    "array-normalize": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/array-normalize/-/array-normalize-1.1.4.tgz",
-      "integrity": "sha512-fCp0wKFLjvSPmCn4F5Tiw4M3lpMZoHlCjfcs7nNzuj3vqQQ1/a8cgB9DXcpDSn18c+coLnaW7rqfcYCvKbyJXg==",
-      "requires": {
-        "array-bounds": "^1.0.0"
-      }
-    },
-    "array-range": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/array-range/-/array-range-1.0.1.tgz",
-      "integrity": "sha1-9W5GWRhDYRxqVvd+8C7afFAIm/w="
-    },
-    "array-rearrange": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/array-rearrange/-/array-rearrange-2.2.2.tgz",
-      "integrity": "sha512-UfobP5N12Qm4Qu4fwLDIi2v6+wZsSf6snYSxAMeKhrh37YGnNWZPRmVEKc/2wfms53TLQnzfpG8wCx2Y/6NG1w=="
     },
     "array-union": {
       "version": "2.1.0",
@@ -4964,11 +4535,6 @@
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
       "dev": true
     },
-    "atob-lite": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/atob-lite/-/atob-lite-2.0.0.tgz",
-      "integrity": "sha1-D+9a1G8b16hQLGVyfwNn1e5D1pY="
-    },
     "autoprefixer": {
       "version": "9.8.6",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.8.6.tgz",
@@ -4988,14 +4554,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
       "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw=="
-    },
-    "axios": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
-      "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
-      "requires": {
-        "follow-redirects": "^1.14.4"
-      }
     },
     "babel-loader": {
       "version": "8.2.2",
@@ -5227,7 +4785,8 @@
     "balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
     },
     "base": {
       "version": "0.11.2",
@@ -5284,11 +4843,6 @@
         }
       }
     },
-    "base-64": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/base-64/-/base-64-1.0.0.tgz",
-      "integrity": "sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg=="
-    },
     "base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -5322,33 +4876,6 @@
       "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
       "dev": true,
       "optional": true
-    },
-    "binary-search-bounds": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/binary-search-bounds/-/binary-search-bounds-2.0.5.tgz",
-      "integrity": "sha512-H0ea4Fd3lS1+sTEB2TgcLoK21lLhwEJzlQv3IN47pJS976Gx4zoWe0ak3q+uYh60ppQxg9F16Ri4tS1sfD4+jA=="
-    },
-    "bit-twiddle": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/bit-twiddle/-/bit-twiddle-1.0.2.tgz",
-      "integrity": "sha1-DGwfq+KyPRcXPZpht7cJPrnhdp4="
-    },
-    "bitmap-sdf": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/bitmap-sdf/-/bitmap-sdf-1.0.3.tgz",
-      "integrity": "sha512-ojYySSvWTx21cbgntR942zgEgqj38wHctN64vr4vYRFf3GKVmI23YlA94meWGkFslidwLwGCsMy2laJ3g/94Sg==",
-      "requires": {
-        "clamp": "^1.0.1"
-      }
-    },
-    "bl": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-2.2.1.tgz",
-      "integrity": "sha512-6Pesp1w0DEX1N550i/uGV/TqucVL4AM/pgThFSN/Qq9si1/DF9aIHs1BxD8V/QU0HoeHO6cQRTAuYnLPKq1e4g==",
-      "requires": {
-        "readable-stream": "^2.3.5",
-        "safe-buffer": "^5.1.1"
-      }
     },
     "bluebird": {
       "version": "3.7.2",
@@ -5392,12 +4919,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
-      "dev": true
-    },
-    "bootstrap": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.4.1.tgz",
-      "integrity": "sha512-tbx5cHubwE6e2ZG7nqM3g/FZ5PQEDMWmMGNrCUBVRPHXTJaH7CBDdsLeu3eCh3B1tzAxTnAbtmrzvWEvT2NNEA==",
       "dev": true
     },
     "boxen": {
@@ -5509,6 +5030,7 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -5677,7 +5199,8 @@
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "dev": true
     },
     "buffer-xor": {
       "version": "1.0.3",
@@ -5871,14 +5394,6 @@
       "integrity": "sha512-JN49KplOgHSXpIsVSF+LUyhD8PUp6xPpAXeRrrcBh4KBeP7W864jHn6RvzJgDlrReyeVjMFJL3PLpPvKIxlIHA==",
       "dev": true
     },
-    "canvas-fit": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/canvas-fit/-/canvas-fit-1.5.0.tgz",
-      "integrity": "sha1-rhO+Zq3kL1vg5IfjRfzjCl5bXl8=",
-      "requires": {
-        "element-size": "^1.1.1"
-      }
-    },
     "capture-exit": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/capture-exit/-/capture-exit-2.0.0.tgz",
@@ -5924,11 +5439,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.4.tgz",
       "integrity": "sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg=="
-    },
-    "charenc": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
-      "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc="
     },
     "chokidar": {
       "version": "3.5.2",
@@ -6042,11 +5552,6 @@
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
       }
-    },
-    "clamp": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/clamp/-/clamp-1.0.1.tgz",
-      "integrity": "sha1-ZqDmQBGBbjcZaCj9yMjBRzEshjQ="
     },
     "class-utils": {
       "version": "0.3.6",
@@ -6246,14 +5751,6 @@
         "object-visit": "^1.0.0"
       }
     },
-    "color-alpha": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/color-alpha/-/color-alpha-1.0.4.tgz",
-      "integrity": "sha512-lr8/t5NPozTSqli+duAN+x+no/2WaKTeWvxhHGN+aXT6AJ8vPlzLa7UriyjWak0pSC2jHol9JgjBYnnHsGha9A==",
-      "requires": {
-        "color-parse": "^1.3.8"
-      }
-    },
     "color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -6263,64 +5760,11 @@
         "color-name": "1.1.3"
       }
     },
-    "color-id": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/color-id/-/color-id-1.1.0.tgz",
-      "integrity": "sha512-2iRtAn6dC/6/G7bBIo0uupVrIne1NsQJvJxZOBCzQOfk7jRq97feaDZ3RdzuHakRXXnHGNwglto3pqtRx1sX0g==",
-      "requires": {
-        "clamp": "^1.0.1"
-      }
-    },
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
-    },
-    "color-normalize": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/color-normalize/-/color-normalize-1.5.0.tgz",
-      "integrity": "sha512-rUT/HDXMr6RFffrR53oX3HGWkDOP9goSAQGBkUaAYKjOE2JxozccdGyufageWDlInRAjm/jYPrf/Y38oa+7obw==",
-      "requires": {
-        "clamp": "^1.0.1",
-        "color-rgba": "^2.1.1",
-        "dtype": "^2.0.0"
-      }
-    },
-    "color-parse": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/color-parse/-/color-parse-1.3.8.tgz",
-      "integrity": "sha512-1Y79qFv0n1xair3lNMTNeoFvmc3nirMVBij24zbs1f13+7fPpQClMg5b4AuKXLt3szj7BRlHMCXHplkce6XlmA==",
-      "requires": {
-        "color-name": "^1.0.0",
-        "defined": "^1.0.0",
-        "is-plain-obj": "^1.1.0"
-      },
-      "dependencies": {
-        "is-plain-obj": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-          "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
-        }
-      }
-    },
-    "color-rgba": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/color-rgba/-/color-rgba-2.1.1.tgz",
-      "integrity": "sha512-VaX97wsqrMwLSOR6H7rU1Doa2zyVdmShabKrPEIFywLlHoibgD3QW9Dw6fSqM4+H/LfjprDNAUUW31qEQcGzNw==",
-      "requires": {
-        "clamp": "^1.0.1",
-        "color-parse": "^1.3.8",
-        "color-space": "^1.14.6"
-      }
-    },
-    "color-space": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/color-space/-/color-space-1.16.0.tgz",
-      "integrity": "sha512-A6WMiFzunQ8KEPFmj02OnnoUnqhmSaHaZ/0LVFcPTdlvm8+3aMJ5x1HRHy3bDHPkovkf4sS0f4wsVvwk71fKkg==",
-      "requires": {
-        "hsluv": "^0.0.3",
-        "mumath": "^3.3.4"
-      }
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
     },
     "colorette": {
       "version": "1.4.0",
@@ -6399,18 +5843,6 @@
         }
       }
     },
-    "compute-dims": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/compute-dims/-/compute-dims-1.1.0.tgz",
-      "integrity": "sha512-YHMiIKjH/8Eom8zATk3g8/lH3HxGCZcVQyEfEoVrfWI7od/WRpTgRGShnei3jArYSx77mQqPxZNokjGHCdLfxg==",
-      "requires": {
-        "utils-copy": "^1.0.0",
-        "validate.io-array": "^1.0.6",
-        "validate.io-matrix-like": "^1.0.2",
-        "validate.io-ndarray-like": "^1.0.0",
-        "validate.io-positive-integer": "^1.0.0"
-      }
-    },
     "compute-scroll-into-view": {
       "version": "1.0.17",
       "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-1.0.17.tgz",
@@ -6420,12 +5852,14 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
     },
     "concat-stream": {
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
       "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "dev": true,
       "requires": {
         "buffer-from": "^1.0.0",
         "inherits": "^2.0.3",
@@ -6444,16 +5878,6 @@
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
       "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
       "dev": true
-    },
-    "const-max-uint32": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/const-max-uint32/-/const-max-uint32-1.0.2.tgz",
-      "integrity": "sha1-8Am7YjDmeO2HTdLWqc2ePL+rtnY="
-    },
-    "const-pinf-float64": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/const-pinf-float64/-/const-pinf-float64-1.0.0.tgz",
-      "integrity": "sha1-9u+w15+cCYbT558pI6v5twtj1yY="
     },
     "constants-browserify": {
       "version": "1.0.0",
@@ -6570,7 +5994,8 @@
     "core-util-is": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "dev": true
     },
     "cosmiconfig": {
       "version": "6.0.0",
@@ -6584,11 +6009,6 @@
         "path-type": "^4.0.0",
         "yaml": "^1.7.2"
       }
-    },
-    "country-regex": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/country-regex/-/country-regex-1.1.0.tgz",
-      "integrity": "sha1-UcMz3N8Sknt+XuucEKyBEqYSCJY="
     },
     "cp-file": {
       "version": "7.0.0",
@@ -6865,11 +6285,6 @@
         "which": "^1.2.9"
       }
     },
-    "crypt": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
-      "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs="
-    },
     "crypto-browserify": {
       "version": "3.12.0",
       "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
@@ -6888,55 +6303,6 @@
         "randombytes": "^2.0.0",
         "randomfill": "^1.0.3"
       }
-    },
-    "css-box-model": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/css-box-model/-/css-box-model-1.2.1.tgz",
-      "integrity": "sha512-a7Vr4Q/kd/aw96bnJG332W9V9LkJO69JRcaCYDUqjp6/z0w6VcZjgAcTbgFxEPfBgdnAwlh3iwu+hLopa+flJw==",
-      "requires": {
-        "tiny-invariant": "^1.0.6"
-      }
-    },
-    "css-font": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/css-font/-/css-font-1.2.0.tgz",
-      "integrity": "sha512-V4U4Wps4dPDACJ4WpgofJ2RT5Yqwe1lEH6wlOOaIxMi0gTjdIijsc5FmxQlZ7ZZyKQkkutqqvULOp07l9c7ssA==",
-      "requires": {
-        "css-font-size-keywords": "^1.0.0",
-        "css-font-stretch-keywords": "^1.0.1",
-        "css-font-style-keywords": "^1.0.1",
-        "css-font-weight-keywords": "^1.0.0",
-        "css-global-keywords": "^1.0.1",
-        "css-system-font-keywords": "^1.0.0",
-        "pick-by-alias": "^1.2.0",
-        "string-split-by": "^1.0.0",
-        "unquote": "^1.1.0"
-      }
-    },
-    "css-font-size-keywords": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/css-font-size-keywords/-/css-font-size-keywords-1.0.0.tgz",
-      "integrity": "sha1-hUh1rOmspqjS7g00WkSq6btttss="
-    },
-    "css-font-stretch-keywords": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/css-font-stretch-keywords/-/css-font-stretch-keywords-1.0.1.tgz",
-      "integrity": "sha1-UM7puboDH7XJUtRyMTnx4Qe1SxA="
-    },
-    "css-font-style-keywords": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/css-font-style-keywords/-/css-font-style-keywords-1.0.1.tgz",
-      "integrity": "sha1-XDUygT9jtKHelU0TzqhqtDM0CeQ="
-    },
-    "css-font-weight-keywords": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/css-font-weight-keywords/-/css-font-weight-keywords-1.0.0.tgz",
-      "integrity": "sha1-m8BGcayFvHJLV07106yWsNYE/Zc="
-    },
-    "css-global-keywords": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/css-global-keywords/-/css-global-keywords-1.0.1.tgz",
-      "integrity": "sha1-cqmupyeW0Bmx0qMlLeTlqqN+Smk="
     },
     "css-loader": {
       "version": "3.6.0",
@@ -7000,21 +6366,11 @@
         "nth-check": "^2.0.0"
       }
     },
-    "css-system-font-keywords": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/css-system-font-keywords/-/css-system-font-keywords-1.0.0.tgz",
-      "integrity": "sha1-hcbwhquk6zLFcaMIav/ENLhII+0="
-    },
     "css-what": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-5.0.1.tgz",
       "integrity": "sha512-FYDTSHb/7KXsWICVsxdmiExPjCfRC4qRFBdVwv7Ax9hMnvMmEjP9RfxTEZ3qPZGmADDn2vAKSo9UcN1jKVYscg==",
       "dev": true
-    },
-    "csscolorparser": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/csscolorparser/-/csscolorparser-1.0.3.tgz",
-      "integrity": "sha1-s085HupNqPPpgjHizNjfnAQfFxs="
     },
     "cssesc": {
       "version": "3.0.0",
@@ -7025,7 +6381,8 @@
     "csstype": {
       "version": "3.0.10",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.10.tgz",
-      "integrity": "sha512-2u44ZG2OcNUO9HDp/Jl8C07x6pU/eTR3ncV91SiK3dhG9TWvRVsCoJw14Ckx5DgWkzGA3waZWO3d7pgqpUI/XA=="
+      "integrity": "sha512-2u44ZG2OcNUO9HDp/Jl8C07x6pU/eTR3ncV91SiK3dhG9TWvRVsCoJw14Ckx5DgWkzGA3waZWO3d7pgqpUI/XA==",
+      "dev": true
     },
     "cyclist": {
       "version": "1.0.1",
@@ -7042,121 +6399,11 @@
         "type": "^1.0.1"
       }
     },
-    "d3-array": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
-      "integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw=="
-    },
-    "d3-collection": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/d3-collection/-/d3-collection-1.0.7.tgz",
-      "integrity": "sha512-ii0/r5f4sjKNTfh84Di+DpztYwqKhEyUlKoPrzUFfeSkWxjW49xU2QzO9qrPrNkpdI0XJkfzvmTu8V2Zylln6A=="
-    },
-    "d3-color": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.4.1.tgz",
-      "integrity": "sha512-p2sTHSLCJI2QKunbGb7ocOh7DgTAn8IrLx21QRc/BSnodXM4sv6aLQlnfpvehFMLZEfBc6g9pH9SWQccFYfJ9Q=="
-    },
-    "d3-dispatch": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-1.0.6.tgz",
-      "integrity": "sha512-fVjoElzjhCEy+Hbn8KygnmMS7Or0a9sI2UzGwoB7cCtvI1XpVN9GpoYlnb3xt2YV66oXYb1fLJ8GMvP4hdU1RA=="
-    },
-    "d3-force": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-1.2.1.tgz",
-      "integrity": "sha512-HHvehyaiUlVo5CxBJ0yF/xny4xoaxFxDnBXNvNcfW9adORGZfyNF1dj6DGLKyk4Yh3brP/1h3rnDzdIAwL08zg==",
-      "requires": {
-        "d3-collection": "1",
-        "d3-dispatch": "1",
-        "d3-quadtree": "1",
-        "d3-timer": "1"
-      }
-    },
-    "d3-format": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.4.5.tgz",
-      "integrity": "sha512-J0piedu6Z8iB6TbIGfZgDzfXxUFN3qQRMofy2oPdXzQibYGqPB/9iMcxr/TGalU+2RsyDO+U4f33id8tbnSRMQ=="
-    },
-    "d3-geo": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-1.12.1.tgz",
-      "integrity": "sha512-XG4d1c/UJSEX9NfU02KwBL6BYPj8YKHxgBEw5om2ZnTRSbIcego6dhHwcxuSR3clxh0EpE38os1DVPOmnYtTPg==",
-      "requires": {
-        "d3-array": "1"
-      }
-    },
-    "d3-geo-projection": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/d3-geo-projection/-/d3-geo-projection-2.9.0.tgz",
-      "integrity": "sha512-ZULvK/zBn87of5rWAfFMc9mJOipeSo57O+BBitsKIXmU4rTVAnX1kSsJkE0R+TxY8pGNoM1nbyRRE7GYHhdOEQ==",
-      "requires": {
-        "commander": "2",
-        "d3-array": "1",
-        "d3-geo": "^1.12.0",
-        "resolve": "^1.1.10"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "2.20.3",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
-        }
-      }
-    },
-    "d3-hierarchy": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-1.1.9.tgz",
-      "integrity": "sha512-j8tPxlqh1srJHAtxfvOUwKNYJkQuBFdM1+JAUfq6xqH5eAqf93L7oG1NVqDa4CpFZNvnNKtCYEUC8KY9yEn9lQ=="
-    },
-    "d3-interpolate": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.4.0.tgz",
-      "integrity": "sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==",
-      "requires": {
-        "d3-color": "1"
-      }
-    },
-    "d3-path": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
-      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg=="
-    },
-    "d3-quadtree": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-1.0.7.tgz",
-      "integrity": "sha512-RKPAeXnkC59IDGD0Wu5mANy0Q2V28L+fNe65pOCXVdVuTJS3WPKaJlFHer32Rbh9gIo9qMuJXio8ra4+YmIymA=="
-    },
-    "d3-shape": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
-      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
-      "requires": {
-        "d3-path": "1"
-      }
-    },
-    "d3-time": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-1.1.0.tgz",
-      "integrity": "sha512-Xh0isrZ5rPYYdqhAVk8VLnMEidhz5aP7htAADH6MfzgmmicPkTo8LhkLxci61/lCB7n7UmE3bN0leRt+qvkLxA=="
-    },
-    "d3-time-format": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.3.0.tgz",
-      "integrity": "sha512-guv6b2H37s2Uq/GefleCDtbe0XZAuy7Wa49VGkPVPMfLL9qObgBST3lEHJBMUp8S7NdLQAGIvr2KXk8Hc98iKQ==",
-      "requires": {
-        "d3-time": "1"
-      }
-    },
-    "d3-timer": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-1.0.10.tgz",
-      "integrity": "sha512-B1JDm0XDaQC+uvo4DT79H0XmBskgS3l6Ve+1SBCfxgmtIb1AVrPIoqd+nPSv+loMX8szQ0sVUhGngL7D5QPiXw=="
-    },
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
       "requires": {
         "ms": "2.0.0"
       }
@@ -7205,7 +6452,8 @@
     "deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
-      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true
     },
     "deep-object-diff": {
       "version": "1.1.0",
@@ -7268,11 +6516,6 @@
         }
       }
     },
-    "defined": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
-      "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM="
-    },
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -7315,11 +6558,6 @@
       "requires": {
         "repeat-string": "^1.5.4"
       }
-    },
-    "detect-kerning": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/detect-kerning/-/detect-kerning-2.1.2.tgz",
-      "integrity": "sha512-I3JIbrnKPAntNLl1I6TpSQQdQ4AutYzv/sKMFKbepawV/hlH0GmYKhUoOEMd4xqaUHT+Bm0f4127lh5qs1m1tw=="
     },
     "detect-port-alt": {
       "version": "1.1.6",
@@ -7503,25 +6741,6 @@
         }
       }
     },
-    "draw-svg-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/draw-svg-path/-/draw-svg-path-1.0.0.tgz",
-      "integrity": "sha1-bxFtli3TFLmepTTW9Y3WbNvWk3k=",
-      "requires": {
-        "abs-svg-path": "~0.1.1",
-        "normalize-svg-path": "~0.1.0"
-      }
-    },
-    "dtype": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/dtype/-/dtype-2.0.0.tgz",
-      "integrity": "sha1-zQUjI84GFETs0uj1dI9popvihDQ="
-    },
-    "dup": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/dup/-/dup-1.0.0.tgz",
-      "integrity": "sha1-UfxaxoX4GWRp3wuQXpNLIK9bQCk="
-    },
     "duplexer": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
@@ -7532,17 +6751,13 @@
       "version": "3.7.1",
       "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
       "integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
+      "dev": true,
       "requires": {
         "end-of-stream": "^1.0.0",
         "inherits": "^2.0.1",
         "readable-stream": "^2.0.0",
         "stream-shift": "^1.0.0"
       }
-    },
-    "earcut": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.3.tgz",
-      "integrity": "sha512-iRDI1QeCQIhMCZk48DRDMVgQSSBDmbzzNhnxIo+pwx3swkfjMh6vh0nWLq1NdvGHLKH6wIrAM3vQWeTj6qeoug=="
     },
     "ee-first": {
       "version": "1.1.1",
@@ -7563,19 +6778,6 @@
       "dev": true,
       "requires": {
         "batch-processor": "1.0.0"
-      }
-    },
-    "element-size": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/element-size/-/element-size-1.1.1.tgz",
-      "integrity": "sha1-ZOXxWdlxIWMYRby67K8nnDm1404="
-    },
-    "elementary-circuits-directed-graph": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/elementary-circuits-directed-graph/-/elementary-circuits-directed-graph-1.3.1.tgz",
-      "integrity": "sha512-ZEiB5qkn2adYmpXGnJKkxT8uJHlW/mxmBpmeqawEHzPxh9HkLD4/1mFYX5l0On+f6rcPIt8/EWlRU2Vo3fX6dQ==",
-      "requires": {
-        "strongly-connected-components": "^1.0.1"
       }
     },
     "elliptic": {
@@ -7634,6 +6836,7 @@
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
       "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "dev": true,
       "requires": {
         "once": "^1.4.0"
       }
@@ -7886,7 +7089,8 @@
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true
     },
     "esrecurse": {
       "version": "4.3.0",
@@ -7908,7 +7112,8 @@
     "estraverse": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw=="
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "dev": true
     },
     "estree-to-babel": {
       "version": "3.2.1",
@@ -7924,7 +7129,8 @@
     "esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true
     },
     "etag": {
       "version": "1.8.1",
@@ -7941,15 +7147,11 @@
         "es5-ext": "~0.10.14"
       }
     },
-    "event-target-shim": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-6.0.2.tgz",
-      "integrity": "sha512-8q3LsZjRezbFZ2PN+uP+Q7pnHUMmAOziU2vA2OwoFaKIXxlxl38IylhSSgUorWu/rf4er67w0ikBqjBFk/pomA=="
-    },
     "events": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
-      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "dev": true
     },
     "evp_bytestokey": {
       "version": "1.0.3",
@@ -8169,24 +7371,6 @@
         }
       }
     },
-    "falafel": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/falafel/-/falafel-2.2.4.tgz",
-      "integrity": "sha512-0HXjo8XASWRmsS0X1EkhwEMZaD3Qvp7FfURwjLKjG1ghfRm/MGZl2r4cWUTv41KdNghTw4OUMmVtdGQp3+H+uQ==",
-      "requires": {
-        "acorn": "^7.1.1",
-        "foreach": "^2.0.5",
-        "isarray": "^2.0.1",
-        "object-keys": "^1.0.6"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-          "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
-        }
-      }
-    },
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -8251,14 +7435,6 @@
         }
       }
     },
-    "fast-isnumeric": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/fast-isnumeric/-/fast-isnumeric-1.1.4.tgz",
-      "integrity": "sha512-1mM8qOr2LYz8zGaUdmiqRDiuue00Dxjgcb1NQR7TnhLVh6sQyngP9xvLo7Sl7LZpP/sk5eb+bcyWXw530NTBZw==",
-      "requires": {
-        "is-string-blank": "^1.0.1"
-      }
-    },
     "fast-json-parse": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/fast-json-parse/-/fast-json-parse-1.0.3.tgz",
@@ -8274,15 +7450,8 @@
     "fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
-    },
-    "fast-xml-parser": {
-      "version": "3.21.1",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.21.1.tgz",
-      "integrity": "sha512-FTFVjYoBOZTJekiUsawGsSYV9QL0A+zDYCRj7y34IO6Jg+2IMYEtQa+bbictpdpV8dHxXywqU7C0gRDEOFtBFg==",
-      "requires": {
-        "strnum": "^1.0.4"
-      }
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
     },
     "fastq": {
       "version": "1.13.0",
@@ -8507,19 +7676,6 @@
       "integrity": "sha512-JaTY/wtrcSyvXJl4IMFHPKyFur1sE9AUqc0QnhOaJ0CxHtAoIV8pYDzeEfAaNEtGkOfq4gr3LBFmdXW5mOQFnA==",
       "dev": true
     },
-    "flatten-vertex-data": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/flatten-vertex-data/-/flatten-vertex-data-1.0.2.tgz",
-      "integrity": "sha512-BvCBFK2NZqerFTdMDgqfHBwxYWnxeCkwONsw6PvBMcUXqo8U/KDWwmXhqx1x2kLIg7DqIsJfOaJFOmlua3Lxuw==",
-      "requires": {
-        "dtype": "^2.0.0"
-      }
-    },
-    "flip-pixels": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/flip-pixels/-/flip-pixels-1.0.2.tgz",
-      "integrity": "sha512-oXbJGbjDnfJRWPC7Va38EFhd+A8JWE5/hCiKcK8qjCdbLj9DTpsq6MEudwpRTH+V4qq+Jw7d3pUgQdSr3x3mTA=="
-    },
     "flush-write-stream": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.1.1.tgz",
@@ -8533,23 +7689,8 @@
     "follow-redirects": {
       "version": "1.14.7",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
-      "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ=="
-    },
-    "font-atlas": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/font-atlas/-/font-atlas-2.1.0.tgz",
-      "integrity": "sha512-kP3AmvX+HJpW4w3d+PiPR2X6E1yvsBXt2yhuCw+yReO9F1WYhvZwx3c95DGZGwg9xYzDGrgJYa885xmVA+28Cg==",
-      "requires": {
-        "css-font": "^1.0.0"
-      }
-    },
-    "font-measure": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/font-measure/-/font-measure-1.2.2.tgz",
-      "integrity": "sha512-mRLEpdrWzKe9hbfaF3Qpr06TAjquuBVP5cHy4b3hyeNdjc9i0PO6HniGsX5vjL5OWv7+Bd++NiooNpT/s8BvIA==",
-      "requires": {
-        "css-font": "^1.2.0"
-      }
+      "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==",
+      "dev": true
     },
     "for-in": {
       "version": "1.0.2",
@@ -8672,6 +7813,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
       "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
+      "dev": true,
       "requires": {
         "inherits": "^2.0.1",
         "readable-stream": "^2.0.0"
@@ -8798,21 +7940,11 @@
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
       "dev": true
     },
-    "geojson-vt": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/geojson-vt/-/geojson-vt-3.2.1.tgz",
-      "integrity": "sha512-EvGQQi/zPrDA6zr6BnJD/YhwAkBP8nnJ9emh3EnHQKVMfg/MRVtPbMYdgVy/IaEmn4UfagD2a6fafPDL5hbtwg=="
-    },
     "get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true
-    },
-    "get-canvas-context": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/get-canvas-context/-/get-canvas-context-1.0.2.tgz",
-      "integrity": "sha1-1ue1C8TkyGNXzTnyJkeoS3NgHpM="
     },
     "get-intrinsic": {
       "version": "1.1.1",
@@ -8859,68 +7991,6 @@
       "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-1.4.0.tgz",
       "integrity": "sha512-w0dzqw/nt51xMVmlaV1+JRzN+oCa1KfcgGEWhxUG16wbdA+Xnt/yoFO8Z8x/V82ZcZ0wy6ln9QDup5avbhiDhQ==",
       "dev": true
-    },
-    "gl-mat4": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/gl-mat4/-/gl-mat4-1.2.0.tgz",
-      "integrity": "sha512-sT5C0pwB1/e9G9AvAoLsoaJtbMGjfd/jfxo8jMCKqYYEnjZuFvqV5rehqar0538EmssjdDeiEWnKyBSTw7quoA=="
-    },
-    "gl-matrix": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.4.3.tgz",
-      "integrity": "sha512-wcCp8vu8FT22BnvKVPjXa/ICBWRq/zjFfdofZy1WSpQZpphblv12/bOQLBC1rMM7SGOFS9ltVmKOHil5+Ml7gA=="
-    },
-    "gl-text": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/gl-text/-/gl-text-1.3.1.tgz",
-      "integrity": "sha512-/f5gcEMiZd+UTBJLTl3D+CkCB/0UFGTx3nflH8ZmyWcLkZhsZ1+Xx5YYkw2rgWAzgPeE35xCqBuHSoMKQVsR+w==",
-      "requires": {
-        "bit-twiddle": "^1.0.2",
-        "color-normalize": "^1.5.0",
-        "css-font": "^1.2.0",
-        "detect-kerning": "^2.1.2",
-        "es6-weak-map": "^2.0.3",
-        "flatten-vertex-data": "^1.0.2",
-        "font-atlas": "^2.1.0",
-        "font-measure": "^1.2.2",
-        "gl-util": "^3.1.2",
-        "is-plain-obj": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "parse-rect": "^1.2.0",
-        "parse-unit": "^1.0.1",
-        "pick-by-alias": "^1.2.0",
-        "regl": "^2.0.0",
-        "to-px": "^1.0.1",
-        "typedarray-pool": "^1.1.0"
-      },
-      "dependencies": {
-        "is-plain-obj": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-          "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
-        }
-      }
-    },
-    "gl-util": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/gl-util/-/gl-util-3.1.3.tgz",
-      "integrity": "sha512-dvRTggw5MSkJnCbh74jZzSoTOGnVYK+Bt+Ckqm39CVcl6+zSsxqWk4lr5NKhkqXHL6qvZAU9h17ZF8mIskY9mA==",
-      "requires": {
-        "is-browser": "^2.0.1",
-        "is-firefox": "^1.0.3",
-        "is-plain-obj": "^1.1.0",
-        "number-is-integer": "^1.0.1",
-        "object-assign": "^4.1.0",
-        "pick-by-alias": "^1.2.0",
-        "weak-map": "^1.0.5"
-      },
-      "dependencies": {
-        "is-plain-obj": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-          "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
-        }
-      }
     },
     "glob": {
       "version": "7.1.7",
@@ -9063,194 +8133,11 @@
         }
       }
     },
-    "glsl-inject-defines": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/glsl-inject-defines/-/glsl-inject-defines-1.0.3.tgz",
-      "integrity": "sha1-3RqswsF/yyvT/DJBHGYz0Ne2D9Q=",
-      "requires": {
-        "glsl-token-inject-block": "^1.0.0",
-        "glsl-token-string": "^1.0.1",
-        "glsl-tokenizer": "^2.0.2"
-      }
-    },
-    "glsl-resolve": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/glsl-resolve/-/glsl-resolve-0.0.1.tgz",
-      "integrity": "sha1-iUvvc5ENeSyBtRQxgANdCnivdtM=",
-      "requires": {
-        "resolve": "^0.6.1",
-        "xtend": "^2.1.2"
-      },
-      "dependencies": {
-        "resolve": {
-          "version": "0.6.3",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.6.3.tgz",
-          "integrity": "sha1-3ZV5gufnNt699TtYpN2RdUV13UY="
-        },
-        "xtend": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.2.0.tgz",
-          "integrity": "sha1-7vax8ZjByN6vrYsXZaBNrUoBxak="
-        }
-      }
-    },
-    "glsl-token-assignments": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/glsl-token-assignments/-/glsl-token-assignments-2.0.2.tgz",
-      "integrity": "sha1-pdgqt4SZwuimuDy2lJXm5mXOAZ8="
-    },
-    "glsl-token-defines": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/glsl-token-defines/-/glsl-token-defines-1.0.0.tgz",
-      "integrity": "sha1-y4kqqVmTYjFyhHDU90AySJaX+p0=",
-      "requires": {
-        "glsl-tokenizer": "^2.0.0"
-      }
-    },
-    "glsl-token-depth": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/glsl-token-depth/-/glsl-token-depth-1.1.2.tgz",
-      "integrity": "sha1-I8XjDuK9JViEtKKLyFC495HpXYQ="
-    },
-    "glsl-token-descope": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/glsl-token-descope/-/glsl-token-descope-1.0.2.tgz",
-      "integrity": "sha1-D8kKsyYYa4L1l7LnfcniHvzTIHY=",
-      "requires": {
-        "glsl-token-assignments": "^2.0.0",
-        "glsl-token-depth": "^1.1.0",
-        "glsl-token-properties": "^1.0.0",
-        "glsl-token-scope": "^1.1.0"
-      }
-    },
-    "glsl-token-inject-block": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/glsl-token-inject-block/-/glsl-token-inject-block-1.1.0.tgz",
-      "integrity": "sha1-4QFfWYDBCRgkraomJfHf3ovQADQ="
-    },
-    "glsl-token-properties": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/glsl-token-properties/-/glsl-token-properties-1.0.1.tgz",
-      "integrity": "sha1-SD3D2Dnw1LXGFx0VkfJJvlPCip4="
-    },
-    "glsl-token-scope": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/glsl-token-scope/-/glsl-token-scope-1.1.2.tgz",
-      "integrity": "sha1-oXKOeN8kRE+cuT/RjvD3VQOmQ7E="
-    },
-    "glsl-token-string": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/glsl-token-string/-/glsl-token-string-1.0.1.tgz",
-      "integrity": "sha1-WUQdL4V958NEnJRWZgIezjWOSOw="
-    },
-    "glsl-token-whitespace-trim": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/glsl-token-whitespace-trim/-/glsl-token-whitespace-trim-1.0.0.tgz",
-      "integrity": "sha1-RtHf6Yx1vX1QTAXX0RsbPpzJOxA="
-    },
-    "glsl-tokenizer": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/glsl-tokenizer/-/glsl-tokenizer-2.1.5.tgz",
-      "integrity": "sha512-XSZEJ/i4dmz3Pmbnpsy3cKh7cotvFlBiZnDOwnj/05EwNp2XrhQ4XKJxT7/pDt4kp4YcpRSKz8eTV7S+mwV6MA==",
-      "requires": {
-        "through2": "^0.6.3"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-        },
-        "readable-stream": {
-          "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-        },
-        "through2": {
-          "version": "0.6.5",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-          "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-          "requires": {
-            "readable-stream": ">=1.0.33-1 <1.1.0-0",
-            "xtend": ">=4.0.0 <4.1.0-0"
-          }
-        }
-      }
-    },
-    "glslify": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/glslify/-/glslify-7.1.1.tgz",
-      "integrity": "sha512-bud98CJ6kGZcP9Yxcsi7Iz647wuDz3oN+IZsjCRi5X1PI7t/xPKeL0mOwXJjo+CRZMqvq0CkSJiywCcY7kVYog==",
-      "requires": {
-        "bl": "^2.2.1",
-        "concat-stream": "^1.5.2",
-        "duplexify": "^3.4.5",
-        "falafel": "^2.1.0",
-        "from2": "^2.3.0",
-        "glsl-resolve": "0.0.1",
-        "glsl-token-whitespace-trim": "^1.0.0",
-        "glslify-bundle": "^5.0.0",
-        "glslify-deps": "^1.2.5",
-        "minimist": "^1.2.5",
-        "resolve": "^1.1.5",
-        "stack-trace": "0.0.9",
-        "static-eval": "^2.0.5",
-        "through2": "^2.0.1",
-        "xtend": "^4.0.0"
-      }
-    },
-    "glslify-bundle": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/glslify-bundle/-/glslify-bundle-5.1.1.tgz",
-      "integrity": "sha512-plaAOQPv62M1r3OsWf2UbjN0hUYAB7Aph5bfH58VxJZJhloRNbxOL9tl/7H71K7OLJoSJ2ZqWOKk3ttQ6wy24A==",
-      "requires": {
-        "glsl-inject-defines": "^1.0.1",
-        "glsl-token-defines": "^1.0.0",
-        "glsl-token-depth": "^1.1.1",
-        "glsl-token-descope": "^1.0.2",
-        "glsl-token-scope": "^1.1.1",
-        "glsl-token-string": "^1.0.1",
-        "glsl-token-whitespace-trim": "^1.0.0",
-        "glsl-tokenizer": "^2.0.2",
-        "murmurhash-js": "^1.0.0",
-        "shallow-copy": "0.0.1"
-      }
-    },
-    "glslify-deps": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/glslify-deps/-/glslify-deps-1.3.2.tgz",
-      "integrity": "sha512-7S7IkHWygJRjcawveXQjRXLO2FTjijPDYC7QfZyAQanY+yGLCFHYnPtsGT9bdyHiwPTw/5a1m1M9hamT2aBpag==",
-      "requires": {
-        "@choojs/findup": "^0.2.0",
-        "events": "^3.2.0",
-        "glsl-resolve": "0.0.1",
-        "glsl-tokenizer": "^2.0.0",
-        "graceful-fs": "^4.1.2",
-        "inherits": "^2.0.1",
-        "map-limit": "0.0.1",
-        "resolve": "^1.0.0"
-      }
-    },
     "graceful-fs": {
       "version": "4.2.6",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
-      "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ=="
-    },
-    "grid-index": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/grid-index/-/grid-index-1.1.0.tgz",
-      "integrity": "sha512-HZRwumpOGUrHyxO5bqKZL0B0GlUpwtCAzZ42sgxUPniu33R1LSFH5yrIcBCHjkctCAh3mtWKcKd9J4vDDdeVHA=="
+      "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
+      "dev": true
     },
     "gud": {
       "version": "1.0.0",
@@ -9310,22 +8197,6 @@
             "is-extglob": "^2.1.0"
           }
         }
-      }
-    },
-    "has-hover": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/has-hover/-/has-hover-1.0.1.tgz",
-      "integrity": "sha1-PZdDeusZnGK4rAisvcU9O8UsF/c=",
-      "requires": {
-        "is-browser": "^2.0.1"
-      }
-    },
-    "has-passive-events": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-passive-events/-/has-passive-events-1.0.0.tgz",
-      "integrity": "sha512-2vSj6IeIsgvsRMyeQ0JaCX5Q3lX4zMn5HpoVc7MEhQ6pv8Iq9rsXjsp+E5ZwaT7T0xhMT0KmU8gtt1EFVdbJiw==",
-      "requires": {
-        "is-browser": "^2.0.1"
       }
     },
     "has-symbols": {
@@ -9501,7 +8372,8 @@
     "he": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
-      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true
     },
     "highlight.js": {
       "version": "10.7.3",
@@ -9524,6 +8396,7 @@
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
       "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "dev": true,
       "requires": {
         "react-is": "^16.7.0"
       }
@@ -9533,16 +8406,6 @@
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
       "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
       "dev": true
-    },
-    "hot-patcher": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/hot-patcher/-/hot-patcher-0.5.0.tgz",
-      "integrity": "sha512-2Uu2W0s8+dnqXzdlg0MRsRzPoDCs1wVjOGSyMRRaMzLDX4bgHw6xDYKccsWafXPPxQpkQfEjgW6+17pwcg60bw=="
-    },
-    "hsluv": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/hsluv/-/hsluv-0.0.3.tgz",
-      "integrity": "sha1-gpEH2vtKn4tSoYCe0C4JHq3mdUw="
     },
     "html-entities": {
       "version": "2.3.2",
@@ -9665,6 +8528,7 @@
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
@@ -9690,7 +8554,8 @@
     "ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true
     },
     "iferr": {
       "version": "0.1.5",
@@ -9703,21 +8568,6 @@
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
       "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
       "dev": true
-    },
-    "image-palette": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/image-palette/-/image-palette-2.1.0.tgz",
-      "integrity": "sha512-3ImSEWD26+xuQFdP0RWR4WSXadZwvgrFhjGNpMEapTG1tf2XrBFS2dlKK5hNgH4UIaSQlSUFRn1NeA+zULIWbQ==",
-      "requires": {
-        "color-id": "^1.1.0",
-        "pxls": "^2.0.0",
-        "quantize": "^1.0.2"
-      }
-    },
-    "immediate": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
-      "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps="
     },
     "immer": {
       "version": "8.0.1",
@@ -9774,7 +8624,8 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
     },
     "ini": {
       "version": "1.3.8",
@@ -9879,11 +8730,6 @@
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
       "dev": true
     },
-    "is-base64": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/is-base64/-/is-base64-0.1.0.tgz",
-      "integrity": "sha512-WRRyllsGXJM7ZN7gPTCCQ/6wNPTRDwiWdPK66l5sJzcU/oOzcIcRRf0Rux8bkpox/1yjt0F6VJRsQOIG2qz5sg=="
-    },
     "is-bigint": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
@@ -9902,11 +8748,6 @@
         "binary-extensions": "^1.0.0"
       }
     },
-    "is-blob": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-blob/-/is-blob-2.1.0.tgz",
-      "integrity": "sha512-SZ/fTft5eUhQM6oF/ZaASFDEdbFVe89Imltn9uZr03wdKMcWNVYSMjQPFtg05QuNkt5l5c135ElvXEQG0rk4tw=="
-    },
     "is-boolean-object": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
@@ -9916,15 +8757,11 @@
         "has-tostringtag": "^1.0.0"
       }
     },
-    "is-browser": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-browser/-/is-browser-2.1.0.tgz",
-      "integrity": "sha512-F5rTJxDQ2sW81fcfOR1GnCXT6sVJC104fCyfj+mjpwNEwaPYSn5fte5jiHmBg3DHsIoL/l8Kvw5VN5SsTRcRFQ=="
-    },
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "dev": true
     },
     "is-callable": {
       "version": "1.2.4",
@@ -9944,6 +8781,7 @@
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.6.0.tgz",
       "integrity": "sha512-wShG8vs60jKfPWpF2KZRaAtvt3a20OAn7+IJ6hLPECpSABLcKtFKTTI4ZtH5QcBruBHlq+WsdHWyz0BCZW7svQ==",
+      "dev": true,
       "requires": {
         "has": "^1.0.3"
       }
@@ -10028,21 +8866,6 @@
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
       "dev": true
     },
-    "is-finite": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.1.0.tgz",
-      "integrity": "sha512-cdyMtqX/BOqqNBBiKlIVkytNHm49MtMlYyn1zxzvJKWmFMlGzm+ry5BBfYyeY9YmNKbRSo/o7OX9w9ale0wg3w=="
-    },
-    "is-firefox": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/is-firefox/-/is-firefox-1.0.3.tgz",
-      "integrity": "sha1-KioVZ3g6QX9uFYMjEI84YbCRhWI="
-    },
-    "is-float-array": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-float-array/-/is-float-array-1.0.0.tgz",
-      "integrity": "sha512-4ew1Sx6B6kEAl3T3NOM0yB94J3NZnBdNt4paw0e8nY73yHHTeTEhyQ3Lj7EQEnv5LD+GxNTaT4L46jcKjjpLiQ=="
-    },
     "is-fullwidth-code-point": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
@@ -10072,20 +8895,10 @@
       "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.4.tgz",
       "integrity": "sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw=="
     },
-    "is-iexplorer": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-iexplorer/-/is-iexplorer-1.0.0.tgz",
-      "integrity": "sha1-HXK8ZtP+Iur2Fw3ajPEJQySM/HY="
-    },
     "is-map": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.2.tgz",
       "integrity": "sha512-cOZFQQozTha1f4MxLFzlgKYPTyj26picdZTx82hbc/Xf4K/tZOOXSCkMvU4pKioRXGDLJRn0GM7Upe7kR721yg=="
-    },
-    "is-mobile": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/is-mobile/-/is-mobile-2.2.2.tgz",
-      "integrity": "sha512-wW/SXnYJkTjs++tVK5b6kVITZpAZPtUrt9SF80vvxGiF/Oywal+COk1jlRkiVq15RFNEQKQY31TkV24/1T5cVg=="
     },
     "is-negative-zero": {
       "version": "2.0.1",
@@ -10119,11 +8932,6 @@
       "requires": {
         "has-tostringtag": "^1.0.0"
       }
-    },
-    "is-obj": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
-      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
     },
     "is-object": {
       "version": "1.0.2",
@@ -10183,16 +8991,6 @@
       "requires": {
         "has-tostringtag": "^1.0.0"
       }
-    },
-    "is-string-blank": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-string-blank/-/is-string-blank-1.0.1.tgz",
-      "integrity": "sha512-9H+ZBCVs3L9OYqv8nuUAzpcT9OTgMD1yAWrG7ihlnibdkbtB850heAmYWxHuXc4CHy4lKeK69tN+ny1K7gBIrw=="
-    },
-    "is-svg-path": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-svg-path/-/is-svg-path-1.0.2.tgz",
-      "integrity": "sha1-d6tZDBKz0gNI5cehPQBAyHeE3aA="
     },
     "is-symbol": {
       "version": "1.0.4",
@@ -10263,7 +9061,8 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
     },
     "isexe": {
       "version": "2.0.0",
@@ -10601,11 +9400,6 @@
         }
       }
     },
-    "jquery": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.0.tgz",
-      "integrity": "sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw=="
-    },
     "js-string-escape": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.1.tgz",
@@ -10669,27 +9463,11 @@
         "graceful-fs": "^4.1.6"
       }
     },
-    "jszip": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.2.2.tgz",
-      "integrity": "sha512-NmKajvAFQpbg3taXQXr/ccS2wcucR1AZ+NtyWp2Nq7HHVsXhcJFR8p0Baf32C2yVvBylFWVeKf+WI2AnvlPhpA==",
-      "requires": {
-        "lie": "~3.3.0",
-        "pako": "~1.0.2",
-        "readable-stream": "~2.3.6",
-        "set-immediate-shim": "~1.0.1"
-      }
-    },
     "junk": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/junk/-/junk-3.1.0.tgz",
       "integrity": "sha512-pBxcB3LFc8QVgdggvZWyeys+hnrNWg4OcZIU/1X59k5jQdLBlCsYGRQaz234SqoRLTCgMH00fY0xRJH+F9METQ==",
       "dev": true
-    },
-    "kdbush": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-3.0.0.tgz",
-      "integrity": "sha512-hRkd6/XW4HTsA9vjVpY9tuXJYLSlelnkTmVFu4M9/7MIYQtFcHpbugAU7UbOfjOiVSVYl2fqgBuJ32JUmRo5Ew=="
     },
     "kind-of": {
       "version": "6.0.3",
@@ -10718,11 +9496,6 @@
       "integrity": "sha512-ZRbnvdg/NxqzC7L9Uyqzf4psi1OM4Cuc+sJAkQPjO6XkQIJTNbfK2Rsmbw8fx1p2mkZdp2FZYo2+LwXYY/uwIA==",
       "dev": true
     },
-    "layerr": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/layerr/-/layerr-0.1.2.tgz",
-      "integrity": "sha512-ob5kTd9H3S4GOG2nVXyQhOu9O8nBgP555XxWPkJI0tR0JeRilfyTp8WtPdIJHLXBmHMSdEq5+KMxiYABeScsIQ=="
-    },
     "lazy-universal-dotenv": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/lazy-universal-dotenv/-/lazy-universal-dotenv-3.0.1.tgz",
@@ -10740,17 +9513,10 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "dev": true,
       "requires": {
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2"
-      }
-    },
-    "lie": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
-      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
-      "requires": {
-        "immediate": "~3.0.5"
       }
     },
     "lines-and-columns": {
@@ -10821,31 +9587,10 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
-    "lodash.clamp": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/lodash.clamp/-/lodash.clamp-4.0.3.tgz",
-      "integrity": "sha1-XCS+3u7vB1NWDcK0y0Zx+Qpt36o="
-    },
     "lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
-    },
-    "lodash.flatten": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
-      "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=",
-      "dev": true
-    },
-    "lodash.ismatch": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz",
-      "integrity": "sha1-dWy1FQyjum8RCFp4hJZF8Yj4Xzc="
-    },
-    "lodash.merge": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
     },
     "lodash.throttle": {
       "version": "4.1.1",
@@ -10932,24 +9677,6 @@
       "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
       "dev": true
     },
-    "map-limit": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/map-limit/-/map-limit-0.0.1.tgz",
-      "integrity": "sha1-63lhAxwPDo0AG/LVb6toXViCLzg=",
-      "requires": {
-        "once": "~1.3.0"
-      },
-      "dependencies": {
-        "once": {
-          "version": "1.3.3",
-          "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-          "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
-          "requires": {
-            "wrappy": "1"
-          }
-        }
-      }
-    },
     "map-or-similar": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/map-or-similar/-/map-or-similar-1.5.0.tgz",
@@ -10963,36 +9690,6 @@
       "dev": true,
       "requires": {
         "object-visit": "^1.0.0"
-      }
-    },
-    "mapbox-gl": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-1.10.1.tgz",
-      "integrity": "sha512-0aHt+lFUpYfvh0kMIqXqNXqoYMuhuAsMlw87TbhWrw78Tx2zfuPI0Lx31/YPUgJ+Ire0tzQ4JnuBL7acDNXmMg==",
-      "requires": {
-        "@mapbox/geojson-rewind": "^0.5.0",
-        "@mapbox/geojson-types": "^1.0.2",
-        "@mapbox/jsonlint-lines-primitives": "^2.0.2",
-        "@mapbox/mapbox-gl-supported": "^1.5.0",
-        "@mapbox/point-geometry": "^0.1.0",
-        "@mapbox/tiny-sdf": "^1.1.1",
-        "@mapbox/unitbezier": "^0.0.0",
-        "@mapbox/vector-tile": "^1.3.1",
-        "@mapbox/whoots-js": "^3.1.0",
-        "csscolorparser": "~1.0.3",
-        "earcut": "^2.2.2",
-        "geojson-vt": "^3.2.1",
-        "gl-matrix": "^3.2.1",
-        "grid-index": "^1.1.0",
-        "minimist": "^1.2.5",
-        "murmurhash-js": "^1.0.0",
-        "pbf": "^3.2.1",
-        "potpack": "^1.0.1",
-        "quickselect": "^2.0.0",
-        "rw": "^1.3.3",
-        "supercluster": "^7.0.0",
-        "tinyqueue": "^2.0.3",
-        "vt-pbf": "^3.1.1"
       }
     },
     "markdown-escapes": {
@@ -11014,21 +9711,6 @@
       "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-7.1.3.tgz",
       "integrity": "sha512-jtQ6VyT7rMT5tPV0g2EJakEnXLiPksnvlYtwQsVVZ611JsWGN8bQ1tVSDX4s6JllfEH6wmsYxNjTUAMrPmNA8w==",
       "dev": true
-    },
-    "math-log2": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/math-log2/-/math-log2-1.0.1.tgz",
-      "integrity": "sha1-+4lBvl9evol55xjmJzsXjlhpRWU="
-    },
-    "md5": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
-      "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
-      "requires": {
-        "charenc": "0.0.2",
-        "crypt": "0.0.2",
-        "is-buffer": "~1.1.6"
-      }
     },
     "md5.js": {
       "version": "1.3.5",
@@ -11443,6 +10125,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -11450,7 +10133,8 @@
     "minimist": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "dev": true
     },
     "minipass": {
       "version": "3.1.5",
@@ -11546,39 +10230,6 @@
         "minimist": "^1.2.5"
       }
     },
-    "monaco-editor": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.27.0.tgz",
-      "integrity": "sha512-UhwP78Wb8w0ZSYoKXQNTV/0CHObp6NS3nCt51QfKE6sKyBo5PBsvuDOHoI2ooBakc6uIwByRLHVeT7+yXQe2fQ=="
-    },
-    "mouse-change": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/mouse-change/-/mouse-change-1.4.0.tgz",
-      "integrity": "sha1-wrd+W/o0pDzhRFyBV6Tk3JiVwU8=",
-      "requires": {
-        "mouse-event": "^1.0.0"
-      }
-    },
-    "mouse-event": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/mouse-event/-/mouse-event-1.0.5.tgz",
-      "integrity": "sha1-s3ie23EJmX1aky0dAdqhVDpQFzI="
-    },
-    "mouse-event-offset": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/mouse-event-offset/-/mouse-event-offset-3.0.2.tgz",
-      "integrity": "sha1-39hqbiSMa6jK1TuQXVA3ogY+mYQ="
-    },
-    "mouse-wheel": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/mouse-wheel/-/mouse-wheel-1.2.0.tgz",
-      "integrity": "sha1-bSkDseqPtI5h8bU7kDZ3PwQs21w=",
-      "requires": {
-        "right-now": "^1.0.0",
-        "signum": "^1.0.0",
-        "to-px": "^1.0.1"
-      }
-    },
     "move-concurrently": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
@@ -11607,20 +10258,8 @@
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-    },
-    "mumath": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/mumath/-/mumath-3.3.4.tgz",
-      "integrity": "sha1-SNSg8P2MrU57Mglu6JsWGmPTC78=",
-      "requires": {
-        "almost-equal": "^1.1.0"
-      }
-    },
-    "murmurhash-js": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/murmurhash-js/-/murmurhash-js-1.0.0.tgz",
-      "integrity": "sha1-sGJ44h/Gw3+lMTcysEEry2rhX1E="
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
     },
     "nanoid": {
       "version": "2.1.11",
@@ -11646,11 +10285,6 @@
         "to-regex": "^3.0.1"
       }
     },
-    "native-promise-only": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/native-promise-only/-/native-promise-only-0.8.1.tgz",
-      "integrity": "sha1-IKMYwwy0X3H+et+/eyHJnBRy7xE="
-    },
     "native-url": {
       "version": "0.2.6",
       "resolved": "https://registry.npmjs.org/native-url/-/native-url-0.2.6.tgz",
@@ -11658,31 +10292,6 @@
       "dev": true,
       "requires": {
         "querystring": "^0.2.0"
-      }
-    },
-    "needle": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/needle/-/needle-2.9.1.tgz",
-      "integrity": "sha512-6R9fqJ5Zcmf+uYaFgdIHmLwNldn5HbK8L5ybn7Uz+ylX/rnOsSp1AHcvQSrCaFN+qNM1wpymHqD7mVasEOlHGQ==",
-      "requires": {
-        "debug": "^3.2.6",
-        "iconv-lite": "^0.4.4",
-        "sax": "^1.2.4"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.2.7",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
-        }
       }
     },
     "negotiator": {
@@ -11702,11 +10311,6 @@
       "resolved": "https://registry.npmjs.org/nested-error-stacks/-/nested-error-stacks-2.1.0.tgz",
       "integrity": "sha512-AO81vsIO1k1sM4Zrd6Hu7regmJN1NSiAja10gc4bX3F0wd+9rQmcuHQaHVQCYIEC8iFXnE+mavh23GOt7wBgug==",
       "dev": true
-    },
-    "nested-property": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/nested-property/-/nested-property-4.0.0.tgz",
-      "integrity": "sha512-yFehXNWRs4cM0+dz7QxCd06hTbWbSkV0ISsqBfkntU6TOY4Qm3Q88fRRLOddkGh2Qq6dZvnKVAahfhjcUvLnyA=="
     },
     "next-tick": {
       "version": "1.1.0",
@@ -11825,11 +10429,6 @@
       "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=",
       "dev": true
     },
-    "normalize-svg-path": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/normalize-svg-path/-/normalize-svg-path-0.1.0.tgz",
-      "integrity": "sha1-RWNg5g7Odfvve11+FgSA5//Rb+U="
-    },
     "npm-run-all": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/npm-run-all/-/npm-run-all-4.1.5.tgz",
@@ -11910,14 +10509,6 @@
       "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
       "integrity": "sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4=",
       "dev": true
-    },
-    "number-is-integer": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/number-is-integer/-/number-is-integer-1.0.1.tgz",
-      "integrity": "sha1-5ZvKFy/+0nMY55x862y3LAlbIVI=",
-      "requires": {
-        "is-finite": "^1.0.1"
-      }
     },
     "number-is-nan": {
       "version": "1.0.1",
@@ -12079,6 +10670,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -12108,6 +10700,7 @@
       "version": "0.8.3",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
       "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
+      "dev": true,
       "requires": {
         "deep-is": "~0.1.3",
         "fast-levenshtein": "~2.0.6",
@@ -12223,12 +10816,8 @@
     "pako": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
-    },
-    "papaparse": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.3.1.tgz",
-      "integrity": "sha512-Dbt2yjLJrCwH2sRqKFFJaN5XgIASO9YOFeFP8rIBRG2Ain8mqk5r1M6DkfvqEVozVcz3r3HaUGw253hA1nLIcA=="
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "dev": true
     },
     "parallel-transform": {
       "version": "1.2.0",
@@ -12259,11 +10848,6 @@
       "requires": {
         "callsites": "^3.0.0"
       }
-    },
-    "parenthesis": {
-      "version": "3.1.8",
-      "resolved": "https://registry.npmjs.org/parenthesis/-/parenthesis-3.1.8.tgz",
-      "integrity": "sha512-KF/U8tk54BgQewkJPvB4s/US3VQY68BRDpH638+7O/n58TpnwiwnOtGIOsT2/i+M78s61BBpeC83STB88d8sqw=="
     },
     "parse-asn1": {
       "version": "5.1.6",
@@ -12302,24 +10886,6 @@
         "json-parse-even-better-errors": "^2.3.0",
         "lines-and-columns": "^1.1.6"
       }
-    },
-    "parse-rect": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/parse-rect/-/parse-rect-1.2.0.tgz",
-      "integrity": "sha512-4QZ6KYbnE6RTwg9E0HpLchUM9EZt6DnDxajFZZDSV4p/12ZJEvPO702DZpGvRYEPo00yKDys7jASi+/w7aO8LA==",
-      "requires": {
-        "pick-by-alias": "^1.2.0"
-      }
-    },
-    "parse-svg-path": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/parse-svg-path/-/parse-svg-path-0.1.2.tgz",
-      "integrity": "sha1-en7A0esG+lMlx9PgCbhZoJtdSes="
-    },
-    "parse-unit": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/parse-unit/-/parse-unit-1.0.1.tgz",
-      "integrity": "sha1-fhu21b7zh0wo45JSaiVBFwKR7s8="
     },
     "parse5": {
       "version": "6.0.1",
@@ -12382,12 +10948,8 @@
     "path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
-    },
-    "path-posix": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/path-posix/-/path-posix-1.0.0.tgz",
-      "integrity": "sha1-BrJhE/Vr6rBCVFojv6iAA8ysJg8="
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true
     },
     "path-to-regexp": {
       "version": "0.1.7",
@@ -12401,15 +10963,6 @@
       "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
       "dev": true
     },
-    "pbf": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/pbf/-/pbf-3.2.1.tgz",
-      "integrity": "sha512-ClrV7pNOn7rtmoQVF4TS1vyU0WhYRnP92fzbfF75jAIwpnzdJXf8iTd4CMEqO4yUenH6NDqLiwjqlh6QgZzgLQ==",
-      "requires": {
-        "ieee754": "^1.1.12",
-        "resolve-protobuf-schema": "^2.1.0"
-      }
-    },
     "pbkdf2": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.2.tgz",
@@ -12422,16 +10975,6 @@
         "safe-buffer": "^5.0.1",
         "sha.js": "^2.4.8"
       }
-    },
-    "performance-now": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
-    },
-    "pick-by-alias": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/pick-by-alias/-/pick-by-alias-1.2.0.tgz",
-      "integrity": "sha1-X3yysfIabh6ISgyHhVqko3NhEHs="
     },
     "picomatch": {
       "version": "2.3.0",
@@ -12553,61 +11096,6 @@
         }
       }
     },
-    "plotly.js": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/plotly.js/-/plotly.js-2.8.3.tgz",
-      "integrity": "sha512-uAgJS8AEJkrbGHQsMB6Ej3a2XSCJlhoRJIWFMhKZq6jFesguSozeKH8DLdnn1uZLMVxpQBKWlLsy5eTWckzi1g==",
-      "requires": {
-        "@plotly/d3": "3.8.0",
-        "@plotly/d3-sankey": "0.7.2",
-        "@plotly/d3-sankey-circular": "0.33.1",
-        "@turf/area": "^6.4.0",
-        "@turf/bbox": "^6.4.0",
-        "@turf/centroid": "^6.0.2",
-        "canvas-fit": "^1.5.0",
-        "color-alpha": "1.0.4",
-        "color-normalize": "1.5.0",
-        "color-parse": "1.3.8",
-        "color-rgba": "2.1.1",
-        "country-regex": "^1.1.0",
-        "d3-force": "^1.2.1",
-        "d3-format": "^1.4.5",
-        "d3-geo": "^1.12.1",
-        "d3-geo-projection": "^2.9.0",
-        "d3-hierarchy": "^1.1.9",
-        "d3-interpolate": "^1.4.0",
-        "d3-time": "^1.1.0",
-        "d3-time-format": "^2.2.3",
-        "fast-isnumeric": "^1.1.4",
-        "gl-mat4": "^1.2.0",
-        "gl-text": "^1.3.1",
-        "glslify": "^7.1.1",
-        "has-hover": "^1.0.1",
-        "has-passive-events": "^1.0.0",
-        "is-mobile": "^2.2.2",
-        "mapbox-gl": "1.10.1",
-        "mouse-change": "^1.4.0",
-        "mouse-event-offset": "^3.0.2",
-        "mouse-wheel": "^1.2.0",
-        "native-promise-only": "^0.8.1",
-        "parse-svg-path": "^0.1.2",
-        "polybooljs": "^1.2.0",
-        "probe-image-size": "^7.2.2",
-        "regl": "^2.1.0",
-        "regl-error2d": "^2.0.12",
-        "regl-line2d": "^3.1.2",
-        "regl-scatter2d": "^3.2.8",
-        "regl-splom": "^1.0.14",
-        "strongly-connected-components": "^1.0.1",
-        "superscript-text": "^1.0.0",
-        "svg-path-sdf": "^1.1.3",
-        "tinycolor2": "^1.4.2",
-        "to-px": "1.0.1",
-        "topojson-client": "^3.1.0",
-        "webgl-context": "^2.2.0",
-        "world-calendars": "^1.0.3"
-      }
-    },
     "pnp-webpack-plugin": {
       "version": "1.6.4",
       "resolved": "https://registry.npmjs.org/pnp-webpack-plugin/-/pnp-webpack-plugin-1.6.4.tgz",
@@ -12625,11 +11113,6 @@
       "requires": {
         "@babel/runtime": "^7.14.0"
       }
-    },
-    "polybooljs": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/polybooljs/-/polybooljs-1.2.0.tgz",
-      "integrity": "sha1-tDkMLgedTCYtOyUExiiNlbp6R1g="
     },
     "popper.js": {
       "version": "1.16.1",
@@ -12784,15 +11267,11 @@
       "integrity": "sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ==",
       "dev": true
     },
-    "potpack": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/potpack/-/potpack-1.0.2.tgz",
-      "integrity": "sha512-choctRBIV9EMT9WGAZHn3V7t0Z2pMQyl0EZE6pFc/6ml3ssw7Dlf/oAOvFwjm1HVsqfQN8GfeFyJ+d8tRzqueQ=="
-    },
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "dev": true
     },
     "prettier": {
       "version": "2.2.1",
@@ -12822,16 +11301,6 @@
       "integrity": "sha512-mNPsedLuk90RVJioIky8ANZEwYm5w9LcvCXrxHlwf4fNVSn8jEipMybMkWUyyF0JhnC+C4VcOVSBuHRKs1L5Ow==",
       "dev": true
     },
-    "probe-image-size": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/probe-image-size/-/probe-image-size-7.2.3.tgz",
-      "integrity": "sha512-HubhG4Rb2UH8YtV4ba0Vp5bQ7L78RTONYu/ujmCu5nBI8wGv24s4E9xSKBi0N1MowRpxk76pFCpJtW0KPzOK0w==",
-      "requires": {
-        "lodash.merge": "^4.6.2",
-        "needle": "^2.5.2",
-        "stream-parser": "~0.3.1"
-      }
-    },
     "process": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
@@ -12841,7 +11310,8 @@
     "process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true
     },
     "promise-inflight": {
       "version": "1.0.1",
@@ -12901,11 +11371,6 @@
       "requires": {
         "xtend": "^4.0.0"
       }
-    },
-    "protocol-buffers-schema": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.0.tgz",
-      "integrity": "sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw=="
     },
     "proxy-addr": {
       "version": "2.0.7",
@@ -12984,26 +11449,6 @@
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true
     },
-    "pxls": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/pxls/-/pxls-2.3.2.tgz",
-      "integrity": "sha512-pQkwgbLqWPcuES5iEmGa10OlCf5xG0blkIF3dg7PpRZShbTYcvAdfFfGL03SMrkaSUaa/V0UpN9HWg40O2AIIw==",
-      "requires": {
-        "arr-flatten": "^1.1.0",
-        "compute-dims": "^1.1.0",
-        "flip-pixels": "^1.0.2",
-        "is-browser": "^2.1.0",
-        "is-buffer": "^2.0.3",
-        "to-uint8": "^1.4.1"
-      },
-      "dependencies": {
-        "is-buffer": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
-          "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ=="
-        }
-      }
-    },
     "qs": {
       "version": "6.10.1",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.1.tgz",
@@ -13012,11 +11457,6 @@
       "requires": {
         "side-channel": "^1.0.4"
       }
-    },
-    "quantize": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/quantize/-/quantize-1.0.2.tgz",
-      "integrity": "sha1-0lrCAKd7bXD0ASfKFxoQ4zyFRt4="
     },
     "querystring": {
       "version": "0.2.0",
@@ -13030,34 +11470,11 @@
       "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=",
       "dev": true
     },
-    "querystringify": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
-      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
-    },
     "queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
       "dev": true
-    },
-    "quickselect": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
-      "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw=="
-    },
-    "raf": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
-      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
-      "requires": {
-        "performance-now": "^2.1.0"
-      }
-    },
-    "raf-schd": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/raf-schd/-/raf-schd-4.0.3.tgz",
-      "integrity": "sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ=="
     },
     "ramda": {
       "version": "0.21.0",
@@ -13133,20 +11550,6 @@
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
-      }
-    },
-    "react-beautiful-dnd": {
-      "version": "13.1.0",
-      "resolved": "https://registry.npmjs.org/react-beautiful-dnd/-/react-beautiful-dnd-13.1.0.tgz",
-      "integrity": "sha512-aGvblPZTJowOWUNiwd6tNfEpgkX5OxmpqxHKNW/4VmvZTNTbeiq7bA3bn5T+QSF2uibXB0D1DmJsb1aC/+3cUA==",
-      "requires": {
-        "@babel/runtime": "^7.9.2",
-        "css-box-model": "^1.2.0",
-        "memoize-one": "^5.1.1",
-        "raf-schd": "^4.0.2",
-        "react-redux": "^7.2.0",
-        "redux": "^4.0.4",
-        "use-memo-one": "^1.1.1"
       }
     },
     "react-colorful": {
@@ -13424,14 +11827,6 @@
         }
       }
     },
-    "react-plotly.js": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/react-plotly.js/-/react-plotly.js-2.5.1.tgz",
-      "integrity": "sha512-Oya14whSHvPsYXdI0nHOGs1pZhMzV2edV7HAW1xFHD58Y73m/LbG2Encvyz1tztL0vfjph0JNhiwO8cGBJnlhg==",
-      "requires": {
-        "prop-types": "^15.7.2"
-      }
-    },
     "react-popper": {
       "version": "2.2.5",
       "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-2.2.5.tgz",
@@ -13457,6 +11852,7 @@
       "version": "7.2.5",
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.5.tgz",
       "integrity": "sha512-Dt29bNyBsbQaysp6s/dN0gUodcq+dVKKER8Qv82UrpeygwYeX1raTtil7O/fftw/rFqzaf6gJhDZRkkZnn6bjg==",
+      "dev": true,
       "requires": {
         "@babel/runtime": "^7.12.1",
         "@types/react-redux": "^7.1.16",
@@ -13517,22 +11913,6 @@
         "loose-envify": "^1.4.0",
         "prop-types": "^15.6.2",
         "react-lifecycles-compat": "^3.0.4"
-      }
-    },
-    "react-virtualized-auto-sizer": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.6.tgz",
-      "integrity": "sha512-7tQ0BmZqfVF6YYEWcIGuoR3OdYe8I/ZFbNclFlGOC3pMqunkYF/oL30NCjSGl9sMEb17AnzixDz98Kqc3N76HQ==",
-      "dev": true
-    },
-    "react-window": {
-      "version": "1.8.6",
-      "resolved": "https://registry.npmjs.org/react-window/-/react-window-1.8.6.tgz",
-      "integrity": "sha512-8VwEEYyjz6DCnGBsd+MgkD0KJ2/OXFULyDtorIiTz+QzwoP94tBoA7CnbtyXMm+cCeAUER5KJcPtWl9cpKbOBg==",
-      "dev": true,
-      "requires": {
-        "@babel/runtime": "^7.0.0",
-        "memoize-one": ">=3.1.1 <6"
       }
     },
     "reactstrap": {
@@ -13611,6 +11991,7 @@
       "version": "2.3.7",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
       "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "dev": true,
       "requires": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -13646,15 +12027,10 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-4.1.1.tgz",
       "integrity": "sha512-hZQZdDEM25UY2P493kPYuKqviVwZ58lEmGQNeQ+gXa+U0gYPUBf7NKYazbe3m+bs/DzM/ahN12DbF+NG8i0CWw==",
+      "dev": true,
       "requires": {
         "@babel/runtime": "^7.9.2"
       }
-    },
-    "redux-thunk": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.1.tgz",
-      "integrity": "sha512-OOYGNY5Jy2TWvTL1KgAlVy6dcx3siPJ1wTq741EPyUKfn6W6nChdICjZwCd0p8AZBs5kWpZlbkXW2nE/zjUa+Q==",
-      "dev": true
     },
     "refractor": {
       "version": "3.4.0",
@@ -13706,11 +12082,6 @@
         "safe-regex": "^1.1.0"
       }
     },
-    "regex-regex": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/regex-regex/-/regex-regex-1.0.0.tgz",
-      "integrity": "sha1-kEih6uuHD01IDavHb8Qs3MC8OnI="
-    },
     "regexp.prototype.flags": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.1.tgz",
@@ -13755,82 +12126,6 @@
           "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
           "dev": true
         }
-      }
-    },
-    "regl": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/regl/-/regl-2.1.0.tgz",
-      "integrity": "sha512-oWUce/aVoEvW5l2V0LK7O5KJMzUSKeiOwFuJehzpSFd43dO5spP9r+sSUfhKtsky4u6MCqWJaRL+abzExynfTg=="
-    },
-    "regl-error2d": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/regl-error2d/-/regl-error2d-2.0.12.tgz",
-      "integrity": "sha512-r7BUprZoPO9AbyqM5qlJesrSRkl+hZnVKWKsVp7YhOl/3RIpi4UDGASGJY0puQ96u5fBYw/OlqV24IGcgJ0McA==",
-      "requires": {
-        "array-bounds": "^1.0.1",
-        "color-normalize": "^1.5.0",
-        "flatten-vertex-data": "^1.0.2",
-        "object-assign": "^4.1.1",
-        "pick-by-alias": "^1.2.0",
-        "to-float32": "^1.1.0",
-        "update-diff": "^1.1.0"
-      }
-    },
-    "regl-line2d": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/regl-line2d/-/regl-line2d-3.1.2.tgz",
-      "integrity": "sha512-nmT7WWS/WxmXAQMkgaMKWXaVmwJ65KCrjbqHGOUjjqQi6shfT96YbBOvelXwO9hG7/hjvbzjtQ2UO0L3e7YaXQ==",
-      "requires": {
-        "array-bounds": "^1.0.1",
-        "array-find-index": "^1.0.2",
-        "array-normalize": "^1.1.4",
-        "color-normalize": "^1.5.0",
-        "earcut": "^2.1.5",
-        "es6-weak-map": "^2.0.3",
-        "flatten-vertex-data": "^1.0.2",
-        "glslify": "^7.0.0",
-        "object-assign": "^4.1.1",
-        "parse-rect": "^1.2.0",
-        "pick-by-alias": "^1.2.0",
-        "to-float32": "^1.1.0"
-      }
-    },
-    "regl-scatter2d": {
-      "version": "3.2.8",
-      "resolved": "https://registry.npmjs.org/regl-scatter2d/-/regl-scatter2d-3.2.8.tgz",
-      "integrity": "sha512-bqrqJyeHkGBa9mEfuBnRd7FUtdtZ1l+gsM2C5Ugr1U3vJG5K3mdWdVWtOAllZ5FHHyWJV/vgjVvftgFUg6CDig==",
-      "requires": {
-        "@plotly/point-cluster": "^3.1.9",
-        "array-range": "^1.0.1",
-        "array-rearrange": "^2.2.2",
-        "clamp": "^1.0.1",
-        "color-id": "^1.1.0",
-        "color-normalize": "^1.5.0",
-        "color-rgba": "^2.1.1",
-        "flatten-vertex-data": "^1.0.2",
-        "glslify": "^7.0.0",
-        "image-palette": "^2.1.0",
-        "is-iexplorer": "^1.0.0",
-        "object-assign": "^4.1.1",
-        "parse-rect": "^1.2.0",
-        "pick-by-alias": "^1.2.0",
-        "to-float32": "^1.1.0",
-        "update-diff": "^1.1.0"
-      }
-    },
-    "regl-splom": {
-      "version": "1.0.14",
-      "resolved": "https://registry.npmjs.org/regl-splom/-/regl-splom-1.0.14.tgz",
-      "integrity": "sha512-OiLqjmPRYbd7kDlHC6/zDf6L8lxgDC65BhC8JirhP4ykrK4x22ZyS+BnY8EUinXKDeMgmpRwCvUmk7BK4Nweuw==",
-      "requires": {
-        "array-bounds": "^1.0.1",
-        "array-range": "^1.0.1",
-        "color-alpha": "^1.0.4",
-        "flatten-vertex-data": "^1.0.2",
-        "parse-rect": "^1.2.0",
-        "pick-by-alias": "^1.2.0",
-        "raf": "^3.4.1",
-        "regl-scatter2d": "^3.2.3"
       }
     },
     "relateurl": {
@@ -14055,15 +12350,11 @@
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
       "dev": true
     },
-    "requires-port": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
-    },
     "resolve": {
       "version": "1.20.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
       "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
+      "dev": true,
       "requires": {
         "is-core-module": "^2.2.0",
         "path-parse": "^1.0.6"
@@ -14074,14 +12365,6 @@
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
       "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
       "dev": true
-    },
-    "resolve-protobuf-schema": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/resolve-protobuf-schema/-/resolve-protobuf-schema-2.1.0.tgz",
-      "integrity": "sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ==",
-      "requires": {
-        "protocol-buffers-schema": "^3.3.1"
-      }
     },
     "resolve-url": {
       "version": "0.2.1",
@@ -14100,11 +12383,6 @@
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
       "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
       "dev": true
-    },
-    "right-now": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/right-now/-/right-now-1.0.0.tgz",
-      "integrity": "sha1-bolgne69fc2vja7Mmuo5z1haCRg="
     },
     "rimraf": {
       "version": "3.0.2",
@@ -14149,15 +12427,11 @@
         "aproba": "^1.1.1"
       }
     },
-    "rw": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
-      "integrity": "sha1-P4Yt+pGrdmsUiF700BEkv9oHT7Q="
-    },
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
     },
     "safe-regex": {
       "version": "1.1.0",
@@ -14171,7 +12445,8 @@
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
     },
     "sane": {
       "version": "4.1.0",
@@ -14198,11 +12473,6 @@
       "requires": {
         "chokidar": ">=3.0.0 <4.0.0"
       }
-    },
-    "sax": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
     "scheduler": {
       "version": "0.20.2",
@@ -14314,11 +12584,6 @@
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
       "dev": true
     },
-    "set-immediate-shim": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
-      "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
-    },
     "set-value": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
@@ -14373,11 +12638,6 @@
         "kind-of": "^6.0.2"
       }
     },
-    "shallow-copy": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/shallow-copy/-/shallow-copy-0.0.1.tgz",
-      "integrity": "sha1-QV9CcC1z2BAzApLMXuhurhoRoXA="
-    },
     "shallowequal": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
@@ -14402,7 +12662,8 @@
     "shell-quote": {
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.2.tgz",
-      "integrity": "sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg=="
+      "integrity": "sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==",
+      "dev": true
     },
     "shortid": {
       "version": "2.2.16",
@@ -14427,11 +12688,6 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
       "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
       "dev": true
-    },
-    "signum": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/signum/-/signum-1.0.0.tgz",
-      "integrity": "sha1-dKfSvyogtA66FqkrFSEk8dVZ+nc="
     },
     "sisteransi": {
       "version": "1.0.5",
@@ -14668,11 +12924,6 @@
       "integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==",
       "dev": true
     },
-    "stack-trace": {
-      "version": "0.0.9",
-      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz",
-      "integrity": "sha1-qPbq7KkGdMMz58Q5U/J1tFFRBpU="
-    },
     "stackframe": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.2.0.tgz",
@@ -14684,34 +12935,6 @@
       "resolved": "https://registry.npmjs.org/state-toggle/-/state-toggle-1.0.3.tgz",
       "integrity": "sha512-d/5Z4/2iiCnHw6Xzghyhb+GcmF89bxwgXG60wjIiZaxnymbyOmI8Hk4VqHXiVVp6u2ysaskFfXg3ekCj4WNftQ==",
       "dev": true
-    },
-    "static-eval": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/static-eval/-/static-eval-2.1.0.tgz",
-      "integrity": "sha512-agtxZ/kWSsCkI5E4QifRwsaPs0P0JmZV6dkLz6ILYfFYQGn+5plctanRN+IC8dJRiFkyXHrwEE3W9Wmx67uDbw==",
-      "requires": {
-        "escodegen": "^1.11.1"
-      },
-      "dependencies": {
-        "escodegen": {
-          "version": "1.14.3",
-          "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.3.tgz",
-          "integrity": "sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==",
-          "requires": {
-            "esprima": "^4.0.1",
-            "estraverse": "^4.2.0",
-            "esutils": "^2.0.2",
-            "optionator": "^0.8.1",
-            "source-map": "~0.6.1"
-          }
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "optional": true
-        }
-      }
     },
     "static-extend": {
       "version": "0.1.2",
@@ -14792,35 +13015,11 @@
         "xtend": "^4.0.0"
       }
     },
-    "stream-parser": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/stream-parser/-/stream-parser-0.3.1.tgz",
-      "integrity": "sha1-FhhUhpRCACGhGC/wrxkRwSl2F3M=",
-      "requires": {
-        "debug": "2"
-      }
-    },
     "stream-shift": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
-      "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ=="
-    },
-    "string-split-by": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/string-split-by/-/string-split-by-1.0.0.tgz",
-      "integrity": "sha512-KaJKY+hfpzNyet/emP81PJA9hTVSfxNLS9SFTWxdCnnW1/zOOwiV248+EfoX7IQFcBaOp4G5YE6xTJMF+pLg6A==",
-      "requires": {
-        "parenthesis": "^3.1.5"
-      }
-    },
-    "string-to-arraybuffer": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/string-to-arraybuffer/-/string-to-arraybuffer-1.0.2.tgz",
-      "integrity": "sha512-DaGZidzi93dwjQen5I2osxR9ERS/R7B1PFyufNMnzhj+fmlDQAc1DSDIJVJhgI8Oq221efIMbABUBdPHDRt43Q==",
-      "requires": {
-        "atob-lite": "^2.0.0",
-        "is-base64": "^0.1.0"
-      }
+      "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==",
+      "dev": true
     },
     "string-width": {
       "version": "1.0.2",
@@ -14893,6 +13092,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
       "requires": {
         "safe-buffer": "~5.1.0"
       }
@@ -14927,16 +13127,6 @@
         "min-indent": "^1.0.0"
       }
     },
-    "strnum": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
-      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
-    },
-    "strongly-connected-components": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/strongly-connected-components/-/strongly-connected-components-1.0.1.tgz",
-      "integrity": "sha1-CSDitN9nyOrulsa2I0/inoc9upk="
-    },
     "style-loader": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-1.3.0.tgz",
@@ -14955,19 +13145,6 @@
         "inline-style-parser": "0.1.1"
       }
     },
-    "supercluster": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-7.1.4.tgz",
-      "integrity": "sha512-GhKkRM1jMR6WUwGPw05fs66pOFWhf59lXq+Q3J3SxPvhNcmgOtLRV6aVQPMRsmXdpaeFJGivt+t7QXUPL3ff4g==",
-      "requires": {
-        "kdbush": "^3.0.0"
-      }
-    },
-    "superscript-text": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/superscript-text/-/superscript-text-1.0.0.tgz",
-      "integrity": "sha1-58snUlZzYN9QvrBhDOjfPXHY39g="
-    },
     "supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -14975,44 +13152,6 @@
       "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
-      }
-    },
-    "svg-arc-to-cubic-bezier": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/svg-arc-to-cubic-bezier/-/svg-arc-to-cubic-bezier-3.2.0.tgz",
-      "integrity": "sha512-djbJ/vZKZO+gPoSDThGNpKDO+o+bAeA4XQKovvkNCqnIS2t+S4qnLAGQhyyrulhCFRl1WWzAp0wUDV8PpTVU3g=="
-    },
-    "svg-path-bounds": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/svg-path-bounds/-/svg-path-bounds-1.0.2.tgz",
-      "integrity": "sha512-H4/uAgLWrppIC0kHsb2/dWUYSmb4GE5UqH06uqWBcg6LBjX2fu0A8+JrO2/FJPZiSsNOKZAhyFFgsLTdYUvSqQ==",
-      "requires": {
-        "abs-svg-path": "^0.1.1",
-        "is-svg-path": "^1.0.1",
-        "normalize-svg-path": "^1.0.0",
-        "parse-svg-path": "^0.1.2"
-      },
-      "dependencies": {
-        "normalize-svg-path": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/normalize-svg-path/-/normalize-svg-path-1.1.0.tgz",
-          "integrity": "sha512-r9KHKG2UUeB5LoTouwDzBy2VxXlHsiM6fyLQvnJa0S5hrhzqElH/CH7TUGhT1fVvIYBIKf3OpY4YJ4CK+iaqHg==",
-          "requires": {
-            "svg-arc-to-cubic-bezier": "^3.0.0"
-          }
-        }
-      }
-    },
-    "svg-path-sdf": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/svg-path-sdf/-/svg-path-sdf-1.1.3.tgz",
-      "integrity": "sha512-vJJjVq/R5lSr2KLfVXVAStktfcfa1pNFjFOgyJnzZFXlO/fDZ5DmM8FpnSKKzLPfEYTVeXuVBTHF296TpxuJVg==",
-      "requires": {
-        "bitmap-sdf": "^1.0.0",
-        "draw-svg-path": "^1.0.0",
-        "is-svg-path": "^1.0.1",
-        "parse-svg-path": "^0.1.2",
-        "svg-path-bounds": "^1.0.1"
       }
     },
     "symbol.prototype.description": {
@@ -15304,6 +13443,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
       "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+      "dev": true,
       "requires": {
         "readable-stream": "~2.3.6",
         "xtend": "~4.0.1"
@@ -15327,36 +13467,11 @@
         "next-tick": "1"
       }
     },
-    "tiny-invariant": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.2.0.tgz",
-      "integrity": "sha512-1Uhn/aqw5C6RI4KejVeTg6mIS7IqxnLJ8Mv2tV5rTc0qWobay7pDUz6Wi392Cnc8ak1H0F2cjoRzb2/AW4+Fvg=="
-    },
-    "tinycolor2": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.4.2.tgz",
-      "integrity": "sha512-vJhccZPs965sV/L2sU4oRQVAos0pQXwsvTLkWYdqJ+a8Q5kPFzJTuOFwy7UniPli44NKQGAglksjvOcpo95aZA=="
-    },
-    "tinyqueue": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-2.0.3.tgz",
-      "integrity": "sha512-ppJZNDuKGgxzkHihX8v9v9G5f+18gzaTfrukGrq6ueg0lmH4nqVnA2IPG0AEH3jKEk2GRJCUhDoqpoiw3PHLBA=="
-    },
     "tmpl": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
       "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
       "dev": true
-    },
-    "to-array-buffer": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/to-array-buffer/-/to-array-buffer-3.2.0.tgz",
-      "integrity": "sha512-zN33mwi0gpL+7xW1ITLfJ48CEj6ZQW0ZAP0MU+2W3kEY0PAIncyuxmD4OqkUVhPAbTP7amq9j/iwvZKYS+lzSQ==",
-      "requires": {
-        "flatten-vertex-data": "^1.0.2",
-        "is-blob": "^2.0.1",
-        "string-to-arraybuffer": "^1.0.0"
-      }
     },
     "to-arraybuffer": {
       "version": "1.0.1",
@@ -15369,11 +13484,6 @@
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
       "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
       "dev": true
-    },
-    "to-float32": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/to-float32/-/to-float32-1.1.0.tgz",
-      "integrity": "sha512-keDnAusn/vc+R3iEiSDw8TOF7gPiTLdK1ArvWtYbJQiVfmRg6i/CAvbKq3uIS0vWroAC7ZecN3DjQKw3aSklUg=="
     },
     "to-object-path": {
       "version": "0.3.0",
@@ -15393,14 +13503,6 @@
             "is-buffer": "^1.1.5"
           }
         }
-      }
-    },
-    "to-px": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/to-px/-/to-px-1.0.1.tgz",
-      "integrity": "sha1-W7rtXl1PdkRbzJA8KTojB90yRkY=",
-      "requires": {
-        "parse-unit": "^1.0.1"
       }
     },
     "to-regex": {
@@ -15425,18 +13527,6 @@
         "repeat-string": "^1.6.1"
       }
     },
-    "to-uint8": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/to-uint8/-/to-uint8-1.4.1.tgz",
-      "integrity": "sha512-o+ochsMlTZyucbww8It401FC2Rx+OP2RpDeYbA6h+y9HgedDl1UjdsJ9CmzKEG7AFP9es5PmJ4eDWeeeXihESg==",
-      "requires": {
-        "arr-flatten": "^1.1.0",
-        "clamp": "^1.0.1",
-        "is-base64": "^0.1.0",
-        "is-float-array": "^1.0.0",
-        "to-array-buffer": "^3.0.0"
-      }
-    },
     "toggle-selection": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
@@ -15448,21 +13538,6 @@
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
       "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
       "dev": true
-    },
-    "topojson-client": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/topojson-client/-/topojson-client-3.1.0.tgz",
-      "integrity": "sha512-605uxS6bcYxGXw9qi62XyrV6Q3xwbndjachmNxu8HWTtVPxZfEJN9fd/SZS1Q54Sn2y0TMyMxFj/cJINqGHrKw==",
-      "requires": {
-        "commander": "2"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "2.20.3",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
-        }
-      }
     },
     "trim": {
       "version": "0.0.1",
@@ -15520,6 +13595,7 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "dev": true,
       "requires": {
         "prelude-ls": "~1.1.2"
       }
@@ -15540,11 +13616,6 @@
         "mime-types": "~2.1.24"
       }
     },
-    "type-name": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/type-name/-/type-name-2.0.2.tgz",
-      "integrity": "sha1-7+fUEj2KxSr/9/QMfk3sUmYAj7Q="
-    },
     "typed-styles": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/typed-styles/-/typed-styles-0.0.7.tgz",
@@ -15553,16 +13624,8 @@
     "typedarray": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
-    },
-    "typedarray-pool": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/typedarray-pool/-/typedarray-pool-1.2.0.tgz",
-      "integrity": "sha512-YTSQbzX43yvtpfRtIDAYygoYtgT+Rpjuxy9iOpczrjpXLgGoyG7aS5USJXV2d3nn8uHTeb9rXDvzS27zUg5KYQ==",
-      "requires": {
-        "bit-twiddle": "^1.0.0",
-        "dup": "^1.0.0"
-      }
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "dev": true
     },
     "typedarray-to-buffer": {
       "version": "3.1.5",
@@ -15758,7 +13821,8 @@
     "unquote": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/unquote/-/unquote-1.1.1.tgz",
-      "integrity": "sha1-j97XMk7G6IoP+LkF58CYzcCG1UQ="
+      "integrity": "sha1-j97XMk7G6IoP+LkF58CYzcCG1UQ=",
+      "dev": true
     },
     "unset-value": {
       "version": "1.0.0",
@@ -15807,11 +13871,6 @@
       "dev": true,
       "optional": true
     },
-    "update-diff": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/update-diff/-/update-diff-1.1.0.tgz",
-      "integrity": "sha1-9RAYLYHugZ+4LDprIrYrve2ngI8="
-    },
     "uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -15845,11 +13904,6 @@
         }
       }
     },
-    "url-join": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
-      "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA=="
-    },
     "url-loader": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/url-loader/-/url-loader-4.1.1.tgz",
@@ -15872,15 +13926,6 @@
             "ajv-keywords": "^3.5.2"
           }
         }
-      }
-    },
-    "url-parse": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.4.tgz",
-      "integrity": "sha512-ITeAByWWoqutFClc/lRZnFplgXgEZr3WJ6XngMM/N9DMIm4K8zXPCZ1Jdu0rERwO84w1WC5wkle2ubwTA4NTBg==",
-      "requires": {
-        "querystringify": "^2.1.1",
-        "requires-port": "^1.0.0"
       }
     },
     "use": {
@@ -15913,11 +13958,6 @@
         "use-isomorphic-layout-effect": "^1.0.0"
       }
     },
-    "use-memo-one": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/use-memo-one/-/use-memo-one-1.1.2.tgz",
-      "integrity": "sha512-u2qFKtxLsia/r8qG0ZKkbytbztzRb317XCkT7yP8wxL0tZ/CzK2G+WWie5vWvpyeP7+YoPIwbJoIHJ4Ba4k0oQ=="
-    },
     "util": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/util/-/util-0.11.1.tgz",
@@ -15938,7 +13978,8 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
     },
     "util.promisify": {
       "version": "1.0.0",
@@ -15956,54 +13997,11 @@
       "integrity": "sha1-ihagXURWV6Oupe7MWxKk+lN5dyw=",
       "dev": true
     },
-    "utils-copy": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/utils-copy/-/utils-copy-1.1.1.tgz",
-      "integrity": "sha1-biuXmCqozXPhGCo+b4vsPA9AWKc=",
-      "requires": {
-        "const-pinf-float64": "^1.0.0",
-        "object-keys": "^1.0.9",
-        "type-name": "^2.0.0",
-        "utils-copy-error": "^1.0.0",
-        "utils-indexof": "^1.0.0",
-        "utils-regex-from-string": "^1.0.0",
-        "validate.io-array": "^1.0.3",
-        "validate.io-buffer": "^1.0.1",
-        "validate.io-nonnegative-integer": "^1.0.0"
-      }
-    },
-    "utils-copy-error": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/utils-copy-error/-/utils-copy-error-1.0.1.tgz",
-      "integrity": "sha1-eR3jk8DwmJCv1Z88vqY18HmpT6U=",
-      "requires": {
-        "object-keys": "^1.0.9",
-        "utils-copy": "^1.1.0"
-      }
-    },
-    "utils-indexof": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/utils-indexof/-/utils-indexof-1.0.0.tgz",
-      "integrity": "sha1-IP6r8J7xAYtSNkPoOA57yD7GG1w=",
-      "requires": {
-        "validate.io-array-like": "^1.0.1",
-        "validate.io-integer-primitive": "^1.0.0"
-      }
-    },
     "utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
       "dev": true
-    },
-    "utils-regex-from-string": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/utils-regex-from-string/-/utils-regex-from-string-1.0.0.tgz",
-      "integrity": "sha1-/hopCfjeD/DVGCyA+8ZU1qaH0Yk=",
-      "requires": {
-        "regex-regex": "^1.0.0",
-        "validate.io-string-primitive": "^1.0.0"
-      }
     },
     "uuid": {
       "version": "3.4.0",
@@ -16045,82 +14043,6 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
-    },
-    "validate.io-array": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/validate.io-array/-/validate.io-array-1.0.6.tgz",
-      "integrity": "sha1-W1osr9j4uFq7L4hroVPy2Tond00="
-    },
-    "validate.io-array-like": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/validate.io-array-like/-/validate.io-array-like-1.0.2.tgz",
-      "integrity": "sha1-evn363tRcVvrIhVmjsXM5U+t21o=",
-      "requires": {
-        "const-max-uint32": "^1.0.2",
-        "validate.io-integer-primitive": "^1.0.0"
-      }
-    },
-    "validate.io-buffer": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/validate.io-buffer/-/validate.io-buffer-1.0.2.tgz",
-      "integrity": "sha1-hS1nNAIZFNXROvwyUxdh43IO1E4="
-    },
-    "validate.io-integer": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/validate.io-integer/-/validate.io-integer-1.0.5.tgz",
-      "integrity": "sha1-FoSWSAuVviJH7EQ/IjPeT4mHgGg=",
-      "requires": {
-        "validate.io-number": "^1.0.3"
-      }
-    },
-    "validate.io-integer-primitive": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/validate.io-integer-primitive/-/validate.io-integer-primitive-1.0.0.tgz",
-      "integrity": "sha1-qaoBA1X+hoHA/qbBp0rSQZyt3cY=",
-      "requires": {
-        "validate.io-number-primitive": "^1.0.0"
-      }
-    },
-    "validate.io-matrix-like": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/validate.io-matrix-like/-/validate.io-matrix-like-1.0.2.tgz",
-      "integrity": "sha1-XsMqddCInaxzbepovdYUWxVe38M="
-    },
-    "validate.io-ndarray-like": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/validate.io-ndarray-like/-/validate.io-ndarray-like-1.0.0.tgz",
-      "integrity": "sha1-2KOw7RZbvx0vwNAHMnDPpVIpWRk="
-    },
-    "validate.io-nonnegative-integer": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/validate.io-nonnegative-integer/-/validate.io-nonnegative-integer-1.0.0.tgz",
-      "integrity": "sha1-gGkkOgjF+Y6VQTySnf17GPP28p8=",
-      "requires": {
-        "validate.io-integer": "^1.0.5"
-      }
-    },
-    "validate.io-number": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/validate.io-number/-/validate.io-number-1.0.3.tgz",
-      "integrity": "sha1-9j/+2iSL8opnqNSODjtGGhZluvg="
-    },
-    "validate.io-number-primitive": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/validate.io-number-primitive/-/validate.io-number-primitive-1.0.0.tgz",
-      "integrity": "sha1-0uAfICmJNp3PEVVElWQgOv5YTlU="
-    },
-    "validate.io-positive-integer": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/validate.io-positive-integer/-/validate.io-positive-integer-1.0.0.tgz",
-      "integrity": "sha1-ftLQO0wnVYzGagCqsPDpIYFKZYI=",
-      "requires": {
-        "validate.io-integer": "^1.0.5"
-      }
-    },
-    "validate.io-string-primitive": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/validate.io-string-primitive/-/validate.io-string-primitive-1.0.1.tgz",
-      "integrity": "sha1-uBNbn7E3K94C/dU60dDM1t55j+4="
     },
     "vary": {
       "version": "1.1.2",
@@ -16166,16 +14088,6 @@
       "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",
       "integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==",
       "dev": true
-    },
-    "vt-pbf": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/vt-pbf/-/vt-pbf-3.1.3.tgz",
-      "integrity": "sha512-2LzDFzt0mZKZ9IpVF2r69G9bXaP2Q2sArJCmcCgvfTdCCZzSyz4aCLoQyUilu37Ll56tCblIZrXFIjNUpGIlmA==",
-      "requires": {
-        "@mapbox/point-geometry": "0.1.0",
-        "@mapbox/vector-tile": "^1.3.1",
-        "pbf": "^3.2.1"
-      }
     },
     "walker": {
       "version": "1.0.7",
@@ -16269,48 +14181,11 @@
         }
       }
     },
-    "weak-map": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/weak-map/-/weak-map-1.0.5.tgz",
-      "integrity": "sha1-eWkVhNmGB/UHC9O3CkDmuyLkAes="
-    },
     "web-namespaces": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-1.1.4.tgz",
       "integrity": "sha512-wYxSGajtmoP4WxfejAPIr4l0fVh+jeMXZb08wNc0tMg6xsfZXj3cECqIK0G7ZAqUq0PP8WlMDtaOGVBTAWztNw==",
       "dev": true
-    },
-    "web-streams-polyfill": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-2.1.1.tgz",
-      "integrity": "sha512-dlNpL2aab3g8CKfGz6rl8FNmGaRWLLn2g/DtSc9IjB30mEdE6XxzPfPSig5BwGSzI+oLxHyETrQGKjrVVhbLCg=="
-    },
-    "webdav": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/webdav/-/webdav-4.8.0.tgz",
-      "integrity": "sha512-CVJvxu0attEfoQUKraDiNh3uMjNPNl+BY0pbcKbyc/X+8IXDnqAT4tT4Ge12w+j49fYuVpFVkpEGwBZabv7Uhw==",
-      "requires": {
-        "axios": "^0.24.0",
-        "base-64": "^1.0.0",
-        "fast-xml-parser": "^3.19.0",
-        "he": "^1.2.0",
-        "hot-patcher": "^0.5.0",
-        "layerr": "^0.1.2",
-        "md5": "^2.3.0",
-        "minimatch": "^3.0.4",
-        "nested-property": "^4.0.0",
-        "path-posix": "^1.0.0",
-        "url-join": "^4.0.1",
-        "url-parse": "^1.5.3"
-      }
-    },
-    "webgl-context": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/webgl-context/-/webgl-context-2.2.0.tgz",
-      "integrity": "sha1-jzfXJXz23xzQpJ5qextyG5TMhqA=",
-      "requires": {
-        "get-canvas-context": "^1.0.1"
-      }
     },
     "webpack": {
       "version": "4.46.0",
@@ -16621,7 +14496,8 @@
     "word-wrap": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ=="
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "dev": true
     },
     "worker-farm": {
       "version": "1.7.0",
@@ -16639,14 +14515,6 @@
       "dev": true,
       "requires": {
         "microevent.ts": "~0.1.1"
-      }
-    },
-    "world-calendars": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/world-calendars/-/world-calendars-1.0.3.tgz",
-      "integrity": "sha1-slxQMrokEo/8QdCfr0pewbnBQzU=",
-      "requires": {
-        "object-assign": "^4.1.0"
       }
     },
     "wrap-ansi": {
@@ -16727,7 +14595,8 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
     },
     "write-file-atomic": {
       "version": "3.0.3",

--- a/packages/dashboard-core-plugins/src/ChartBuilderPlugin.tsx
+++ b/packages/dashboard-core-plugins/src/ChartBuilderPlugin.tsx
@@ -1,0 +1,75 @@
+import React, { useCallback } from 'react';
+import { ChartModelFactory, ChartUtils } from '@deephaven/chart';
+import {
+  assertIsDashboardPluginProps,
+  DashboardPluginComponentProps,
+  LayoutUtils,
+  useListener,
+} from '@deephaven/dashboard';
+import { Table } from '@deephaven/jsapi-shim';
+import shortid from 'shortid';
+import { IrisGridEvent } from './events';
+import { ChartPanel } from './panels';
+
+export type ChartBuilderPluginProps = Partial<DashboardPluginComponentProps>;
+
+/**
+ * Listens for IrisGridEvent.CREATE_CHART and creates a chart from the settings provided
+ * Requires the GridPlugin and ChartPlugin plugins to be loaded as well
+ */
+export const ChartBuilderPlugin = (
+  props: ChartBuilderPluginProps
+): JSX.Element => {
+  assertIsDashboardPluginProps(props);
+  const { id, layout } = props;
+  const handleCreateChart = useCallback(
+    ({
+      metadata,
+      panelId = shortid.generate(),
+      table,
+    }: {
+      metadata: {
+        settings: {
+          type: string;
+          series: string[];
+          xAxis: string;
+          isLinked: boolean;
+          hiddenSeries?: string[];
+        };
+        sourcePanelId: string;
+        table: string;
+        tableSettings: Record<string, unknown>;
+      };
+      panelId?: string;
+      table: Table;
+    }) => {
+      const { settings } = metadata;
+      const makeModel = () =>
+        ChartModelFactory.makeModelFromSettings(settings, table);
+      const title = ChartUtils.titleFromSettings(settings);
+
+      const config = {
+        type: 'react-component',
+        component: ChartPanel.COMPONENT,
+        props: {
+          localDashboardId: id,
+          id: panelId,
+          metadata,
+          makeModel,
+        },
+        title,
+        id: panelId,
+      };
+
+      const { root } = layout;
+      LayoutUtils.openComponent({ root, config });
+    },
+    [id, layout]
+  );
+
+  useListener(layout.eventHub, IrisGridEvent.CREATE_CHART, handleCreateChart);
+
+  return <></>;
+};
+
+export default ChartBuilderPlugin;

--- a/packages/dashboard-core-plugins/src/GridPlugin.tsx
+++ b/packages/dashboard-core-plugins/src/GridPlugin.tsx
@@ -12,6 +12,11 @@ import { Table, VariableDefinition } from '@deephaven/jsapi-shim';
 import shortid from 'shortid';
 import { IrisGridPanel } from './panels';
 
+export const SUPPORTED_TYPES: string[] = [
+  dh.VariableType.TABLE,
+  dh.VariableType.TREETABLE,
+];
+
 export type GridPluginProps = Partial<DashboardPluginComponentProps> & {
   getDownloadWorker?: () => Promise<ServiceWorker>;
   loadPlugin?: (name: string) => ReturnType<typeof React.forwardRef>;
@@ -43,7 +48,7 @@ export const GridPlugin = (props: GridPluginProps): JSX.Element => {
       widget: VariableDefinition;
     }) => {
       const { name, type } = widget;
-      if (type !== dh.VariableType.TABLE) {
+      if (!SUPPORTED_TYPES.includes(type)) {
         return;
       }
 

--- a/packages/dashboard-core-plugins/src/GridPlugin.tsx
+++ b/packages/dashboard-core-plugins/src/GridPlugin.tsx
@@ -11,7 +11,6 @@ import { IrisGridModelFactory, IrisGridThemeType } from '@deephaven/iris-grid';
 import { Table, VariableDefinition } from '@deephaven/jsapi-shim';
 import shortid from 'shortid';
 import { IrisGridPanel } from './panels';
-import { IrisGridEvent } from './events';
 
 export type GridPluginProps = Partial<DashboardPluginComponentProps> & {
   getDownloadWorker?: () => Promise<ServiceWorker>;

--- a/packages/dashboard-core-plugins/src/PandasPlugin.tsx
+++ b/packages/dashboard-core-plugins/src/PandasPlugin.tsx
@@ -1,4 +1,4 @@
-import React, { DragEvent, useCallback, useEffect } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import {
   assertIsDashboardPluginProps,
   DashboardPluginComponentProps,
@@ -7,11 +7,10 @@ import {
   PanelHydrateFunction,
   useListener,
 } from '@deephaven/dashboard';
-import { IrisGridModel, IrisGridModelFactory } from '@deephaven/iris-grid';
+import { IrisGridModelFactory } from '@deephaven/iris-grid';
 import { Table } from '@deephaven/jsapi-shim';
 import shortid from 'shortid';
 import { PandasPanel } from './panels';
-import { PandasEvent } from './events';
 
 export type PandasPluginProps = Partial<DashboardPluginComponentProps> & {
   hydrate: PanelHydrateFunction;
@@ -20,32 +19,6 @@ export type PandasPluginProps = Partial<DashboardPluginComponentProps> & {
 export const PandasPlugin = (props: PandasPluginProps): JSX.Element => {
   assertIsDashboardPluginProps(props);
   const { hydrate, id, layout, registerComponent } = props;
-  const handleOpen = useCallback(
-    (
-      title: string,
-      makeModel: () => IrisGridModel,
-      metadata: Record<string, unknown> = {},
-      panelId = shortid.generate(),
-      dragEvent?: DragEvent
-    ) => {
-      const config = {
-        type: 'react-component',
-        component: PandasPanel.COMPONENT,
-        props: {
-          localDashboardId: id,
-          id: panelId,
-          metadata,
-          makeModel,
-        },
-        title,
-        id: panelId,
-      };
-
-      const { root } = layout;
-      LayoutUtils.openComponent({ root, config, dragEvent });
-    },
-    [id, layout]
-  );
 
   const handlePanelOpen = useCallback(
     ({ dragEvent, fetch, panelId = shortid.generate(), widget }) => {
@@ -76,15 +49,6 @@ export const PandasPlugin = (props: PandasPluginProps): JSX.Element => {
     [id, layout]
   );
 
-  const handleClose = useCallback(
-    (panelId: string) => {
-      const config = { component: PandasPanel.COMPONENT, id: panelId };
-      const { root } = layout;
-      LayoutUtils.closeComponent(root, config);
-    },
-    [layout]
-  );
-
   useEffect(() => {
     const cleanups = [
       registerComponent(PandasPanel.COMPONENT, PandasPanel, hydrate),
@@ -95,8 +59,6 @@ export const PandasPlugin = (props: PandasPluginProps): JSX.Element => {
     };
   }, [hydrate, registerComponent]);
 
-  useListener(layout.eventHub, PandasEvent.OPEN, handleOpen);
-  useListener(layout.eventHub, PandasEvent.CLOSE, handleClose);
   useListener(layout.eventHub, PanelEvent.OPEN, handlePanelOpen);
 
   return <></>;

--- a/packages/dashboard-core-plugins/src/events/ChartEvent.js
+++ b/packages/dashboard-core-plugins/src/events/ChartEvent.js
@@ -1,6 +1,8 @@
 class ChartEvent {
+  /** @deprecated Use PanelEvent.OPEN instead */
   static OPEN = 'ChartEvent.OPEN';
 
+  /** @deprecated Use PanelEvent.CLOSE instead */
   static CLOSE = 'ChartEvent.CLOSE';
 
   static COLUMN_SELECTED = 'ChartEvent.COLUMN_SELECTED';

--- a/packages/dashboard-core-plugins/src/events/IrisGridEvent.js
+++ b/packages/dashboard-core-plugins/src/events/IrisGridEvent.js
@@ -1,6 +1,8 @@
 class IrisGridEvent {
+  /** @deprecated Use PanelEvent.OPEN instead */
   static OPEN_GRID = 'IrisGridEvent.OPEN_GRID';
 
+  /** @deprecated Use PanelEvent.CLOSE instead */
   static CLOSE_GRID = 'IrisGridEvent.CLOSE_GRID';
 
   static DATA_SELECTED = 'IrisGridEvent.DATA_SELECTED';

--- a/packages/dashboard-core-plugins/src/events/IrisGridEvent.js
+++ b/packages/dashboard-core-plugins/src/events/IrisGridEvent.js
@@ -10,6 +10,8 @@ class IrisGridEvent {
   static COLUMN_SELECTED = 'IrisGridEvent.COLUMN_SELECTED';
 
   static STATE_CHANGED = 'IrisGridEvent.STATE_CHANGED';
+
+  static CREATE_CHART = 'IrisGridevent.CREATE_CHART';
 }
 
 export default IrisGridEvent;

--- a/packages/dashboard-core-plugins/src/events/PandasEvent.js
+++ b/packages/dashboard-core-plugins/src/events/PandasEvent.js
@@ -1,6 +1,8 @@
 class PandasEvent {
+  /** @deprecated Use PanelEvent.OPEN */
   static OPEN = 'PandasEvent.OPEN';
 
+  /** @deprecated Use PanelEvent.CLOSE */
   static CLOSE = 'PandasEvent.CLOSE';
 }
 

--- a/packages/dashboard-core-plugins/src/index.test.tsx
+++ b/packages/dashboard-core-plugins/src/index.test.tsx
@@ -19,9 +19,9 @@ it('handles mounting and unmount core plugins properly', () => {
     <Provider store={store}>
       <Dashboard>
         <FilterPlugin />
+        <GridPlugin hydrate={() => undefined} />
         <ChartPlugin hydrate={() => undefined} />
         <ConsolePlugin />
-        <GridPlugin hydrate={() => undefined} />
         <LinkerPlugin />
         <MarkdownPlugin />
         <PandasPlugin hydrate={() => undefined} />

--- a/packages/dashboard-core-plugins/src/index.ts
+++ b/packages/dashboard-core-plugins/src/index.ts
@@ -1,4 +1,5 @@
 export { default as ChartPlugin } from './ChartPlugin';
+export { default as ChartBuilderPlugin } from './ChartBuilderPlugin';
 export { default as ConsolePlugin } from './ConsolePlugin';
 export { default as FilterPlugin } from './FilterPlugin';
 export { default as GridPlugin } from './GridPlugin';

--- a/packages/dashboard-core-plugins/src/panels/IrisGridPanel.jsx
+++ b/packages/dashboard-core-plugins/src/panels/IrisGridPanel.jsx
@@ -201,7 +201,11 @@ export class IrisGridPanel extends PureComponent {
       <div className="iris-grid-plugin">
         <Plugin
           ref={this.pluginRef}
+          filter={this.handlePluginFilter}
+          // onFilter is deprecated
           onFilter={this.handlePluginFilter}
+          fetchColumns={this.handlePluginFetchColumns}
+          // onFetchColumns is deprecated
           onFetchColumns={this.handlePluginFetchColumns}
           table={table}
           user={user}

--- a/packages/dashboard-core-plugins/src/panels/IrisGridPanel.jsx
+++ b/packages/dashboard-core-plugins/src/panels/IrisGridPanel.jsx
@@ -5,7 +5,6 @@ import memoize from 'memoize-one';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import debounce from 'lodash.debounce';
-import { ChartModelFactory, ChartUtils } from '@deephaven/chart';
 import { GLPropTypes, LayoutUtils } from '@deephaven/dashboard';
 import {
   IrisGrid,
@@ -19,12 +18,7 @@ import Log from '@deephaven/log';
 import { getSettings, getUser, getWorkspace } from '@deephaven/redux';
 import { PromiseUtils } from '@deephaven/utils';
 import { ContextMenuRoot } from '@deephaven/components';
-import {
-  ChartEvent,
-  ConsoleEvent,
-  InputFilterEvent,
-  IrisGridEvent,
-} from '../events';
+import { ConsoleEvent, InputFilterEvent, IrisGridEvent } from '../events';
 import {
   getInputFiltersForDashboard,
   getLinksForDashboard,
@@ -452,32 +446,38 @@ export class IrisGridPanel extends PureComponent {
     glEventHub.emit(ConsoleEvent.SEND_COMMAND, command, false, true);
   }
 
-  handleCreateChart(settings, table) {
+  /**
+   * Create a chart with the specified settings
+   * @param {ChartBuilderSettings} settings The settings from the chart builder
+   * @param {string} settings.type The settings from the chart builder
+   * @param {string[]} settings.series The names of the series
+   * @param {string} xAxis The xAxis for this chart
+   * @param {boolean} isLinked Whether this chart should be linked or not
+   * @param {IrisGridModel} model The IrisGridModel object
+   */
+  handleCreateChart(settings, model) {
     // Panel state is stored with the created chart, so flush it first
     this.savePanelState.flush();
 
     this.setState(
       () => null,
       () => {
-        const makeModel = () =>
-          ChartModelFactory.makeModelFromSettings(settings, table);
-
         const { glEventHub, inputFilters, metadata } = this.props;
-        const { querySerial, table: tableName } = metadata;
+        const { table } = metadata;
         const { panelState } = this.state;
-        const id = LayoutUtils.getIdFromPanel(this);
-
+        const sourcePanelId = LayoutUtils.getIdFromPanel(this);
         const tableSettings = IrisGridUtils.extractTableSettings(
           panelState,
           inputFilters
         );
-        const title = ChartUtils.titleFromSettings(settings);
-        glEventHub.emit(ChartEvent.OPEN, title, makeModel, {
-          querySerial,
-          settings: ChartUtils.dehydrateSettings(settings),
-          sourcePanelId: id,
-          table: tableName,
-          tableSettings,
+        glEventHub.emit(IrisGridEvent.CREATE_CHART, {
+          metadata: {
+            settings,
+            sourcePanelId,
+            table,
+            tableSettings,
+          },
+          table: model.table,
         });
       }
     );

--- a/packages/dashboard/package-lock.json
+++ b/packages/dashboard/package-lock.json
@@ -1356,93 +1356,6 @@
         "minimist": "^1.2.0"
       }
     },
-    "@deephaven/components": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@deephaven/components/-/components-0.9.1.tgz",
-      "integrity": "sha512-B96vtZW3NHN27z+pfo7WO0FmZlt/uESaPi0WmQbzxJj3XNZifgfEWZy258udvG27FXy4Md4J/poXaCjdaauQmw==",
-      "dev": true,
-      "requires": {
-        "@deephaven/icons": "^0.9.1",
-        "@deephaven/react-hooks": "^0.9.1",
-        "@deephaven/utils": "^0.9.1",
-        "@fortawesome/fontawesome-svg-core": "^1.2.32",
-        "@fortawesome/react-fontawesome": "^0.1.12",
-        "bootstrap": "4.4.1",
-        "classnames": "^2.3.1",
-        "event-target-shim": "^6.0.2",
-        "jquery": "^3.5.1",
-        "lodash.debounce": "^4.0.8",
-        "lodash.flatten": "^4.4.0",
-        "memoizee": "^0.4.15",
-        "popper.js": "^1.16.1",
-        "prop-types": "^15.7.2",
-        "react-beautiful-dnd": "^13.0.0",
-        "react-transition-group": "^2.3.1",
-        "react-virtualized-auto-sizer": "^1.0.2",
-        "react-window": "^1.8.5",
-        "reactstrap": "^8.4.1",
-        "shortid": "^2.2.15"
-      }
-    },
-    "@deephaven/golden-layout": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@deephaven/golden-layout/-/golden-layout-0.9.1.tgz",
-      "integrity": "sha512-sQWdxXEv38y79ZlgeI0NyK46T1LAmePGcP67RxjVkq3lgK+bCB78Q2X+0H7bP2YekPLAgZfY3zWXgCNUXFoIeg==",
-      "requires": {
-        "jquery": "^3.5.1"
-      }
-    },
-    "@deephaven/icons": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@deephaven/icons/-/icons-0.9.1.tgz",
-      "integrity": "sha512-nLLZez6hNl4Ep6b7IjjIxLTGRa9WxeagNC2BP2IWVXs/ONvHHv0t5SYeCCJ/IaH8Bz2UWnxf09VivVPdIGZYig==",
-      "dev": true,
-      "requires": {
-        "@fortawesome/fontawesome-common-types": "^0.2.35"
-      }
-    },
-    "@deephaven/log": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@deephaven/log/-/log-0.9.1.tgz",
-      "integrity": "sha512-L/yKtSYOrNZlvyElqpgdrnL3JBaY07szFjhA37XK31+uH/jcPcbMxsn2Uf+++yyFcn6GKO1XXXP44V3xBkBQJg==",
-      "dev": true,
-      "requires": {
-        "event-target-shim": "^6.0.2"
-      }
-    },
-    "@deephaven/mocks": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@deephaven/mocks/-/mocks-0.9.0.tgz",
-      "integrity": "sha512-PkCZ0UtFemj1wlD+fGmmmkafOsieK/ts1PyRAdBH4EBDg0WEBjCRsD9lltGydXB1LSUDy0G0xtGOjX/BPPviRA==",
-      "dev": true
-    },
-    "@deephaven/react-hooks": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@deephaven/react-hooks/-/react-hooks-0.9.1.tgz",
-      "integrity": "sha512-v7r2DZoPahHNBspbulCtvUgCqJ+i9WPEA8cK9nEsTVTeuR3mhwLw4E/0g+WlXJ78FsUdA0K9FECJfUg1YTvyLg=="
-    },
-    "@deephaven/redux": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@deephaven/redux/-/redux-0.9.1.tgz",
-      "integrity": "sha512-5wvTVtWgtn3DRdLvUrw7S6ln5GY9Im5Pt6BODotgMXmTJkmecYsPGj8jRLRT08LNVVwz+QTP8XR0Ntda3dofZA==",
-      "dev": true,
-      "requires": {
-        "deep-equal": "^2.0.4",
-        "redux-thunk": "^2.3.0"
-      }
-    },
-    "@deephaven/tsconfig": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@deephaven/tsconfig/-/tsconfig-0.9.0.tgz",
-      "integrity": "sha512-zYKPllv+W+UhAuzC2pbsaQynxzsE0bBK/XjfiK0LWiGMkMhp43rwEaCiMODSYaxGmaV5eA+ijm8r1Y8v21pH4w==",
-      "dev": true
-    },
-    "@deephaven/utils": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@deephaven/utils/-/utils-0.9.1.tgz",
-      "integrity": "sha512-kll4L5bNOOPdtpeSDpIvC8+NnlaToKrsPoJ3kvsZvJVmILdIKAIXcviGPxZO5SCjyzgV/NmfLUmHq0CcMAYnEg==",
-      "dev": true
-    },
     "@discoveryjs/json-ext": {
       "version": "0.5.5",
       "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.5.tgz",
@@ -1580,58 +1493,11 @@
       "integrity": "sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==",
       "dev": true
     },
-    "@fortawesome/fontawesome-common-types": {
-      "version": "0.2.36",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.36.tgz",
-      "integrity": "sha512-a/7BiSgobHAgBWeN7N0w+lAhInrGxksn13uK7231n2m8EDPE3BMCl9NZLTGrj9ZXfCmC6LM0QLqXidIizVQ6yg==",
-      "dev": true
-    },
-    "@fortawesome/fontawesome-svg-core": {
-      "version": "1.2.36",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.36.tgz",
-      "integrity": "sha512-YUcsLQKYb6DmaJjIHdDWpBIGCcyE/W+p/LMGvjQem55Mm2XWVAP5kWTMKWLv9lwpCVjpLxPyOMOyUocP1GxrtA==",
-      "dev": true,
-      "requires": {
-        "@fortawesome/fontawesome-common-types": "^0.2.36"
-      }
-    },
-    "@fortawesome/react-fontawesome": {
-      "version": "0.1.17",
-      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.1.17.tgz",
-      "integrity": "sha512-dX43Z5IvMaW7fwzU8farosYjKNGfRb2HB/DgjVBHeJZ/NSnuuaujPPx0YOdcAq+n3mqn70tyCde2HM1mqbhiuw==",
-      "dev": true,
-      "requires": {
-        "prop-types": "^15.8.1"
-      },
-      "dependencies": {
-        "prop-types": {
-          "version": "15.8.1",
-          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
-          "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-          "dev": true,
-          "requires": {
-            "loose-envify": "^1.4.0",
-            "object-assign": "^4.1.1",
-            "react-is": "^16.13.1"
-          }
-        }
-      }
-    },
     "@gar/promisify": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.2.tgz",
       "integrity": "sha512-82cpyJyKRoQoRi+14ibCeGPu0CwypgtBAdBhq1WfvagpCZNKqwXbKwXllYSMG91DhmG4jt9gN8eP6lGOtozuaw==",
       "dev": true
-    },
-    "@hypnosphi/create-react-context": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@hypnosphi/create-react-context/-/create-react-context-0.3.1.tgz",
-      "integrity": "sha512-V1klUed202XahrWJLLOT3EXNeCpFHCcJntdFGI15ntCwau+jfT386w7OFTMaCqOgXUH1fa0w/I1oZs+i/Rfr0A==",
-      "dev": true,
-      "requires": {
-        "gud": "^1.0.0",
-        "warning": "^4.0.3"
-      }
     },
     "@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
@@ -5043,12 +4909,6 @@
       "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
       "dev": true
     },
-    "bootstrap": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.4.1.tgz",
-      "integrity": "sha512-tbx5cHubwE6e2ZG7nqM3g/FZ5PQEDMWmMGNrCUBVRPHXTJaH7CBDdsLeu3eCh3B1tzAxTnAbtmrzvWEvT2NNEA==",
-      "dev": true
-    },
     "boxen": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/boxen/-/boxen-4.2.0.tgz",
@@ -5707,12 +5567,6 @@
           }
         }
       }
-    },
-    "classnames": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
-      "integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA==",
-      "dev": true
     },
     "clean-css": {
       "version": "4.2.3",
@@ -6438,15 +6292,6 @@
         "randomfill": "^1.0.3"
       }
     },
-    "css-box-model": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/css-box-model/-/css-box-model-1.2.1.tgz",
-      "integrity": "sha512-a7Vr4Q/kd/aw96bnJG332W9V9LkJO69JRcaCYDUqjp6/z0w6VcZjgAcTbgFxEPfBgdnAwlh3iwu+hLopa+flJw==",
-      "dev": true,
-      "requires": {
-        "tiny-invariant": "^1.0.6"
-      }
-    },
     "css-loader": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-3.6.0.tgz",
@@ -6532,16 +6377,6 @@
       "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-1.0.1.tgz",
       "integrity": "sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=",
       "dev": true
-    },
-    "d": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
-      "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
-      "dev": true,
-      "requires": {
-        "es5-ext": "^0.10.50",
-        "type": "^1.0.1"
-      }
     },
     "debug": {
       "version": "2.6.9",
@@ -6757,15 +6592,6 @@
       "dev": true,
       "requires": {
         "utila": "~0.4"
-      }
-    },
-    "dom-helpers": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.4.0.tgz",
-      "integrity": "sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==",
-      "dev": true,
-      "requires": {
-        "@babel/runtime": "^7.1.2"
       }
     },
     "dom-serializer": {
@@ -7116,69 +6942,17 @@
         "is-symbol": "^1.0.2"
       }
     },
-    "es5-ext": {
-      "version": "0.10.53",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
-      "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
-      "dev": true,
-      "requires": {
-        "es6-iterator": "~2.0.3",
-        "es6-symbol": "~3.1.3",
-        "next-tick": "~1.0.0"
-      },
-      "dependencies": {
-        "next-tick": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
-          "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
-          "dev": true
-        }
-      }
-    },
     "es5-shim": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/es5-shim/-/es5-shim-4.6.2.tgz",
       "integrity": "sha512-n0XTVMGps+Deyr38jtqKPR5F5hb9owYeRQcKJW39eFvzUk/u/9Ww315werRzbiNMnHCUw/YHDPBphTlEnzdi+A==",
       "dev": true
     },
-    "es6-iterator": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
-      "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
-      "dev": true,
-      "requires": {
-        "d": "1",
-        "es5-ext": "^0.10.35",
-        "es6-symbol": "^3.1.1"
-      }
-    },
     "es6-shim": {
       "version": "0.35.6",
       "resolved": "https://registry.npmjs.org/es6-shim/-/es6-shim-0.35.6.tgz",
       "integrity": "sha512-EmTr31wppcaIAgblChZiuN/l9Y7DPyw8Xtbg7fIVngn6zMW+IEBJDJngeKC3x6wr0V/vcA2wqeFnaw1bFJbDdA==",
       "dev": true
-    },
-    "es6-symbol": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
-      "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
-      "dev": true,
-      "requires": {
-        "d": "^1.0.1",
-        "ext": "^1.1.2"
-      }
-    },
-    "es6-weak-map": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.3.tgz",
-      "integrity": "sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==",
-      "dev": true,
-      "requires": {
-        "d": "1",
-        "es5-ext": "^0.10.46",
-        "es6-iterator": "^2.0.3",
-        "es6-symbol": "^3.1.1"
-      }
     },
     "escalade": {
       "version": "3.1.1",
@@ -7286,22 +7060,6 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
-      "dev": true
-    },
-    "event-emitter": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
-      "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
-      "dev": true,
-      "requires": {
-        "d": "1",
-        "es5-ext": "~0.10.14"
-      }
-    },
-    "event-target-shim": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-6.0.2.tgz",
-      "integrity": "sha512-8q3LsZjRezbFZ2PN+uP+Q7pnHUMmAOziU2vA2OwoFaKIXxlxl38IylhSSgUorWu/rf4er67w0ikBqjBFk/pomA==",
       "dev": true
     },
     "events": {
@@ -7418,23 +7176,6 @@
           "version": "6.7.0",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
           "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
-          "dev": true
-        }
-      }
-    },
-    "ext": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/ext/-/ext-1.6.0.tgz",
-      "integrity": "sha512-sdBImtzkq2HpkdRLtlLWDa6w4DX22ijZLKx8BMPUuKe1c5lbN6xwQDQCxSfxBQnHZ13ls/FH0MQZx/q/gr6FQg==",
-      "dev": true,
-      "requires": {
-        "type": "^2.5.0"
-      },
-      "dependencies": {
-        "type": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/type/-/type-2.5.0.tgz",
-          "integrity": "sha512-180WMDQaIMm3+7hGXWf12GtdniDEy7nYcyFMKJn/eZz/6tSLXrUN9V0wKSbMjej0I1WHWbpREDEKHtqPQa9NNw==",
           "dev": true
         }
       }
@@ -9114,12 +8855,6 @@
         "isobject": "^3.0.1"
       }
     },
-    "is-promise": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
-      "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==",
-      "dev": true
-    },
     "is-regex": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
@@ -9760,12 +9495,6 @@
       "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
       "dev": true
     },
-    "lodash.flatten": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
-      "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=",
-      "dev": true
-    },
     "lodash.ismatch": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz",
@@ -9816,15 +9545,6 @@
       "dev": true,
       "requires": {
         "yallist": "^4.0.0"
-      }
-    },
-    "lru-queue": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz",
-      "integrity": "sha1-Jzi9nw089PhEkMVzbEhpmsYyzaM=",
-      "dev": true,
-      "requires": {
-        "es5-ext": "~0.10.2"
       }
     },
     "make-dir": {
@@ -9949,28 +9669,6 @@
       "dev": true,
       "requires": {
         "fs-monkey": "1.0.3"
-      }
-    },
-    "memoize-one": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
-      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
-      "dev": true
-    },
-    "memoizee": {
-      "version": "0.4.15",
-      "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.4.15.tgz",
-      "integrity": "sha512-UBWmJpLZd5STPm7PMUlOw/TSy972M+z8gcyQ5veOnSDRREz/0bmpyTfKt3/51DhEBqCZQn1udM/5flcSPYhkdQ==",
-      "dev": true,
-      "requires": {
-        "d": "^1.0.1",
-        "es5-ext": "^0.10.53",
-        "es6-weak-map": "^2.0.3",
-        "event-emitter": "^0.3.5",
-        "is-promise": "^2.2.2",
-        "lru-queue": "^0.1.0",
-        "next-tick": "^1.1.0",
-        "timers-ext": "^0.1.7"
       }
     },
     "memoizerific": {
@@ -10304,12 +10002,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/nested-error-stacks/-/nested-error-stacks-2.1.0.tgz",
       "integrity": "sha512-AO81vsIO1k1sM4Zrd6Hu7regmJN1NSiAja10gc4bX3F0wd+9rQmcuHQaHVQCYIEC8iFXnE+mavh23GOt7wBgug==",
-      "dev": true
-    },
-    "next-tick": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
-      "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==",
       "dev": true
     },
     "nice-try": {
@@ -11110,12 +10802,6 @@
         "@babel/runtime": "^7.14.0"
       }
     },
-    "popper.js": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
-      "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==",
-      "dev": true
-    },
     "posix-character-classes": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
@@ -11474,12 +11160,6 @@
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
       "dev": true
     },
-    "raf-schd": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/raf-schd/-/raf-schd-4.0.3.tgz",
-      "integrity": "sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ==",
-      "dev": true
-    },
     "ramda": {
       "version": "0.21.0",
       "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.21.0.tgz",
@@ -11554,21 +11234,6 @@
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
-      }
-    },
-    "react-beautiful-dnd": {
-      "version": "13.1.0",
-      "resolved": "https://registry.npmjs.org/react-beautiful-dnd/-/react-beautiful-dnd-13.1.0.tgz",
-      "integrity": "sha512-aGvblPZTJowOWUNiwd6tNfEpgkX5OxmpqxHKNW/4VmvZTNTbeiq7bA3bn5T+QSF2uibXB0D1DmJsb1aC/+3cUA==",
-      "dev": true,
-      "requires": {
-        "@babel/runtime": "^7.9.2",
-        "css-box-model": "^1.2.0",
-        "memoize-one": "^5.1.1",
-        "raf-schd": "^4.0.2",
-        "react-redux": "^7.2.0",
-        "redux": "^4.0.4",
-        "use-memo-one": "^1.1.1"
       }
     },
     "react-colorful": {
@@ -11889,90 +11554,6 @@
         "use-latest": "^1.0.0"
       }
     },
-    "react-transition-group": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.9.0.tgz",
-      "integrity": "sha512-+HzNTCHpeQyl4MJ/bdE0u6XRMe9+XG/+aL4mCxVN4DnPBQ0/5bfHWPDuOZUzYdMj94daZaZdCCc1Dzt9R/xSSg==",
-      "dev": true,
-      "requires": {
-        "dom-helpers": "^3.4.0",
-        "loose-envify": "^1.4.0",
-        "prop-types": "^15.6.2",
-        "react-lifecycles-compat": "^3.0.4"
-      }
-    },
-    "react-virtualized-auto-sizer": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.6.tgz",
-      "integrity": "sha512-7tQ0BmZqfVF6YYEWcIGuoR3OdYe8I/ZFbNclFlGOC3pMqunkYF/oL30NCjSGl9sMEb17AnzixDz98Kqc3N76HQ==",
-      "dev": true
-    },
-    "react-window": {
-      "version": "1.8.6",
-      "resolved": "https://registry.npmjs.org/react-window/-/react-window-1.8.6.tgz",
-      "integrity": "sha512-8VwEEYyjz6DCnGBsd+MgkD0KJ2/OXFULyDtorIiTz+QzwoP94tBoA7CnbtyXMm+cCeAUER5KJcPtWl9cpKbOBg==",
-      "dev": true,
-      "requires": {
-        "@babel/runtime": "^7.0.0",
-        "memoize-one": ">=3.1.1 <6"
-      }
-    },
-    "reactstrap": {
-      "version": "8.10.1",
-      "resolved": "https://registry.npmjs.org/reactstrap/-/reactstrap-8.10.1.tgz",
-      "integrity": "sha512-StjLADa/12yMNjafrSs+UD7sZAGtKpLO9fZp++2Dj0IzJinqY7eQhXlM3nFf0q40YsIcLvQdFc9pKF8PF4f0Qg==",
-      "dev": true,
-      "requires": {
-        "@babel/runtime": "^7.12.5",
-        "classnames": "^2.2.3",
-        "prop-types": "^15.5.8",
-        "react-popper": "^1.3.6",
-        "react-transition-group": "^3.0.0"
-      },
-      "dependencies": {
-        "deep-equal": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
-          "integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
-          "dev": true,
-          "requires": {
-            "is-arguments": "^1.0.4",
-            "is-date-object": "^1.0.1",
-            "is-regex": "^1.0.4",
-            "object-is": "^1.0.1",
-            "object-keys": "^1.1.1",
-            "regexp.prototype.flags": "^1.2.0"
-          }
-        },
-        "react-popper": {
-          "version": "1.3.11",
-          "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-1.3.11.tgz",
-          "integrity": "sha512-VSA/bS+pSndSF2fiasHK/PTEEAyOpX60+H5EPAjoArr8JGm+oihu4UbrqcEBpQibJxBVCpYyjAX7abJ+7DoYVg==",
-          "dev": true,
-          "requires": {
-            "@babel/runtime": "^7.1.2",
-            "@hypnosphi/create-react-context": "^0.3.1",
-            "deep-equal": "^1.1.1",
-            "popper.js": "^1.14.4",
-            "prop-types": "^15.6.1",
-            "typed-styles": "^0.0.7",
-            "warning": "^4.0.2"
-          }
-        },
-        "react-transition-group": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-3.0.0.tgz",
-          "integrity": "sha512-A9ojB/LWECbFj58SNfjK1X9aaAU+1olLS0DFSikvrr2KfMaiBELemHDa5dKNvcTk2t3gUtDL/PJpFrBKDfMpLg==",
-          "dev": true,
-          "requires": {
-            "dom-helpers": "^3.4.0",
-            "loose-envify": "^1.4.0",
-            "prop-types": "^15.6.2",
-            "react-lifecycles-compat": "^3.0.4"
-          }
-        }
-      }
-    },
     "read-pkg": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
@@ -12048,12 +11629,6 @@
       "requires": {
         "@babel/runtime": "^7.9.2"
       }
-    },
-    "redux-thunk": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.1.tgz",
-      "integrity": "sha512-OOYGNY5Jy2TWvTL1KgAlVy6dcx3siPJ1wTq741EPyUKfn6W6nChdICjZwCd0p8AZBs5kWpZlbkXW2nE/zjUa+Q==",
-      "dev": true
     },
     "refractor": {
       "version": "3.4.0",
@@ -13451,22 +13026,6 @@
         "setimmediate": "^1.0.4"
       }
     },
-    "timers-ext": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.7.tgz",
-      "integrity": "sha512-b85NUNzTSdodShTIbky6ZF02e8STtVVfD+fu4aXXShEELpozH+bCpJLYMPZbsABN2wDH7fJpqIoXxJpzbf0NqQ==",
-      "dev": true,
-      "requires": {
-        "es5-ext": "~0.10.46",
-        "next-tick": "1"
-      }
-    },
-    "tiny-invariant": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.2.0.tgz",
-      "integrity": "sha512-1Uhn/aqw5C6RI4KejVeTg6mIS7IqxnLJ8Mv2tV5rTc0qWobay7pDUz6Wi392Cnc8ak1H0F2cjoRzb2/AW4+Fvg==",
-      "dev": true
-    },
     "tmpl": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -13587,12 +13146,6 @@
       "integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=",
       "dev": true
     },
-    "type": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
-      "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==",
-      "dev": true
-    },
     "type-check": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
@@ -13617,12 +13170,6 @@
         "media-typer": "0.3.0",
         "mime-types": "~2.1.24"
       }
-    },
-    "typed-styles": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/typed-styles/-/typed-styles-0.0.7.tgz",
-      "integrity": "sha512-pzP0PWoZUhsECYjABgCGQlRGL1n7tOHsgwYv3oIiEpJwGhFTuty/YNeduxQYzXXa3Ge5BdT6sHYIQYpl4uJ+5Q==",
-      "dev": true
     },
     "typedarray": {
       "version": "0.0.6",
@@ -13969,12 +13516,6 @@
       "requires": {
         "use-isomorphic-layout-effect": "^1.0.0"
       }
-    },
-    "use-memo-one": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/use-memo-one/-/use-memo-one-1.1.2.tgz",
-      "integrity": "sha512-u2qFKtxLsia/r8qG0ZKkbytbztzRb317XCkT7yP8wxL0tZ/CzK2G+WWie5vWvpyeP7+YoPIwbJoIHJ4Ba4k0oQ==",
-      "dev": true
     },
     "util": {
       "version": "0.11.1",

--- a/packages/dashboard/src/Dashboard.tsx
+++ b/packages/dashboard/src/Dashboard.tsx
@@ -12,6 +12,10 @@ import './layout/golden-layout';
 import LayoutUtils from './layout/LayoutUtils';
 import PanelPlaceholder from './PanelPlaceholder';
 import DashboardLayout from './DashboardLayout';
+import {
+  PanelDehydrateFunction,
+  PanelHydrateFunction,
+} from './DashboardPlugin';
 import './Dashboard.scss';
 
 const RESIZE_THROTTLE = 100;
@@ -30,6 +34,8 @@ export type DashboardProps = {
   onGoldenLayoutChange?: (goldenLayout: GoldenLayout) => void;
   onLayoutInitialized?: () => void;
   fallbackComponent?: ForwardRefExoticComponent<RefAttributes<unknown>>;
+  hydrate?: PanelHydrateFunction;
+  dehydrate?: PanelDehydrateFunction;
 };
 
 export const Dashboard = ({
@@ -42,6 +48,8 @@ export const Dashboard = ({
   onGoldenLayoutChange = DEFAULT_CALLBACK,
   onLayoutInitialized = DEFAULT_CALLBACK,
   fallbackComponent = PanelPlaceholder,
+  hydrate,
+  dehydrate,
 }: DashboardProps): JSX.Element => {
   const layoutElement = useRef<HTMLDivElement>(null);
   const [isInitialized, setIsInitialized] = useState(false);
@@ -114,6 +122,8 @@ export const Dashboard = ({
           layoutConfig={layoutConfig}
           onLayoutChange={onLayoutConfigChange}
           onLayoutInitialized={onLayoutInitialized}
+          hydrate={hydrate}
+          dehydrate={dehydrate}
         >
           {children}
         </DashboardLayout>

--- a/packages/dashboard/src/PanelEvent.js
+++ b/packages/dashboard/src/PanelEvent.js
@@ -26,6 +26,11 @@ export default Object.freeze({
   // Panel was closed
   CLOSED: 'PanelEvent.CLOSED',
 
+  // Event to open a new panel
+  // Plugins will need to register to open based on this event.
+  // Multiple plugins could open panels for the same event if desired.
+  OPEN: 'PanelEvent.OPEN',
+
   // Event to close a panel that's currently open
   CLOSE: 'PanelEvent.CLOSE',
 });

--- a/packages/dashboard/src/PanelManager.ts
+++ b/packages/dashboard/src/PanelManager.ts
@@ -103,6 +103,7 @@ class PanelManager {
     eventHub.on(PanelEvent.DELETE, this.handleDeleted);
     eventHub.on(PanelEvent.CLOSED, this.handleClosed);
     eventHub.on(PanelEvent.CLOSE, this.handleControlClose);
+    // PanelEvent.OPEN should be listened to by plugins to open a panel
   }
 
   stopListening(): void {

--- a/packages/file-explorer/package-lock.json
+++ b/packages/file-explorer/package-lock.json
@@ -1355,168 +1355,6 @@
         "minimist": "^1.2.0"
       }
     },
-    "@deephaven/components": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@deephaven/components/-/components-0.9.1.tgz",
-      "integrity": "sha512-B96vtZW3NHN27z+pfo7WO0FmZlt/uESaPi0WmQbzxJj3XNZifgfEWZy258udvG27FXy4Md4J/poXaCjdaauQmw==",
-      "dev": true,
-      "requires": {
-        "@deephaven/icons": "^0.9.1",
-        "@deephaven/react-hooks": "^0.9.1",
-        "@deephaven/utils": "^0.9.1",
-        "@fortawesome/fontawesome-svg-core": "^1.2.32",
-        "@fortawesome/react-fontawesome": "^0.1.12",
-        "bootstrap": "4.4.1",
-        "classnames": "^2.3.1",
-        "event-target-shim": "^6.0.2",
-        "jquery": "^3.5.1",
-        "lodash.debounce": "^4.0.8",
-        "lodash.flatten": "^4.4.0",
-        "memoizee": "^0.4.15",
-        "popper.js": "^1.16.1",
-        "prop-types": "^15.7.2",
-        "react-beautiful-dnd": "^13.0.0",
-        "react-transition-group": "^2.3.1",
-        "react-virtualized-auto-sizer": "^1.0.2",
-        "react-window": "^1.8.5",
-        "reactstrap": "^8.4.1",
-        "shortid": "^2.2.15"
-      }
-    },
-    "@deephaven/grid": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@deephaven/grid/-/grid-0.9.1.tgz",
-      "integrity": "sha512-INVZKFo/2bK+FpT5vqN7wfdrW66Xl5fxDOkr8I8PO9LL23RMfdiPvilzO8Ji7fKP3fOZtvCznO7yLMEzVBhFLA==",
-      "requires": {
-        "classnames": "^2.3.1",
-        "color-convert": "^2.0.1",
-        "event-target-shim": "^6.0.2",
-        "lodash.clamp": "^4.0.3",
-        "memoize-one": "^5.1.1",
-        "memoizee": "^0.4.15",
-        "prop-types": "^15.7.2"
-      },
-      "dependencies": {
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-        }
-      }
-    },
-    "@deephaven/icons": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@deephaven/icons/-/icons-0.9.1.tgz",
-      "integrity": "sha512-nLLZez6hNl4Ep6b7IjjIxLTGRa9WxeagNC2BP2IWVXs/ONvHHv0t5SYeCCJ/IaH8Bz2UWnxf09VivVPdIGZYig==",
-      "requires": {
-        "@fortawesome/fontawesome-common-types": "^0.2.35"
-      }
-    },
-    "@deephaven/iris-grid": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@deephaven/iris-grid/-/iris-grid-0.9.1.tgz",
-      "integrity": "sha512-KHZwBKu/oVZY3GyrEAuMqrV0BKX4SYCBtFc5p11xSMwfduwGm01ppcrv5T4j90P9vNTt2KffLgIya6JS3JMzlQ==",
-      "requires": {
-        "@deephaven/grid": "^0.9.1",
-        "@deephaven/icons": "^0.9.1",
-        "@deephaven/jsapi-shim": "^0.9.1",
-        "@deephaven/react-hooks": "^0.9.1",
-        "@deephaven/utils": "^0.9.1",
-        "@fortawesome/react-fontawesome": "^0.1.12",
-        "classnames": "^2.3.1",
-        "deep-equal": "^2.0.4",
-        "lodash.clamp": "^4.0.3",
-        "lodash.debounce": "^4.0.8",
-        "lodash.throttle": "^4.1.1",
-        "memoize-one": "^5.1.1",
-        "memoizee": "^0.4.15",
-        "monaco-editor": "^0.27.0",
-        "prop-types": "^15.7.2",
-        "react-beautiful-dnd": "^13.0.0",
-        "react-transition-group": "^2.3.1",
-        "shortid": "^2.2.15",
-        "web-streams-polyfill": "^2.1.0"
-      },
-      "dependencies": {
-        "deep-equal": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.0.5.tgz",
-          "integrity": "sha512-nPiRgmbAtm1a3JsnLCf6/SLfXcjyN5v8L1TXzdCmHrXJ4hx+gW/w1YCcn7z8gJtSiDArZCgYtbao3QqLm/N1Sw==",
-          "requires": {
-            "call-bind": "^1.0.0",
-            "es-get-iterator": "^1.1.1",
-            "get-intrinsic": "^1.0.1",
-            "is-arguments": "^1.0.4",
-            "is-date-object": "^1.0.2",
-            "is-regex": "^1.1.1",
-            "isarray": "^2.0.5",
-            "object-is": "^1.1.4",
-            "object-keys": "^1.1.1",
-            "object.assign": "^4.1.2",
-            "regexp.prototype.flags": "^1.3.0",
-            "side-channel": "^1.0.3",
-            "which-boxed-primitive": "^1.0.1",
-            "which-collection": "^1.0.1",
-            "which-typed-array": "^1.1.2"
-          }
-        },
-        "isarray": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-          "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
-        }
-      }
-    },
-    "@deephaven/jsapi-shim": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@deephaven/jsapi-shim/-/jsapi-shim-0.9.1.tgz",
-      "integrity": "sha512-soBU7sU9qZgzDXJyYrU96GiB7UBCdHScUaQjl4ISx2igIdK+Qfe7JOYVxYjJdV8KEVK/l+smSkahAIT5/NJY4Q==",
-      "requires": {
-        "prop-types": "^15.7.2"
-      }
-    },
-    "@deephaven/log": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@deephaven/log/-/log-0.9.1.tgz",
-      "integrity": "sha512-L/yKtSYOrNZlvyElqpgdrnL3JBaY07szFjhA37XK31+uH/jcPcbMxsn2Uf+++yyFcn6GKO1XXXP44V3xBkBQJg==",
-      "dev": true,
-      "requires": {
-        "event-target-shim": "^6.0.2"
-      }
-    },
-    "@deephaven/react-hooks": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@deephaven/react-hooks/-/react-hooks-0.9.1.tgz",
-      "integrity": "sha512-v7r2DZoPahHNBspbulCtvUgCqJ+i9WPEA8cK9nEsTVTeuR3mhwLw4E/0g+WlXJ78FsUdA0K9FECJfUg1YTvyLg=="
-    },
-    "@deephaven/storage": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@deephaven/storage/-/storage-0.9.1.tgz",
-      "integrity": "sha512-Bcsuaaib5RLX0IEYfPlLl5CfOb/yNssq+4FbD4h0R8SBmFN7oTmRlWLMDWflFpV9FVwBBKojp5GyvKhxyTkHBQ==",
-      "requires": {
-        "@deephaven/iris-grid": "^0.9.1",
-        "lodash.throttle": "^4.1.1"
-      }
-    },
-    "@deephaven/tsconfig": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@deephaven/tsconfig/-/tsconfig-0.9.0.tgz",
-      "integrity": "sha512-zYKPllv+W+UhAuzC2pbsaQynxzsE0bBK/XjfiK0LWiGMkMhp43rwEaCiMODSYaxGmaV5eA+ijm8r1Y8v21pH4w==",
-      "dev": true
-    },
-    "@deephaven/utils": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@deephaven/utils/-/utils-0.9.1.tgz",
-      "integrity": "sha512-kll4L5bNOOPdtpeSDpIvC8+NnlaToKrsPoJ3kvsZvJVmILdIKAIXcviGPxZO5SCjyzgV/NmfLUmHq0CcMAYnEg=="
-    },
     "@discoveryjs/json-ext": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.3.tgz",
@@ -3803,15 +3641,6 @@
         "@types/unist": "*"
       }
     },
-    "@types/hoist-non-react-statics": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
-      "integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
-      "requires": {
-        "@types/react": "*",
-        "hoist-non-react-statics": "^3.3.0"
-      }
-    },
     "@types/html-minifier-terser": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/@types/html-minifier-terser/-/html-minifier-terser-5.1.2.tgz",
@@ -3942,7 +3771,8 @@
     "@types/prop-types": {
       "version": "15.7.4",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.4.tgz",
-      "integrity": "sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ=="
+      "integrity": "sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ==",
+      "dev": true
     },
     "@types/qs": {
       "version": "6.9.7",
@@ -3963,21 +3793,11 @@
       "version": "17.0.39",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.39.tgz",
       "integrity": "sha512-UVavlfAxDd/AgAacMa60Azl7ygyQNRwC/DsHZmKgNvPmRR5p70AJ5Q9EAmL2NWOJmeV+vVUI4IAP7GZrN8h8Ug==",
+      "dev": true,
       "requires": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
         "csstype": "^3.0.2"
-      }
-    },
-    "@types/react-redux": {
-      "version": "7.1.22",
-      "resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-7.1.22.tgz",
-      "integrity": "sha512-GxIA1kM7ClU73I6wg9IRTVwSO9GS+SAKZKe0Enj+82HMU6aoESFU2HNAdNi3+J53IaOHPiUfT3kSG4L828joDQ==",
-      "requires": {
-        "@types/hoist-non-react-statics": "^3.3.0",
-        "@types/react": "*",
-        "hoist-non-react-statics": "^3.3.0",
-        "redux": "^4.0.0"
       }
     },
     "@types/react-syntax-highlighter": {
@@ -3992,7 +3812,8 @@
     "@types/scheduler": {
       "version": "0.16.2",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
-      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew=="
+      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
+      "dev": true
     },
     "@types/source-list-map": {
       "version": "0.1.2",
@@ -4711,11 +4532,6 @@
         "postcss-value-parser": "^4.1.0"
       }
     },
-    "available-typed-arrays": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
-      "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw=="
-    },
     "axios": {
       "version": "0.21.4",
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
@@ -5093,12 +4909,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
-      "dev": true
-    },
-    "bootstrap": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.4.1.tgz",
-      "integrity": "sha512-tbx5cHubwE6e2ZG7nqM3g/FZ5PQEDMWmMGNrCUBVRPHXTJaH7CBDdsLeu3eCh3B1tzAxTnAbtmrzvWEvT2NNEA==",
       "dev": true
     },
     "boxen": {
@@ -6497,14 +6307,6 @@
         "randomfill": "^1.0.3"
       }
     },
-    "css-box-model": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/css-box-model/-/css-box-model-1.2.1.tgz",
-      "integrity": "sha512-a7Vr4Q/kd/aw96bnJG332W9V9LkJO69JRcaCYDUqjp6/z0w6VcZjgAcTbgFxEPfBgdnAwlh3iwu+hLopa+flJw==",
-      "requires": {
-        "tiny-invariant": "^1.0.6"
-      }
-    },
     "css-loader": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-3.6.0.tgz",
@@ -6582,22 +6384,14 @@
     "csstype": {
       "version": "3.0.10",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.10.tgz",
-      "integrity": "sha512-2u44ZG2OcNUO9HDp/Jl8C07x6pU/eTR3ncV91SiK3dhG9TWvRVsCoJw14Ckx5DgWkzGA3waZWO3d7pgqpUI/XA=="
+      "integrity": "sha512-2u44ZG2OcNUO9HDp/Jl8C07x6pU/eTR3ncV91SiK3dhG9TWvRVsCoJw14Ckx5DgWkzGA3waZWO3d7pgqpUI/XA==",
+      "dev": true
     },
     "cyclist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-1.0.1.tgz",
       "integrity": "sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=",
       "dev": true
-    },
-    "d": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
-      "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
-      "requires": {
-        "es5-ext": "^0.10.50",
-        "type": "^1.0.1"
-      }
     },
     "debug": {
       "version": "2.6.9",
@@ -7096,6 +6890,7 @@
       "version": "1.18.6",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.6.tgz",
       "integrity": "sha512-kAeIT4cku5eNLNuUKhlmtuk1/TRZvQoYccn6TO0cSVdf1kzB0T7+dYuVK9MWM7l+/53W2Q8M7N2c6MQvhXFcUQ==",
+      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "es-to-primitive": "^1.2.1",
@@ -7127,6 +6922,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.2.tgz",
       "integrity": "sha512-+DTO8GYwbMCwbywjimwZMHp8AuYXOS2JZFWoi2AlPOS3ebnII9w/NLpNZtA7A0YLaVDw+O7KFCeoIV7OPvM7hQ==",
+      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "get-intrinsic": "^1.1.0",
@@ -7141,7 +6937,8 @@
         "isarray": {
           "version": "2.0.5",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-          "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
+          "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+          "dev": true
         }
       }
     },
@@ -7149,27 +6946,11 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
       "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+      "dev": true,
       "requires": {
         "is-callable": "^1.1.4",
         "is-date-object": "^1.0.1",
         "is-symbol": "^1.0.2"
-      }
-    },
-    "es5-ext": {
-      "version": "0.10.53",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
-      "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
-      "requires": {
-        "es6-iterator": "~2.0.3",
-        "es6-symbol": "~3.1.3",
-        "next-tick": "~1.0.0"
-      },
-      "dependencies": {
-        "next-tick": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
-          "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
-        }
       }
     },
     "es5-shim": {
@@ -7178,41 +6959,11 @@
       "integrity": "sha512-n0XTVMGps+Deyr38jtqKPR5F5hb9owYeRQcKJW39eFvzUk/u/9Ww315werRzbiNMnHCUw/YHDPBphTlEnzdi+A==",
       "dev": true
     },
-    "es6-iterator": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
-      "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
-      "requires": {
-        "d": "1",
-        "es5-ext": "^0.10.35",
-        "es6-symbol": "^3.1.1"
-      }
-    },
     "es6-shim": {
       "version": "0.35.6",
       "resolved": "https://registry.npmjs.org/es6-shim/-/es6-shim-0.35.6.tgz",
       "integrity": "sha512-EmTr31wppcaIAgblChZiuN/l9Y7DPyw8Xtbg7fIVngn6zMW+IEBJDJngeKC3x6wr0V/vcA2wqeFnaw1bFJbDdA==",
       "dev": true
-    },
-    "es6-symbol": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
-      "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
-      "requires": {
-        "d": "^1.0.1",
-        "ext": "^1.1.2"
-      }
-    },
-    "es6-weak-map": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.3.tgz",
-      "integrity": "sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==",
-      "requires": {
-        "d": "1",
-        "es5-ext": "^0.10.46",
-        "es6-iterator": "^2.0.3",
-        "es6-symbol": "^3.1.1"
-      }
     },
     "escalade": {
       "version": "3.1.1",
@@ -7321,20 +7072,6 @@
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
       "dev": true
-    },
-    "event-emitter": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
-      "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
-      "requires": {
-        "d": "1",
-        "es5-ext": "~0.10.14"
-      }
-    },
-    "event-target-shim": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-6.0.2.tgz",
-      "integrity": "sha512-8q3LsZjRezbFZ2PN+uP+Q7pnHUMmAOziU2vA2OwoFaKIXxlxl38IylhSSgUorWu/rf4er67w0ikBqjBFk/pomA=="
     },
     "events": {
       "version": "3.3.0",
@@ -7451,21 +7188,6 @@
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
           "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
           "dev": true
-        }
-      }
-    },
-    "ext": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/ext/-/ext-1.6.0.tgz",
-      "integrity": "sha512-sdBImtzkq2HpkdRLtlLWDa6w4DX22ijZLKx8BMPUuKe1c5lbN6xwQDQCxSfxBQnHZ13ls/FH0MQZx/q/gr6FQg==",
-      "requires": {
-        "type": "^2.5.0"
-      },
-      "dependencies": {
-        "type": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/type/-/type-2.5.0.tgz",
-          "integrity": "sha512-180WMDQaIMm3+7hGXWf12GtdniDEy7nYcyFMKJn/eZz/6tSLXrUN9V0wKSbMjej0I1WHWbpREDEKHtqPQa9NNw=="
         }
       }
     },
@@ -7895,11 +7617,6 @@
       "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
       "dev": true
     },
-    "foreach": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
-      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
-    },
     "foreground-child": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-2.0.0.tgz",
@@ -8172,6 +7889,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
       "integrity": "sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==",
+      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "get-intrinsic": "^1.1.1"
@@ -8368,7 +8086,8 @@
     "has-bigints": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.1.tgz",
-      "integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA=="
+      "integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==",
+      "dev": true
     },
     "has-flag": {
       "version": "3.0.0",
@@ -8592,6 +8311,7 @@
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
       "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "dev": true,
       "requires": {
         "react-is": "^16.7.0"
       }
@@ -8843,6 +8563,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
       "integrity": "sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==",
+      "dev": true,
       "requires": {
         "get-intrinsic": "^1.1.0",
         "has": "^1.0.3",
@@ -8937,6 +8658,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
       "integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
+      "dev": true,
       "requires": {
         "has-bigints": "^1.0.1"
       }
@@ -8955,6 +8677,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
       "integrity": "sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==",
+      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
@@ -8968,7 +8691,8 @@
     "is-callable": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
-      "integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w=="
+      "integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==",
+      "dev": true
     },
     "is-ci": {
       "version": "2.0.0",
@@ -9102,12 +8826,14 @@
     "is-map": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.2.tgz",
-      "integrity": "sha512-cOZFQQozTha1f4MxLFzlgKYPTyj26picdZTx82hbc/Xf4K/tZOOXSCkMvU4pKioRXGDLJRn0GM7Upe7kR721yg=="
+      "integrity": "sha512-cOZFQQozTha1f4MxLFzlgKYPTyj26picdZTx82hbc/Xf4K/tZOOXSCkMvU4pKioRXGDLJRn0GM7Upe7kR721yg==",
+      "dev": true
     },
     "is-negative-zero": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
-      "integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w=="
+      "integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w==",
+      "dev": true
     },
     "is-number": {
       "version": "3.0.0",
@@ -9133,6 +8859,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.6.tgz",
       "integrity": "sha512-bEVOqiRcvo3zO1+G2lVMy+gkkEm9Yh7cDMRusKKu5ZJKPUYSJwICTKZrNKHA2EbSP0Tu0+6B/emsYNHZyn6K8g==",
+      "dev": true,
       "requires": {
         "has-tostringtag": "^1.0.0"
       }
@@ -9158,11 +8885,6 @@
         "isobject": "^3.0.1"
       }
     },
-    "is-promise": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
-      "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ=="
-    },
     "is-regex": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
@@ -9181,7 +8903,8 @@
     "is-set": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.2.tgz",
-      "integrity": "sha512-+2cnTEZeY5z/iXGbLhPrOAaK/Mau5k5eXq9j14CpRTftq0pAJu2MwVRSZhyZWBzx3o6X795Lz6Bpb6R0GKf37g=="
+      "integrity": "sha512-+2cnTEZeY5z/iXGbLhPrOAaK/Mau5k5eXq9j14CpRTftq0pAJu2MwVRSZhyZWBzx3o6X795Lz6Bpb6R0GKf37g==",
+      "dev": true
     },
     "is-stream": {
       "version": "1.1.0",
@@ -9193,6 +8916,7 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
       "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
+      "dev": true,
       "requires": {
         "has-tostringtag": "^1.0.0"
       }
@@ -9201,20 +8925,9 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
       "integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
+      "dev": true,
       "requires": {
         "has-symbols": "^1.0.2"
-      }
-    },
-    "is-typed-array": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.8.tgz",
-      "integrity": "sha512-HqH41TNZq2fgtGT8WHVFVJhBVGuY3AnP3Q36K8JKXUxSxRgk/d+7NjmwG2vo2mYmXK8UYZKu0qH8bVP5gEisjA==",
-      "requires": {
-        "available-typed-arrays": "^1.0.5",
-        "call-bind": "^1.0.2",
-        "es-abstract": "^1.18.5",
-        "foreach": "^2.0.5",
-        "has-tostringtag": "^1.0.0"
       }
     },
     "is-typedarray": {
@@ -9222,20 +8935,6 @@
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
       "dev": true
-    },
-    "is-weakmap": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.1.tgz",
-      "integrity": "sha512-NSBR4kH5oVj1Uwvv970ruUkCV7O1mzgVFO4/rev2cLRda9Tm9HrL70ZPut4rOHgY0FNrUu9BCbXA2sdQ+x0chA=="
-    },
-    "is-weakset": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.2.tgz",
-      "integrity": "sha512-t2yVvttHkQktwnNNmBQ98AhENLdPUTDTE21uPqAQ0ARwQfGeQKRVS0NNurH7bTf7RrvcVn1OOge45CnBeHCSmg==",
-      "requires": {
-        "call-bind": "^1.0.2",
-        "get-intrinsic": "^1.1.1"
-      }
     },
     "is-whitespace-character": {
       "version": "1.0.4",
@@ -9609,12 +9308,6 @@
         }
       }
     },
-    "jquery": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.0.tgz",
-      "integrity": "sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw==",
-      "dev": true
-    },
     "js-string-escape": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.1.tgz",
@@ -9807,20 +9500,10 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
-    "lodash.clamp": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/lodash.clamp/-/lodash.clamp-4.0.3.tgz",
-      "integrity": "sha1-XCS+3u7vB1NWDcK0y0Zx+Qpt36o="
-    },
     "lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
-    },
-    "lodash.flatten": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
-      "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=",
+      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
       "dev": true
     },
     "lodash.throttle": {
@@ -9868,14 +9551,6 @@
       "dev": true,
       "requires": {
         "yallist": "^4.0.0"
-      }
-    },
-    "lru-queue": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz",
-      "integrity": "sha1-Jzi9nw089PhEkMVzbEhpmsYyzaM=",
-      "requires": {
-        "es5-ext": "~0.10.2"
       }
     },
     "make-dir": {
@@ -10010,26 +9685,6 @@
       "dev": true,
       "requires": {
         "fs-monkey": "1.0.3"
-      }
-    },
-    "memoize-one": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
-      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q=="
-    },
-    "memoizee": {
-      "version": "0.4.15",
-      "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.4.15.tgz",
-      "integrity": "sha512-UBWmJpLZd5STPm7PMUlOw/TSy972M+z8gcyQ5veOnSDRREz/0bmpyTfKt3/51DhEBqCZQn1udM/5flcSPYhkdQ==",
-      "requires": {
-        "d": "^1.0.1",
-        "es5-ext": "^0.10.53",
-        "es6-weak-map": "^2.0.3",
-        "event-emitter": "^0.3.5",
-        "is-promise": "^2.2.2",
-        "lru-queue": "^0.1.0",
-        "next-tick": "^1.1.0",
-        "timers-ext": "^0.1.7"
       }
     },
     "memoizerific": {
@@ -10282,11 +9937,6 @@
         "minimist": "^1.2.5"
       }
     },
-    "monaco-editor": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.27.0.tgz",
-      "integrity": "sha512-UhwP78Wb8w0ZSYoKXQNTV/0CHObp6NS3nCt51QfKE6sKyBo5PBsvuDOHoI2ooBakc6uIwByRLHVeT7+yXQe2fQ=="
-    },
     "move-concurrently": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
@@ -10317,11 +9967,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
-    },
-    "nanoid": {
-      "version": "2.1.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.1.11.tgz",
-      "integrity": "sha512-s/snB+WGm6uwi0WjsZdaVcuf3KJXlfGl2LcxgwkEwJF0D/BWzVWAZW/XY4bFaiR7s0Jk3FPvlnepg1H1b1UwlA=="
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -10373,11 +10018,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/nested-property/-/nested-property-4.0.0.tgz",
       "integrity": "sha512-yFehXNWRs4cM0+dz7QxCd06hTbWbSkV0ISsqBfkntU6TOY4Qm3Q88fRRLOddkGh2Qq6dZvnKVAahfhjcUvLnyA=="
-    },
-    "next-tick": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
-      "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
     },
     "nice-try": {
       "version": "1.0.5",
@@ -10617,7 +10257,8 @@
     "object-inspect": {
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.0.tgz",
-      "integrity": "sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg=="
+      "integrity": "sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg==",
+      "dev": true
     },
     "object-is": {
       "version": "1.1.5",
@@ -10646,6 +10287,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
       "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+      "dev": true,
       "requires": {
         "call-bind": "^1.0.0",
         "define-properties": "^1.1.3",
@@ -11550,11 +11192,6 @@
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
       "dev": true
     },
-    "raf-schd": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/raf-schd/-/raf-schd-4.0.3.tgz",
-      "integrity": "sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ=="
-    },
     "ramda": {
       "version": "0.21.0",
       "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.21.0.tgz",
@@ -11629,20 +11266,6 @@
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
-      }
-    },
-    "react-beautiful-dnd": {
-      "version": "13.1.0",
-      "resolved": "https://registry.npmjs.org/react-beautiful-dnd/-/react-beautiful-dnd-13.1.0.tgz",
-      "integrity": "sha512-aGvblPZTJowOWUNiwd6tNfEpgkX5OxmpqxHKNW/4VmvZTNTbeiq7bA3bn5T+QSF2uibXB0D1DmJsb1aC/+3cUA==",
-      "requires": {
-        "@babel/runtime": "^7.9.2",
-        "css-box-model": "^1.2.0",
-        "memoize-one": "^5.1.1",
-        "raf-schd": "^4.0.2",
-        "react-redux": "^7.2.0",
-        "redux": "^4.0.4",
-        "use-memo-one": "^1.1.1"
       }
     },
     "react-colorful": {
@@ -11895,26 +11518,6 @@
         "react-popper": "^2.2.4"
       }
     },
-    "react-redux": {
-      "version": "7.2.6",
-      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.6.tgz",
-      "integrity": "sha512-10RPdsz0UUrRL1NZE0ejTkucnclYSgXp5q+tB5SWx2qeG2ZJQJyymgAhwKy73yiL/13btfB6fPr+rgbMAaZIAQ==",
-      "requires": {
-        "@babel/runtime": "^7.15.4",
-        "@types/react-redux": "^7.1.20",
-        "hoist-non-react-statics": "^3.3.2",
-        "loose-envify": "^1.4.0",
-        "prop-types": "^15.7.2",
-        "react-is": "^17.0.2"
-      },
-      "dependencies": {
-        "react-is": {
-          "version": "17.0.2",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-          "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
-        }
-      }
-    },
     "react-refresh": {
       "version": "0.8.3",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.8.3.tgz",
@@ -11966,22 +11569,6 @@
         "loose-envify": "^1.4.0",
         "prop-types": "^15.6.2",
         "react-lifecycles-compat": "^3.0.4"
-      }
-    },
-    "react-virtualized-auto-sizer": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.6.tgz",
-      "integrity": "sha512-7tQ0BmZqfVF6YYEWcIGuoR3OdYe8I/ZFbNclFlGOC3pMqunkYF/oL30NCjSGl9sMEb17AnzixDz98Kqc3N76HQ==",
-      "dev": true
-    },
-    "react-window": {
-      "version": "1.8.6",
-      "resolved": "https://registry.npmjs.org/react-window/-/react-window-1.8.6.tgz",
-      "integrity": "sha512-8VwEEYyjz6DCnGBsd+MgkD0KJ2/OXFULyDtorIiTz+QzwoP94tBoA7CnbtyXMm+cCeAUER5KJcPtWl9cpKbOBg==",
-      "dev": true,
-      "requires": {
-        "@babel/runtime": "^7.0.0",
-        "memoize-one": ">=3.1.1 <6"
       }
     },
     "reactstrap": {
@@ -12077,14 +11664,6 @@
       "dev": true,
       "requires": {
         "minimatch": "3.0.4"
-      }
-    },
-    "redux": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-4.1.2.tgz",
-      "integrity": "sha512-SH8PglcebESbd/shgf6mii6EIoRM0zrQyjcuQ+ojmfxjTtE0z9Y8pa62iA/OJ58qjP6j27uyW4kUF4jl/jd6sw==",
-      "requires": {
-        "@babel/runtime": "^7.9.2"
       }
     },
     "refractor": {
@@ -12682,18 +12261,11 @@
       "integrity": "sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==",
       "dev": true
     },
-    "shortid": {
-      "version": "2.2.16",
-      "resolved": "https://registry.npmjs.org/shortid/-/shortid-2.2.16.tgz",
-      "integrity": "sha512-Ugt+GIZqvGXCIItnsL+lvFJOiN7RYqlGy7QE41O3YC1xbNSeDGIRO7xg2JJXIAj1cAGnOeC1r7/T9pgrtQbv4g==",
-      "requires": {
-        "nanoid": "^2.1.0"
-      }
-    },
     "side-channel": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
       "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+      "dev": true,
       "requires": {
         "call-bind": "^1.0.0",
         "get-intrinsic": "^1.0.2",
@@ -13092,6 +12664,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
       "integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3"
@@ -13101,6 +12674,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
       "integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3"
@@ -13482,20 +13056,6 @@
         "setimmediate": "^1.0.4"
       }
     },
-    "timers-ext": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.7.tgz",
-      "integrity": "sha512-b85NUNzTSdodShTIbky6ZF02e8STtVVfD+fu4aXXShEELpozH+bCpJLYMPZbsABN2wDH7fJpqIoXxJpzbf0NqQ==",
-      "requires": {
-        "es5-ext": "~0.10.46",
-        "next-tick": "1"
-      }
-    },
-    "tiny-invariant": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.2.0.tgz",
-      "integrity": "sha512-1Uhn/aqw5C6RI4KejVeTg6mIS7IqxnLJ8Mv2tV5rTc0qWobay7pDUz6Wi392Cnc8ak1H0F2cjoRzb2/AW4+Fvg=="
-    },
     "tmpl": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -13616,11 +13176,6 @@
       "integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=",
       "dev": true
     },
-    "type": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
-      "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg=="
-    },
     "type-check": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
@@ -13670,6 +13225,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
       "integrity": "sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==",
+      "dev": true,
       "requires": {
         "function-bind": "^1.1.1",
         "has-bigints": "^1.0.1",
@@ -14011,11 +13567,6 @@
         "use-isomorphic-layout-effect": "^1.0.0"
       }
     },
-    "use-memo-one": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/use-memo-one/-/use-memo-one-1.1.2.tgz",
-      "integrity": "sha512-u2qFKtxLsia/r8qG0ZKkbytbztzRb317XCkT7yP8wxL0tZ/CzK2G+WWie5vWvpyeP7+YoPIwbJoIHJ4Ba4k0oQ=="
-    },
     "util": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/util/-/util-0.11.1.tgz",
@@ -14248,11 +13799,6 @@
       "integrity": "sha512-wYxSGajtmoP4WxfejAPIr4l0fVh+jeMXZb08wNc0tMg6xsfZXj3cECqIK0G7ZAqUq0PP8WlMDtaOGVBTAWztNw==",
       "dev": true
     },
-    "web-streams-polyfill": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-2.1.1.tgz",
-      "integrity": "sha512-dlNpL2aab3g8CKfGz6rl8FNmGaRWLLn2g/DtSc9IjB30mEdE6XxzPfPSig5BwGSzI+oLxHyETrQGKjrVVhbLCg=="
-    },
     "webdav": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/webdav/-/webdav-4.7.0.tgz",
@@ -14471,36 +14017,13 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
       "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
+      "dev": true,
       "requires": {
         "is-bigint": "^1.0.1",
         "is-boolean-object": "^1.1.0",
         "is-number-object": "^1.0.4",
         "is-string": "^1.0.5",
         "is-symbol": "^1.0.3"
-      }
-    },
-    "which-collection": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.1.tgz",
-      "integrity": "sha512-W8xeTUwaln8i3K/cY1nGXzdnVZlidBcagyNFtBdD5kxnb4TvGKR7FfSIS3mYpwWS1QUCutfKz8IY8RjftB0+1A==",
-      "requires": {
-        "is-map": "^2.0.1",
-        "is-set": "^2.0.1",
-        "is-weakmap": "^2.0.1",
-        "is-weakset": "^2.0.1"
-      }
-    },
-    "which-typed-array": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.7.tgz",
-      "integrity": "sha512-vjxaB4nfDqwKI0ws7wZpxIlde1XrLX5uB0ZjpfshgmapJMD7jJWhZI+yToJTqaFByF0eNBcYxbjmCzoRP7CfEw==",
-      "requires": {
-        "available-typed-arrays": "^1.0.5",
-        "call-bind": "^1.0.2",
-        "es-abstract": "^1.18.5",
-        "foreach": "^2.0.5",
-        "has-tostringtag": "^1.0.0",
-        "is-typed-array": "^1.1.7"
       }
     },
     "wide-align": {

--- a/packages/grid/package-lock.json
+++ b/packages/grid/package-lock.json
@@ -21,12 +21,6 @@
         "source-map": "^0.5.0"
       }
     },
-    "@deephaven/tsconfig": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@deephaven/tsconfig/-/tsconfig-0.9.0.tgz",
-      "integrity": "sha512-zYKPllv+W+UhAuzC2pbsaQynxzsE0bBK/XjfiK0LWiGMkMhp43rwEaCiMODSYaxGmaV5eA+ijm8r1Y8v21pH4w==",
-      "dev": true
-    },
     "@nicolo-ribaudo/chokidar-2": {
       "version": "2.1.8-no-fsevents.3",
       "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/chokidar-2/-/chokidar-2-2.1.8-no-fsevents.3.tgz",

--- a/packages/icons/package-lock.json
+++ b/packages/icons/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@fortawesome/fontawesome-common-types": {
-      "version": "0.2.35",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.35.tgz",
-      "integrity": "sha512-IHUfxSEDS9dDGqYwIW7wTN6tn/O8E0n5PcAHz9cAaBoZw6UpG20IG/YM3NNLaGPwPqgjBAFjIURzqoQs3rrtuw=="
+      "version": "0.2.36",
+      "resolved": "https://npm.fontawesome.com/@fortawesome/fontawesome-common-types/-/0.2.36/fontawesome-common-types-0.2.36.tgz",
+      "integrity": "sha512-a/7BiSgobHAgBWeN7N0w+lAhInrGxksn13uK7231n2m8EDPE3BMCl9NZLTGrj9ZXfCmC6LM0QLqXidIizVQ6yg=="
     },
     "@types/q": {
       "version": "1.5.4",

--- a/packages/iris-grid/package-lock.json
+++ b/packages/iris-grid/package-lock.json
@@ -331,125 +331,12 @@
 				"to-fast-properties": "^2.0.0"
 			}
 		},
-		"@deephaven/components": {
-			"version": "0.9.1",
-			"resolved": "https://registry.npmjs.org/@deephaven/components/-/components-0.9.1.tgz",
-			"integrity": "sha512-B96vtZW3NHN27z+pfo7WO0FmZlt/uESaPi0WmQbzxJj3XNZifgfEWZy258udvG27FXy4Md4J/poXaCjdaauQmw==",
-			"dev": true,
-			"requires": {
-				"@deephaven/icons": "^0.9.1",
-				"@deephaven/react-hooks": "^0.9.1",
-				"@deephaven/utils": "^0.9.1",
-				"@fortawesome/fontawesome-svg-core": "^1.2.32",
-				"@fortawesome/react-fontawesome": "^0.1.12",
-				"bootstrap": "4.4.1",
-				"classnames": "^2.3.1",
-				"event-target-shim": "^6.0.2",
-				"jquery": "^3.5.1",
-				"lodash.debounce": "^4.0.8",
-				"lodash.flatten": "^4.4.0",
-				"memoizee": "^0.4.15",
-				"popper.js": "^1.16.1",
-				"prop-types": "^15.7.2",
-				"react-beautiful-dnd": "^13.0.0",
-				"react-transition-group": "^2.3.1",
-				"react-virtualized-auto-sizer": "^1.0.2",
-				"react-window": "^1.8.5",
-				"reactstrap": "^8.4.1",
-				"shortid": "^2.2.15"
-			}
-		},
-		"@deephaven/grid": {
-			"version": "0.9.1",
-			"resolved": "https://registry.npmjs.org/@deephaven/grid/-/grid-0.9.1.tgz",
-			"integrity": "sha512-INVZKFo/2bK+FpT5vqN7wfdrW66Xl5fxDOkr8I8PO9LL23RMfdiPvilzO8Ji7fKP3fOZtvCznO7yLMEzVBhFLA==",
-			"requires": {
-				"classnames": "^2.3.1",
-				"color-convert": "^2.0.1",
-				"event-target-shim": "^6.0.2",
-				"lodash.clamp": "^4.0.3",
-				"memoize-one": "^5.1.1",
-				"memoizee": "^0.4.15",
-				"prop-types": "^15.7.2"
-			}
-		},
-		"@deephaven/icons": {
-			"version": "0.9.1",
-			"resolved": "https://registry.npmjs.org/@deephaven/icons/-/icons-0.9.1.tgz",
-			"integrity": "sha512-nLLZez6hNl4Ep6b7IjjIxLTGRa9WxeagNC2BP2IWVXs/ONvHHv0t5SYeCCJ/IaH8Bz2UWnxf09VivVPdIGZYig==",
-			"requires": {
-				"@fortawesome/fontawesome-common-types": "^0.2.35"
-			}
-		},
-		"@deephaven/jsapi-shim": {
-			"version": "0.9.1",
-			"resolved": "https://registry.npmjs.org/@deephaven/jsapi-shim/-/jsapi-shim-0.9.1.tgz",
-			"integrity": "sha512-soBU7sU9qZgzDXJyYrU96GiB7UBCdHScUaQjl4ISx2igIdK+Qfe7JOYVxYjJdV8KEVK/l+smSkahAIT5/NJY4Q==",
-			"requires": {
-				"prop-types": "^15.7.2"
-			}
-		},
-		"@deephaven/log": {
-			"version": "0.9.1",
-			"resolved": "https://registry.npmjs.org/@deephaven/log/-/log-0.9.1.tgz",
-			"integrity": "sha512-L/yKtSYOrNZlvyElqpgdrnL3JBaY07szFjhA37XK31+uH/jcPcbMxsn2Uf+++yyFcn6GKO1XXXP44V3xBkBQJg==",
-			"dev": true,
-			"requires": {
-				"event-target-shim": "^6.0.2"
-			}
-		},
-		"@deephaven/mocks": {
-			"version": "0.9.0",
-			"resolved": "https://registry.npmjs.org/@deephaven/mocks/-/mocks-0.9.0.tgz",
-			"integrity": "sha512-PkCZ0UtFemj1wlD+fGmmmkafOsieK/ts1PyRAdBH4EBDg0WEBjCRsD9lltGydXB1LSUDy0G0xtGOjX/BPPviRA==",
-			"dev": true
-		},
-		"@deephaven/react-hooks": {
-			"version": "0.9.1",
-			"resolved": "https://registry.npmjs.org/@deephaven/react-hooks/-/react-hooks-0.9.1.tgz",
-			"integrity": "sha512-v7r2DZoPahHNBspbulCtvUgCqJ+i9WPEA8cK9nEsTVTeuR3mhwLw4E/0g+WlXJ78FsUdA0K9FECJfUg1YTvyLg=="
-		},
-		"@deephaven/tsconfig": {
-			"version": "0.9.0",
-			"resolved": "https://registry.npmjs.org/@deephaven/tsconfig/-/tsconfig-0.9.0.tgz",
-			"integrity": "sha512-zYKPllv+W+UhAuzC2pbsaQynxzsE0bBK/XjfiK0LWiGMkMhp43rwEaCiMODSYaxGmaV5eA+ijm8r1Y8v21pH4w==",
-			"dev": true
-		},
-		"@deephaven/utils": {
-			"version": "0.9.1",
-			"resolved": "https://registry.npmjs.org/@deephaven/utils/-/utils-0.9.1.tgz",
-			"integrity": "sha512-kll4L5bNOOPdtpeSDpIvC8+NnlaToKrsPoJ3kvsZvJVmILdIKAIXcviGPxZO5SCjyzgV/NmfLUmHq0CcMAYnEg=="
-		},
-		"@fortawesome/fontawesome-common-types": {
-			"version": "0.2.36",
-			"resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.36.tgz",
-			"integrity": "sha512-a/7BiSgobHAgBWeN7N0w+lAhInrGxksn13uK7231n2m8EDPE3BMCl9NZLTGrj9ZXfCmC6LM0QLqXidIizVQ6yg=="
-		},
-		"@fortawesome/fontawesome-svg-core": {
-			"version": "1.2.36",
-			"resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.36.tgz",
-			"integrity": "sha512-YUcsLQKYb6DmaJjIHdDWpBIGCcyE/W+p/LMGvjQem55Mm2XWVAP5kWTMKWLv9lwpCVjpLxPyOMOyUocP1GxrtA==",
-			"dev": true,
-			"requires": {
-				"@fortawesome/fontawesome-common-types": "^0.2.36"
-			}
-		},
 		"@fortawesome/react-fontawesome": {
 			"version": "0.1.15",
 			"resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.1.15.tgz",
 			"integrity": "sha512-/HFHdcoLESxxMkqZAcZ6RXDJ69pVApwdwRos/B2kiMWxDSAX2dFK8Er2/+rG+RsrzWB/dsAyjefLmemgmfE18g==",
 			"requires": {
 				"prop-types": "^15.7.2"
-			}
-		},
-		"@hypnosphi/create-react-context": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/@hypnosphi/create-react-context/-/create-react-context-0.3.1.tgz",
-			"integrity": "sha512-V1klUed202XahrWJLLOT3EXNeCpFHCcJntdFGI15ntCwau+jfT386w7OFTMaCqOgXUH1fa0w/I1oZs+i/Rfr0A==",
-			"dev": true,
-			"requires": {
-				"gud": "^1.0.0",
-				"warning": "^4.0.3"
 			}
 		},
 		"@nicolo-ribaudo/chokidar-2": {
@@ -753,12 +640,6 @@
 			"integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
 			"dev": true
 		},
-		"bootstrap": {
-			"version": "4.4.1",
-			"resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.4.1.tgz",
-			"integrity": "sha512-tbx5cHubwE6e2ZG7nqM3g/FZ5PQEDMWmMGNrCUBVRPHXTJaH7CBDdsLeu3eCh3B1tzAxTnAbtmrzvWEvT2NNEA==",
-			"dev": true
-		},
 		"brace-expansion": {
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -973,19 +854,6 @@
 					}
 				}
 			}
-		},
-		"color-convert": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-			"requires": {
-				"color-name": "~1.1.4"
-			}
-		},
-		"color-name": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
 		},
 		"colorette": {
 			"version": "1.3.0",
@@ -1392,11 +1260,6 @@
 				"es5-ext": "~0.10.14"
 			}
 		},
-		"event-target-shim": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-6.0.2.tgz",
-			"integrity": "sha512-8q3LsZjRezbFZ2PN+uP+Q7pnHUMmAOziU2vA2OwoFaKIXxlxl38IylhSSgUorWu/rf4er67w0ikBqjBFk/pomA=="
-		},
 		"ext": {
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/ext/-/ext-1.5.0.tgz",
@@ -1502,12 +1365,6 @@
 			"version": "4.2.6",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
 			"integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
-			"dev": true
-		},
-		"gud": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/gud/-/gud-1.0.0.tgz",
-			"integrity": "sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw==",
 			"dev": true
 		},
 		"has": {
@@ -1742,12 +1599,6 @@
 			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
 			"dev": true
 		},
-		"jquery": {
-			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.0.tgz",
-			"integrity": "sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw==",
-			"dev": true
-		},
 		"js-tokens": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -1852,12 +1703,6 @@
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
 			"integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
-		},
-		"lodash.flatten": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
-			"integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=",
-			"dev": true
 		},
 		"lodash.throttle": {
 			"version": "4.1.1",
@@ -2213,12 +2058,6 @@
 			"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
 			"dev": true
 		},
-		"popper.js": {
-			"version": "1.16.1",
-			"resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
-			"integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==",
-			"dev": true
-		},
 		"prettier": {
 			"version": "2.3.2",
 			"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.2.tgz",
@@ -2301,37 +2140,6 @@
 			"resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
 			"integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
 		},
-		"react-popper": {
-			"version": "1.3.11",
-			"resolved": "https://registry.npmjs.org/react-popper/-/react-popper-1.3.11.tgz",
-			"integrity": "sha512-VSA/bS+pSndSF2fiasHK/PTEEAyOpX60+H5EPAjoArr8JGm+oihu4UbrqcEBpQibJxBVCpYyjAX7abJ+7DoYVg==",
-			"dev": true,
-			"requires": {
-				"@babel/runtime": "^7.1.2",
-				"@hypnosphi/create-react-context": "^0.3.1",
-				"deep-equal": "^1.1.1",
-				"popper.js": "^1.14.4",
-				"prop-types": "^15.6.1",
-				"typed-styles": "^0.0.7",
-				"warning": "^4.0.2"
-			},
-			"dependencies": {
-				"deep-equal": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
-					"integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
-					"dev": true,
-					"requires": {
-						"is-arguments": "^1.0.4",
-						"is-date-object": "^1.0.1",
-						"is-regex": "^1.0.4",
-						"object-is": "^1.0.1",
-						"object-keys": "^1.1.1",
-						"regexp.prototype.flags": "^1.2.0"
-					}
-				}
-			}
-		},
 		"react-transition-group": {
 			"version": "2.9.0",
 			"resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.9.0.tgz",
@@ -2341,49 +2149,6 @@
 				"loose-envify": "^1.4.0",
 				"prop-types": "^15.6.2",
 				"react-lifecycles-compat": "^3.0.4"
-			}
-		},
-		"react-virtualized-auto-sizer": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.6.tgz",
-			"integrity": "sha512-7tQ0BmZqfVF6YYEWcIGuoR3OdYe8I/ZFbNclFlGOC3pMqunkYF/oL30NCjSGl9sMEb17AnzixDz98Kqc3N76HQ==",
-			"dev": true
-		},
-		"react-window": {
-			"version": "1.8.6",
-			"resolved": "https://registry.npmjs.org/react-window/-/react-window-1.8.6.tgz",
-			"integrity": "sha512-8VwEEYyjz6DCnGBsd+MgkD0KJ2/OXFULyDtorIiTz+QzwoP94tBoA7CnbtyXMm+cCeAUER5KJcPtWl9cpKbOBg==",
-			"dev": true,
-			"requires": {
-				"@babel/runtime": "^7.0.0",
-				"memoize-one": ">=3.1.1 <6"
-			}
-		},
-		"reactstrap": {
-			"version": "8.10.1",
-			"resolved": "https://registry.npmjs.org/reactstrap/-/reactstrap-8.10.1.tgz",
-			"integrity": "sha512-StjLADa/12yMNjafrSs+UD7sZAGtKpLO9fZp++2Dj0IzJinqY7eQhXlM3nFf0q40YsIcLvQdFc9pKF8PF4f0Qg==",
-			"dev": true,
-			"requires": {
-				"@babel/runtime": "^7.12.5",
-				"classnames": "^2.2.3",
-				"prop-types": "^15.5.8",
-				"react-popper": "^1.3.6",
-				"react-transition-group": "^3.0.0"
-			},
-			"dependencies": {
-				"react-transition-group": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-3.0.0.tgz",
-					"integrity": "sha512-A9ojB/LWECbFj58SNfjK1X9aaAU+1olLS0DFSikvrr2KfMaiBELemHDa5dKNvcTk2t3gUtDL/PJpFrBKDfMpLg==",
-					"dev": true,
-					"requires": {
-						"dom-helpers": "^3.4.0",
-						"loose-envify": "^1.4.0",
-						"prop-types": "^15.6.2",
-						"react-lifecycles-compat": "^3.0.4"
-					}
-				}
 			}
 		},
 		"read-pkg": {
@@ -2709,12 +2474,6 @@
 			"resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
 			"integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg=="
 		},
-		"typed-styles": {
-			"version": "0.0.7",
-			"resolved": "https://registry.npmjs.org/typed-styles/-/typed-styles-0.0.7.tgz",
-			"integrity": "sha512-pzP0PWoZUhsECYjABgCGQlRGL1n7tOHsgwYv3oIiEpJwGhFTuty/YNeduxQYzXXa3Ge5BdT6sHYIQYpl4uJ+5Q==",
-			"dev": true
-		},
 		"unbox-primitive": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
@@ -2766,15 +2525,6 @@
 			"requires": {
 				"spdx-correct": "^3.0.0",
 				"spdx-expression-parse": "^3.0.0"
-			}
-		},
-		"warning": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
-			"integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
-			"dev": true,
-			"requires": {
-				"loose-envify": "^1.0.0"
 			}
 		},
 		"web-streams-polyfill": {

--- a/packages/iris-grid/src/IrisGrid.jsx
+++ b/packages/iris-grid/src/IrisGrid.jsx
@@ -1845,7 +1845,7 @@ export class IrisGrid extends Component {
 
   handleChartCreate(settings) {
     const { model, onCreateChart } = this.props;
-    onCreateChart(settings, model.table);
+    onCreateChart(settings, model);
   }
 
   handleGridError(error) {
@@ -2368,6 +2368,7 @@ export class IrisGrid extends Component {
       advancedSettings,
       onAdvancedSettingsChange,
       canDownloadCsv,
+      onCreateChart,
     } = this.props;
     const {
       metricCalculator,
@@ -2822,7 +2823,7 @@ export class IrisGrid extends Component {
     }
 
     const optionItems = this.getCachedOptionItems(
-      model.isChartBuilderAvailable,
+      onCreateChart !== undefined && model.isChartBuilderAvailable,
       model.isCustomColumnsAvailable,
       model.isRollupAvailable,
       model.isTotalsAvailable,
@@ -3265,7 +3266,7 @@ IrisGrid.defaultProps = {
   movedRows: [],
   inputFilters: [],
   customFilters: [],
-  onCreateChart: () => {},
+  onCreateChart: undefined,
   onColumnSelected: () => {},
   onDataSelected: () => {},
   onError: () => {},

--- a/packages/iris-grid/src/IrisGridModelFactory.js
+++ b/packages/iris-grid/src/IrisGridModelFactory.js
@@ -10,18 +10,7 @@ class IrisGridModelFactory {
    * @param {Formatter} formatter The formatter to use
    * @returns {Promise<IrisGridModel>} An IrisGridModel that uses the table provided
    */
-  static async makeModel(
-    table,
-    isConsoleTable = false,
-    formatter = new Formatter()
-  ) {
-    if (!isConsoleTable && table.isUncoalesced) {
-      table.close();
-      throw new Error(
-        'Table is uncoalesced. Tables must contain a where clause when part of persistent queries to be viewable.'
-      );
-    }
-
+  static async makeModel(table, formatter = new Formatter()) {
     let inputTable = null;
     if (table.hasInputTable) {
       inputTable = await table.inputTable();

--- a/packages/iris-grid/src/sidebar/ChartBuilder.jsx
+++ b/packages/iris-grid/src/sidebar/ChartBuilder.jsx
@@ -246,7 +246,7 @@ class ChartBuilder extends PureComponent {
     const { onSubmit } = this.props;
     const { type, seriesItems, xAxis, isLinked } = this.state;
     const series = seriesItems.map(item => item.value);
-    onSubmit({ type, series, xAxis, isLinked });
+    onSubmit({ type: `${type}`, series, xAxis, isLinked });
   }
 
   handleTypeClick(event) {

--- a/packages/jsapi-shim/package-lock.json
+++ b/packages/jsapi-shim/package-lock.json
@@ -21,12 +21,6 @@
 				"source-map": "^0.5.0"
 			}
 		},
-		"@deephaven/tsconfig": {
-			"version": "0.9.0",
-			"resolved": "https://registry.npmjs.org/@deephaven/tsconfig/-/tsconfig-0.9.0.tgz",
-			"integrity": "sha512-zYKPllv+W+UhAuzC2pbsaQynxzsE0bBK/XjfiK0LWiGMkMhp43rwEaCiMODSYaxGmaV5eA+ijm8r1Y8v21pH4w==",
-			"dev": true
-		},
 		"@nicolo-ribaudo/chokidar-2": {
 			"version": "2.1.8-no-fsevents.3",
 			"resolved": "https://registry.npmjs.org/@nicolo-ribaudo/chokidar-2/-/chokidar-2-2.1.8-no-fsevents.3.tgz",

--- a/packages/jsapi-shim/package-lock.json
+++ b/packages/jsapi-shim/package-lock.json
@@ -5,9 +5,9 @@
 	"requires": true,
 	"dependencies": {
 		"@babel/cli": {
-			"version": "7.16.7",
-			"resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.16.7.tgz",
-			"integrity": "sha512-0iBF+G2Qml0y3mY5dirolyToLSR88a/KB6F2Gm8J/lOnyL8wbEOHak0DHF8gjc9XZGgTDGv/jYXNiapvsYyHTA==",
+			"version": "7.16.8",
+			"resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.16.8.tgz",
+			"integrity": "sha512-FTKBbxyk5TclXOGmwYyqelqP5IF6hMxaeJskd85jbR5jBfYlwqgwAbJwnixi1ZBbTqKfFuAA95mdmUFeSRwyJA==",
 			"dev": true,
 			"requires": {
 				"@nicolo-ribaudo/chokidar-2": "2.1.8-no-fsevents.3",
@@ -109,9 +109,9 @@
 			}
 		},
 		"chokidar": {
-			"version": "3.5.2",
-			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
-			"integrity": "sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==",
+			"version": "3.5.3",
+			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+			"integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
 			"dev": true,
 			"optional": true,
 			"requires": {
@@ -200,9 +200,9 @@
 			}
 		},
 		"es-abstract": {
-			"version": "1.18.6",
-			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.6.tgz",
-			"integrity": "sha512-kAeIT4cku5eNLNuUKhlmtuk1/TRZvQoYccn6TO0cSVdf1kzB0T7+dYuVK9MWM7l+/53W2Q8M7N2c6MQvhXFcUQ==",
+			"version": "1.19.1",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.1.tgz",
+			"integrity": "sha512-2vJ6tjA/UfqLm2MPs7jxVybLoB8i1t1Jd9R3kISld20sIxPcTbLuggQOUxeWeAvIUkduv/CfMjuh4WmiXr2v9w==",
 			"dev": true,
 			"requires": {
 				"call-bind": "^1.0.2",
@@ -216,7 +216,9 @@
 				"is-callable": "^1.2.4",
 				"is-negative-zero": "^2.0.1",
 				"is-regex": "^1.1.4",
+				"is-shared-array-buffer": "^1.0.1",
 				"is-string": "^1.0.7",
+				"is-weakref": "^1.0.1",
 				"object-inspect": "^1.11.0",
 				"object-keys": "^1.1.1",
 				"object.assign": "^4.1.2",
@@ -299,9 +301,9 @@
 			}
 		},
 		"glob": {
-			"version": "7.1.7",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
-			"integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+			"integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
 			"dev": true,
 			"requires": {
 				"fs.realpath": "^1.0.0",
@@ -323,9 +325,9 @@
 			}
 		},
 		"graceful-fs": {
-			"version": "4.2.6",
-			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
-			"integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
+			"version": "4.2.9",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.9.tgz",
+			"integrity": "sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ==",
 			"dev": true
 		},
 		"has": {
@@ -439,9 +441,9 @@
 			"dev": true
 		},
 		"is-core-module": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.6.0.tgz",
-			"integrity": "sha512-wShG8vs60jKfPWpF2KZRaAtvt3a20OAn7+IJ6hLPECpSABLcKtFKTTI4ZtH5QcBruBHlq+WsdHWyz0BCZW7svQ==",
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
+			"integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
 			"dev": true,
 			"requires": {
 				"has": "^1.0.3"
@@ -474,9 +476,9 @@
 			}
 		},
 		"is-negative-zero": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
-			"integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
+			"integrity": "sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==",
 			"dev": true
 		},
 		"is-number": {
@@ -505,6 +507,12 @@
 				"has-tostringtag": "^1.0.0"
 			}
 		},
+		"is-shared-array-buffer": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.1.tgz",
+			"integrity": "sha512-IU0NmyknYZN0rChcKhRO1X8LYz5Isj/Fsqh8NJOSf+N/hCOTwy29F32Ik7a+QszE63IdvmwdTPDd6cZ5pg4cwA==",
+			"dev": true
+		},
 		"is-string": {
 			"version": "1.0.7",
 			"resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
@@ -521,6 +529,15 @@
 			"dev": true,
 			"requires": {
 				"has-symbols": "^1.0.2"
+			}
+		},
+		"is-weakref": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
+			"integrity": "sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==",
+			"dev": true,
+			"requires": {
+				"call-bind": "^1.0.2"
 			}
 		},
 		"isexe": {
@@ -686,9 +703,9 @@
 			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
 		},
 		"object-inspect": {
-			"version": "1.11.0",
-			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.0.tgz",
-			"integrity": "sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg==",
+			"version": "1.12.0",
+			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.0.tgz",
+			"integrity": "sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==",
 			"dev": true
 		},
 		"object-keys": {
@@ -783,13 +800,13 @@
 			"dev": true
 		},
 		"prop-types": {
-			"version": "15.7.2",
-			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
-			"integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+			"version": "15.8.1",
+			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+			"integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
 			"requires": {
 				"loose-envify": "^1.4.0",
 				"object-assign": "^4.1.1",
-				"react-is": "^16.8.1"
+				"react-is": "^16.13.1"
 			}
 		},
 		"react-is": {
@@ -819,13 +836,14 @@
 			}
 		},
 		"resolve": {
-			"version": "1.20.0",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
-			"integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
+			"version": "1.21.0",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.21.0.tgz",
+			"integrity": "sha512-3wCbTpk5WJlyE4mSOtDLhqQmGFi0/TD9VPwmiolnk8U0wRgMEktqCXd3vy5buTO3tljvalNvKrjHEfrd2WpEKA==",
 			"dev": true,
 			"requires": {
-				"is-core-module": "^2.2.0",
-				"path-parse": "^1.0.6"
+				"is-core-module": "^2.8.0",
+				"path-parse": "^1.0.7",
+				"supports-preserve-symlinks-flag": "^1.0.0"
 			}
 		},
 		"rimraf": {
@@ -865,9 +883,9 @@
 			"dev": true
 		},
 		"shell-quote": {
-			"version": "1.7.2",
-			"resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.2.tgz",
-			"integrity": "sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==",
+			"version": "1.7.3",
+			"resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.3.tgz",
+			"integrity": "sha512-Vpfqwm4EnqGdlsBFNmHhxhElJYrdfcxPThu+ryKS5J8L/fhAwLazFZtq+S+TWZ9ANj2piSQLGj6NQg+lKPmxrw==",
 			"dev": true
 		},
 		"side-channel": {
@@ -920,20 +938,20 @@
 			}
 		},
 		"spdx-license-ids": {
-			"version": "3.0.10",
-			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.10.tgz",
-			"integrity": "sha512-oie3/+gKf7QtpitB0LYLETe+k8SifzsX4KixvpOsbI6S0kRiRQ5MKOio8eMSAKQ17N06+wdEOXRiId+zOxo0hA==",
+			"version": "3.0.11",
+			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.11.tgz",
+			"integrity": "sha512-Ctl2BrFiM0X3MANYgj3CkygxhRmr9mi6xhejbdO960nF6EDJApTYpn0BQnDKlnNBULKiCN1n3w9EBkHK8ZWg+g==",
 			"dev": true
 		},
 		"string.prototype.padend": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/string.prototype.padend/-/string.prototype.padend-3.1.2.tgz",
-			"integrity": "sha512-/AQFLdYvePENU3W5rgurfWSMU6n+Ww8n/3cUt7E+vPBB/D7YDG8x+qjoFs4M/alR2bW7Qg6xMjVwWUOvuQ0XpQ==",
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/string.prototype.padend/-/string.prototype.padend-3.1.3.tgz",
+			"integrity": "sha512-jNIIeokznm8SD/TZISQsZKYu7RJyheFNt84DUPrh482GC8RVp2MKqm2O5oBRdGxbDQoXrhhWtPIWQOiy20svUg==",
 			"dev": true,
 			"requires": {
 				"call-bind": "^1.0.2",
 				"define-properties": "^1.1.3",
-				"es-abstract": "^1.18.0-next.2"
+				"es-abstract": "^1.19.1"
 			}
 		},
 		"string.prototype.trimend": {
@@ -970,6 +988,12 @@
 			"requires": {
 				"has-flag": "^3.0.0"
 			}
+		},
+		"supports-preserve-symlinks-flag": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+			"integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+			"dev": true
 		},
 		"to-regex-range": {
 			"version": "5.0.1",

--- a/packages/jsapi-shim/src/dh.types.ts
+++ b/packages/jsapi-shim/src/dh.types.ts
@@ -38,6 +38,9 @@ export interface VariableDefinition<
   T extends VariableTypeUnion = VariableTypeUnion
 > {
   type: T;
+  name?: string;
+  title?: string;
+  id?: string;
 }
 
 export interface IdeSession {

--- a/packages/log/package-lock.json
+++ b/packages/log/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@babel/cli": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.16.7.tgz",
-      "integrity": "sha512-0iBF+G2Qml0y3mY5dirolyToLSR88a/KB6F2Gm8J/lOnyL8wbEOHak0DHF8gjc9XZGgTDGv/jYXNiapvsYyHTA==",
+      "version": "7.16.8",
+      "resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.16.8.tgz",
+      "integrity": "sha512-FTKBbxyk5TclXOGmwYyqelqP5IF6hMxaeJskd85jbR5jBfYlwqgwAbJwnixi1ZBbTqKfFuAA95mdmUFeSRwyJA==",
       "dev": true,
       "requires": {
         "@nicolo-ribaudo/chokidar-2": "2.1.8-no-fsevents.3",
@@ -109,9 +109,9 @@
       }
     },
     "chokidar": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
-      "integrity": "sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -330,9 +330,9 @@
       }
     },
     "graceful-fs": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
-      "integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==",
+      "version": "4.2.9",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.9.tgz",
+      "integrity": "sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ==",
       "dev": true
     },
     "harmony-reflect": {
@@ -461,9 +461,9 @@
       "dev": true
     },
     "is-core-module": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.0.tgz",
-      "integrity": "sha512-vd15qHsaqrRL7dtH6QNuy0ndJmRDrS9HAM1CAiSifNUFv4x1a0CCVsj18hJ1mShxIG6T2i1sO78MkP56r0nYRw==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
+      "integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
       "dev": true,
       "requires": {
         "has": "^1.0.3"
@@ -496,9 +496,9 @@
       }
     },
     "is-negative-zero": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
-      "integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
+      "integrity": "sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==",
       "dev": true
     },
     "is-number": {
@@ -552,12 +552,12 @@
       }
     },
     "is-weakref": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.1.tgz",
-      "integrity": "sha512-b2jKc2pQZjaeFYWEf7ScFj+Be1I+PXmlu572Q8coTXZ+LD/QQZ7ShPMst8h16riVgyXTQwUsFEl74mDvc/3MHQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
+      "integrity": "sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==",
       "dev": true,
       "requires": {
-        "call-bind": "^1.0.0"
+        "call-bind": "^1.0.2"
       }
     },
     "isexe": {
@@ -705,9 +705,9 @@
       }
     },
     "object-inspect": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.0.tgz",
-      "integrity": "sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.0.tgz",
+      "integrity": "sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==",
       "dev": true
     },
     "object-keys": {
@@ -783,9 +783,9 @@
       }
     },
     "picomatch": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
-      "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "dev": true,
       "optional": true
     },
@@ -823,13 +823,14 @@
       }
     },
     "resolve": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
-      "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.21.0.tgz",
+      "integrity": "sha512-3wCbTpk5WJlyE4mSOtDLhqQmGFi0/TD9VPwmiolnk8U0wRgMEktqCXd3vy5buTO3tljvalNvKrjHEfrd2WpEKA==",
       "dev": true,
       "requires": {
-        "is-core-module": "^2.2.0",
-        "path-parse": "^1.0.6"
+        "is-core-module": "^2.8.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
       }
     },
     "rimraf": {
@@ -924,9 +925,9 @@
       }
     },
     "spdx-license-ids": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.10.tgz",
-      "integrity": "sha512-oie3/+gKf7QtpitB0LYLETe+k8SifzsX4KixvpOsbI6S0kRiRQ5MKOio8eMSAKQ17N06+wdEOXRiId+zOxo0hA==",
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.11.tgz",
+      "integrity": "sha512-Ctl2BrFiM0X3MANYgj3CkygxhRmr9mi6xhejbdO960nF6EDJApTYpn0BQnDKlnNBULKiCN1n3w9EBkHK8ZWg+g==",
       "dev": true
     },
     "string.prototype.padend": {
@@ -974,6 +975,12 @@
       "requires": {
         "has-flag": "^3.0.0"
       }
+    },
+    "supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true
     },
     "to-regex-range": {
       "version": "5.0.1",

--- a/packages/log/package-lock.json
+++ b/packages/log/package-lock.json
@@ -21,12 +21,6 @@
         "source-map": "^0.5.0"
       }
     },
-    "@deephaven/tsconfig": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@deephaven/tsconfig/-/tsconfig-0.9.0.tgz",
-      "integrity": "sha512-zYKPllv+W+UhAuzC2pbsaQynxzsE0bBK/XjfiK0LWiGMkMhp43rwEaCiMODSYaxGmaV5eA+ijm8r1Y8v21pH4w==",
-      "dev": true
-    },
     "@nicolo-ribaudo/chokidar-2": {
       "version": "2.1.8-no-fsevents.3",
       "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/chokidar-2/-/chokidar-2-2.1.8-no-fsevents.3.tgz",

--- a/packages/react-hooks/package-lock.json
+++ b/packages/react-hooks/package-lock.json
@@ -21,12 +21,6 @@
         "source-map": "^0.5.0"
       }
     },
-    "@deephaven/tsconfig": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@deephaven/tsconfig/-/tsconfig-0.9.0.tgz",
-      "integrity": "sha512-zYKPllv+W+UhAuzC2pbsaQynxzsE0bBK/XjfiK0LWiGMkMhp43rwEaCiMODSYaxGmaV5eA+ijm8r1Y8v21pH4w==",
-      "dev": true
-    },
     "@nicolo-ribaudo/chokidar-2": {
       "version": "2.1.8-no-fsevents.3",
       "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/chokidar-2/-/chokidar-2-2.1.8-no-fsevents.3.tgz",

--- a/packages/redux/package-lock.json
+++ b/packages/redux/package-lock.json
@@ -31,14 +31,14 @@
       }
     },
     "@deephaven/components": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@deephaven/components/-/components-0.9.0.tgz",
-      "integrity": "sha512-PKLV4vkXNKpnxoitxDoxl5HmoRmD8yRUawDEfAD7HjDYQImE3m9VWMjgX8xpyxKmXKVTUDn5S9qf4iYGUkwZ/g==",
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@deephaven/components/-/components-0.9.1.tgz",
+      "integrity": "sha512-B96vtZW3NHN27z+pfo7WO0FmZlt/uESaPi0WmQbzxJj3XNZifgfEWZy258udvG27FXy4Md4J/poXaCjdaauQmw==",
       "dev": true,
       "requires": {
-        "@deephaven/icons": "^0.9.0",
-        "@deephaven/react-hooks": "^0.9.0",
-        "@deephaven/utils": "^0.9.0",
+        "@deephaven/icons": "^0.9.1",
+        "@deephaven/react-hooks": "^0.9.1",
+        "@deephaven/utils": "^0.9.1",
         "@fortawesome/fontawesome-svg-core": "^1.2.32",
         "@fortawesome/react-fontawesome": "^0.1.12",
         "bootstrap": "4.4.1",
@@ -59,15 +59,15 @@
       }
     },
     "@deephaven/console": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@deephaven/console/-/console-0.9.0.tgz",
-      "integrity": "sha512-Jr3fy0mgkiHrkNlnJNzBqHXQoZuwLC2Wv5FDLeSNphAwjROev908zEu/4NUptTULELQl/mAf2YbabK9WVKglLQ==",
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@deephaven/console/-/console-0.9.1.tgz",
+      "integrity": "sha512-E1dSc9s2qJO9t9TUhfmB40Mb5TUuYO5EHdaR6KLSUGkI75YrFcs+TpGDuyQS7HbOuKkApcpEUG2KKMJZnFh3aw==",
       "dev": true,
       "requires": {
-        "@deephaven/icons": "^0.9.0",
-        "@deephaven/jsapi-shim": "^0.9.0",
-        "@deephaven/storage": "^0.9.0",
-        "@deephaven/utils": "^0.9.0",
+        "@deephaven/icons": "^0.9.1",
+        "@deephaven/jsapi-shim": "^0.9.1",
+        "@deephaven/storage": "^0.9.1",
+        "@deephaven/utils": "^0.9.1",
         "@fortawesome/react-fontawesome": "^0.1.12",
         "classnames": "^2.3.1",
         "jszip": "3.2.2",
@@ -82,14 +82,14 @@
       }
     },
     "@deephaven/file-explorer": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@deephaven/file-explorer/-/file-explorer-0.9.0.tgz",
-      "integrity": "sha512-sz578KdUv5f+LOO+gIMaelFqayjUAxzALUnwSwTxx30LcvBSoXd91JPBleOK7Bo34cs7c6eZD+z1ymVyCGUvUw==",
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@deephaven/file-explorer/-/file-explorer-0.9.1.tgz",
+      "integrity": "sha512-b66MJOruKBkmo6W06599RM2+5i5fSBR6lIgrmvyGYisiT6bhjzz6BnZC0DkPZropZpK4B0jYH33cLJZ7+32Ftw==",
       "dev": true,
       "requires": {
-        "@deephaven/icons": "^0.9.0",
-        "@deephaven/storage": "^0.9.0",
-        "@deephaven/utils": "^0.9.0",
+        "@deephaven/icons": "^0.9.1",
+        "@deephaven/storage": "^0.9.1",
+        "@deephaven/utils": "^0.9.1",
         "@fortawesome/fontawesome-svg-core": "^1.2.32",
         "@fortawesome/react-fontawesome": "^0.1.12",
         "classnames": "^2.3.1",
@@ -100,9 +100,9 @@
       }
     },
     "@deephaven/grid": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@deephaven/grid/-/grid-0.9.0.tgz",
-      "integrity": "sha512-I6Cyqd/wPrH2MSeFQK4DB0vimyQ9zMX1lzczOfFppGQprb8Mj4pUpNyqKB6fj+tOY2ZdjmG/m6vp3TIoIO+EKw==",
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@deephaven/grid/-/grid-0.9.1.tgz",
+      "integrity": "sha512-INVZKFo/2bK+FpT5vqN7wfdrW66Xl5fxDOkr8I8PO9LL23RMfdiPvilzO8Ji7fKP3fOZtvCznO7yLMEzVBhFLA==",
       "dev": true,
       "requires": {
         "classnames": "^2.3.1",
@@ -132,25 +132,25 @@
       }
     },
     "@deephaven/icons": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@deephaven/icons/-/icons-0.9.0.tgz",
-      "integrity": "sha512-Md+B9iIf6+Z63AxDsg11mTeaVXNgEHwjoixK8nu3BtWrO6FnCgaZxN4D3Ml/ge4zXxd8174lvQOUTPLf8cHOsA==",
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@deephaven/icons/-/icons-0.9.1.tgz",
+      "integrity": "sha512-nLLZez6hNl4Ep6b7IjjIxLTGRa9WxeagNC2BP2IWVXs/ONvHHv0t5SYeCCJ/IaH8Bz2UWnxf09VivVPdIGZYig==",
       "dev": true,
       "requires": {
         "@fortawesome/fontawesome-common-types": "^0.2.35"
       }
     },
     "@deephaven/iris-grid": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@deephaven/iris-grid/-/iris-grid-0.9.0.tgz",
-      "integrity": "sha512-ohpnVu5YQlSrN87msuK+xCpbvgPqQnguIhTV2kpemJO9UdE5rrxJuRE0D2NSvryuwipuID76n7pOBW/RktmbWA==",
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@deephaven/iris-grid/-/iris-grid-0.9.1.tgz",
+      "integrity": "sha512-KHZwBKu/oVZY3GyrEAuMqrV0BKX4SYCBtFc5p11xSMwfduwGm01ppcrv5T4j90P9vNTt2KffLgIya6JS3JMzlQ==",
       "dev": true,
       "requires": {
-        "@deephaven/grid": "^0.9.0",
-        "@deephaven/icons": "^0.9.0",
-        "@deephaven/jsapi-shim": "^0.9.0",
-        "@deephaven/react-hooks": "^0.9.0",
-        "@deephaven/utils": "^0.9.0",
+        "@deephaven/grid": "^0.9.1",
+        "@deephaven/icons": "^0.9.1",
+        "@deephaven/jsapi-shim": "^0.9.1",
+        "@deephaven/react-hooks": "^0.9.1",
+        "@deephaven/utils": "^0.9.1",
         "@fortawesome/react-fontawesome": "^0.1.12",
         "classnames": "^2.3.1",
         "deep-equal": "^2.0.4",
@@ -168,36 +168,36 @@
       }
     },
     "@deephaven/jsapi-shim": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@deephaven/jsapi-shim/-/jsapi-shim-0.9.0.tgz",
-      "integrity": "sha512-0jLQh1Xl4u0bXHDzt2Y8vlNNJ87sCzX3yAqg1ZrwPL7Fjj26zeFr05EAOJWakLBRUnEpW1ltJ31tqGoS3zpfsA==",
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@deephaven/jsapi-shim/-/jsapi-shim-0.9.1.tgz",
+      "integrity": "sha512-soBU7sU9qZgzDXJyYrU96GiB7UBCdHScUaQjl4ISx2igIdK+Qfe7JOYVxYjJdV8KEVK/l+smSkahAIT5/NJY4Q==",
       "dev": true,
       "requires": {
         "prop-types": "^15.7.2"
       }
     },
     "@deephaven/log": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@deephaven/log/-/log-0.9.0.tgz",
-      "integrity": "sha512-zvy77W/FrfqJAPofhX9d+9ZniQdXMyc2AvwVnXZx0IDZMb82WR1JkruYonoSiAW/NTxeAF8gbU4pMdiCTCtlag==",
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@deephaven/log/-/log-0.9.1.tgz",
+      "integrity": "sha512-L/yKtSYOrNZlvyElqpgdrnL3JBaY07szFjhA37XK31+uH/jcPcbMxsn2Uf+++yyFcn6GKO1XXXP44V3xBkBQJg==",
       "dev": true,
       "requires": {
         "event-target-shim": "^6.0.2"
       }
     },
     "@deephaven/react-hooks": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@deephaven/react-hooks/-/react-hooks-0.9.0.tgz",
-      "integrity": "sha512-R5VDXMwcGHMaLxgp/PKoJ2ynbDM1emLQN5Y0jIQKG4XrwGVFUKRC68unQ1tStG4qAvrDhaGmpK0VpenLLPkmwg==",
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@deephaven/react-hooks/-/react-hooks-0.9.1.tgz",
+      "integrity": "sha512-v7r2DZoPahHNBspbulCtvUgCqJ+i9WPEA8cK9nEsTVTeuR3mhwLw4E/0g+WlXJ78FsUdA0K9FECJfUg1YTvyLg==",
       "dev": true
     },
     "@deephaven/storage": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@deephaven/storage/-/storage-0.9.0.tgz",
-      "integrity": "sha512-rZK50Ga+tsqXNRajPWYfc30DTSKKHYt+X4sp7YFqim523kFk828dsgxNbatCLp+4xHRkVIv6zLeHy9iZEoR52g==",
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@deephaven/storage/-/storage-0.9.1.tgz",
+      "integrity": "sha512-Bcsuaaib5RLX0IEYfPlLl5CfOb/yNssq+4FbD4h0R8SBmFN7oTmRlWLMDWflFpV9FVwBBKojp5GyvKhxyTkHBQ==",
       "dev": true,
       "requires": {
-        "@deephaven/iris-grid": "^0.9.0",
+        "@deephaven/iris-grid": "^0.9.1",
         "lodash.throttle": "^4.1.1"
       }
     },
@@ -208,20 +208,20 @@
       "dev": true
     },
     "@deephaven/utils": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@deephaven/utils/-/utils-0.9.0.tgz",
-      "integrity": "sha512-He3BL49YxJQ1XJdsYGc/d/iTNRW4UczVYELKCEj8fvhgfqjc/IyrgIXeomhOCFPAe4tj3Km+7EF/QaNRlbRWOQ==",
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@deephaven/utils/-/utils-0.9.1.tgz",
+      "integrity": "sha512-kll4L5bNOOPdtpeSDpIvC8+NnlaToKrsPoJ3kvsZvJVmILdIKAIXcviGPxZO5SCjyzgV/NmfLUmHq0CcMAYnEg==",
       "dev": true
     },
     "@fortawesome/fontawesome-common-types": {
       "version": "0.2.36",
-      "resolved": "https://npm.fontawesome.com/@fortawesome/fontawesome-common-types/-/0.2.36/fontawesome-common-types-0.2.36.tgz",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.36.tgz",
       "integrity": "sha512-a/7BiSgobHAgBWeN7N0w+lAhInrGxksn13uK7231n2m8EDPE3BMCl9NZLTGrj9ZXfCmC6LM0QLqXidIizVQ6yg==",
       "dev": true
     },
     "@fortawesome/fontawesome-svg-core": {
       "version": "1.2.36",
-      "resolved": "https://npm.fontawesome.com/@fortawesome/fontawesome-svg-core/-/1.2.36/fontawesome-svg-core-1.2.36.tgz",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.36.tgz",
       "integrity": "sha512-YUcsLQKYb6DmaJjIHdDWpBIGCcyE/W+p/LMGvjQem55Mm2XWVAP5kWTMKWLv9lwpCVjpLxPyOMOyUocP1GxrtA==",
       "dev": true,
       "requires": {
@@ -229,12 +229,12 @@
       }
     },
     "@fortawesome/react-fontawesome": {
-      "version": "0.1.16",
-      "resolved": "https://npm.fontawesome.com/@fortawesome/react-fontawesome/-/0.1.16/react-fontawesome-0.1.16.tgz",
-      "integrity": "sha512-aLmzDwC9rEOAJv2UJdMns89VZR5Ry4IHu5dQQh24Z/lWKEm44lfQr1UNalZlkUaQN8d155tNh+CS7ntntj1VMA==",
+      "version": "0.1.17",
+      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.1.17.tgz",
+      "integrity": "sha512-dX43Z5IvMaW7fwzU8farosYjKNGfRb2HB/DgjVBHeJZ/NSnuuaujPPx0YOdcAq+n3mqn70tyCde2HM1mqbhiuw==",
       "dev": true,
       "requires": {
-        "prop-types": "^15.7.2"
+        "prop-types": "^15.8.1"
       }
     },
     "@hypnosphi/create-react-context": {

--- a/packages/redux/package-lock.json
+++ b/packages/redux/package-lock.json
@@ -25,227 +25,7 @@
       "version": "7.15.4",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.15.4.tgz",
       "integrity": "sha512-99catp6bHCaxr4sJ/DbTGgHS4+Rs2RVd2g7iOap6SLGPDknRK9ztKNsE/Fg6QhSeh1FGE5f6gHGQmvvn3I3xhw==",
-      "dev": true,
-      "requires": {
-        "@fortawesome/fontawesome-common-types": "^0.2.35"
-      }
-    },
-    "@deephaven/components": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@deephaven/components/-/components-0.9.1.tgz",
-      "integrity": "sha512-B96vtZW3NHN27z+pfo7WO0FmZlt/uESaPi0WmQbzxJj3XNZifgfEWZy258udvG27FXy4Md4J/poXaCjdaauQmw==",
-      "dev": true,
-      "requires": {
-        "@deephaven/icons": "^0.9.1",
-        "@deephaven/react-hooks": "^0.9.1",
-        "@deephaven/utils": "^0.9.1",
-        "@fortawesome/fontawesome-svg-core": "^1.2.32",
-        "@fortawesome/react-fontawesome": "^0.1.12",
-        "bootstrap": "4.4.1",
-        "classnames": "^2.3.1",
-        "event-target-shim": "^6.0.2",
-        "jquery": "^3.5.1",
-        "lodash.debounce": "^4.0.8",
-        "lodash.flatten": "^4.4.0",
-        "memoizee": "^0.4.15",
-        "popper.js": "^1.16.1",
-        "prop-types": "^15.7.2",
-        "react-beautiful-dnd": "^13.0.0",
-        "react-transition-group": "^2.3.1",
-        "react-virtualized-auto-sizer": "^1.0.2",
-        "react-window": "^1.8.5",
-        "reactstrap": "^8.4.1",
-        "shortid": "^2.2.15"
-      }
-    },
-    "@deephaven/console": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@deephaven/console/-/console-0.9.1.tgz",
-      "integrity": "sha512-E1dSc9s2qJO9t9TUhfmB40Mb5TUuYO5EHdaR6KLSUGkI75YrFcs+TpGDuyQS7HbOuKkApcpEUG2KKMJZnFh3aw==",
-      "dev": true,
-      "requires": {
-        "@deephaven/icons": "^0.9.1",
-        "@deephaven/jsapi-shim": "^0.9.1",
-        "@deephaven/storage": "^0.9.1",
-        "@deephaven/utils": "^0.9.1",
-        "@fortawesome/react-fontawesome": "^0.1.12",
-        "classnames": "^2.3.1",
-        "jszip": "3.2.2",
-        "lodash.debounce": "^4.0.8",
-        "lodash.throttle": "^4.1.1",
-        "memoize-one": "^5.1.1",
-        "memoizee": "^0.4.15",
-        "monaco-editor": "^0.27.0",
-        "papaparse": "^5.2.0",
-        "prop-types": "^15.7.2",
-        "shell-quote": "^1.7.2"
-      }
-    },
-    "@deephaven/file-explorer": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@deephaven/file-explorer/-/file-explorer-0.9.1.tgz",
-      "integrity": "sha512-b66MJOruKBkmo6W06599RM2+5i5fSBR6lIgrmvyGYisiT6bhjzz6BnZC0DkPZropZpK4B0jYH33cLJZ7+32Ftw==",
-      "dev": true,
-      "requires": {
-        "@deephaven/icons": "^0.9.1",
-        "@deephaven/storage": "^0.9.1",
-        "@deephaven/utils": "^0.9.1",
-        "@fortawesome/fontawesome-svg-core": "^1.2.32",
-        "@fortawesome/react-fontawesome": "^0.1.12",
-        "classnames": "^2.3.1",
-        "lodash.throttle": "^4.1.1",
-        "prop-types": "^15.7.2",
-        "reactstrap": "^8.4.1",
-        "webdav": "^4.6.1"
-      }
-    },
-    "@deephaven/grid": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@deephaven/grid/-/grid-0.9.1.tgz",
-      "integrity": "sha512-INVZKFo/2bK+FpT5vqN7wfdrW66Xl5fxDOkr8I8PO9LL23RMfdiPvilzO8Ji7fKP3fOZtvCznO7yLMEzVBhFLA==",
-      "dev": true,
-      "requires": {
-        "classnames": "^2.3.1",
-        "color-convert": "^2.0.1",
-        "event-target-shim": "^6.0.2",
-        "lodash.clamp": "^4.0.3",
-        "memoize-one": "^5.1.1",
-        "memoizee": "^0.4.15",
-        "prop-types": "^15.7.2"
-      },
-      "dependencies": {
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
-        }
-      }
-    },
-    "@deephaven/icons": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@deephaven/icons/-/icons-0.9.1.tgz",
-      "integrity": "sha512-nLLZez6hNl4Ep6b7IjjIxLTGRa9WxeagNC2BP2IWVXs/ONvHHv0t5SYeCCJ/IaH8Bz2UWnxf09VivVPdIGZYig==",
-      "dev": true,
-      "requires": {
-        "@fortawesome/fontawesome-common-types": "^0.2.35"
-      }
-    },
-    "@deephaven/iris-grid": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@deephaven/iris-grid/-/iris-grid-0.9.1.tgz",
-      "integrity": "sha512-KHZwBKu/oVZY3GyrEAuMqrV0BKX4SYCBtFc5p11xSMwfduwGm01ppcrv5T4j90P9vNTt2KffLgIya6JS3JMzlQ==",
-      "dev": true,
-      "requires": {
-        "@deephaven/grid": "^0.9.1",
-        "@deephaven/icons": "^0.9.1",
-        "@deephaven/jsapi-shim": "^0.9.1",
-        "@deephaven/react-hooks": "^0.9.1",
-        "@deephaven/utils": "^0.9.1",
-        "@fortawesome/react-fontawesome": "^0.1.12",
-        "classnames": "^2.3.1",
-        "deep-equal": "^2.0.4",
-        "lodash.clamp": "^4.0.3",
-        "lodash.debounce": "^4.0.8",
-        "lodash.throttle": "^4.1.1",
-        "memoize-one": "^5.1.1",
-        "memoizee": "^0.4.15",
-        "monaco-editor": "^0.27.0",
-        "prop-types": "^15.7.2",
-        "react-beautiful-dnd": "^13.0.0",
-        "react-transition-group": "^2.3.1",
-        "shortid": "^2.2.15",
-        "web-streams-polyfill": "^2.1.0"
-      }
-    },
-    "@deephaven/jsapi-shim": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@deephaven/jsapi-shim/-/jsapi-shim-0.9.1.tgz",
-      "integrity": "sha512-soBU7sU9qZgzDXJyYrU96GiB7UBCdHScUaQjl4ISx2igIdK+Qfe7JOYVxYjJdV8KEVK/l+smSkahAIT5/NJY4Q==",
-      "dev": true,
-      "requires": {
-        "prop-types": "^15.7.2"
-      }
-    },
-    "@deephaven/log": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@deephaven/log/-/log-0.9.1.tgz",
-      "integrity": "sha512-L/yKtSYOrNZlvyElqpgdrnL3JBaY07szFjhA37XK31+uH/jcPcbMxsn2Uf+++yyFcn6GKO1XXXP44V3xBkBQJg==",
-      "dev": true,
-      "requires": {
-        "event-target-shim": "^6.0.2"
-      }
-    },
-    "@deephaven/react-hooks": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@deephaven/react-hooks/-/react-hooks-0.9.1.tgz",
-      "integrity": "sha512-v7r2DZoPahHNBspbulCtvUgCqJ+i9WPEA8cK9nEsTVTeuR3mhwLw4E/0g+WlXJ78FsUdA0K9FECJfUg1YTvyLg==",
       "dev": true
-    },
-    "@deephaven/storage": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@deephaven/storage/-/storage-0.9.1.tgz",
-      "integrity": "sha512-Bcsuaaib5RLX0IEYfPlLl5CfOb/yNssq+4FbD4h0R8SBmFN7oTmRlWLMDWflFpV9FVwBBKojp5GyvKhxyTkHBQ==",
-      "dev": true,
-      "requires": {
-        "@deephaven/iris-grid": "^0.9.1",
-        "lodash.throttle": "^4.1.1"
-      }
-    },
-    "@deephaven/tsconfig": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@deephaven/tsconfig/-/tsconfig-0.9.0.tgz",
-      "integrity": "sha512-zYKPllv+W+UhAuzC2pbsaQynxzsE0bBK/XjfiK0LWiGMkMhp43rwEaCiMODSYaxGmaV5eA+ijm8r1Y8v21pH4w==",
-      "dev": true
-    },
-    "@deephaven/utils": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@deephaven/utils/-/utils-0.9.1.tgz",
-      "integrity": "sha512-kll4L5bNOOPdtpeSDpIvC8+NnlaToKrsPoJ3kvsZvJVmILdIKAIXcviGPxZO5SCjyzgV/NmfLUmHq0CcMAYnEg==",
-      "dev": true
-    },
-    "@fortawesome/fontawesome-common-types": {
-      "version": "0.2.36",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.36.tgz",
-      "integrity": "sha512-a/7BiSgobHAgBWeN7N0w+lAhInrGxksn13uK7231n2m8EDPE3BMCl9NZLTGrj9ZXfCmC6LM0QLqXidIizVQ6yg==",
-      "dev": true
-    },
-    "@fortawesome/fontawesome-svg-core": {
-      "version": "1.2.36",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.36.tgz",
-      "integrity": "sha512-YUcsLQKYb6DmaJjIHdDWpBIGCcyE/W+p/LMGvjQem55Mm2XWVAP5kWTMKWLv9lwpCVjpLxPyOMOyUocP1GxrtA==",
-      "dev": true,
-      "requires": {
-        "@fortawesome/fontawesome-common-types": "^0.2.36"
-      }
-    },
-    "@fortawesome/react-fontawesome": {
-      "version": "0.1.17",
-      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.1.17.tgz",
-      "integrity": "sha512-dX43Z5IvMaW7fwzU8farosYjKNGfRb2HB/DgjVBHeJZ/NSnuuaujPPx0YOdcAq+n3mqn70tyCde2HM1mqbhiuw==",
-      "dev": true,
-      "requires": {
-        "prop-types": "^15.8.1"
-      }
-    },
-    "@hypnosphi/create-react-context": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@hypnosphi/create-react-context/-/create-react-context-0.3.1.tgz",
-      "integrity": "sha512-V1klUed202XahrWJLLOT3EXNeCpFHCcJntdFGI15ntCwau+jfT386w7OFTMaCqOgXUH1fa0w/I1oZs+i/Rfr0A==",
-      "dev": true,
-      "requires": {
-        "gud": "^1.0.0",
-        "warning": "^4.0.3"
-      }
     },
     "@nicolo-ribaudo/chokidar-2": {
       "version": "2.1.8-no-fsevents.3",
@@ -258,51 +38,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@types/deep-equal/-/deep-equal-1.0.1.tgz",
       "integrity": "sha512-mMUu4nWHLBlHtxXY17Fg6+ucS/MnndyOWyOe7MmwkoMYxvfQU2ajtRaEvqSUv+aVkMqH/C0NCI8UoVfRNQ10yg==",
-      "dev": true
-    },
-    "@types/hoist-non-react-statics": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
-      "integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
-      "dev": true,
-      "requires": {
-        "@types/react": "*",
-        "hoist-non-react-statics": "^3.3.0"
-      }
-    },
-    "@types/prop-types": {
-      "version": "15.7.4",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.4.tgz",
-      "integrity": "sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ==",
-      "dev": true
-    },
-    "@types/react": {
-      "version": "17.0.38",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.38.tgz",
-      "integrity": "sha512-SI92X1IA+FMnP3qM5m4QReluXzhcmovhZnLNm3pyeQlooi02qI7sLiepEYqT678uNiyc25XfCqxREFpy3W7YhQ==",
-      "dev": true,
-      "requires": {
-        "@types/prop-types": "*",
-        "@types/scheduler": "*",
-        "csstype": "^3.0.2"
-      }
-    },
-    "@types/react-redux": {
-      "version": "7.1.22",
-      "resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-7.1.22.tgz",
-      "integrity": "sha512-GxIA1kM7ClU73I6wg9IRTVwSO9GS+SAKZKe0Enj+82HMU6aoESFU2HNAdNi3+J53IaOHPiUfT3kSG4L828joDQ==",
-      "dev": true,
-      "requires": {
-        "@types/hoist-non-react-statics": "^3.3.0",
-        "@types/react": "*",
-        "hoist-non-react-statics": "^3.3.0",
-        "redux": "^4.0.0"
-      }
-    },
-    "@types/scheduler": {
-      "version": "0.16.2",
-      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
-      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
       "dev": true
     },
     "ansi-styles": {
@@ -330,25 +65,10 @@
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
       "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw=="
     },
-    "axios": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
-      "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
-      "dev": true,
-      "requires": {
-        "follow-redirects": "^1.14.4"
-      }
-    },
     "balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
-    },
-    "base-64": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/base-64/-/base-64-1.0.0.tgz",
-      "integrity": "sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg==",
       "dev": true
     },
     "binary-extensions": {
@@ -357,12 +77,6 @@
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
       "dev": true,
       "optional": true
-    },
-    "bootstrap": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.4.1.tgz",
-      "integrity": "sha512-tbx5cHubwE6e2ZG7nqM3g/FZ5PQEDMWmMGNrCUBVRPHXTJaH7CBDdsLeu3eCh3B1tzAxTnAbtmrzvWEvT2NNEA==",
-      "dev": true
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -404,12 +118,6 @@
         "supports-color": "^5.3.0"
       }
     },
-    "charenc": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
-      "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc=",
-      "dev": true
-    },
     "chokidar": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
@@ -426,12 +134,6 @@
         "normalize-path": "~3.0.0",
         "readdirp": "~3.6.0"
       }
-    },
-    "classnames": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
-      "integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA==",
-      "dev": true
     },
     "color-convert": {
       "version": "1.9.3",
@@ -465,16 +167,9 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.8.0.tgz",
       "integrity": "sha512-+OQdjP49zViI/6i7nIJpA8rAl4sV/JdPfU9nZs3VqOwGIgizICvuN2ru6fMd+4llL0tar18UYJXfZ/TWtmhUjA==",
       "dev": true,
-      "optional": true,
       "requires": {
         "safe-buffer": "~5.1.1"
       }
-    },
-    "core-util-is": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-      "dev": true
     },
     "cross-env": {
       "version": "7.0.3",
@@ -494,37 +189,6 @@
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
         "which": "^2.0.1"
-      }
-    },
-    "crypt": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
-      "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs=",
-      "dev": true
-    },
-    "css-box-model": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/css-box-model/-/css-box-model-1.2.1.tgz",
-      "integrity": "sha512-a7Vr4Q/kd/aw96bnJG332W9V9LkJO69JRcaCYDUqjp6/z0w6VcZjgAcTbgFxEPfBgdnAwlh3iwu+hLopa+flJw==",
-      "dev": true,
-      "requires": {
-        "tiny-invariant": "^1.0.6"
-      }
-    },
-    "csstype": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.10.tgz",
-      "integrity": "sha512-2u44ZG2OcNUO9HDp/Jl8C07x6pU/eTR3ncV91SiK3dhG9TWvRVsCoJw14Ckx5DgWkzGA3waZWO3d7pgqpUI/XA==",
-      "dev": true
-    },
-    "d": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
-      "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
-      "dev": true,
-      "requires": {
-        "es5-ext": "^0.10.50",
-        "type": "^1.0.1"
       }
     },
     "deep-equal": {
@@ -555,15 +219,6 @@
       "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
       "requires": {
         "object-keys": "^1.0.12"
-      }
-    },
-    "dom-helpers": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.4.0.tgz",
-      "integrity": "sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==",
-      "dev": true,
-      "requires": {
-        "@babel/runtime": "^7.1.2"
       }
     },
     "error-ex": {
@@ -625,105 +280,11 @@
         "is-symbol": "^1.0.2"
       }
     },
-    "es5-ext": {
-      "version": "0.10.53",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
-      "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
-      "dev": true,
-      "requires": {
-        "es6-iterator": "~2.0.3",
-        "es6-symbol": "~3.1.3",
-        "next-tick": "~1.0.0"
-      },
-      "dependencies": {
-        "next-tick": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
-          "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
-          "dev": true
-        }
-      }
-    },
-    "es6-iterator": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
-      "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
-      "dev": true,
-      "requires": {
-        "d": "1",
-        "es5-ext": "^0.10.35",
-        "es6-symbol": "^3.1.1"
-      }
-    },
-    "es6-symbol": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
-      "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
-      "dev": true,
-      "requires": {
-        "d": "^1.0.1",
-        "ext": "^1.1.2"
-      }
-    },
-    "es6-weak-map": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.3.tgz",
-      "integrity": "sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==",
-      "dev": true,
-      "requires": {
-        "d": "1",
-        "es5-ext": "^0.10.46",
-        "es6-iterator": "^2.0.3",
-        "es6-symbol": "^3.1.1"
-      }
-    },
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
-    },
-    "event-emitter": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
-      "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
-      "dev": true,
-      "requires": {
-        "d": "1",
-        "es5-ext": "~0.10.14"
-      }
-    },
-    "event-target-shim": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-6.0.2.tgz",
-      "integrity": "sha512-8q3LsZjRezbFZ2PN+uP+Q7pnHUMmAOziU2vA2OwoFaKIXxlxl38IylhSSgUorWu/rf4er67w0ikBqjBFk/pomA==",
-      "dev": true
-    },
-    "ext": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/ext/-/ext-1.6.0.tgz",
-      "integrity": "sha512-sdBImtzkq2HpkdRLtlLWDa6w4DX22ijZLKx8BMPUuKe1c5lbN6xwQDQCxSfxBQnHZ13ls/FH0MQZx/q/gr6FQg==",
-      "dev": true,
-      "requires": {
-        "type": "^2.5.0"
-      },
-      "dependencies": {
-        "type": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/type/-/type-2.5.0.tgz",
-          "integrity": "sha512-180WMDQaIMm3+7hGXWf12GtdniDEy7nYcyFMKJn/eZz/6tSLXrUN9V0wKSbMjej0I1WHWbpREDEKHtqPQa9NNw==",
-          "dev": true
-        }
-      }
-    },
-    "fast-xml-parser": {
-      "version": "3.21.1",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.21.1.tgz",
-      "integrity": "sha512-FTFVjYoBOZTJekiUsawGsSYV9QL0A+zDYCRj7y34IO6Jg+2IMYEtQa+bbictpdpV8dHxXywqU7C0gRDEOFtBFg==",
-      "dev": true,
-      "requires": {
-        "strnum": "^1.0.4"
-      }
     },
     "fill-range": {
       "version": "7.0.1",
@@ -734,12 +295,6 @@
       "requires": {
         "to-regex-range": "^5.0.1"
       }
-    },
-    "follow-redirects": {
-      "version": "1.14.7",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
-      "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==",
-      "dev": true
     },
     "foreach": {
       "version": "2.0.5",
@@ -819,12 +374,6 @@
       "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
       "dev": true
     },
-    "gud": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/gud/-/gud-1.0.0.tgz",
-      "integrity": "sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw==",
-      "dev": true
-    },
     "has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -857,37 +406,10 @@
         "has-symbols": "^1.0.2"
       }
     },
-    "he": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
-      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
-      "dev": true
-    },
-    "hoist-non-react-statics": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
-      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
-      "dev": true,
-      "requires": {
-        "react-is": "^16.7.0"
-      }
-    },
     "hosted-git-info": {
       "version": "2.8.9",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
       "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
-      "dev": true
-    },
-    "hot-patcher": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/hot-patcher/-/hot-patcher-0.5.0.tgz",
-      "integrity": "sha512-2Uu2W0s8+dnqXzdlg0MRsRzPoDCs1wVjOGSyMRRaMzLDX4bgHw6xDYKccsWafXPPxQpkQfEjgW6+17pwcg60bw==",
-      "dev": true
-    },
-    "immediate": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
-      "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps=",
       "dev": true
     },
     "inflight": {
@@ -958,12 +480,6 @@
         "has-tostringtag": "^1.0.0"
       }
     },
-    "is-buffer": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "dev": true
-    },
     "is-callable": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
@@ -1028,12 +544,6 @@
         "has-tostringtag": "^1.0.0"
       }
     },
-    "is-promise": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
-      "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==",
-      "dev": true
-    },
     "is-regex": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
@@ -1097,50 +607,11 @@
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
-    "jquery": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.0.tgz",
-      "integrity": "sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw==",
-      "dev": true
-    },
-    "js-tokens": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
-    },
     "json-parse-better-errors": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
       "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
       "dev": true
-    },
-    "jszip": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.2.2.tgz",
-      "integrity": "sha512-NmKajvAFQpbg3taXQXr/ccS2wcucR1AZ+NtyWp2Nq7HHVsXhcJFR8p0Baf32C2yVvBylFWVeKf+WI2AnvlPhpA==",
-      "dev": true,
-      "requires": {
-        "lie": "~3.3.0",
-        "pako": "~1.0.2",
-        "readable-stream": "~2.3.6",
-        "set-immediate-shim": "~1.0.1"
-      }
-    },
-    "layerr": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/layerr/-/layerr-0.1.2.tgz",
-      "integrity": "sha512-ob5kTd9H3S4GOG2nVXyQhOu9O8nBgP555XxWPkJI0tR0JeRilfyTp8WtPdIJHLXBmHMSdEq5+KMxiYABeScsIQ==",
-      "dev": true
-    },
-    "lie": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
-      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
-      "dev": true,
-      "requires": {
-        "immediate": "~3.0.5"
-      }
     },
     "load-json-file": {
       "version": "4.0.0",
@@ -1162,48 +633,6 @@
         }
       }
     },
-    "lodash.clamp": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/lodash.clamp/-/lodash.clamp-4.0.3.tgz",
-      "integrity": "sha1-XCS+3u7vB1NWDcK0y0Zx+Qpt36o=",
-      "dev": true
-    },
-    "lodash.debounce": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
-      "dev": true
-    },
-    "lodash.flatten": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
-      "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=",
-      "dev": true
-    },
-    "lodash.throttle": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
-      "integrity": "sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ=",
-      "dev": true
-    },
-    "loose-envify": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
-      "requires": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
-      }
-    },
-    "lru-queue": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz",
-      "integrity": "sha1-Jzi9nw089PhEkMVzbEhpmsYyzaM=",
-      "dev": true,
-      "requires": {
-        "es5-ext": "~0.10.2"
-      }
-    },
     "make-dir": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
@@ -1212,39 +641,6 @@
       "requires": {
         "pify": "^4.0.1",
         "semver": "^5.6.0"
-      }
-    },
-    "md5": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
-      "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
-      "dev": true,
-      "requires": {
-        "charenc": "0.0.2",
-        "crypt": "0.0.2",
-        "is-buffer": "~1.1.6"
-      }
-    },
-    "memoize-one": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
-      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
-      "dev": true
-    },
-    "memoizee": {
-      "version": "0.4.15",
-      "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.4.15.tgz",
-      "integrity": "sha512-UBWmJpLZd5STPm7PMUlOw/TSy972M+z8gcyQ5veOnSDRREz/0bmpyTfKt3/51DhEBqCZQn1udM/5flcSPYhkdQ==",
-      "dev": true,
-      "requires": {
-        "d": "^1.0.1",
-        "es5-ext": "^0.10.53",
-        "es6-weak-map": "^2.0.3",
-        "event-emitter": "^0.3.5",
-        "is-promise": "^2.2.2",
-        "lru-queue": "^0.1.0",
-        "next-tick": "^1.1.0",
-        "timers-ext": "^0.1.7"
       }
     },
     "memorystream": {
@@ -1261,30 +657,6 @@
       "requires": {
         "brace-expansion": "^1.1.7"
       }
-    },
-    "monaco-editor": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.27.0.tgz",
-      "integrity": "sha512-UhwP78Wb8w0ZSYoKXQNTV/0CHObp6NS3nCt51QfKE6sKyBo5PBsvuDOHoI2ooBakc6uIwByRLHVeT7+yXQe2fQ==",
-      "dev": true
-    },
-    "nanoid": {
-      "version": "2.1.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.1.11.tgz",
-      "integrity": "sha512-s/snB+WGm6uwi0WjsZdaVcuf3KJXlfGl2LcxgwkEwJF0D/BWzVWAZW/XY4bFaiR7s0Jk3FPvlnepg1H1b1UwlA==",
-      "dev": true
-    },
-    "nested-property": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/nested-property/-/nested-property-4.0.0.tgz",
-      "integrity": "sha512-yFehXNWRs4cM0+dz7QxCd06hTbWbSkV0ISsqBfkntU6TOY4Qm3Q88fRRLOddkGh2Qq6dZvnKVAahfhjcUvLnyA==",
-      "dev": true
-    },
-    "next-tick": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
-      "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==",
-      "dev": true
     },
     "nice-try": {
       "version": "1.0.5",
@@ -1373,12 +745,6 @@
         }
       }
     },
-    "object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-      "dev": true
-    },
     "object-inspect": {
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.0.tgz",
@@ -1418,18 +784,6 @@
         "wrappy": "1"
       }
     },
-    "pako": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
-      "dev": true
-    },
-    "papaparse": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.3.1.tgz",
-      "integrity": "sha512-Dbt2yjLJrCwH2sRqKFFJaN5XgIASO9YOFeFP8rIBRG2Ain8mqk5r1M6DkfvqEVozVcz3r3HaUGw253hA1nLIcA==",
-      "dev": true
-    },
     "parse-json": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
@@ -1456,12 +810,6 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "dev": true
-    },
-    "path-posix": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/path-posix/-/path-posix-1.0.0.tgz",
-      "integrity": "sha1-BrJhE/Vr6rBCVFojv6iAA8ysJg8=",
       "dev": true
     },
     "path-type": {
@@ -1500,176 +848,6 @@
       "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
       "dev": true
     },
-    "popper.js": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
-      "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==",
-      "dev": true
-    },
-    "process-nextick-args": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "dev": true
-    },
-    "prop-types": {
-      "version": "15.8.1",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
-      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
-      "requires": {
-        "loose-envify": "^1.4.0",
-        "object-assign": "^4.1.1",
-        "react-is": "^16.13.1"
-      }
-    },
-    "querystringify": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
-      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
-      "dev": true
-    },
-    "raf-schd": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/raf-schd/-/raf-schd-4.0.3.tgz",
-      "integrity": "sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ==",
-      "dev": true
-    },
-    "react-beautiful-dnd": {
-      "version": "13.1.0",
-      "resolved": "https://registry.npmjs.org/react-beautiful-dnd/-/react-beautiful-dnd-13.1.0.tgz",
-      "integrity": "sha512-aGvblPZTJowOWUNiwd6tNfEpgkX5OxmpqxHKNW/4VmvZTNTbeiq7bA3bn5T+QSF2uibXB0D1DmJsb1aC/+3cUA==",
-      "dev": true,
-      "requires": {
-        "@babel/runtime": "^7.9.2",
-        "css-box-model": "^1.2.0",
-        "memoize-one": "^5.1.1",
-        "raf-schd": "^4.0.2",
-        "react-redux": "^7.2.0",
-        "redux": "^4.0.4",
-        "use-memo-one": "^1.1.1"
-      }
-    },
-    "react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true
-    },
-    "react-lifecycles-compat": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
-      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
-      "dev": true
-    },
-    "react-popper": {
-      "version": "1.3.11",
-      "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-1.3.11.tgz",
-      "integrity": "sha512-VSA/bS+pSndSF2fiasHK/PTEEAyOpX60+H5EPAjoArr8JGm+oihu4UbrqcEBpQibJxBVCpYyjAX7abJ+7DoYVg==",
-      "dev": true,
-      "requires": {
-        "@babel/runtime": "^7.1.2",
-        "@hypnosphi/create-react-context": "^0.3.1",
-        "deep-equal": "^1.1.1",
-        "popper.js": "^1.14.4",
-        "prop-types": "^15.6.1",
-        "typed-styles": "^0.0.7",
-        "warning": "^4.0.2"
-      },
-      "dependencies": {
-        "deep-equal": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
-          "integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
-          "dev": true,
-          "requires": {
-            "is-arguments": "^1.0.4",
-            "is-date-object": "^1.0.1",
-            "is-regex": "^1.0.4",
-            "object-is": "^1.0.1",
-            "object-keys": "^1.1.1",
-            "regexp.prototype.flags": "^1.2.0"
-          }
-        }
-      }
-    },
-    "react-redux": {
-      "version": "7.2.6",
-      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.6.tgz",
-      "integrity": "sha512-10RPdsz0UUrRL1NZE0ejTkucnclYSgXp5q+tB5SWx2qeG2ZJQJyymgAhwKy73yiL/13btfB6fPr+rgbMAaZIAQ==",
-      "dev": true,
-      "requires": {
-        "@babel/runtime": "^7.15.4",
-        "@types/react-redux": "^7.1.20",
-        "hoist-non-react-statics": "^3.3.2",
-        "loose-envify": "^1.4.0",
-        "prop-types": "^15.7.2",
-        "react-is": "^17.0.2"
-      },
-      "dependencies": {
-        "react-is": {
-          "version": "17.0.2",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-          "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-          "dev": true
-        }
-      }
-    },
-    "react-transition-group": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.9.0.tgz",
-      "integrity": "sha512-+HzNTCHpeQyl4MJ/bdE0u6XRMe9+XG/+aL4mCxVN4DnPBQ0/5bfHWPDuOZUzYdMj94daZaZdCCc1Dzt9R/xSSg==",
-      "dev": true,
-      "requires": {
-        "dom-helpers": "^3.4.0",
-        "loose-envify": "^1.4.0",
-        "prop-types": "^15.6.2",
-        "react-lifecycles-compat": "^3.0.4"
-      }
-    },
-    "react-virtualized-auto-sizer": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.6.tgz",
-      "integrity": "sha512-7tQ0BmZqfVF6YYEWcIGuoR3OdYe8I/ZFbNclFlGOC3pMqunkYF/oL30NCjSGl9sMEb17AnzixDz98Kqc3N76HQ==",
-      "dev": true
-    },
-    "react-window": {
-      "version": "1.8.6",
-      "resolved": "https://registry.npmjs.org/react-window/-/react-window-1.8.6.tgz",
-      "integrity": "sha512-8VwEEYyjz6DCnGBsd+MgkD0KJ2/OXFULyDtorIiTz+QzwoP94tBoA7CnbtyXMm+cCeAUER5KJcPtWl9cpKbOBg==",
-      "dev": true,
-      "requires": {
-        "@babel/runtime": "^7.0.0",
-        "memoize-one": ">=3.1.1 <6"
-      }
-    },
-    "reactstrap": {
-      "version": "8.10.1",
-      "resolved": "https://registry.npmjs.org/reactstrap/-/reactstrap-8.10.1.tgz",
-      "integrity": "sha512-StjLADa/12yMNjafrSs+UD7sZAGtKpLO9fZp++2Dj0IzJinqY7eQhXlM3nFf0q40YsIcLvQdFc9pKF8PF4f0Qg==",
-      "dev": true,
-      "requires": {
-        "@babel/runtime": "^7.12.5",
-        "classnames": "^2.2.3",
-        "prop-types": "^15.5.8",
-        "react-popper": "^1.3.6",
-        "react-transition-group": "^3.0.0"
-      },
-      "dependencies": {
-        "react-transition-group": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-3.0.0.tgz",
-          "integrity": "sha512-A9ojB/LWECbFj58SNfjK1X9aaAU+1olLS0DFSikvrr2KfMaiBELemHDa5dKNvcTk2t3gUtDL/PJpFrBKDfMpLg==",
-          "dev": true,
-          "requires": {
-            "dom-helpers": "^3.4.0",
-            "loose-envify": "^1.4.0",
-            "prop-types": "^15.6.2",
-            "react-lifecycles-compat": "^3.0.4"
-          }
-        }
-      }
-    },
     "read-pkg": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
@@ -1679,29 +857,6 @@
         "load-json-file": "^4.0.0",
         "normalize-package-data": "^2.3.2",
         "path-type": "^3.0.0"
-      }
-    },
-    "readable-stream": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-      "dev": true,
-      "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
-        }
       }
     },
     "readdirp": {
@@ -1737,12 +892,6 @@
         "define-properties": "^1.1.3"
       }
     },
-    "requires-port": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
-      "dev": true
-    },
     "resolve": {
       "version": "1.20.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
@@ -1774,12 +923,6 @@
       "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
       "dev": true
     },
-    "set-immediate-shim": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
-      "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
-      "dev": true
-    },
     "shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -1800,15 +943,6 @@
       "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.2.tgz",
       "integrity": "sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==",
       "dev": true
-    },
-    "shortid": {
-      "version": "2.2.16",
-      "resolved": "https://registry.npmjs.org/shortid/-/shortid-2.2.16.tgz",
-      "integrity": "sha512-Ugt+GIZqvGXCIItnsL+lvFJOiN7RYqlGy7QE41O3YC1xbNSeDGIRO7xg2JJXIAj1cAGnOeC1r7/T9pgrtQbv4g==",
-      "dev": true,
-      "requires": {
-        "nanoid": "^2.1.0"
-      }
     },
     "side-channel": {
       "version": "1.0.4",
@@ -1893,25 +1027,10 @@
         "define-properties": "^1.1.3"
       }
     },
-    "string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
     "strip-bom": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
       "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-      "dev": true
-    },
-    "strnum": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
-      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
       "dev": true
     },
     "supports-color": {
@@ -1923,22 +1042,6 @@
         "has-flag": "^3.0.0"
       }
     },
-    "timers-ext": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.7.tgz",
-      "integrity": "sha512-b85NUNzTSdodShTIbky6ZF02e8STtVVfD+fu4aXXShEELpozH+bCpJLYMPZbsABN2wDH7fJpqIoXxJpzbf0NqQ==",
-      "dev": true,
-      "requires": {
-        "es5-ext": "~0.10.46",
-        "next-tick": "1"
-      }
-    },
-    "tiny-invariant": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.2.0.tgz",
-      "integrity": "sha512-1Uhn/aqw5C6RI4KejVeTg6mIS7IqxnLJ8Mv2tV5rTc0qWobay7pDUz6Wi392Cnc8ak1H0F2cjoRzb2/AW4+Fvg==",
-      "dev": true
-    },
     "to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -1948,18 +1051,6 @@
       "requires": {
         "is-number": "^7.0.0"
       }
-    },
-    "type": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
-      "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==",
-      "dev": true
-    },
-    "typed-styles": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/typed-styles/-/typed-styles-0.0.7.tgz",
-      "integrity": "sha512-pzP0PWoZUhsECYjABgCGQlRGL1n7tOHsgwYv3oIiEpJwGhFTuty/YNeduxQYzXXa3Ge5BdT6sHYIQYpl4uJ+5Q==",
-      "dev": true
     },
     "unbox-primitive": {
       "version": "1.0.1",
@@ -1972,34 +1063,6 @@
         "which-boxed-primitive": "^1.0.2"
       }
     },
-    "url-join": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
-      "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
-      "dev": true
-    },
-    "url-parse": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.4.tgz",
-      "integrity": "sha512-ITeAByWWoqutFClc/lRZnFplgXgEZr3WJ6XngMM/N9DMIm4K8zXPCZ1Jdu0rERwO84w1WC5wkle2ubwTA4NTBg==",
-      "dev": true,
-      "requires": {
-        "querystringify": "^2.1.1",
-        "requires-port": "^1.0.0"
-      }
-    },
-    "use-memo-one": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/use-memo-one/-/use-memo-one-1.1.2.tgz",
-      "integrity": "sha512-u2qFKtxLsia/r8qG0ZKkbytbztzRb317XCkT7yP8wxL0tZ/CzK2G+WWie5vWvpyeP7+YoPIwbJoIHJ4Ba4k0oQ==",
-      "dev": true
-    },
-    "util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
-    },
     "validate-npm-package-license": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
@@ -2008,41 +1071,6 @@
       "requires": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
-      }
-    },
-    "warning": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
-      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
-      "dev": true,
-      "requires": {
-        "loose-envify": "^1.0.0"
-      }
-    },
-    "web-streams-polyfill": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-2.1.1.tgz",
-      "integrity": "sha512-dlNpL2aab3g8CKfGz6rl8FNmGaRWLLn2g/DtSc9IjB30mEdE6XxzPfPSig5BwGSzI+oLxHyETrQGKjrVVhbLCg==",
-      "dev": true
-    },
-    "webdav": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/webdav/-/webdav-4.8.0.tgz",
-      "integrity": "sha512-CVJvxu0attEfoQUKraDiNh3uMjNPNl+BY0pbcKbyc/X+8IXDnqAT4tT4Ge12w+j49fYuVpFVkpEGwBZabv7Uhw==",
-      "dev": true,
-      "requires": {
-        "axios": "^0.24.0",
-        "base-64": "^1.0.0",
-        "fast-xml-parser": "^3.19.0",
-        "he": "^1.2.0",
-        "hot-patcher": "^0.5.0",
-        "layerr": "^0.1.2",
-        "md5": "^2.3.0",
-        "minimatch": "^3.0.4",
-        "nested-property": "^4.0.0",
-        "path-posix": "^1.0.0",
-        "url-join": "^4.0.1",
-        "url-parse": "^1.5.3"
       }
     },
     "which": {

--- a/packages/redux/src/actionTypes.ts
+++ b/packages/redux/src/actionTypes.ts
@@ -8,6 +8,8 @@ export const SET_DASHBOARD_STORAGE = 'SET_DASHBOARD_STORAGE';
 
 export const SET_FILE_STORAGE = 'SET_FILE_STORAGE';
 
+export const SET_PLUGINS = 'SET_PLUGINS';
+
 export const SET_USER = 'SET_USER';
 
 export const SET_WORKSPACE = 'SET_WORKSPACE';

--- a/packages/redux/src/actions.ts
+++ b/packages/redux/src/actions.ts
@@ -3,6 +3,7 @@ import type { ThunkAction } from 'redux-thunk';
 import type { CommandHistoryStorage } from '@deephaven/console';
 import type { FileStorage } from '@deephaven/file-explorer';
 import {
+  SET_PLUGINS,
   SET_USER,
   SET_WORKSPACE,
   SET_COMMAND_HISTORY_STORAGE,
@@ -11,6 +12,7 @@ import {
   SET_FILE_STORAGE,
 } from './actionTypes';
 import type {
+  DeephavenPluginModuleMap,
   RootState,
   User,
   Workspace,
@@ -109,4 +111,9 @@ export const saveSettings = (
 export const setActiveTool: PayloadActionCreator<string> = payload => ({
   type: SET_ACTIVE_TOOL,
   payload,
+});
+
+export const setPlugins: PayloadActionCreator<DeephavenPluginModuleMap> = plugins => ({
+  type: SET_PLUGINS,
+  payload: plugins,
 });

--- a/packages/redux/src/reducers/index.ts
+++ b/packages/redux/src/reducers/index.ts
@@ -1,10 +1,12 @@
 import activeTool from './activeTool';
+import plugins from './plugins';
 import storage from './storage';
 import user from './user';
 import workspace from './workspace';
 
 const reducers = {
   activeTool,
+  plugins,
   storage,
   user,
   workspace,

--- a/packages/redux/src/reducers/plugins.ts
+++ b/packages/redux/src/reducers/plugins.ts
@@ -1,0 +1,7 @@
+/**
+ * The plugins that have been loaded
+ */
+import { SET_PLUGINS } from '../actionTypes';
+import { replaceReducer } from './common';
+
+export default replaceReducer(SET_PLUGINS, null);

--- a/packages/redux/src/selectors.ts
+++ b/packages/redux/src/selectors.ts
@@ -8,7 +8,7 @@ import type {
 
 const EMPTY_OBJECT = Object.freeze({});
 
-const EMPTY_MAP = new Map();
+const EMPTY_MAP: ReadonlyMap<unknown, unknown> = new Map();
 
 type Selector<R> = (state: RootState) => R;
 

--- a/packages/redux/src/selectors.ts
+++ b/packages/redux/src/selectors.ts
@@ -8,8 +8,6 @@ import type {
 
 const EMPTY_OBJECT = Object.freeze({});
 
-const EMPTY_ARRAY = Object.freeze([]);
-
 const EMPTY_MAP = new Map();
 
 type Selector<R> = (state: RootState) => R;

--- a/packages/redux/src/selectors.ts
+++ b/packages/redux/src/selectors.ts
@@ -8,6 +8,10 @@ import type {
 
 const EMPTY_OBJECT = Object.freeze({});
 
+const EMPTY_ARRAY = Object.freeze([]);
+
+const EMPTY_MAP = new Map();
+
 type Selector<R> = (state: RootState) => R;
 
 // User
@@ -79,3 +83,6 @@ export const getShortcutOverrides: Selector<
 
 export const getActiveTool: Selector<RootState['activeTool']> = store =>
   store.activeTool;
+
+export const getPlugins: Selector<RootState['plugins']> = store =>
+  store.plugins ?? EMPTY_MAP;

--- a/packages/redux/src/store.ts
+++ b/packages/redux/src/store.ts
@@ -7,6 +7,12 @@ import rootMiddleware from './middleware';
 import reducers from './reducers';
 import reducerRegistry from './reducerRegistry';
 
+// A DeephavenPluginModule. This interface should have new fields added to it from different levels of plugins.
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface DeephavenPluginModule {}
+
+export type DeephavenPluginModuleMap = Map<string, DeephavenPluginModule>;
+
 export interface User {
   name: string;
   operateAs: string;
@@ -56,10 +62,11 @@ export interface WorkspaceStorage {
 }
 
 export type RootState = {
-  user: User;
-  storage: Storage;
-  workspace: Workspace;
   activeTool: string;
+  plugins: DeephavenPluginModuleMap;
+  storage: Storage;
+  user: User;
+  workspace: Workspace;
 };
 
 Object.entries(reducers).map(([name, reducer]) =>

--- a/packages/storage/package-lock.json
+++ b/packages/storage/package-lock.json
@@ -22,17 +22,17 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.7.tgz",
-      "integrity": "sha512-9E9FJowqAsytyOY6LG+1KuueckRL+aQW+mKvXRXnuFGyRAyepJPmEo9vgMfXUA6O9u3IeEdv9MAkppFcaQwogQ==",
+      "version": "7.17.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.2.tgz",
+      "integrity": "sha512-hzeyJyMA1YGdJTuWU0e/j4wKXrU4OMFvY2MSlaI9B7VQb0r5cxTE3EAIS2Q7Tn2RIcDkRvTA/v2JsAEhxe99uw==",
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
     },
     "@deephaven/grid": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@deephaven/grid/-/grid-0.9.1.tgz",
-      "integrity": "sha512-INVZKFo/2bK+FpT5vqN7wfdrW66Xl5fxDOkr8I8PO9LL23RMfdiPvilzO8Ji7fKP3fOZtvCznO7yLMEzVBhFLA==",
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/@deephaven/grid/-/grid-0.9.3.tgz",
+      "integrity": "sha512-wRtYMnMLGFkZeSM39I1wvlxfUuz2Blmxj8w5oH2d9w3otMRKhnIitrTx5qUepLVJb/3gJaf20lNCfLP7MOJKIQ==",
       "requires": {
         "classnames": "^2.3.1",
         "color-convert": "^2.0.1",
@@ -59,20 +59,20 @@
       }
     },
     "@deephaven/icons": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@deephaven/icons/-/icons-0.9.1.tgz",
-      "integrity": "sha512-nLLZez6hNl4Ep6b7IjjIxLTGRa9WxeagNC2BP2IWVXs/ONvHHv0t5SYeCCJ/IaH8Bz2UWnxf09VivVPdIGZYig==",
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/@deephaven/icons/-/icons-0.9.3.tgz",
+      "integrity": "sha512-/GRDznQiJ2rcSppfmHoGfVmT6NEhgh3XopgEH/2qTtUKqnJQmSVASvEbyM3ACLqNK5ZrTnBxnAdPeZNN2Mo0hQ==",
       "requires": {
-        "@fortawesome/fontawesome-common-types": "^0.2.35"
+        "@fortawesome/fontawesome-common-types": "0.2.36"
       }
     },
     "@deephaven/iris-grid": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@deephaven/iris-grid/-/iris-grid-0.9.1.tgz",
-      "integrity": "sha512-KHZwBKu/oVZY3GyrEAuMqrV0BKX4SYCBtFc5p11xSMwfduwGm01ppcrv5T4j90P9vNTt2KffLgIya6JS3JMzlQ==",
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/@deephaven/iris-grid/-/iris-grid-0.9.3.tgz",
+      "integrity": "sha512-23FcBKpg4VA7KT2tdYUuDMQyov4cwhLLGlBoWjWrTQoMaZ+VaJHQlxi+zywfveXGkE/uPvM/JMygcc4OTReCQA==",
       "requires": {
-        "@deephaven/grid": "^0.9.1",
-        "@deephaven/icons": "^0.9.1",
+        "@deephaven/grid": "^0.9.3",
+        "@deephaven/icons": "^0.9.3",
         "@deephaven/jsapi-shim": "^0.9.1",
         "@deephaven/react-hooks": "^0.9.1",
         "@deephaven/utils": "^0.9.1",
@@ -175,9 +175,9 @@
       "integrity": "sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ=="
     },
     "@types/react": {
-      "version": "17.0.38",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.38.tgz",
-      "integrity": "sha512-SI92X1IA+FMnP3qM5m4QReluXzhcmovhZnLNm3pyeQlooi02qI7sLiepEYqT678uNiyc25XfCqxREFpy3W7YhQ==",
+      "version": "17.0.39",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.39.tgz",
+      "integrity": "sha512-UVavlfAxDd/AgAacMa60Azl7ygyQNRwC/DsHZmKgNvPmRR5p70AJ5Q9EAmL2NWOJmeV+vVUI4IAP7GZrN8h8Ug==",
       "requires": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -544,9 +544,9 @@
       },
       "dependencies": {
         "type": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/type/-/type-2.5.0.tgz",
-          "integrity": "sha512-180WMDQaIMm3+7hGXWf12GtdniDEy7nYcyFMKJn/eZz/6tSLXrUN9V0wKSbMjej0I1WHWbpREDEKHtqPQa9NNw=="
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/type/-/type-2.6.0.tgz",
+          "integrity": "sha512-eiDBDOmkih5pMbo9OqsqPRGMljLodLcwd5XD5JbtNB0o89xZAwynY9EdCDsJU7LtcVCClu9DvM7/0Ep1hYX3EQ=="
         }
       }
     },

--- a/packages/storage/package-lock.json
+++ b/packages/storage/package-lock.json
@@ -21,138 +21,12 @@
         "source-map": "^0.5.0"
       }
     },
-    "@babel/runtime": {
-      "version": "7.17.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.2.tgz",
-      "integrity": "sha512-hzeyJyMA1YGdJTuWU0e/j4wKXrU4OMFvY2MSlaI9B7VQb0r5cxTE3EAIS2Q7Tn2RIcDkRvTA/v2JsAEhxe99uw==",
-      "requires": {
-        "regenerator-runtime": "^0.13.4"
-      }
-    },
-    "@deephaven/grid": {
-      "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/@deephaven/grid/-/grid-0.9.3.tgz",
-      "integrity": "sha512-wRtYMnMLGFkZeSM39I1wvlxfUuz2Blmxj8w5oH2d9w3otMRKhnIitrTx5qUepLVJb/3gJaf20lNCfLP7MOJKIQ==",
-      "requires": {
-        "classnames": "^2.3.1",
-        "color-convert": "^2.0.1",
-        "event-target-shim": "^6.0.2",
-        "lodash.clamp": "^4.0.3",
-        "memoize-one": "^5.1.1",
-        "memoizee": "^0.4.15",
-        "prop-types": "^15.7.2"
-      },
-      "dependencies": {
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-        }
-      }
-    },
-    "@deephaven/icons": {
-      "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/@deephaven/icons/-/icons-0.9.3.tgz",
-      "integrity": "sha512-/GRDznQiJ2rcSppfmHoGfVmT6NEhgh3XopgEH/2qTtUKqnJQmSVASvEbyM3ACLqNK5ZrTnBxnAdPeZNN2Mo0hQ==",
-      "requires": {
-        "@fortawesome/fontawesome-common-types": "0.2.36"
-      }
-    },
-    "@deephaven/iris-grid": {
-      "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/@deephaven/iris-grid/-/iris-grid-0.9.3.tgz",
-      "integrity": "sha512-23FcBKpg4VA7KT2tdYUuDMQyov4cwhLLGlBoWjWrTQoMaZ+VaJHQlxi+zywfveXGkE/uPvM/JMygcc4OTReCQA==",
-      "requires": {
-        "@deephaven/grid": "^0.9.3",
-        "@deephaven/icons": "^0.9.3",
-        "@deephaven/jsapi-shim": "^0.9.1",
-        "@deephaven/react-hooks": "^0.9.1",
-        "@deephaven/utils": "^0.9.1",
-        "@fortawesome/react-fontawesome": "^0.1.12",
-        "classnames": "^2.3.1",
-        "deep-equal": "^2.0.4",
-        "lodash.clamp": "^4.0.3",
-        "lodash.debounce": "^4.0.8",
-        "lodash.throttle": "^4.1.1",
-        "memoize-one": "^5.1.1",
-        "memoizee": "^0.4.15",
-        "monaco-editor": "^0.27.0",
-        "prop-types": "^15.7.2",
-        "react-beautiful-dnd": "^13.0.0",
-        "react-transition-group": "^2.3.1",
-        "shortid": "^2.2.15",
-        "web-streams-polyfill": "^2.1.0"
-      }
-    },
-    "@deephaven/jsapi-shim": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@deephaven/jsapi-shim/-/jsapi-shim-0.9.1.tgz",
-      "integrity": "sha512-soBU7sU9qZgzDXJyYrU96GiB7UBCdHScUaQjl4ISx2igIdK+Qfe7JOYVxYjJdV8KEVK/l+smSkahAIT5/NJY4Q==",
-      "requires": {
-        "prop-types": "^15.7.2"
-      }
-    },
-    "@deephaven/log": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@deephaven/log/-/log-0.9.1.tgz",
-      "integrity": "sha512-L/yKtSYOrNZlvyElqpgdrnL3JBaY07szFjhA37XK31+uH/jcPcbMxsn2Uf+++yyFcn6GKO1XXXP44V3xBkBQJg==",
-      "dev": true,
-      "requires": {
-        "event-target-shim": "^6.0.2"
-      }
-    },
-    "@deephaven/react-hooks": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@deephaven/react-hooks/-/react-hooks-0.9.1.tgz",
-      "integrity": "sha512-v7r2DZoPahHNBspbulCtvUgCqJ+i9WPEA8cK9nEsTVTeuR3mhwLw4E/0g+WlXJ78FsUdA0K9FECJfUg1YTvyLg=="
-    },
-    "@deephaven/tsconfig": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@deephaven/tsconfig/-/tsconfig-0.9.0.tgz",
-      "integrity": "sha512-zYKPllv+W+UhAuzC2pbsaQynxzsE0bBK/XjfiK0LWiGMkMhp43rwEaCiMODSYaxGmaV5eA+ijm8r1Y8v21pH4w==",
-      "dev": true
-    },
-    "@deephaven/utils": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@deephaven/utils/-/utils-0.9.1.tgz",
-      "integrity": "sha512-kll4L5bNOOPdtpeSDpIvC8+NnlaToKrsPoJ3kvsZvJVmILdIKAIXcviGPxZO5SCjyzgV/NmfLUmHq0CcMAYnEg=="
-    },
-    "@fortawesome/fontawesome-common-types": {
-      "version": "0.2.36",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.36.tgz",
-      "integrity": "sha512-a/7BiSgobHAgBWeN7N0w+lAhInrGxksn13uK7231n2m8EDPE3BMCl9NZLTGrj9ZXfCmC6LM0QLqXidIizVQ6yg=="
-    },
-    "@fortawesome/react-fontawesome": {
-      "version": "0.1.17",
-      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.1.17.tgz",
-      "integrity": "sha512-dX43Z5IvMaW7fwzU8farosYjKNGfRb2HB/DgjVBHeJZ/NSnuuaujPPx0YOdcAq+n3mqn70tyCde2HM1mqbhiuw==",
-      "requires": {
-        "prop-types": "^15.8.1"
-      }
-    },
     "@nicolo-ribaudo/chokidar-2": {
       "version": "2.1.8-no-fsevents.3",
       "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/chokidar-2/-/chokidar-2-2.1.8-no-fsevents.3.tgz",
       "integrity": "sha512-s88O1aVtXftvp5bCPB7WnmXc5IwOZZ7YPuwNPt+GtOOXpPvad1LfbmjYv+qII7zP6RU2QGnqve27dnLycEnyEQ==",
       "dev": true,
       "optional": true
-    },
-    "@types/hoist-non-react-statics": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
-      "integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
-      "requires": {
-        "@types/react": "*",
-        "hoist-non-react-statics": "^3.3.0"
-      }
     },
     "@types/lodash": {
       "version": "4.14.172",
@@ -168,37 +42,6 @@
       "requires": {
         "@types/lodash": "*"
       }
-    },
-    "@types/prop-types": {
-      "version": "15.7.4",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.4.tgz",
-      "integrity": "sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ=="
-    },
-    "@types/react": {
-      "version": "17.0.39",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.39.tgz",
-      "integrity": "sha512-UVavlfAxDd/AgAacMa60Azl7ygyQNRwC/DsHZmKgNvPmRR5p70AJ5Q9EAmL2NWOJmeV+vVUI4IAP7GZrN8h8Ug==",
-      "requires": {
-        "@types/prop-types": "*",
-        "@types/scheduler": "*",
-        "csstype": "^3.0.2"
-      }
-    },
-    "@types/react-redux": {
-      "version": "7.1.22",
-      "resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-7.1.22.tgz",
-      "integrity": "sha512-GxIA1kM7ClU73I6wg9IRTVwSO9GS+SAKZKe0Enj+82HMU6aoESFU2HNAdNi3+J53IaOHPiUfT3kSG4L828joDQ==",
-      "requires": {
-        "@types/hoist-non-react-statics": "^3.3.0",
-        "@types/react": "*",
-        "hoist-non-react-statics": "^3.3.0",
-        "redux": "^4.0.0"
-      }
-    },
-    "@types/scheduler": {
-      "version": "0.16.2",
-      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
-      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew=="
     },
     "ansi-styles": {
       "version": "3.2.1",
@@ -219,11 +62,6 @@
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
       }
-    },
-    "available-typed-arrays": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
-      "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw=="
     },
     "balanced-match": {
       "version": "1.0.2",
@@ -262,6 +100,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
       "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "dev": true,
       "requires": {
         "function-bind": "^1.1.1",
         "get-intrinsic": "^1.0.2"
@@ -293,11 +132,6 @@
         "normalize-path": "~3.0.0",
         "readdirp": "~3.6.0"
       }
-    },
-    "classnames": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
-      "integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA=="
     },
     "color-convert": {
       "version": "1.9.3",
@@ -355,64 +189,13 @@
         "which": "^2.0.1"
       }
     },
-    "css-box-model": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/css-box-model/-/css-box-model-1.2.1.tgz",
-      "integrity": "sha512-a7Vr4Q/kd/aw96bnJG332W9V9LkJO69JRcaCYDUqjp6/z0w6VcZjgAcTbgFxEPfBgdnAwlh3iwu+hLopa+flJw==",
-      "requires": {
-        "tiny-invariant": "^1.0.6"
-      }
-    },
-    "csstype": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.10.tgz",
-      "integrity": "sha512-2u44ZG2OcNUO9HDp/Jl8C07x6pU/eTR3ncV91SiK3dhG9TWvRVsCoJw14Ckx5DgWkzGA3waZWO3d7pgqpUI/XA=="
-    },
-    "d": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
-      "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
-      "requires": {
-        "es5-ext": "^0.10.50",
-        "type": "^1.0.1"
-      }
-    },
-    "deep-equal": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.0.5.tgz",
-      "integrity": "sha512-nPiRgmbAtm1a3JsnLCf6/SLfXcjyN5v8L1TXzdCmHrXJ4hx+gW/w1YCcn7z8gJtSiDArZCgYtbao3QqLm/N1Sw==",
-      "requires": {
-        "call-bind": "^1.0.0",
-        "es-get-iterator": "^1.1.1",
-        "get-intrinsic": "^1.0.1",
-        "is-arguments": "^1.0.4",
-        "is-date-object": "^1.0.2",
-        "is-regex": "^1.1.1",
-        "isarray": "^2.0.5",
-        "object-is": "^1.1.4",
-        "object-keys": "^1.1.1",
-        "object.assign": "^4.1.2",
-        "regexp.prototype.flags": "^1.3.0",
-        "side-channel": "^1.0.3",
-        "which-boxed-primitive": "^1.0.1",
-        "which-collection": "^1.0.1",
-        "which-typed-array": "^1.1.2"
-      }
-    },
     "define-properties": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
       "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "dev": true,
       "requires": {
         "object-keys": "^1.0.12"
-      }
-    },
-    "dom-helpers": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.4.0.tgz",
-      "integrity": "sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==",
-      "requires": {
-        "@babel/runtime": "^7.1.2"
       }
     },
     "error-ex": {
@@ -428,6 +211,7 @@
       "version": "1.18.6",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.6.tgz",
       "integrity": "sha512-kAeIT4cku5eNLNuUKhlmtuk1/TRZvQoYccn6TO0cSVdf1kzB0T7+dYuVK9MWM7l+/53W2Q8M7N2c6MQvhXFcUQ==",
+      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "es-to-primitive": "^1.2.1",
@@ -449,105 +233,15 @@
         "unbox-primitive": "^1.0.1"
       }
     },
-    "es-get-iterator": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.2.tgz",
-      "integrity": "sha512-+DTO8GYwbMCwbywjimwZMHp8AuYXOS2JZFWoi2AlPOS3ebnII9w/NLpNZtA7A0YLaVDw+O7KFCeoIV7OPvM7hQ==",
-      "requires": {
-        "call-bind": "^1.0.2",
-        "get-intrinsic": "^1.1.0",
-        "has-symbols": "^1.0.1",
-        "is-arguments": "^1.1.0",
-        "is-map": "^2.0.2",
-        "is-set": "^2.0.2",
-        "is-string": "^1.0.5",
-        "isarray": "^2.0.5"
-      }
-    },
     "es-to-primitive": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
       "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+      "dev": true,
       "requires": {
         "is-callable": "^1.1.4",
         "is-date-object": "^1.0.1",
         "is-symbol": "^1.0.2"
-      }
-    },
-    "es5-ext": {
-      "version": "0.10.53",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
-      "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
-      "requires": {
-        "es6-iterator": "~2.0.3",
-        "es6-symbol": "~3.1.3",
-        "next-tick": "~1.0.0"
-      },
-      "dependencies": {
-        "next-tick": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
-          "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
-        }
-      }
-    },
-    "es6-iterator": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
-      "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
-      "requires": {
-        "d": "1",
-        "es5-ext": "^0.10.35",
-        "es6-symbol": "^3.1.1"
-      }
-    },
-    "es6-symbol": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
-      "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
-      "requires": {
-        "d": "^1.0.1",
-        "ext": "^1.1.2"
-      }
-    },
-    "es6-weak-map": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.3.tgz",
-      "integrity": "sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==",
-      "requires": {
-        "d": "1",
-        "es5-ext": "^0.10.46",
-        "es6-iterator": "^2.0.3",
-        "es6-symbol": "^3.1.1"
-      }
-    },
-    "event-emitter": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
-      "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
-      "requires": {
-        "d": "1",
-        "es5-ext": "~0.10.14"
-      }
-    },
-    "event-target-shim": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-6.0.2.tgz",
-      "integrity": "sha512-8q3LsZjRezbFZ2PN+uP+Q7pnHUMmAOziU2vA2OwoFaKIXxlxl38IylhSSgUorWu/rf4er67w0ikBqjBFk/pomA=="
-    },
-    "ext": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/ext/-/ext-1.6.0.tgz",
-      "integrity": "sha512-sdBImtzkq2HpkdRLtlLWDa6w4DX22ijZLKx8BMPUuKe1c5lbN6xwQDQCxSfxBQnHZ13ls/FH0MQZx/q/gr6FQg==",
-      "requires": {
-        "type": "^2.5.0"
-      },
-      "dependencies": {
-        "type": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/type/-/type-2.6.0.tgz",
-          "integrity": "sha512-eiDBDOmkih5pMbo9OqsqPRGMljLodLcwd5XD5JbtNB0o89xZAwynY9EdCDsJU7LtcVCClu9DvM7/0Ep1hYX3EQ=="
-        }
       }
     },
     "fill-range": {
@@ -559,11 +253,6 @@
       "requires": {
         "to-regex-range": "^5.0.1"
       }
-    },
-    "foreach": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
-      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
     },
     "fs-readdir-recursive": {
       "version": "1.1.0",
@@ -587,12 +276,14 @@
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
     },
     "get-intrinsic": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
       "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+      "dev": true,
       "requires": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
@@ -603,6 +294,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
       "integrity": "sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==",
+      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "get-intrinsic": "^1.1.1"
@@ -642,6 +334,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
       "requires": {
         "function-bind": "^1.1.1"
       }
@@ -649,7 +342,8 @@
     "has-bigints": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.1.tgz",
-      "integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA=="
+      "integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==",
+      "dev": true
     },
     "has-flag": {
       "version": "3.0.0",
@@ -660,22 +354,16 @@
     "has-symbols": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
-      "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw=="
+      "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+      "dev": true
     },
     "has-tostringtag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
       "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
+      "dev": true,
       "requires": {
         "has-symbols": "^1.0.2"
-      }
-    },
-    "hoist-non-react-statics": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
-      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
-      "requires": {
-        "react-is": "^16.7.0"
       }
     },
     "hosted-git-info": {
@@ -704,19 +392,11 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
       "integrity": "sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==",
+      "dev": true,
       "requires": {
         "get-intrinsic": "^1.1.0",
         "has": "^1.0.3",
         "side-channel": "^1.0.4"
-      }
-    },
-    "is-arguments": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
-      "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
-      "requires": {
-        "call-bind": "^1.0.2",
-        "has-tostringtag": "^1.0.0"
       }
     },
     "is-arrayish": {
@@ -729,6 +409,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
       "integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
+      "dev": true,
       "requires": {
         "has-bigints": "^1.0.1"
       }
@@ -747,6 +428,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
       "integrity": "sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==",
+      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
@@ -755,7 +437,8 @@
     "is-callable": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
-      "integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w=="
+      "integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==",
+      "dev": true
     },
     "is-core-module": {
       "version": "2.6.0",
@@ -770,6 +453,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
       "integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
+      "dev": true,
       "requires": {
         "has-tostringtag": "^1.0.0"
       }
@@ -791,15 +475,11 @@
         "is-extglob": "^2.1.1"
       }
     },
-    "is-map": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.2.tgz",
-      "integrity": "sha512-cOZFQQozTha1f4MxLFzlgKYPTyj26picdZTx82hbc/Xf4K/tZOOXSCkMvU4pKioRXGDLJRn0GM7Upe7kR721yg=="
-    },
     "is-negative-zero": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
-      "integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w=="
+      "integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w==",
+      "dev": true
     },
     "is-number": {
       "version": "7.0.0",
@@ -812,33 +492,26 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.6.tgz",
       "integrity": "sha512-bEVOqiRcvo3zO1+G2lVMy+gkkEm9Yh7cDMRusKKu5ZJKPUYSJwICTKZrNKHA2EbSP0Tu0+6B/emsYNHZyn6K8g==",
+      "dev": true,
       "requires": {
         "has-tostringtag": "^1.0.0"
       }
-    },
-    "is-promise": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
-      "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ=="
     },
     "is-regex": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
       "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
+      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
       }
     },
-    "is-set": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.2.tgz",
-      "integrity": "sha512-+2cnTEZeY5z/iXGbLhPrOAaK/Mau5k5eXq9j14CpRTftq0pAJu2MwVRSZhyZWBzx3o6X795Lz6Bpb6R0GKf37g=="
-    },
     "is-string": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
       "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
+      "dev": true,
       "requires": {
         "has-tostringtag": "^1.0.0"
       }
@@ -847,40 +520,10 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
       "integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
+      "dev": true,
       "requires": {
         "has-symbols": "^1.0.2"
       }
-    },
-    "is-typed-array": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.8.tgz",
-      "integrity": "sha512-HqH41TNZq2fgtGT8WHVFVJhBVGuY3AnP3Q36K8JKXUxSxRgk/d+7NjmwG2vo2mYmXK8UYZKu0qH8bVP5gEisjA==",
-      "requires": {
-        "available-typed-arrays": "^1.0.5",
-        "call-bind": "^1.0.2",
-        "es-abstract": "^1.18.5",
-        "foreach": "^2.0.5",
-        "has-tostringtag": "^1.0.0"
-      }
-    },
-    "is-weakmap": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.1.tgz",
-      "integrity": "sha512-NSBR4kH5oVj1Uwvv970ruUkCV7O1mzgVFO4/rev2cLRda9Tm9HrL70ZPut4rOHgY0FNrUu9BCbXA2sdQ+x0chA=="
-    },
-    "is-weakset": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.2.tgz",
-      "integrity": "sha512-t2yVvttHkQktwnNNmBQ98AhENLdPUTDTE21uPqAQ0ARwQfGeQKRVS0NNurH7bTf7RrvcVn1OOge45CnBeHCSmg==",
-      "requires": {
-        "call-bind": "^1.0.2",
-        "get-intrinsic": "^1.1.1"
-      }
-    },
-    "isarray": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
     },
     "isexe": {
       "version": "2.0.0",
@@ -891,7 +534,8 @@
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
     },
     "json-parse-better-errors": {
       "version": "1.0.2",
@@ -919,16 +563,6 @@
         }
       }
     },
-    "lodash.clamp": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/lodash.clamp/-/lodash.clamp-4.0.3.tgz",
-      "integrity": "sha1-XCS+3u7vB1NWDcK0y0Zx+Qpt36o="
-    },
-    "lodash.debounce": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
-    },
     "lodash.throttle": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
@@ -938,16 +572,9 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
-      }
-    },
-    "lru-queue": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz",
-      "integrity": "sha1-Jzi9nw089PhEkMVzbEhpmsYyzaM=",
-      "requires": {
-        "es5-ext": "~0.10.2"
       }
     },
     "make-dir": {
@@ -958,26 +585,6 @@
       "requires": {
         "pify": "^4.0.1",
         "semver": "^5.6.0"
-      }
-    },
-    "memoize-one": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
-      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q=="
-    },
-    "memoizee": {
-      "version": "0.4.15",
-      "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.4.15.tgz",
-      "integrity": "sha512-UBWmJpLZd5STPm7PMUlOw/TSy972M+z8gcyQ5veOnSDRREz/0bmpyTfKt3/51DhEBqCZQn1udM/5flcSPYhkdQ==",
-      "requires": {
-        "d": "^1.0.1",
-        "es5-ext": "^0.10.53",
-        "es6-weak-map": "^2.0.3",
-        "event-emitter": "^0.3.5",
-        "is-promise": "^2.2.2",
-        "lru-queue": "^0.1.0",
-        "next-tick": "^1.1.0",
-        "timers-ext": "^0.1.7"
       }
     },
     "memorystream": {
@@ -994,21 +601,6 @@
       "requires": {
         "brace-expansion": "^1.1.7"
       }
-    },
-    "monaco-editor": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.27.0.tgz",
-      "integrity": "sha512-UhwP78Wb8w0ZSYoKXQNTV/0CHObp6NS3nCt51QfKE6sKyBo5PBsvuDOHoI2ooBakc6uIwByRLHVeT7+yXQe2fQ=="
-    },
-    "nanoid": {
-      "version": "2.1.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.1.11.tgz",
-      "integrity": "sha512-s/snB+WGm6uwi0WjsZdaVcuf3KJXlfGl2LcxgwkEwJF0D/BWzVWAZW/XY4bFaiR7s0Jk3FPvlnepg1H1b1UwlA=="
-    },
-    "next-tick": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
-      "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
     },
     "nice-try": {
       "version": "1.0.5",
@@ -1100,31 +692,26 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
     },
     "object-inspect": {
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.0.tgz",
-      "integrity": "sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg=="
-    },
-    "object-is": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
-      "integrity": "sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==",
-      "requires": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3"
-      }
+      "integrity": "sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg==",
+      "dev": true
     },
     "object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true
     },
     "object.assign": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
       "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+      "dev": true,
       "requires": {
         "call-bind": "^1.0.0",
         "define-properties": "^1.1.3",
@@ -1205,21 +792,6 @@
       "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
       "dev": true
     },
-    "prop-types": {
-      "version": "15.8.1",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
-      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "requires": {
-        "loose-envify": "^1.4.0",
-        "object-assign": "^4.1.1",
-        "react-is": "^16.13.1"
-      }
-    },
-    "raf-schd": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/raf-schd/-/raf-schd-4.0.3.tgz",
-      "integrity": "sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ=="
-    },
     "react": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
@@ -1228,61 +800,6 @@
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
-      }
-    },
-    "react-beautiful-dnd": {
-      "version": "13.1.0",
-      "resolved": "https://registry.npmjs.org/react-beautiful-dnd/-/react-beautiful-dnd-13.1.0.tgz",
-      "integrity": "sha512-aGvblPZTJowOWUNiwd6tNfEpgkX5OxmpqxHKNW/4VmvZTNTbeiq7bA3bn5T+QSF2uibXB0D1DmJsb1aC/+3cUA==",
-      "requires": {
-        "@babel/runtime": "^7.9.2",
-        "css-box-model": "^1.2.0",
-        "memoize-one": "^5.1.1",
-        "raf-schd": "^4.0.2",
-        "react-redux": "^7.2.0",
-        "redux": "^4.0.4",
-        "use-memo-one": "^1.1.1"
-      }
-    },
-    "react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
-    },
-    "react-lifecycles-compat": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
-      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
-    },
-    "react-redux": {
-      "version": "7.2.6",
-      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.6.tgz",
-      "integrity": "sha512-10RPdsz0UUrRL1NZE0ejTkucnclYSgXp5q+tB5SWx2qeG2ZJQJyymgAhwKy73yiL/13btfB6fPr+rgbMAaZIAQ==",
-      "requires": {
-        "@babel/runtime": "^7.15.4",
-        "@types/react-redux": "^7.1.20",
-        "hoist-non-react-statics": "^3.3.2",
-        "loose-envify": "^1.4.0",
-        "prop-types": "^15.7.2",
-        "react-is": "^17.0.2"
-      },
-      "dependencies": {
-        "react-is": {
-          "version": "17.0.2",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-          "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
-        }
-      }
-    },
-    "react-transition-group": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.9.0.tgz",
-      "integrity": "sha512-+HzNTCHpeQyl4MJ/bdE0u6XRMe9+XG/+aL4mCxVN4DnPBQ0/5bfHWPDuOZUzYdMj94daZaZdCCc1Dzt9R/xSSg==",
-      "requires": {
-        "dom-helpers": "^3.4.0",
-        "loose-envify": "^1.4.0",
-        "prop-types": "^15.6.2",
-        "react-lifecycles-compat": "^3.0.4"
       }
     },
     "read-pkg": {
@@ -1304,28 +821,6 @@
       "optional": true,
       "requires": {
         "picomatch": "^2.2.1"
-      }
-    },
-    "redux": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-4.1.2.tgz",
-      "integrity": "sha512-SH8PglcebESbd/shgf6mii6EIoRM0zrQyjcuQ+ojmfxjTtE0z9Y8pa62iA/OJ58qjP6j27uyW4kUF4jl/jd6sw==",
-      "requires": {
-        "@babel/runtime": "^7.9.2"
-      }
-    },
-    "regenerator-runtime": {
-      "version": "0.13.9",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
-    },
-    "regexp.prototype.flags": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.1.tgz",
-      "integrity": "sha512-pMR7hBVUUGI7PMA37m2ofIdQCsomVnas+Jn5UPGAHQ+/LlwKm/aTLJHdasmHRzlfeZwHiAOaRSo2rbBDm3nNUQ==",
-      "requires": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3"
       }
     },
     "resolve": {
@@ -1380,18 +875,11 @@
       "integrity": "sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==",
       "dev": true
     },
-    "shortid": {
-      "version": "2.2.16",
-      "resolved": "https://registry.npmjs.org/shortid/-/shortid-2.2.16.tgz",
-      "integrity": "sha512-Ugt+GIZqvGXCIItnsL+lvFJOiN7RYqlGy7QE41O3YC1xbNSeDGIRO7xg2JJXIAj1cAGnOeC1r7/T9pgrtQbv4g==",
-      "requires": {
-        "nanoid": "^2.1.0"
-      }
-    },
     "side-channel": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
       "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+      "dev": true,
       "requires": {
         "call-bind": "^1.0.0",
         "get-intrinsic": "^1.0.2",
@@ -1457,6 +945,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
       "integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3"
@@ -1466,6 +955,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
       "integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3"
@@ -1486,20 +976,6 @@
         "has-flag": "^3.0.0"
       }
     },
-    "timers-ext": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.7.tgz",
-      "integrity": "sha512-b85NUNzTSdodShTIbky6ZF02e8STtVVfD+fu4aXXShEELpozH+bCpJLYMPZbsABN2wDH7fJpqIoXxJpzbf0NqQ==",
-      "requires": {
-        "es5-ext": "~0.10.46",
-        "next-tick": "1"
-      }
-    },
-    "tiny-invariant": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.2.0.tgz",
-      "integrity": "sha512-1Uhn/aqw5C6RI4KejVeTg6mIS7IqxnLJ8Mv2tV5rTc0qWobay7pDUz6Wi392Cnc8ak1H0F2cjoRzb2/AW4+Fvg=="
-    },
     "to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -1510,26 +986,17 @@
         "is-number": "^7.0.0"
       }
     },
-    "type": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
-      "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg=="
-    },
     "unbox-primitive": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
       "integrity": "sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==",
+      "dev": true,
       "requires": {
         "function-bind": "^1.1.1",
         "has-bigints": "^1.0.1",
         "has-symbols": "^1.0.2",
         "which-boxed-primitive": "^1.0.2"
       }
-    },
-    "use-memo-one": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/use-memo-one/-/use-memo-one-1.1.2.tgz",
-      "integrity": "sha512-u2qFKtxLsia/r8qG0ZKkbytbztzRb317XCkT7yP8wxL0tZ/CzK2G+WWie5vWvpyeP7+YoPIwbJoIHJ4Ba4k0oQ=="
     },
     "validate-npm-package-license": {
       "version": "3.0.4",
@@ -1540,11 +1007,6 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
-    },
-    "web-streams-polyfill": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-2.1.1.tgz",
-      "integrity": "sha512-dlNpL2aab3g8CKfGz6rl8FNmGaRWLLn2g/DtSc9IjB30mEdE6XxzPfPSig5BwGSzI+oLxHyETrQGKjrVVhbLCg=="
     },
     "which": {
       "version": "2.0.2",
@@ -1559,36 +1021,13 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
       "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
+      "dev": true,
       "requires": {
         "is-bigint": "^1.0.1",
         "is-boolean-object": "^1.1.0",
         "is-number-object": "^1.0.4",
         "is-string": "^1.0.5",
         "is-symbol": "^1.0.3"
-      }
-    },
-    "which-collection": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.1.tgz",
-      "integrity": "sha512-W8xeTUwaln8i3K/cY1nGXzdnVZlidBcagyNFtBdD5kxnb4TvGKR7FfSIS3mYpwWS1QUCutfKz8IY8RjftB0+1A==",
-      "requires": {
-        "is-map": "^2.0.1",
-        "is-set": "^2.0.1",
-        "is-weakmap": "^2.0.1",
-        "is-weakset": "^2.0.1"
-      }
-    },
-    "which-typed-array": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.7.tgz",
-      "integrity": "sha512-vjxaB4nfDqwKI0ws7wZpxIlde1XrLX5uB0ZjpfshgmapJMD7jJWhZI+yToJTqaFByF0eNBcYxbjmCzoRP7CfEw==",
-      "requires": {
-        "available-typed-arrays": "^1.0.5",
-        "call-bind": "^1.0.2",
-        "es-abstract": "^1.18.5",
-        "foreach": "^2.0.5",
-        "has-tostringtag": "^1.0.0",
-        "is-typed-array": "^1.1.7"
       }
     },
     "wrappy": {

--- a/packages/utils/package-lock.json
+++ b/packages/utils/package-lock.json
@@ -21,27 +21,12 @@
         "source-map": "^0.5.0"
       }
     },
-    "@deephaven/tsconfig": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@deephaven/tsconfig/-/tsconfig-0.9.0.tgz",
-      "integrity": "sha512-zYKPllv+W+UhAuzC2pbsaQynxzsE0bBK/XjfiK0LWiGMkMhp43rwEaCiMODSYaxGmaV5eA+ijm8r1Y8v21pH4w==",
-      "dev": true
-    },
     "@nicolo-ribaudo/chokidar-2": {
       "version": "2.1.8-no-fsevents.3",
       "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/chokidar-2/-/chokidar-2-2.1.8-no-fsevents.3.tgz",
       "integrity": "sha512-s88O1aVtXftvp5bCPB7WnmXc5IwOZZ7YPuwNPt+GtOOXpPvad1LfbmjYv+qII7zP6RU2QGnqve27dnLycEnyEQ==",
       "dev": true,
-      "optional": true,
-      "requires": {
-        "async-each": "^1.0.1",
-        "glob-parent": "^5.1.2",
-        "inherits": "^2.0.3",
-        "is-glob": "^4.0.0",
-        "normalize-path": "^3.0.0",
-        "path-is-absolute": "^1.0.0",
-        "upath": "^1.1.1"
-      }
+      "optional": true
     },
     "ansi-styles": {
       "version": "3.2.1",
@@ -59,7 +44,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "normalize-path": "^2.1.1"
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
       },
       "dependencies": {
         "normalize-path": {
@@ -70,13 +56,6 @@
           "optional": true
         }
       }
-    },
-    "async-each": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
-      "integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==",
-      "dev": true,
-      "optional": true
     },
     "balanced-match": {
       "version": "1.0.2",
@@ -953,13 +932,6 @@
         "has-symbols": "^1.0.2",
         "which-boxed-primitive": "^1.0.2"
       }
-    },
-    "upath": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
-      "integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==",
-      "dev": true,
-      "optional": true
     },
     "validate-npm-package-license": {
       "version": "3.0.4",


### PR DESCRIPTION
Expects a manifest.json file of a format similar to the following:

```
{
  "plugins": [
    { "name": "@deephaven/matplotlib-js-plugin", "main": "@deephaven/matplotlib-js-plugin/dist/index.js" }
  ]
}
```
 
To help test, follow the instructions in https://github.com/mofojed/deephaven-core/tree/js-remote-plugin-2
It will load the matplotlib plugin published from https://github.com/mofojed/deephaven-js-dashboard-plugin/tree/matplotlib

BREAKING CHANGES:
- Now just use PanelEvent.OPEN/CLOSE, deprecate IrisGridEvent.OPEN/CLOSE, ChartEvent.OPEN/CLOSE, PandasEvent.OPEN/CLOSE.
- Now ConsolePanel/AppMainContainer just emit a PanelEvent.OPEN for all widget types, and registered plugins listen for and open based on those events.
- IrisGridModelFactory - Remove uncoalesced table check - in community, no tables are from a PQ so that check does not apply. It should be checked outside of IrisGridModelFactory (in the `fetch` function in `openWidget`)
- New `IrisGridEvent.CREATE_CHART` event. Previously `IrisGridPanel` (and subsequently the `GridPlugin`) had a dependency on `@deephaven/chart`. Now it no longer requires a dependency on `@deephaven/chart`. There is now the `ChartBuilderPlugin` that is the glue listening for the CREATE_CHART event and opening the proper ChartPanel. At some point we should instead pass the entire ChartBuilder UI in to the IrisGrid menu, so that it is completely abstracted out (think different charting libraries supporting different types of charts).
