### PR TITLE
DH-9053 expose chart titles when specified

### DIFF
--- a/packages/chart/src/Chart.jsx
+++ b/packages/chart/src/Chart.jsx
@@ -10,6 +10,7 @@ import Plot from './plotly/Plot';
 
 import ChartModel from './ChartModel';
 import ChartUtils from './ChartUtils';
+import ChartTheme from './ChartTheme';
 import './Chart.scss';
 
 const log = Log.module('Chart');
@@ -182,11 +183,21 @@ export class Chart extends Component {
   initData() {
     const { model } = this.props;
     const { layout } = this.state;
+    const data = model.getData();
+    const title = data[0].name;
     this.setState({
-      data: model.getData(),
+      data,
       layout: {
         ...layout,
         ...model.getLayout(),
+        title: {
+          text: title,
+          font: {
+            color: ChartTheme.title_color,
+            size: 14,
+          },
+          y: 0.95, // relative to bottom of chart with range [0-1]
+        },
       },
     });
   }


### PR DESCRIPTION
I used the same query from the ticket:

```
sampleTable2 = db.t("LearnDeephaven", "EODTrades").where("ImportDate=`2017-11-01`")
 .where("Ticker=`CSC`")

samplePlot2 = plot("Price Trend", sampleTable2, "EODTimestamp", "Close")
 .chartTitle(sampleTable2, "Ticker")
 .show()
```