### PR TITLE
Fix table row color darken for depth 0

### DIFF
--- a/packages/grid/src/GridColorUtils.ts
+++ b/packages/grid/src/GridColorUtils.ts
@@ -14,7 +14,7 @@ export function darkenForDepth(
   depth: number,
   maxDepth = 6
 ): GridColor {
-  const lab = convert.hex.lab(color);
+  const lab = convert.hex.lab.raw(color);
   lab[0] = Math.max(lab[0] - (lab[0] / maxDepth) * depth, 0);
   return `#${convert.lab.hex(lab)}`;
 }


### PR DESCRIPTION
Lab precision was being rounded, so at depth 0 the hex -> lab -> hex round trip lost precision and modified the colours. Use full raw value to maintain color accuracy.

https://github.com/Qix-/color-convert#api