### PR TITLE
DH-12166: Allow truncating number columns with pound symbol

### DIFF
--- a/packages/code-studio/src/main/AppInit.jsx
+++ b/packages/code-studio/src/main/AppInit.jsx
@@ -166,6 +166,10 @@ const AppInit = props => {
         };
       }
 
+      if (settings.truncateNumbersWithPound === undefined) {
+        settings.truncateNumbersWithPound = false;
+      }
+
       // Set any shortcuts that user has overridden on this platform
       const { shortcutOverrides = {} } = settings;
       const isMac = Shortcut.isMacPlatform;

--- a/packages/code-studio/src/settings/FormattingSectionContent.jsx
+++ b/packages/code-studio/src/settings/FormattingSectionContent.jsx
@@ -191,6 +191,9 @@ export class FormattingSectionContent extends PureComponent {
     this.handleResetDecimalFormat = this.handleResetDecimalFormat.bind(this);
     this.handleResetIntegerFormat = this.handleResetIntegerFormat.bind(this);
     this.handleResetTimeZone = this.handleResetTimeZone.bind(this);
+    this.handletruncateNumbersWithPoundChange = this.handletruncateNumbersWithPoundChange.bind(
+      this
+    );
 
     const {
       formatter,
@@ -470,6 +473,17 @@ export class FormattingSectionContent extends PureComponent {
     );
   }
 
+  handletruncateNumbersWithPoundChange() {
+    this.setState(
+      state => ({
+        truncateNumbersWithPound: !state.truncateNumbersWithPound,
+      }),
+      () => {
+        this.debouncedCommitChanges();
+      }
+    );
+  }
+
   handleFormatRuleEntered(elem) {
     this.scrollToFormatBlockBottom();
     FormattingSectionContent.focusFirstInputInContainer(elem);
@@ -484,6 +498,7 @@ export class FormattingSectionContent extends PureComponent {
       timeZone,
       defaultDecimalFormatOptions,
       defaultIntegerFormatOptions,
+      truncateNumbersWithPound,
     } = this.state;
 
     const formatter = formatSettings
@@ -498,6 +513,7 @@ export class FormattingSectionContent extends PureComponent {
       showTimeZone,
       showTSeparator,
       timeZone,
+      truncateNumbersWithPound,
     };
     if (
       FormattingSectionContent.isValidFormat(
@@ -766,6 +782,7 @@ export class FormattingSectionContent extends PureComponent {
       timeZone,
       showTimeZone,
       showTSeparator,
+      truncateNumbersWithPound,
     } = this.state;
 
     const {
@@ -946,7 +963,7 @@ export class FormattingSectionContent extends PureComponent {
               />
             </div>
           </div>
-          <div className="form-row mb-3">
+          <div className="form-row mb-2">
             <label
               className="col-form-label col-3"
               htmlFor="default-integer-format-input"
@@ -986,6 +1003,16 @@ export class FormattingSectionContent extends PureComponent {
                   hidden: isIntegerOptionsDefault,
                 })}
               />
+            </div>
+          </div>
+          <div className="form-row mb-3">
+            <div className="offset-3 col-9">
+              <Checkbox
+                checked={truncateNumbersWithPound}
+                onChange={this.handletruncateNumbersWithPoundChange}
+              >
+                Truncate numbers with #
+              </Checkbox>
             </div>
           </div>
         </div>

--- a/packages/code-studio/src/settings/FormattingSectionContent.jsx
+++ b/packages/code-studio/src/settings/FormattingSectionContent.jsx
@@ -23,6 +23,7 @@ import {
   getTimeZone,
   getShowTimeZone,
   getShowTSeparator,
+  getTruncateNumbersWithPound,
   getSettings,
   saveSettings as saveSettingsAction,
 } from '@deephaven/redux';
@@ -203,6 +204,7 @@ export class FormattingSectionContent extends PureComponent {
       showTimeZone,
       showTSeparator,
       timeZone,
+      truncateNumbersWithPound,
     } = props;
 
     const formatSettings = formatter.map((item, i) => ({
@@ -224,6 +226,7 @@ export class FormattingSectionContent extends PureComponent {
       defaultDateTimeFormat,
       defaultDecimalFormatOptions,
       defaultIntegerFormatOptions,
+      truncateNumbersWithPound,
       timestampAtMenuOpen: new Date(),
     };
   }
@@ -1043,6 +1046,7 @@ FormattingSectionContent.propTypes = {
   showTimeZone: PropTypes.bool.isRequired,
   showTSeparator: PropTypes.bool.isRequired,
   timeZone: PropTypes.string.isRequired,
+  truncateNumbersWithPound: PropTypes.bool.isRequired,
   settings: PropTypes.shape({}).isRequired,
   saveSettings: PropTypes.func.isRequired,
   scrollTo: PropTypes.func,
@@ -1090,6 +1094,7 @@ const mapStateToProps = state => ({
   defaultIntegerFormatOptions: getDefaultIntegerFormatOptions(state),
   showTimeZone: getShowTimeZone(state),
   showTSeparator: getShowTSeparator(state),
+  truncateNumbersWithPound: getTruncateNumbersWithPound(state),
   timeZone: getTimeZone(state),
   settings: getSettings(state),
 });

--- a/packages/code-studio/src/settings/FormattingSectionContent.jsx
+++ b/packages/code-studio/src/settings/FormattingSectionContent.jsx
@@ -192,7 +192,7 @@ export class FormattingSectionContent extends PureComponent {
     this.handleResetDecimalFormat = this.handleResetDecimalFormat.bind(this);
     this.handleResetIntegerFormat = this.handleResetIntegerFormat.bind(this);
     this.handleResetTimeZone = this.handleResetTimeZone.bind(this);
-    this.handletruncateNumbersWithPoundChange = this.handletruncateNumbersWithPoundChange.bind(
+    this.handleTruncateNumbersWithPoundChange = this.handleTruncateNumbersWithPoundChange.bind(
       this
     );
 
@@ -476,7 +476,7 @@ export class FormattingSectionContent extends PureComponent {
     );
   }
 
-  handletruncateNumbersWithPoundChange() {
+  handleTruncateNumbersWithPoundChange() {
     this.setState(
       state => ({
         truncateNumbersWithPound: !state.truncateNumbersWithPound,
@@ -1012,7 +1012,7 @@ export class FormattingSectionContent extends PureComponent {
             <div className="offset-3 col-9">
               <Checkbox
                 checked={truncateNumbersWithPound}
-                onChange={this.handletruncateNumbersWithPoundChange}
+                onChange={this.handleTruncateNumbersWithPoundChange}
               >
                 Truncate numbers with #
               </Checkbox>

--- a/packages/grid/src/GridModel.ts
+++ b/packages/grid/src/GridModel.ts
@@ -51,6 +51,19 @@ abstract class GridModel<
   abstract textForCell(column: ModelIndex, row: ModelIndex): string;
 
   /**
+   * Get the truncation character for the specified cell. Can be undefined
+   * @param column Column to get the truncation character for
+   * @param row Row to get the truncation character for
+   * @returns Truncation character for the specified cell
+   */
+  truncationCharForCell(
+    column: ModelIndex,
+    row: ModelIndex
+  ): string | undefined {
+    return undefined;
+  }
+
+  /**
    * Get the text alignment for the specified cell
    * @param column Column to get the alignment for
    * @param row Row to get the alignment for

--- a/packages/grid/src/GridModel.ts
+++ b/packages/grid/src/GridModel.ts
@@ -51,7 +51,8 @@ abstract class GridModel<
   abstract textForCell(column: ModelIndex, row: ModelIndex): string;
 
   /**
-   * Get the truncation character for the specified cell. Can be undefined
+   * Get the character to replace text when truncated for a specific cell.
+   * Leave undefined to show text truncated with ellipsis
    * @param column Column to get the truncation character for
    * @param row Row to get the truncation character for
    * @returns Truncation character for the specified cell

--- a/packages/iris-grid/src/Formatter.ts
+++ b/packages/iris-grid/src/Formatter.ts
@@ -72,6 +72,7 @@ class Formatter {
    * @param dateTimeOptions Optional object with DateTime configuration
    * @param decimalFormatOptions Optional object with Decimal configuration
    * @param integerFormatOptions Optional object with Integer configuration
+   * @param truncateNumbersWithPound Determine if numbers should be truncated w/ repeating # instead of ellipsis at the end
    */
   constructor(
     columnFormattingRules: FormattingRule[] = [],
@@ -81,7 +82,8 @@ class Formatter {
     >[0],
     integerFormatOptions?: ConstructorParameters<
       typeof IntegerColumnFormatter
-    >[0]
+    >[0],
+    truncateNumbersWithPound = false
   ) {
     // Formatting order:
     // - columnFormatMap[type][name]
@@ -111,6 +113,7 @@ class Formatter {
 
     // Formats indexed by data type and column name
     this.columnFormatMap = Formatter.makeColumnFormatMap(columnFormattingRules);
+    this.truncateNumbersWithPound = truncateNumbersWithPound;
   }
 
   defaultColumnFormatter: TableColumnFormatter;
@@ -118,6 +121,8 @@ class Formatter {
   typeFormatterMap: Map<DataType, TableColumnFormatter>;
 
   columnFormatMap: Map<DataType, Map<string, TableColumnFormat>>;
+
+  truncateNumbersWithPound: boolean;
 
   /**
    * Gets columnFormatMap indexed by name for a given column type, creates new Map entry if necessary

--- a/packages/iris-grid/src/IrisGrid.jsx
+++ b/packages/iris-grid/src/IrisGrid.jsx
@@ -240,6 +240,7 @@ export class IrisGrid extends Component {
     this.dateTimeFormatterOptions = {};
     this.decimalFormatOptions = {};
     this.integerFormatOptions = {};
+    this.truncateNumbersWithPound = false;
 
     // When the loading scrim started/when it should extend to the end of the screen.
     this.loadingScrimStartTime = null;
@@ -1109,6 +1110,7 @@ export class IrisGrid extends Component {
     const {
       defaultDecimalFormatOptions = {},
       defaultIntegerFormatOptions = {},
+      truncateNumbersWithPound = false,
     } = settings;
 
     const isColumnFormatChanged = !deepEqual(
@@ -1127,16 +1129,20 @@ export class IrisGrid extends Component {
       this.integerFormatOptions,
       defaultIntegerFormatOptions
     );
+    const isTruncateNumbersChanged =
+      this.truncateNumbersWithPound !== truncateNumbersWithPound;
     if (
       isColumnFormatChanged ||
       isDateFormattingChanged ||
       isDecimalFormattingChanged ||
-      isIntegerFormattingChanged
+      isIntegerFormattingChanged ||
+      isTruncateNumbersChanged
     ) {
       this.globalColumnFormats = globalColumnFormats;
       this.dateTimeFormatterOptions = dateTimeFormatterOptions;
       this.decimalFormatOptions = defaultDecimalFormatOptions;
       this.integerFormatOptions = defaultIntegerFormatOptions;
+      this.truncateNumbersWithPound = truncateNumbersWithPound;
       this.updateFormatter({}, forceUpdate);
 
       if (isDateFormattingChanged && forceUpdate) {
@@ -1191,7 +1197,8 @@ export class IrisGrid extends Component {
       mergedColumnFormats,
       this.dateTimeFormatterOptions,
       this.decimalFormatOptions,
-      this.integerFormatOptions
+      this.integerFormatOptions,
+      this.truncateNumbersWithPound
     );
 
     log.debug('updateFormatter', this.globalColumnFormats, mergedColumnFormats);
@@ -3427,6 +3434,7 @@ IrisGrid.propTypes = {
     defaultDateTimeFormat: PropTypes.string.isRequired,
     showTimeZone: PropTypes.bool.isRequired,
     showTSeparator: PropTypes.bool.isRequired,
+    truncateNumbersWithPound: PropTypes.bool.isRequired,
     formatter: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
   }),
   userColumnWidths: PropTypes.instanceOf(Map),
@@ -3537,6 +3545,7 @@ IrisGrid.defaultProps = {
     defaultDateTimeFormat: DateUtils.FULL_DATE_FORMAT,
     showTimeZone: false,
     showTSeparator: true,
+    truncateNumbersWithPound: false,
     formatter: [],
     decimalFormatOptions: PropTypes.shape({
       defaultFormatString: PropTypes.string,

--- a/packages/iris-grid/src/IrisGrid.test.jsx
+++ b/packages/iris-grid/src/IrisGrid.test.jsx
@@ -20,6 +20,7 @@ const DEFAULT_SETTINGS = {
   showTimeZone: false,
   showTSeparator: true,
   formatter: [],
+  truncateNumbersWithPound: false,
 };
 
 function makeMockCanvas() {

--- a/packages/iris-grid/src/IrisGridProxyModel.js
+++ b/packages/iris-grid/src/IrisGridProxyModel.js
@@ -173,6 +173,10 @@ class IrisGridProxyModel extends IrisGridModel {
     return this.model.textForCell(...args);
   }
 
+  truncationCharForCell(...args) {
+    return this.model.truncationCharForCell(...args);
+  }
+
   textAlignForCell(...args) {
     return this.model.textAlignForCell(...args);
   }

--- a/packages/iris-grid/src/IrisGridRenderer.js
+++ b/packages/iris-grid/src/IrisGridRenderer.js
@@ -760,7 +760,8 @@ class IrisGridRenderer extends GridRenderer {
       context,
       text,
       textWidth,
-      fontWidth
+      fontWidth,
+      model.truncationCharForCell(modelColumn, modelRow)
     );
     context.restore();
 

--- a/packages/iris-grid/src/IrisGridTableModel.js
+++ b/packages/iris-grid/src/IrisGridTableModel.js
@@ -399,6 +399,19 @@ class IrisGridTableModel extends IrisGridModel {
     return text;
   }
 
+  truncationCharForCell(x) {
+    const column = this.columns[x];
+    const { type } = column;
+    if (
+      TableUtils.isNumberType(type) &&
+      this.formatter.truncateNumbersWithPound
+    ) {
+      return '#';
+    }
+
+    return undefined;
+  }
+
   colorForCell(x, y, theme) {
     const data = this.dataForCell(x, y);
     if (data) {

--- a/packages/redux/src/selectors.ts
+++ b/packages/redux/src/selectors.ts
@@ -67,6 +67,10 @@ export const getShowTSeparator: Selector<
   WorkspaceSettings['showTSeparator']
 > = store => getSettings(store).showTSeparator;
 
+export const getTruncateNumbersWithPound: Selector<
+  WorkspaceSettings['truncateNumbersWithPound']
+> = store => getSettings(store).truncateNumbersWithPound;
+
 export const getDisableMoveConfirmation: Selector<
   WorkspaceSettings['disableMoveConfirmation']
 > = store => getSettings(store).disableMoveConfirmation || false;

--- a/packages/redux/src/store.ts
+++ b/packages/redux/src/store.ts
@@ -37,6 +37,7 @@ export interface WorkspaceSettings {
   timeZone: string;
   showTimeZone: boolean;
   showTSeparator: boolean;
+  truncateNumbersWithPound: boolean;
   disableMoveConfirmation: boolean;
   showSystemBadge: boolean;
   shortcutOverrides?: {


### PR DESCRIPTION
This adds the ability to truncate number columns with ### instead of cutting and adding an ellipsis at the end. There is a new setting in the settings panel to toggle the option.

Tested with this python snippet

```python
from deephaven.TableTools import newTable, intCol, doubleCol

table = newTable(
    intCol("Int", 123456789, 234567890, 42, 8675309, 1),
    doubleCol("Double", 123.456, 555555.5555, 1234567890.1234567890, 42.42, 1.0)
)
```