### PR TITLE
Always populate the calculated item size maps

### DIFF
--- a/packages/grid/src/GridMetricCalculator.ts
+++ b/packages/grid/src/GridMetricCalculator.ts
@@ -1423,7 +1423,9 @@ export class GridMetricCalculator {
     userSizes: ModelSizeMap,
     calculateSize: () => number
   ): number {
-    return userSizes.get(modelIndex) ?? calculateSize();
+    // Always re-calculate the size of the item so the calculated size maps are populated
+    const calculatedSize = calculateSize();
+    return userSizes.get(modelIndex) ?? calculatedSize;
   }
 
   /**

--- a/packages/iris-grid/src/IrisGridMetricCalculator.ts
+++ b/packages/iris-grid/src/IrisGridMetricCalculator.ts
@@ -35,19 +35,21 @@ class IrisGridMetricCalculator extends GridMetricCalculator {
     const hiddenColumns = model.layoutHints?.hiddenColumns ?? [];
     const modelColumn = this.getModelColumn(column, state);
 
-    const existingWidth = this.userColumnWidths.get(modelColumn);
-    if (existingWidth !== undefined) {
-      return existingWidth;
-    }
-    if (hiddenColumns.includes(model.columns[modelColumn].name)) {
-      return 0;
-    }
-    return super.getVisibleColumnWidth(
+    // Need to make sure super is called so column width is always re-calculated correctly
+    const columnWidth = super.getVisibleColumnWidth(
       column,
       state,
       firstColumn,
       treePaddingX
     );
+    const hasUserSetWidth = this.userColumnWidths.has(modelColumn);
+    if (
+      !hasUserSetWidth &&
+      hiddenColumns.includes(model.columns[modelColumn].name)
+    ) {
+      return 0;
+    }
+    return columnWidth;
   }
 
   getGridY(state: IrisGridMetricState): number {


### PR DESCRIPTION
We weren't re-caculating the size of the column if the user width was set when the grid was loaded.

Fixes #476
