### PR TITLE
Remove enzyme from ChartBuilder tests

### DIFF
--- a/packages/iris-grid/src/sidebar/ChartBuilder.jsx
+++ b/packages/iris-grid/src/sidebar/ChartBuilder.jsx
@@ -186,7 +186,9 @@ class ChartBuilder extends PureComponent {
   }
 
   handleLinkStateChange(event) {
-    this.setState({ isLinked: event.target.value === 'true' });
+    this.setState({ isLinked: event.target.value === 'true' }, () => {
+      this.sendChange();
+    });
   }
 
   handleReset() {

--- a/packages/iris-grid/src/sidebar/ChartBuilder.jsx
+++ b/packages/iris-grid/src/sidebar/ChartBuilder.jsx
@@ -141,6 +141,7 @@ class ChartBuilder extends PureComponent {
     this.handleSubmit = this.handleSubmit.bind(this);
     this.handleTypeClick = this.handleTypeClick.bind(this);
     this.handleXAxisChange = this.handleXAxisChange.bind(this);
+    this.sendChange = this.sendChange.bind(this);
 
     const { model } = props;
     const { columns } = model;
@@ -165,30 +166,23 @@ class ChartBuilder extends PureComponent {
   }
 
   handleAddSeries() {
-    this.setState(
-      state => {
-        let { seriesItems } = state;
-        seriesItems = [].concat(seriesItems);
+    this.setState(state => {
+      let { seriesItems } = state;
+      seriesItems = [].concat(seriesItems);
 
-        const { model } = this.props;
-        const { columns } = model;
-        seriesItems.push({
-          id: shortid.generate(),
-          value: columns[0].name,
-        });
+      const { model } = this.props;
+      const { columns } = model;
+      seriesItems.push({
+        id: shortid.generate(),
+        value: columns[0].name,
+      });
 
-        return { seriesItems };
-      },
-      () => {
-        this.sendChange();
-      }
-    );
+      return { seriesItems };
+    }, this.sendChange);
   }
 
   handleLinkStateChange(event) {
-    this.setState({ isLinked: event.target.value === 'true' }, () => {
-      this.sendChange();
-    });
+    this.setState({ isLinked: event.target.value === 'true' }, this.sendChange);
   }
 
   handleReset() {
@@ -200,46 +194,34 @@ class ChartBuilder extends PureComponent {
     const seriesItems = ChartBuilder.makeDefaultSeriesItems(type, columns);
     const isLinked = true;
 
-    this.setState({ type, seriesItems, xAxis, isLinked }, () => {
-      this.sendChange();
-    });
+    this.setState({ type, seriesItems, xAxis, isLinked }, this.sendChange);
   }
 
   handleSeriesChange(event) {
     const { value } = event.target;
     const index = event.target.getAttribute('data-index');
 
-    this.setState(
-      state => {
-        let { seriesItems } = state;
+    this.setState(state => {
+      let { seriesItems } = state;
 
-        seriesItems = [].concat(seriesItems);
-        seriesItems[index].value = value;
+      seriesItems = [].concat(seriesItems);
+      seriesItems[index].value = value;
 
-        return { seriesItems };
-      },
-      () => {
-        this.sendChange();
-      }
-    );
+      return { seriesItems };
+    }, this.sendChange);
   }
 
   handleSeriesDeleteClick(event) {
     const index = event.target.getAttribute('data-index');
 
-    this.setState(
-      state => {
-        let { seriesItems } = state;
+    this.setState(state => {
+      let { seriesItems } = state;
 
-        seriesItems = [].concat(seriesItems);
-        seriesItems.splice(index, 1);
+      seriesItems = [].concat(seriesItems);
+      seriesItems.splice(index, 1);
 
-        return { seriesItems };
-      },
-      () => {
-        this.sendChange();
-      }
-    );
+      return { seriesItems };
+    }, this.sendChange);
   }
 
   handleSubmit(event) {
@@ -257,32 +239,25 @@ class ChartBuilder extends PureComponent {
 
     log.debug2('handleTypeSelect', type);
 
-    this.setState(
-      state => {
-        const maxSeriesCount = ChartBuilder.getMaxSeriesCount(type);
-        let { seriesItems } = state;
-        seriesItems = seriesItems.slice(0, maxSeriesCount);
-        if (seriesItems.length === 0 && maxSeriesCount > 0) {
-          const { model } = this.props;
-          const { columns } = model;
-          seriesItems = ChartBuilder.makeDefaultSeriesItems(type, columns);
-        }
-
-        return { type, seriesItems };
-      },
-      () => {
-        this.sendChange();
+    this.setState(state => {
+      const maxSeriesCount = ChartBuilder.getMaxSeriesCount(type);
+      let { seriesItems } = state;
+      seriesItems = seriesItems.slice(0, maxSeriesCount);
+      if (seriesItems.length === 0 && maxSeriesCount > 0) {
+        const { model } = this.props;
+        const { columns } = model;
+        seriesItems = ChartBuilder.makeDefaultSeriesItems(type, columns);
       }
-    );
+
+      return { type, seriesItems };
+    }, this.sendChange);
   }
 
   handleXAxisChange(event) {
     const xAxis = event.target.value;
     log.debug2('x-axis change', xAxis);
 
-    this.setState({ xAxis }, () => {
-      this.sendChange();
-    });
+    this.setState({ xAxis }, this.sendChange);
   }
 
   sendChange() {
@@ -346,6 +321,7 @@ class ChartBuilder extends PureComponent {
             <div
               className="form-row form-inline form-series-item"
               key={seriesItem.id}
+              data-testid={`form-series-item-${i}`}
             >
               <label className="col-2 label-left">
                 {i === 0 ? seriesLabel : ''}
@@ -354,6 +330,7 @@ class ChartBuilder extends PureComponent {
                 className="form-control custom-select select-series col"
                 value={seriesItem.value}
                 onChange={this.handleSeriesChange}
+                data-testid={`select-series-item-${i}`}
                 data-index={i}
               >
                 {columns.map(column => (
@@ -367,6 +344,7 @@ class ChartBuilder extends PureComponent {
                   type="button"
                   className="btn btn-link btn-link-icon btn-delete-series ml-2 px-2"
                   data-index={i}
+                  data-testid={`delete-series-${i}`}
                   onClick={this.handleSeriesDeleteClick}
                 >
                   <FontAwesomeIcon icon={vsTrash} />

--- a/packages/iris-grid/src/sidebar/ChartBuilder.test.jsx
+++ b/packages/iris-grid/src/sidebar/ChartBuilder.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import ChartBuilder from './ChartBuilder';
 import IrisGridTestUtils from '../IrisGridTestUtils';
@@ -24,19 +24,18 @@ it('renders without crashing', () => {
 });
 
 it('updates the chart type', () => {
-  const { container, unmount } = makeChartBuilderWrapper();
+  const { unmount } = makeChartBuilderWrapper();
 
-  let chartButtons = container.querySelectorAll('.btn-chart-type');
+  const lineButton = screen.getByText('Line');
+  const barButton = screen.getByText('Bar');
 
-  expect(chartButtons[0].classList.contains('active')).toBe(true);
-  expect(chartButtons[1].classList.contains('active')).toBe(false);
+  expect(lineButton.classList.contains('active')).toBe(true);
+  expect(barButton.classList.contains('active')).toBe(false);
 
-  userEvent.click(chartButtons[1]);
+  userEvent.click(barButton);
 
-  chartButtons = container.querySelectorAll('.btn-chart-type');
-
-  expect(chartButtons[0].classList.contains('active')).toBe(false);
-  expect(chartButtons[1].classList.contains('active')).toBe(true);
+  expect(lineButton.classList.contains('active')).toBe(false);
+  expect(barButton.classList.contains('active')).toBe(true);
 
   unmount();
 });
@@ -69,24 +68,30 @@ it('updates series selection with the proper columns', () => {
 });
 
 it('add and deletes series items', () => {
-  const { container } = makeChartBuilderWrapper();
-  const addSeriesItemBtn = container.querySelector('.btn-add-series');
+  const { unmount } = makeChartBuilderWrapper();
+  const addSeriesItemBtn = screen.getByText('Add Series');
 
-  expect(container.querySelectorAll('.form-series-item').length).toBe(1);
+  expect(screen.getAllByTestId(/form-series-item-./).length).toBe(1);
 
   userEvent.click(addSeriesItemBtn);
   userEvent.click(addSeriesItemBtn);
 
-  const seriesItems = container.querySelectorAll('.select-series');
-  userEvent.selectOptions(seriesItems[1], COLUMN_NAMES[3]);
-  userEvent.selectOptions(seriesItems[2], COLUMN_NAMES[2]);
+  const seriesItem1 = screen.getByTestId('select-series-item-1');
+  const seriesItem2 = screen.getByTestId('select-series-item-2');
+  userEvent.selectOptions(seriesItem1, COLUMN_NAMES[3]);
+  userEvent.selectOptions(seriesItem2, COLUMN_NAMES[2]);
 
-  expect(seriesItems[1].value).toBe(COLUMN_NAMES[3]);
-  expect(seriesItems[2].value).toBe(COLUMN_NAMES[2]);
+  expect(seriesItem1.value).toBe(COLUMN_NAMES[3]);
+  expect(seriesItem2.value).toBe(COLUMN_NAMES[2]);
 
-  userEvent.click(container.querySelector('.btn-delete-series'));
+  userEvent.click(screen.getByTestId('delete-series-1'));
 
-  expect(container.querySelectorAll('.form-series-item').length).toBe(2);
+  expect(screen.getAllByTestId(/form-series-item-./).length).toBe(2);
+  expect(screen.getByTestId('select-series-item-1').value).toBe(
+    COLUMN_NAMES[2]
+  );
+
+  unmount();
 });
 
 it('updates linked state', () => {
@@ -135,7 +140,7 @@ it('handles form submission', () => {
 
   userEvent.click(container.querySelector('.btn-submit'));
 
-  expect(onSubmit).toHaveBeenCalled();
+  expect(onSubmit).toHaveBeenCalledTimes(1);
 
   unmount();
 });

--- a/packages/iris-grid/src/sidebar/ChartBuilder.test.jsx
+++ b/packages/iris-grid/src/sidebar/ChartBuilder.test.jsx
@@ -48,7 +48,9 @@ it('has x-axis selection with the proper columns', () => {
   expect(xAxisSelectElm.querySelectorAll('option').length).toBe(
     COLUMN_NAMES.length
   );
-  expect(xAxisSelectElm.value).toBe(COLUMN_NAMES[0]);
+  userEvent.selectOptions(xAxisSelectElm, COLUMN_NAMES[1]);
+
+  expect(xAxisSelectElm.value).toBe(COLUMN_NAMES[1]);
   unmount();
 });
 
@@ -60,6 +62,8 @@ it('updates series selection with the proper columns', () => {
     COLUMN_NAMES.length
   );
   expect(seriesSelectElm.value).toBe(COLUMN_NAMES[1]);
+  userEvent.selectOptions(seriesSelectElm, COLUMN_NAMES[2]);
+  expect(seriesSelectElm.value).toBe(COLUMN_NAMES[2]);
 
   unmount();
 });
@@ -73,7 +77,29 @@ it('add and deletes series items', () => {
   userEvent.click(addSeriesItemBtn);
   userEvent.click(addSeriesItemBtn);
 
-  expect(container.querySelectorAll('.form-series-item').length).toBe(3);
+  const seriesItems = container.querySelectorAll('.select-series');
+  userEvent.selectOptions(seriesItems[1], COLUMN_NAMES[3]);
+  userEvent.selectOptions(seriesItems[2], COLUMN_NAMES[2]);
+
+  expect(seriesItems[1].value).toBe(COLUMN_NAMES[3]);
+  expect(seriesItems[2].value).toBe(COLUMN_NAMES[2]);
+
+  userEvent.click(container.querySelector('.btn-delete-series'));
+
+  expect(container.querySelectorAll('.form-series-item').length).toBe(2);
+});
+
+it('updates linked state', () => {
+  const { container } = makeChartBuilderWrapper();
+  const chartBuilderLinks = container.querySelectorAll(
+    '.chart-builder-link input[type="radio"]'
+  );
+
+  userEvent.click(chartBuilderLinks[1]);
+  expect(chartBuilderLinks[1].value).toBe('false');
+
+  userEvent.click(chartBuilderLinks[0]);
+  expect(chartBuilderLinks[0].value).toBe('true');
 });
 
 it('resets the form properly', () => {

--- a/packages/iris-grid/src/sidebar/ChartBuilder.test.jsx
+++ b/packages/iris-grid/src/sidebar/ChartBuilder.test.jsx
@@ -90,16 +90,29 @@ it('add and deletes series items', () => {
 });
 
 it('updates linked state', () => {
-  const { container } = makeChartBuilderWrapper();
-  const chartBuilderLinks = container.querySelectorAll(
-    '.chart-builder-link input[type="radio"]'
+  const onChange = jest.fn();
+  const { container } = makeChartBuilderWrapper({ onChange });
+
+  const linkButton = container.querySelector(
+    '.chart-builder-link input[type="radio"][value="true"]'
+  );
+  const unlinkButton = container.querySelector(
+    '.chart-builder-link input[type="radio"][value="false"]'
   );
 
-  userEvent.click(chartBuilderLinks[1]);
-  expect(chartBuilderLinks[1].value).toBe('false');
+  expect(onChange).not.toHaveBeenCalled();
 
-  userEvent.click(chartBuilderLinks[0]);
-  expect(chartBuilderLinks[0].value).toBe('true');
+  userEvent.click(unlinkButton);
+
+  expect(onChange).toHaveBeenCalledWith(
+    expect.objectContaining({ isLinked: false })
+  );
+  onChange.mockClear();
+
+  userEvent.click(linkButton);
+  expect(onChange).toHaveBeenCalledWith(
+    expect.objectContaining({ isLinked: true })
+  );
 });
 
 it('resets the form properly', () => {

--- a/packages/iris-grid/src/sidebar/ChartBuilder.test.jsx
+++ b/packages/iris-grid/src/sidebar/ChartBuilder.test.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { mount } from 'enzyme';
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import ChartBuilder from './ChartBuilder';
 import IrisGridTestUtils from '../IrisGridTestUtils';
 
@@ -12,152 +13,114 @@ function makeChartBuilderWrapper({
     IrisGridTestUtils.makeTable(COLUMN_NAMES.map(IrisGridTestUtils.makeColumn))
   ),
 } = {}) {
-  return mount(
+  return render(
     <ChartBuilder onChange={onChange} onSubmit={onSubmit} model={model} />
   );
 }
 
 it('renders without crashing', () => {
-  const wrapper = makeChartBuilderWrapper();
-  wrapper.unmount();
+  const { unmount } = makeChartBuilderWrapper();
+  unmount();
 });
 
 it('updates the chart type', () => {
-  const wrapper = makeChartBuilderWrapper();
+  const { container, unmount } = makeChartBuilderWrapper();
 
-  let chartButtons = wrapper.find('.btn-chart-type');
-  expect(wrapper.state('type')).toBe(ChartBuilder.types[0]);
-  expect(chartButtons.at(0).hasClass('active')).toBe(true);
-  expect(chartButtons.at(1).hasClass('active')).toBe(false);
+  let chartButtons = container.querySelectorAll('.btn-chart-type');
 
-  chartButtons.at(1).simulate('click');
+  expect(chartButtons[0].classList.contains('active')).toBe(true);
+  expect(chartButtons[1].classList.contains('active')).toBe(false);
 
-  chartButtons = wrapper.find('.btn-chart-type');
+  userEvent.click(chartButtons[1]);
 
-  expect(wrapper.state('type')).toBe(ChartBuilder.types[1]);
-  expect(chartButtons.at(0).hasClass('active')).toBe(false);
-  expect(chartButtons.at(1).hasClass('active')).toBe(true);
+  chartButtons = container.querySelectorAll('.btn-chart-type');
 
-  wrapper.unmount();
+  expect(chartButtons[0].classList.contains('active')).toBe(false);
+  expect(chartButtons[1].classList.contains('active')).toBe(true);
+
+  unmount();
 });
 
 it('has x-axis selection with the proper columns', () => {
-  const wrapper = makeChartBuilderWrapper();
+  const { container, unmount } = makeChartBuilderWrapper();
+  const xAxisSelectElm = container.querySelector('.select-x-axis');
 
-  expect(wrapper.find('.select-x-axis').children().length).toBe(
+  expect(xAxisSelectElm.querySelectorAll('option').length).toBe(
     COLUMN_NAMES.length
   );
-  expect(wrapper.find('.select-x-axis').instance().value).toBe(COLUMN_NAMES[0]);
-  expect(wrapper.state('xAxis')).toBe(COLUMN_NAMES[0]);
-
-  wrapper.find('.select-x-axis').childAt(1).simulate('change');
-  expect(wrapper.state('xAxis')).toBe(COLUMN_NAMES[1]);
-
-  wrapper.unmount();
+  expect(xAxisSelectElm.value).toBe(COLUMN_NAMES[0]);
+  unmount();
 });
 
 it('updates series selection with the proper columns', () => {
-  const wrapper = makeChartBuilderWrapper();
+  const { container, unmount } = makeChartBuilderWrapper();
+  const seriesSelectElm = container.querySelector('.select-series');
 
-  expect(wrapper.find('.select-series').children().length).toBe(
+  expect(seriesSelectElm.querySelectorAll('option').length).toBe(
     COLUMN_NAMES.length
   );
-  expect(wrapper.find('.select-series').instance().value).toBe(COLUMN_NAMES[1]);
-  expect(wrapper.state('seriesItems').map(item => item.value)).toEqual([
-    COLUMN_NAMES[1],
-  ]);
+  expect(seriesSelectElm.value).toBe(COLUMN_NAMES[1]);
 
-  wrapper.find('.select-series').childAt(2).simulate('change');
-  expect(wrapper.state('seriesItems').map(item => item.value)).toEqual([
-    COLUMN_NAMES[2],
-  ]);
-
-  wrapper.unmount();
+  unmount();
 });
 
 it('add and deletes series items', () => {
-  const wrapper = makeChartBuilderWrapper();
+  const { container } = makeChartBuilderWrapper();
+  const addSeriesItemBtn = container.querySelector('.btn-add-series');
 
-  expect(wrapper.state('seriesItems').length).toBe(1);
+  expect(container.querySelectorAll('.form-series-item').length).toBe(1);
 
-  wrapper.find('.btn-add-series').simulate('click');
-  wrapper.find('.btn-add-series').simulate('click');
+  userEvent.click(addSeriesItemBtn);
+  userEvent.click(addSeriesItemBtn);
 
-  expect(wrapper.state('seriesItems').length).toBe(3);
-
-  wrapper.find('.select-series').at(1).childAt(3).simulate('change');
-  wrapper.find('.select-series').at(2).childAt(2).simulate('change');
-
-  expect(wrapper.state('seriesItems').map(item => item.value)).toEqual([
-    COLUMN_NAMES[1],
-    COLUMN_NAMES[3],
-    COLUMN_NAMES[2],
-  ]);
-
-  wrapper.find('.btn-delete-series').at(0).simulate('click');
-
-  expect(wrapper.state('seriesItems').map(item => item.value)).toEqual([
-    COLUMN_NAMES[3],
-    COLUMN_NAMES[2],
-  ]);
-});
-
-it('updates linked state', () => {
-  const wrapper = makeChartBuilderWrapper();
-
-  expect(wrapper.state('isLinked')).toBe(true);
-
-  wrapper
-    .find('.chart-builder-link input[type="radio"]')
-    .at(1)
-    .simulate('change', { target: { value: 'false' } });
-
-  expect(wrapper.state('isLinked')).toBe(false);
-
-  wrapper
-    .find('.chart-builder-link input[type="radio"]')
-    .at(0)
-    .simulate('change', { target: { value: 'true' } });
-
-  expect(wrapper.state('isLinked')).toBe(true);
+  expect(container.querySelectorAll('.form-series-item').length).toBe(3);
 });
 
 it('resets the form properly', () => {
-  const wrapper = makeChartBuilderWrapper();
+  const { container, unmount } = makeChartBuilderWrapper();
+  const addSeriesItemBtn = container.querySelector('.btn-add-series');
 
-  wrapper.find('.btn-add-series').simulate('click');
-  wrapper.find('.btn-add-series').simulate('click');
-  wrapper.find('.btn-add-series').simulate('click');
+  userEvent.click(addSeriesItemBtn);
+  userEvent.click(addSeriesItemBtn);
 
-  wrapper.find('.btn-reset').simulate('click');
+  userEvent.click(container.querySelector('.btn-reset'));
 
-  expect(wrapper.state('seriesItems').length).toBe(1);
+  expect(container.querySelectorAll('.form-series-item').length).toBe(1);
 
-  wrapper.unmount();
+  unmount();
 });
 
 it('handles form submission', () => {
   const onSubmit = jest.fn();
-  const wrapper = makeChartBuilderWrapper({ onSubmit });
+  const { container, unmount } = makeChartBuilderWrapper({ onSubmit });
 
-  wrapper.find('.btn-submit').simulate('submit');
+  userEvent.click(container.querySelector('.btn-submit'));
 
   expect(onSubmit).toHaveBeenCalled();
 
-  wrapper.unmount();
+  unmount();
 });
 
 it('calls onChange when fields are updated', () => {
   const onChange = jest.fn();
-  const wrapper = makeChartBuilderWrapper({ onChange });
+  const { container, unmount } = makeChartBuilderWrapper({ onChange });
+  const addSeriesItemBtn = container.querySelector('.btn-add-series');
 
-  wrapper.find('.select-series').childAt(1).simulate('change');
-  wrapper.find('.btn-add-series').simulate('click');
-  wrapper.find('.btn-add-series').simulate('click');
-  wrapper.find('.select-series').at(2).childAt(2).simulate('change');
-  wrapper.find('.btn-chart-type').at(1).simulate('click');
+  userEvent.selectOptions(
+    container.querySelector('.select-series'),
+    COLUMN_NAMES[1]
+  );
+
+  userEvent.click(addSeriesItemBtn);
+  userEvent.click(addSeriesItemBtn);
+  userEvent.selectOptions(
+    container.querySelectorAll('.select-series')[2],
+    COLUMN_NAMES[2]
+  );
+
+  userEvent.click(container.querySelectorAll('.btn-chart-type')[1]);
 
   expect(onChange).toHaveBeenCalledTimes(5);
 
-  wrapper.unmount();
+  unmount();
 });

--- a/packages/iris-grid/src/sidebar/ChartBuilder.test.jsx
+++ b/packages/iris-grid/src/sidebar/ChartBuilder.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import ChartBuilder from './ChartBuilder';
 import IrisGridTestUtils from '../IrisGridTestUtils';
@@ -19,15 +19,14 @@ function makeChartBuilderWrapper({
 }
 
 it('renders without crashing', () => {
-  const { unmount } = makeChartBuilderWrapper();
-  unmount();
+  makeChartBuilderWrapper();
 });
 
 it('updates the chart type', () => {
-  const { unmount } = makeChartBuilderWrapper();
+  const { getByText } = makeChartBuilderWrapper();
 
-  const lineButton = screen.getByText('Line');
-  const barButton = screen.getByText('Bar');
+  const lineButton = getByText('Line');
+  const barButton = getByText('Bar');
 
   expect(lineButton.classList.contains('active')).toBe(true);
   expect(barButton.classList.contains('active')).toBe(false);
@@ -36,12 +35,10 @@ it('updates the chart type', () => {
 
   expect(lineButton.classList.contains('active')).toBe(false);
   expect(barButton.classList.contains('active')).toBe(true);
-
-  unmount();
 });
 
 it('has x-axis selection with the proper columns', () => {
-  const { container, unmount } = makeChartBuilderWrapper();
+  const { container } = makeChartBuilderWrapper();
   const xAxisSelectElm = container.querySelector('.select-x-axis');
 
   expect(xAxisSelectElm.querySelectorAll('option').length).toBe(
@@ -50,11 +47,10 @@ it('has x-axis selection with the proper columns', () => {
   userEvent.selectOptions(xAxisSelectElm, COLUMN_NAMES[1]);
 
   expect(xAxisSelectElm.value).toBe(COLUMN_NAMES[1]);
-  unmount();
 });
 
 it('updates series selection with the proper columns', () => {
-  const { container, unmount } = makeChartBuilderWrapper();
+  const { container } = makeChartBuilderWrapper();
   const seriesSelectElm = container.querySelector('.select-series');
 
   expect(seriesSelectElm.querySelectorAll('option').length).toBe(
@@ -63,35 +59,29 @@ it('updates series selection with the proper columns', () => {
   expect(seriesSelectElm.value).toBe(COLUMN_NAMES[1]);
   userEvent.selectOptions(seriesSelectElm, COLUMN_NAMES[2]);
   expect(seriesSelectElm.value).toBe(COLUMN_NAMES[2]);
-
-  unmount();
 });
 
 it('add and deletes series items', () => {
-  const { unmount } = makeChartBuilderWrapper();
-  const addSeriesItemBtn = screen.getByText('Add Series');
+  const { getAllByTestId, getByTestId, getByText } = makeChartBuilderWrapper();
+  const addSeriesItemBtn = getByText('Add Series');
 
-  expect(screen.getAllByTestId(/form-series-item-./).length).toBe(1);
+  expect(getAllByTestId(/form-series-item-./).length).toBe(1);
 
   userEvent.click(addSeriesItemBtn);
   userEvent.click(addSeriesItemBtn);
 
-  const seriesItem1 = screen.getByTestId('select-series-item-1');
-  const seriesItem2 = screen.getByTestId('select-series-item-2');
+  const seriesItem1 = getByTestId('select-series-item-1');
+  const seriesItem2 = getByTestId('select-series-item-2');
   userEvent.selectOptions(seriesItem1, COLUMN_NAMES[3]);
   userEvent.selectOptions(seriesItem2, COLUMN_NAMES[2]);
 
   expect(seriesItem1.value).toBe(COLUMN_NAMES[3]);
   expect(seriesItem2.value).toBe(COLUMN_NAMES[2]);
 
-  userEvent.click(screen.getByTestId('delete-series-1'));
+  userEvent.click(getByTestId('delete-series-1'));
 
-  expect(screen.getAllByTestId(/form-series-item-./).length).toBe(2);
-  expect(screen.getByTestId('select-series-item-1').value).toBe(
-    COLUMN_NAMES[2]
-  );
-
-  unmount();
+  expect(getAllByTestId(/form-series-item-./).length).toBe(2);
+  expect(getByTestId('select-series-item-1').value).toBe(COLUMN_NAMES[2]);
 });
 
 it('updates linked state', () => {
@@ -121,7 +111,7 @@ it('updates linked state', () => {
 });
 
 it('resets the form properly', () => {
-  const { container, unmount } = makeChartBuilderWrapper();
+  const { container } = makeChartBuilderWrapper();
   const addSeriesItemBtn = container.querySelector('.btn-add-series');
 
   userEvent.click(addSeriesItemBtn);
@@ -130,24 +120,20 @@ it('resets the form properly', () => {
   userEvent.click(container.querySelector('.btn-reset'));
 
   expect(container.querySelectorAll('.form-series-item').length).toBe(1);
-
-  unmount();
 });
 
 it('handles form submission', () => {
   const onSubmit = jest.fn();
-  const { container, unmount } = makeChartBuilderWrapper({ onSubmit });
+  const { container } = makeChartBuilderWrapper({ onSubmit });
 
   userEvent.click(container.querySelector('.btn-submit'));
 
   expect(onSubmit).toHaveBeenCalledTimes(1);
-
-  unmount();
 });
 
 it('calls onChange when fields are updated', () => {
   const onChange = jest.fn();
-  const { container, unmount } = makeChartBuilderWrapper({ onChange });
+  const { container } = makeChartBuilderWrapper({ onChange });
   const addSeriesItemBtn = container.querySelector('.btn-add-series');
 
   userEvent.selectOptions(
@@ -165,6 +151,4 @@ it('calls onChange when fields are updated', () => {
   userEvent.click(container.querySelectorAll('.btn-chart-type')[1]);
 
   expect(onChange).toHaveBeenCalledTimes(5);
-
-  unmount();
 });


### PR DESCRIPTION
- rm enzyme: refactor ChartBuilder tests to use RTL
- Send an event on isLinked update - before we weren't sending it, which wasn't really an issue because we didn't have live previews, but it was inconsistent.
- Replaces #491 