### PR TITLE
Fix flakey test

### DIFF
--- a/packages/components/src/context-actions/ContextActions.test.tsx
+++ b/packages/components/src/context-actions/ContextActions.test.tsx
@@ -4,6 +4,20 @@ import { TestUtils } from '@deephaven/utils';
 import ContextActionUtils from './ContextActionUtils';
 import ContextMenuRoot from './ContextMenuRoot';
 
+let spy: jest.SpyInstance;
+beforeEach(() => {
+  spy = jest.spyOn(window, 'requestAnimationFrame').mockImplementation(cb => {
+    // mock request animation frame
+    // only safe to mock like this if RAF is non-recursive
+    cb(0);
+    return 0;
+  });
+});
+
+afterEach(() => {
+  spy.mockRestore();
+});
+
 type ContextMenuMock = {
   addEventListener: jest.Mock<void>;
   removeEventListener: jest.Mock<void>;


### PR DESCRIPTION
Codecov reporting the test was changing coverage amount. I think it might be the requestAnimationFrame, and mocking that should fix it.

Resolves #508