### PR TITLE
Re-enable Codecov reporting

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -93,15 +93,15 @@ jobs:
       - name: Test (Pull Request)
         if: ${{ github.event_name == 'pull_request' }}
         run: |
-          npm run test:unit -- --maxWorkers=2 --cacheDirectory node_modules/.cache/jest
-          npm run test:lint -- --maxWorkers=2 --cacheDirectory node_modules/.cache/jest --changedSince origin/${{ github.event.pull_request.base.ref }}
+          npm run test:unit -- --cacheDirectory node_modules/.cache/jest
+          npm run test:lint -- --cacheDirectory node_modules/.cache/jest --changedSince origin/${{ github.event.pull_request.base.ref }}
           npm run test:golden-layout
 
       - name: Test (Push)
         if: ${{ github.event_name == 'push' }}
         run: |
-          npm run test:unit -- --maxWorkers=2 --cacheDirectory node_modules/.cache/jest
-          npm run test:lint -- --maxWorkers=2 --cacheDirectory node_modules/.cache/jest --lastCommit
+          npm run test:unit -- --cacheDirectory node_modules/.cache/jest
+          npm run test:lint -- --cacheDirectory node_modules/.cache/jest --lastCommit
           npm run test:golden-layout
 
       - name: Codecov report

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -62,7 +62,7 @@ jobs:
             packages/*/.eslintcache
             .stylelintcache
             packages/*/.stylelintcache
-          key: ${{ runner.os }}-lintcache-${{ github.ref }}
+          key: ${{ runner.os }}-lintcache-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-lintcache-
 
@@ -77,13 +77,13 @@ jobs:
       # PRs should hit the cache on the base branch first, then future commits hit the cache on the PR
       # Don't skip this on node_modules hit b/c package-lock will change less often than this cache
       # The result would be less recent build caches if it were skipped
-      - name: Cache node_mocules/.cache
+      - name: Cache node_modules/.cache
         uses: actions/cache@v2
         with:
           path: |
             node_modules/.cache
             packages/*/node_modules/.cache
-          key: ${{ runner.os }}-build-cache-${{ github.ref }}
+          key: ${{ runner.os }}-build-cache-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-build-cache-
 
@@ -95,15 +95,15 @@ jobs:
       - name: Test (Pull Request)
         if: ${{ github.event_name == 'pull_request' }}
         run: |
-          npm run test:unit -- --maxWorkers=50% --cacheDirectory node_modules/.cache/jest
-          npm run test:lint -- --maxWorkers=50% --cacheDirectory node_modules/.cache/jest --changedSince origin/${{ github.event.pull_request.base.ref }}
+          npm run test:unit -- --cacheDirectory node_modules/.cache/jest
+          npm run test:lint -- --changedSince origin/${{ github.event.pull_request.base.ref }} --cacheDirectory node_modules/.cache/jest
           npm run test:golden-layout
 
       - name: Test (Push)
         if: ${{ github.event_name == 'push' }}
         run: |
-          npm run test:unit -- --maxWorkers=50% --cacheDirectory node_modules/.cache/jest
-          npm run test:lint -- --maxWorkers=50% --cacheDirectory node_modules/.cache/jest --lastCommit
+          npm run test:unit -- --cacheDirectory node_modules/.cache/jest
+          npm run test:lint -- --lastCommit --cacheDirectory node_modules/.cache/jest
           npm run test:golden-layout
 
       - name: Codecov report

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -36,21 +36,6 @@ jobs:
             packages/*/node_modules
           key: ${{ runner.os }}-modules-${{ hashFiles('package-lock.json') }}
 
-      # This is for webpack/terser cache mainly which helps build speed
-      # Cache on pushes to main should end up using the cache from the previous commit to main
-      # PRs should hit the cache on the base branch first, then future commits hit the cache on the PR
-      # Don't skip this on node_modules hit b/c package-lock will change less often than this cache
-      # The result would be less recent build caches if it were skipped
-      - name: Cache node_mocules/.cache
-        uses: actions/cache@v2
-        with:
-          path: |
-            node_modules/.cache
-            packages/*/node_modules/.cache
-          key: ${{ runner.os }}-build-cache-${{ github.ref }}
-          restore-keys: |
-            ${{ runner.os }}-build-cache-
-
       - name: Cache npm
         uses: actions/cache@v2
         with:
@@ -81,6 +66,21 @@ jobs:
       - name: Install dependencies
         if: steps.cache-node-modules.outputs.cache-hit == 'false'
         run: npm ci
+
+      # This is for webpack/terser cache mainly which helps build speed
+      # Cache on pushes to main should end up using the cache from the previous commit to main
+      # PRs should hit the cache on the base branch first, then future commits hit the cache on the PR
+      # Don't skip this on node_modules hit b/c package-lock will change less often than this cache
+      # The result would be less recent build caches if it were skipped
+      - name: Cache node_mocules/.cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            node_modules/.cache
+            packages/*/node_modules/.cache
+          key: ${{ runner.os }}-build-cache-${{ github.ref }}
+          restore-keys: |
+            ${{ runner.os }}-build-cache-
 
       - name: Build
         run: npm run build

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     concurrency:
-      group: ${{ github.ref }}
+      group: ${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: true
 
     steps:
@@ -90,6 +90,8 @@ jobs:
       - name: Build
         run: npm run build
 
+      # Run unit tests on all files for accurate code coverage
+      # Lint only changed files so linting is faster
       - name: Test (Pull Request)
         if: ${{ github.event_name == 'pull_request' }}
         run: |

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -34,23 +34,38 @@ jobs:
           path: |
             node_modules
             packages/*/node_modules
-          key: ${{ runner.os }}-modules-${{ hashFiles('package.json', 'packages/*/package.json', 'package-lock.json', 'packages/*/package-lock.json') }}
+          key: ${{ runner.os }}-modules-${{ hashFiles('package-lock.json') }}
 
-      - name: Cache npm cache
+      # This is for webpack/terser cache mainly which helps build speed
+      # Cache on pushes to main should end up using the cache from the previous commit to main
+      # PRs should hit the cache on the base branch first, then future commits hit the cache on the PR
+      # Don't skip this on node_modules hit b/c package-lock will change less often than this cache
+      # The result would be less recent build caches if it were skipped
+      - name: Cache node_mocules/.cache
         uses: actions/cache@v2
-        env:
-          cache-name: cache-npm-cache
+        with:
+          path: |
+            node_modules/.cache
+            packages/*/node_modules/.cache
+          key: ${{ runner.os }}-build-cache-${{ github.ref }}
+          restore-keys: |
+            ${{ runner.os }}-build-cache-
+
+      - name: Cache npm
+        uses: actions/cache@v2
         with:
           # npm cache files are stored in `~/.npm` on Linux/macOS
+          # Only needed if package-lock changed and we'll do npm ci
+          # It's possible we don't want to skip this since caches are evicted after 7 days of no access
+          # If no new packages are installed for a while, the install could take longer
+          # It might not be worth it though if the install only takes another minute vs 10-15s per action to cache this
           path: ~/.npm
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ matrix.node-version }}-${{ hashFiles('package-lock.json', 'packages/*/package-lock.json') }}
+          if: steps.cache-node-modules.outputs.cache-hit == 'false'
+          key: ${{ runner.os }}-npm-${{ hashFiles('package-lock.json') }}
           restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-${{ matrix.node-version }}
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
+            ${{ runner.os }}-npm-
 
-      - name: Cache linter caches
+      - name: Cache linters
         uses: actions/cache@v2
         with:
           path: |
@@ -58,14 +73,13 @@ jobs:
             packages/*/.eslintcache
             .stylelintcache
             packages/*/.stylelintcache
-          key: ${{ runner.os }}-lintcache-${{ github.head_ref }}
+          key: ${{ runner.os }}-lintcache-${{ github.ref }}
           restore-keys: |
             ${{ runner.os }}-lintcache-
-            ${{ runner.os }}-
 
       # Only need to install and bootstrap deps if package-locks changed
       - name: Install dependencies
-        if: steps.cache-node-modules.outputs.cache-hit != 'true'
+        if: steps.cache-node-modules.outputs.cache-hit == 'false'
         run: npm ci
 
       - name: Build
@@ -74,11 +88,20 @@ jobs:
       - name: Test (Pull Request)
         if: ${{ github.event_name == 'pull_request' }}
         run: |
-          npm run test:ci -- --changedSince origin/${{ github.event.pull_request.base.ref }}
+          npm run test:unit -- --maxWorkers=2 --cacheDirectory node_modules/.cache/jest
+          npm run test:lint -- --maxWorkers=2 --cacheDirectory node_modules/.cache/jest --changedSince origin/${{ github.event.pull_request.base.ref }}
           npm run test:golden-layout
 
       - name: Test (Push)
         if: ${{ github.event_name == 'push' }}
         run: |
-          npm run test:ci -- --lastCommit
+          npm run test:unit -- --maxWorkers=2 --cacheDirectory node_modules/.cache/jest
+          npm run test:lint -- --maxWorkers=2 --cacheDirectory node_modules/.cache/jest --lastCommit
           npm run test:golden-layout
+
+      - name: Codecov report
+        uses: codecov/codecov-action@v2
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          directory: ./coverage
+          flags: unit

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -12,13 +12,17 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.ref }}
+      cancel-in-progress: true
 
     steps:
       - uses: actions/checkout@v2
         with:
           fetch-depth: '0' # This action defaults to only getting the latest commit. Setting to 0 makes it retrieve the full git commit history
 
-      - name: Fetch base branch
+      - name: Fetch base branch (PR)
+        if: ${{ github.event_name == 'pull_request' }}
         run: git fetch --no-tags origin ${{ github.event.pull_request.base.ref }}
 
       - name: Use Node.js
@@ -30,7 +34,7 @@ jobs:
         id: cache-node-modules
         uses: actions/cache@v2
         with:
-          # If no package-lock.json or package.json files have changed, it should be safe to restore all node_modules as they were
+          # If package-lock has not changed, it should be safe to restore all node_modules as they were
           path: |
             node_modules
             packages/*/node_modules
@@ -38,6 +42,7 @@ jobs:
 
       - name: Cache npm
         uses: actions/cache@v2
+        if: steps.cache-node-modules.outputs.cache-hit == 'false'
         with:
           # npm cache files are stored in `~/.npm` on Linux/macOS
           # Only needed if package-lock changed and we'll do npm ci
@@ -45,7 +50,6 @@ jobs:
           # If no new packages are installed for a while, the install could take longer
           # It might not be worth it though if the install only takes another minute vs 10-15s per action to cache this
           path: ~/.npm
-          if: steps.cache-node-modules.outputs.cache-hit == 'false'
           key: ${{ runner.os }}-npm-${{ hashFiles('package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-npm-
@@ -62,7 +66,8 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-lintcache-
 
-      # Only need to install and bootstrap deps if package-locks changed
+      # Only need to install deps if package-lock changed
+      # Do this before restoring build cache since npm ci cleans node_modules
       - name: Install dependencies
         if: steps.cache-node-modules.outputs.cache-hit == 'false'
         run: npm ci

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Cache npm
         uses: actions/cache@v2
-        if: steps.cache-node-modules.outputs.cache-hit == 'false'
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
         with:
           # npm cache files are stored in `~/.npm` on Linux/macOS
           # Only needed if package-lock changed and we'll do npm ci
@@ -69,7 +69,7 @@ jobs:
       # Only need to install deps if package-lock changed
       # Do this before restoring build cache since npm ci cleans node_modules
       - name: Install dependencies
-        if: steps.cache-node-modules.outputs.cache-hit == 'false'
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: npm ci
 
       # This is for webpack/terser cache mainly which helps build speed

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -70,7 +70,7 @@ jobs:
       # Do this before restoring build cache since npm ci cleans node_modules
       - name: Install dependencies
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
-        run: npm ci
+        run: npm ci --no-audit
 
       # This is for webpack/terser cache mainly which helps build speed
       # Cache on pushes to main should end up using the cache from the previous commit to main

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -95,15 +95,15 @@ jobs:
       - name: Test (Pull Request)
         if: ${{ github.event_name == 'pull_request' }}
         run: |
-          npm run test:unit -- --cacheDirectory node_modules/.cache/jest
-          npm run test:lint -- --cacheDirectory node_modules/.cache/jest --changedSince origin/${{ github.event.pull_request.base.ref }}
+          npm run test:unit -- --maxWorkers=50% --cacheDirectory node_modules/.cache/jest
+          npm run test:lint -- --maxWorkers=50% --cacheDirectory node_modules/.cache/jest --changedSince origin/${{ github.event.pull_request.base.ref }}
           npm run test:golden-layout
 
       - name: Test (Push)
         if: ${{ github.event_name == 'push' }}
         run: |
-          npm run test:unit -- --cacheDirectory node_modules/.cache/jest
-          npm run test:lint -- --cacheDirectory node_modules/.cache/jest --lastCommit
+          npm run test:unit -- --maxWorkers=50% --cacheDirectory node_modules/.cache/jest
+          npm run test:lint -- --maxWorkers=50% --cacheDirectory node_modules/.cache/jest --lastCommit
           npm run test:golden-layout
 
       - name: Codecov report

--- a/.stylelintignore
+++ b/.stylelintignore
@@ -1,1 +1,0 @@
-packages/golden-layout/*

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,28 +1,15 @@
 const baseConfig = require('./jest.config.base.cjs');
+const unitConfig = require('./jest.config.unit.cjs');
+const lintConfig = require('./jest.config.lint.cjs');
 
 module.exports = {
   ...baseConfig,
-  projects: [
-    {
-      displayName: 'eslint',
-      runner: 'jest-runner-eslint',
-      testMatch: ['<rootDir>/packages/*/src/**/*.{js,jsx,ts,tsx}'],
-      testPathIgnorePatterns: ['<rootDir>/packages/golden-layout/*'],
-    },
-    {
-      displayName: 'stylelint',
-      runner: 'jest-runner-stylelint',
-      testMatch: ['<rootDir>/packages/*/src/**/*.scss'],
-      testPathIgnorePatterns: ['<rootDir>/packages/golden-layout/*'],
-      moduleFileExtensions: ['scss'],
-    },
-    '<rootDir>/packages/*/jest.config.cjs',
-  ],
+  projects: [...lintConfig.projects, ...unitConfig.projects],
   watchPlugins: [
     'jest-watch-typeahead/filename',
     'jest-watch-typeahead/testname',
     'jest-watch-select-projects',
   ],
-  collectCoverage: false,
+  collectCoverage: true,
   collectCoverageFrom: ['./src/**/*.{js,ts,jsx,tsx}'], // This is relative to individual project root due to how Jest handles it
 };

--- a/jest.config.lint.cjs
+++ b/jest.config.lint.cjs
@@ -1,0 +1,17 @@
+module.exports = {
+  projects: [
+    {
+      displayName: 'eslint',
+      runner: 'jest-runner-eslint',
+      testMatch: ['<rootDir>/packages/*/src/**/*.{js,jsx,ts,tsx}'],
+      testPathIgnorePatterns: ['<rootDir>/packages/golden-layout/*'],
+    },
+    {
+      displayName: 'stylelint',
+      runner: 'jest-runner-stylelint',
+      testMatch: ['<rootDir>/packages/*/src/**/*.scss'],
+      testPathIgnorePatterns: ['<rootDir>/packages/golden-layout/*'],
+      moduleFileExtensions: ['scss'],
+    },
+  ],
+};

--- a/jest.config.unit.cjs
+++ b/jest.config.unit.cjs
@@ -1,0 +1,9 @@
+const baseConfig = require('./jest.config.base.cjs');
+
+module.exports = {
+  ...baseConfig,
+  projects: ['<rootDir>/packages/*/jest.config.cjs'],
+  collectCoverage: true,
+  collectCoverageFrom: ['./src/**/*.{js,ts,jsx,tsx}'], // This is relative to individual project root due to how Jest handles it
+  coverageDirectory: './coverage',
+};

--- a/package.json
+++ b/package.json
@@ -36,8 +36,9 @@
     "start:packages": "lerna run watch --ignore=@deephaven/{code-studio,embed-grid} --stream --parallel",
     "pretest": "npm run build:necessary",
     "test": "jest --watch --changedSince origin/main",
-    "pretest:ci": "npm run pretest",
-    "test:ci": "jest --maxWorkers=2",
+    "pretest:unit": "npm run pretest",
+    "test:unit": "jest --config jest.config.unit.cjs",
+    "test:lint": "jest --config jest.config.lint.cjs",
     "test:golden-layout": "lerna run test:ci --scope=@deephaven/golden-layout --stream",
     "version-bump": "lerna version --no-git-tag-version --no-push",
     "changelog": "lerna-changelog"

--- a/package.json
+++ b/package.json
@@ -80,7 +80,8 @@
     "ignoreFiles": [
       "node_modules",
       "*.*",
-      "!*.scss"
+      "!*.scss",
+      "packages/golden-layout/*"
     ],
     "extends": [
       "@deephaven/stylelint-config"


### PR DESCRIPTION
Fixes #394 

The Jest tests have been changed to run all unit tests and only lint changed files in CI. Local `npm test` still does changed only in watch mode.

Updated caching to utilize jest cache (helps schedule tests for faster runs) and webpack/terser caches. These are stored in `node_modules/.cache` so they need to be restored after `npm ci` which removes `node_modules` if it exists.

The cache for PRs should hit the previous tested commit in the PR or the latest target branch cache entry. On pushes to main, the cache should always hit the previous commit.