### PR TITLE
Disable formatting for array columns

### DIFF
--- a/packages/iris-grid/src/sidebar/conditional-formatting/ConditionEditor.tsx
+++ b/packages/iris-grid/src/sidebar/conditional-formatting/ConditionEditor.tsx
@@ -275,7 +275,7 @@ const ConditionEditor = (props: ConditionEditorProps): JSX.Element => {
     if (TableUtils.isCharType(selectedColumnType)) {
       return charConditions;
     }
-    if (TableUtils.isTextType(selectedColumnType)) {
+    if (TableUtils.isStringType(selectedColumnType)) {
       return stringConditions;
     }
     if (TableUtils.isDateType(selectedColumnType)) {
@@ -374,7 +374,7 @@ const ConditionEditor = (props: ConditionEditorProps): JSX.Element => {
         conditionValue
       );
     }
-    if (TableUtils.isTextType(selectedColumnType)) {
+    if (TableUtils.isStringType(selectedColumnType)) {
       return getStringInputs(
         selectedCondition as StringCondition,
         handleValueChange,

--- a/packages/iris-grid/src/sidebar/conditional-formatting/ConditionalFormatEditor.tsx
+++ b/packages/iris-grid/src/sidebar/conditional-formatting/ConditionalFormatEditor.tsx
@@ -9,6 +9,7 @@ import {
   BaseFormatConfig,
   FormatterType,
   FormattingRule,
+  isSupportedColumn,
   ModelColumn,
 } from './ConditionalFormattingUtils';
 import './ConditionalFormatEditor.scss';
@@ -55,12 +56,14 @@ const ConditionalFormatEditor = (
   props: ConditionalFormatEditorProps
 ): JSX.Element => {
   const {
-    columns,
+    columns: originalColumns,
     onSave = DEFAULT_CALLBACK,
     onUpdate = DEFAULT_CALLBACK,
     onCancel = DEFAULT_CALLBACK,
     rule: defaultRule,
   } = props;
+
+  const columns = originalColumns.filter(isSupportedColumn);
 
   const [selectedFormatter, setFormatter] = useState(
     defaultRule?.type ?? formatterTypes[0]

--- a/packages/iris-grid/src/sidebar/conditional-formatting/ConditionalFormattingMenu.tsx
+++ b/packages/iris-grid/src/sidebar/conditional-formatting/ConditionalFormattingMenu.tsx
@@ -54,7 +54,7 @@ function getRuleValue(config: BaseFormatConfig): string {
       ? ''
       : `${config.value}`;
   }
-  if (TableUtils.isTextType(type)) {
+  if (TableUtils.isStringType(type)) {
     return config.condition === StringCondition.IS_NULL ||
       config.condition === StringCondition.IS_NOT_NULL
       ? ''

--- a/packages/iris-grid/src/sidebar/conditional-formatting/ConditionalFormattingUtils.ts
+++ b/packages/iris-grid/src/sidebar/conditional-formatting/ConditionalFormattingUtils.ts
@@ -256,7 +256,7 @@ export function getConditionDBString(config: BaseFormatConfig): string {
   if (TableUtils.isCharType(column.type)) {
     return getCharConditionText(config);
   }
-  if (TableUtils.isTextType(column.type)) {
+  if (TableUtils.isStringType(column.type)) {
     return getStringConditionText(config);
   }
   if (TableUtils.isDateType(column.type)) {
@@ -369,7 +369,7 @@ export function getDefaultConditionForType(columnType: string): Condition {
   if (TableUtils.isCharType(columnType)) {
     return CharCondition.IS_EQUAL;
   }
-  if (TableUtils.isTextType(columnType)) {
+  if (TableUtils.isStringType(columnType)) {
     return StringCondition.IS_EXACTLY;
   }
   if (TableUtils.isDateType(columnType)) {
@@ -386,7 +386,7 @@ export function getDefaultValueForType(columnType: string): string | undefined {
   if (TableUtils.isCharType(columnType)) {
     return '';
   }
-  if (TableUtils.isTextType(columnType)) {
+  if (TableUtils.isStringType(columnType)) {
     return '';
   }
   return undefined;
@@ -629,7 +629,7 @@ export function getShortLabelForConditionType(
   if (TableUtils.isCharType(columnType)) {
     return getShortLabelForCharCondition(condition as CharCondition);
   }
-  if (TableUtils.isTextType(columnType)) {
+  if (TableUtils.isStringType(columnType)) {
     return getShortLabelForStringCondition(condition as StringCondition);
   }
   if (TableUtils.isDateType(columnType)) {
@@ -690,4 +690,14 @@ export function getFormatColumns(
   });
 
   return result;
+}
+
+export function isSupportedColumn({ type }: ModelColumn): boolean {
+  return (
+    TableUtils.isNumberType(type) ||
+    TableUtils.isCharType(type) ||
+    TableUtils.isStringType(type) ||
+    TableUtils.isDateType(type) ||
+    TableUtils.isBooleanType(type)
+  );
 }


### PR DESCRIPTION
- Filter out unsupported columns in ConditionalFormatEditor
- Use more specific `isStringType` instead of `isTextType`

Fixes #483