### PR TITLE
Move plugins to root instead of within @deephaven/babel-preset

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -9,5 +9,16 @@ module.exports = api => {
       /\.stories.(tsx?|jsx?|mdx?)$/,
       '**/*.scss',
     ].filter(Boolean),
+    plugins: [
+      api.env('test') ? false : ['babel-plugin-add-import-extension'],
+      [
+        'transform-rename-import',
+        {
+          // The babel-plugin-add-import-extension adds the .js to .scss imports, just convert them back to .css
+          original: '^(.+?)\\.s?css.js$',
+          replacement: '$1.css',
+        },
+      ],
+    ].filter(Boolean),
   };
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -2900,9 +2900,7 @@
 				"@babel/plugin-proposal-class-properties": "^7.16.0",
 				"@babel/preset-env": "^7.16.0",
 				"@babel/preset-react": "^7.16.0",
-				"@babel/preset-typescript": "^7.16.0",
-				"babel-plugin-add-import-extension": "^1.6.0",
-				"babel-plugin-transform-rename-import": "^2.3.0"
+				"@babel/preset-typescript": "^7.16.0"
 			},
 			"dependencies": {
 				"@babel/core": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,8 @@
   "repository": "https://github.com/deephaven/web-client-ui",
   "devDependencies": {
     "@babel/core": "^7.16.0",
+    "babel-plugin-add-import-extension": "^1.6.0",
+    "babel-plugin-transform-rename-import": "^2.3.0",
     "@deephaven/babel-preset": "file:packages/babel-preset",
     "@deephaven/eslint-config": "file:packages/eslint-config",
     "@deephaven/prettier-config": "file:packages/prettier-config",

--- a/packages/babel-preset/index.js
+++ b/packages/babel-preset/index.js
@@ -17,15 +17,4 @@ module.exports = api => ({
     '@babel/preset-react',
     ['@babel/preset-typescript', { allowDeclareFields: true }],
   ],
-  plugins: [
-    api.env('test') ? false : ['babel-plugin-add-import-extension'],
-    [
-      'transform-rename-import',
-      {
-        // The babel-plugin-add-import-extension adds the .js to .scss imports, just convert them back to .css
-        original: '^(.+?)\\.s?css.js$',
-        replacement: '$1.css',
-      },
-    ],
-  ].filter(Boolean),
 });

--- a/packages/babel-preset/package.json
+++ b/packages/babel-preset/package.json
@@ -15,9 +15,7 @@
     "@babel/plugin-proposal-class-properties": "^7.16.0",
     "@babel/preset-env": "^7.16.0",
     "@babel/preset-react": "^7.16.0",
-    "@babel/preset-typescript": "^7.16.0",
-    "babel-plugin-add-import-extension": "^1.6.0",
-    "babel-plugin-transform-rename-import": "^2.3.0"
+    "@babel/preset-typescript": "^7.16.0"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Some consumer may want to use the babel-preset without the plugins
