### PR TITLE
Fix sass deprecation warnings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8213,19 +8213,16 @@
       "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
     },
     "node_modules/bootstrap": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.4.1.tgz",
-      "integrity": "sha512-tbx5cHubwE6e2ZG7nqM3g/FZ5PQEDMWmMGNrCUBVRPHXTJaH7CBDdsLeu3eCh3B1tzAxTnAbtmrzvWEvT2NNEA==",
-      "engines": {
-        "node": ">=6"
-      },
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.6.1.tgz",
+      "integrity": "sha512-0dj+VgI9Ecom+rvvpNZ4MUZJz8dcX7WCX+eTID9+/8HgOkv3dsRzi8BGeZJCQU6flWQVYxwTQnEZFrmJSEO7og==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/bootstrap"
       },
       "peerDependencies": {
         "jquery": "1.9.1 - 3",
-        "popper.js": "^1.16.0"
+        "popper.js": "^1.16.1"
       }
     },
     "node_modules/brace-expansion": {
@@ -38474,7 +38471,7 @@
         "@deephaven/utils": "file:../utils",
         "@fortawesome/fontawesome-svg-core": "1.2.36",
         "@fortawesome/react-fontawesome": "^0.1.15",
-        "bootstrap": "4.4.1",
+        "bootstrap": "4.6.1",
         "classnames": "^2.3.1",
         "event-target-shim": "^6.0.2",
         "jquery": "^3.6.0",
@@ -38641,7 +38638,7 @@
         "@types/node": "^16.11.7",
         "@types/react": "^17.0.2",
         "@types/react-dom": "^17.0.9",
-        "bootstrap": "4.4.1",
+        "bootstrap": "4.6.1",
         "classnames": "^2.3.1",
         "deep-equal": "^2.0.5",
         "fira": "mozilla/fira#4.202",
@@ -40241,7 +40238,7 @@
         "@deephaven/utils": "file:../utils",
         "@fortawesome/fontawesome-svg-core": "1.2.36",
         "@fortawesome/react-fontawesome": "^0.1.15",
-        "bootstrap": "4.4.1",
+        "bootstrap": "4.6.1",
         "classnames": "^2.3.1",
         "event-target-shim": "^6.0.2",
         "jquery": "^3.6.0",
@@ -40355,7 +40352,7 @@
         "@types/node": "^16.11.7",
         "@types/react": "^17.0.2",
         "@types/react-dom": "^17.0.9",
-        "bootstrap": "4.4.1",
+        "bootstrap": "4.6.1",
         "classnames": "^2.3.1",
         "deep-equal": "^2.0.5",
         "fira": "mozilla/fira#4.202",
@@ -45384,9 +45381,9 @@
       "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
     },
     "bootstrap": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.4.1.tgz",
-      "integrity": "sha512-tbx5cHubwE6e2ZG7nqM3g/FZ5PQEDMWmMGNrCUBVRPHXTJaH7CBDdsLeu3eCh3B1tzAxTnAbtmrzvWEvT2NNEA==",
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.6.1.tgz",
+      "integrity": "sha512-0dj+VgI9Ecom+rvvpNZ4MUZJz8dcX7WCX+eTID9+/8HgOkv3dsRzi8BGeZJCQU6flWQVYxwTQnEZFrmJSEO7og==",
       "requires": {}
     },
     "brace-expansion": {

--- a/packages/code-studio/src/main/AppMainContainer.scss
+++ b/packages/code-studio/src/main/AppMainContainer.scss
@@ -227,15 +227,15 @@ $nav-space: 4px; // give a gap around some buttons for focus area that are in na
       white-space: nowrap;
       height: $tab-height - $nav-space;
       line-height: $tab-height - $nav-space - $input-border-width * 2;
-      margin: $nav-space/2 0 $nav-space/2 $tab-button-side-padding;
+      margin: $nav-space * 0.5 0 $nav-space * 0.5 $tab-button-side-padding;
 
       &::before {
         content: '';
         position: absolute;
         left: -$tab-button-side-padding;
         width: 1px;
-        top: ($tab-height - $tab-button-separator-height)/2 - $nav-space/2 -
-          $input-border-width;
+        top: ($tab-height - $tab-button-separator-height) * 0.5 - $nav-space *
+          0.5 - $input-border-width;
         height: $tab-button-separator-height;
         background: $tab-button-separator-color;
       }
@@ -268,7 +268,7 @@ $nav-space: 4px; // give a gap around some buttons for focus area that are in na
     line-height: $tab-height - $nav-space;
     padding: 0 $tab-button-side-padding;
     cursor: pointer;
-    margin: $nav-space/2 0 $nav-space/2 0;
+    margin: $nav-space * 0.5 0 $nav-space * 0.5 0;
 
     &.btn-settings-menu {
       margin-right: $input-border-width;

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -35,7 +35,7 @@
     "@deephaven/utils": "file:../utils",
     "@fortawesome/fontawesome-svg-core": "1.2.36",
     "@fortawesome/react-fontawesome": "^0.1.15",
-    "bootstrap": "4.4.1",
+    "bootstrap": "4.6.1",
     "classnames": "^2.3.1",
     "event-target-shim": "^6.0.2",
     "jquery": "^3.6.0",

--- a/packages/components/src/SocketedButton.scss
+++ b/packages/components/src/SocketedButton.scss
@@ -87,7 +87,7 @@ $socket-bg: $content-bg;
     position: absolute;
     bottom: 1px; // looked slightly low
     left: 50%;
-    transform: translate(-50%, $socket-size/2);
+    transform: translate(-50%, $socket-size * 0.5);
     z-index: 1; // appear above the circle
   }
 
@@ -121,7 +121,7 @@ $socket-bg: $content-bg;
     position: absolute;
     bottom: 1px; // looked slightly low
     left: 50%;
-    transform: translate(-50%, $socket-size/2);
+    transform: translate(-50%, $socket-size * 0.5);
     z-index: 1; // appear above the circle
   }
 

--- a/packages/components/src/TimeSlider.scss
+++ b/packages/components/src/TimeSlider.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 @import '../scss/custom.scss';
 
 $track-height: 15px;
@@ -41,7 +43,7 @@ $tick-label-color: $gray-300;
     margin: 4px;
     height: $track-height;
     background: $track-background;
-    border-radius: $track-height/2;
+    border-radius: $track-height * 0.5;
     position: relative;
 
     .track-fills {
@@ -50,11 +52,11 @@ $tick-label-color: $gray-300;
       left: 0;
       width: 100%;
       height: 100%;
-      border-radius: $track-height/2;
+      border-radius: $track-height * 0.5;
       overflow: hidden;
 
       .track-fill {
-        border-radius: $track-height/2;
+        border-radius: $track-height * 0.5;
         background: $primary-dark;
         height: 100%;
         width: 100%;
@@ -122,7 +124,7 @@ $tick-label-color: $gray-300;
       flex-direction: row;
       div {
         display: block;
-        width: percentage(1/24); //one box per hour in day
+        width: percentage(math.div(1, 24)); //one box per hour in day
         height: $track-height;
         border-right: 1px solid $tick-color;
       }
@@ -145,7 +147,7 @@ $tick-label-color: $gray-300;
 
     .tick-label {
       width: percentage(
-        1/24
+        math.div(1, 24)
       ); // the first label is outside of wrapper and always visible
 
       text-align: left;
@@ -155,15 +157,18 @@ $tick-label-color: $gray-300;
     //if less then min width, the visible tick labels wrap into overflow hidden zone,
     //while the absolutely positioned children stay in place
     .tick-label-wrapper {
-      width: 100% - percentage(1/24); // minus the first label
+      width: 100% - percentage(math.div(1, 24)); // minus the first label
       min-width: 300px; // point where extra labels wrap
-      margin-left: percentage(1/24) / 2 * -1; // offset by half so that labels fall on ticks, not between
+      margin-left: percentage(math.div(1, 24)) * 0.5 * -1; // offset by half so that labels fall on ticks, not between
       display: flex;
 
       .tick-label {
-        width: percentage(1/23); //remaining number of labels excluding first
         text-align: center;
         visibility: hidden;
+        width: percentage(
+          math.div(1, 23)
+        ); //remaining number of labels excluding first
+
         // used to center text in a box potentially smaller then the text it contains
         &::before {
           content: '';
@@ -189,11 +194,11 @@ $tick-label-color: $gray-300;
       div:nth-child(12) {
         position: absolute;
         top: 0;
-        left: percentage(1/23) * 11;
+        left: percentage(math.div(1, 23)) * 11;
       }
       div:nth-child(13) {
         margin-left: percentage(
-          1/24
+          math.div(1, 24)
         ); //compensate the labels to the right to account for removed 12th label
       }
       div:nth-child(24) {

--- a/packages/embed-grid/package.json
+++ b/packages/embed-grid/package.json
@@ -34,7 +34,7 @@
     "@types/node": "^16.11.7",
     "@types/react": "^17.0.2",
     "@types/react-dom": "^17.0.9",
-    "bootstrap": "4.4.1",
+    "bootstrap": "4.6.1",
     "classnames": "^2.3.1",
     "deep-equal": "^2.0.5",
     "fira": "mozilla/fira#4.202",

--- a/packages/stylelint-config/index.js
+++ b/packages/stylelint-config/index.js
@@ -1,12 +1,8 @@
 module.exports = {
   extends: ['stylelint-config-standard-scss', 'stylelint-config-prettier-scss'],
   rules: {
-    'at-rule-no-unknown': [
-      true,
-      {
-        ignoreAtRules: ['function', 'if', 'each', 'include', 'mixin'],
-      },
-    ],
+    'at-rule-no-unknown': null,
+    'scss/at-rule-no-unknown': true,
     'selector-pseudo-class-no-unknown': [
       true,
       {


### PR DESCRIPTION
- Update Bootstrap version to 4.6.1
- Use sass-migrator to migrate division used in TimeSlider.scss and AppMainContainer.scss
```
npx sass-migrator division packages/components/src/TimeSlider.scss
npx sass-migrator division packages/code-studio/src/main/AppMainContainer.scss
```
- Visual smoke test to ensure visual consistency
- Use scss aware at-rule-no-unknown
- Fixes #484
