### PR TITLE
Focus irisgrid on tab click

### DIFF
--- a/packages/dashboard-core-plugins/src/panels/IrisGridPanel.jsx
+++ b/packages/dashboard-core-plugins/src/panels/IrisGridPanel.jsx
@@ -60,6 +60,7 @@ export class IrisGridPanel extends PureComponent {
     this.handleCreateChart = this.handleCreateChart.bind(this);
     this.handleResize = this.handleResize.bind(this);
     this.handleShow = this.handleShow.bind(this);
+    this.handleTabClicked = this.handleTabClicked.bind(this);
     this.handleDisconnect = this.handleDisconnect.bind(this);
     this.handleReconnect = this.handleReconnect.bind(this);
     this.handleLoadSuccess = this.handleLoadSuccess.bind(this);
@@ -504,6 +505,12 @@ export class IrisGridPanel extends PureComponent {
     this.updateGrid();
   }
 
+  handleTabClicked() {
+    if (this.irisGrid.current) {
+      this.irisGrid.current.focus();
+    }
+  }
+
   handleError(error) {
     log.error(error);
     this.setState({ error, isLoading: false });
@@ -935,6 +942,7 @@ export class IrisGridPanel extends PureComponent {
         onResize={this.handleResize}
         onShow={this.handleShow}
         onTabFocus={this.handleShow}
+        onTabClicked={this.handleTabClicked}
         queryName={queryName}
         querySerial={querySerial}
         widgetName={name}

--- a/packages/dashboard-core-plugins/src/panels/Panel.jsx
+++ b/packages/dashboard-core-plugins/src/panels/Panel.jsx
@@ -36,7 +36,7 @@ class Panel extends PureComponent {
     this.handleRenameCancel = this.handleRenameCancel.bind(this);
     this.handleRenameSubmit = this.handleRenameSubmit.bind(this);
     this.handleShowRenameDialog = this.handleShowRenameDialog.bind(this);
-
+    this.handleTabClicked = this.handleTabClicked.bind(this);
     this.handleTab = this.handleTab.bind(this);
 
     const { glContainer } = this.props;
@@ -54,6 +54,7 @@ class Panel extends PureComponent {
     glContainer.on('shown', this.handleShow);
     glContainer.on('hide', this.handleHide);
     glContainer.on('tab', this.handleTab);
+    glContainer.on('tabClicked', this.handleTabClicked);
     glEventHub.on(ConsoleEvent.SESSION_CLOSED, this.handleSessionClosed);
     glEventHub.on(ConsoleEvent.SESSION_OPENED, this.handleSessionOpened);
     glEventHub.on(TabEvent.focus, this.handleTabFocus);
@@ -98,6 +99,11 @@ class Panel extends PureComponent {
 
     const { onTab } = this.props;
     onTab(tab);
+  }
+
+  handleTabClicked(...args) {
+    const { onTabClicked } = this.props;
+    onTabClicked(...args);
   }
 
   handleClearAllFilters(...args) {
@@ -293,6 +299,7 @@ Panel.propTypes = {
   onFocus: PropTypes.func,
   onBlur: PropTypes.func,
   onTab: PropTypes.func,
+  onTabClicked: PropTypes.func,
   onClearAllFilters: PropTypes.func,
   onHide: PropTypes.func,
   onResize: PropTypes.func,
@@ -314,6 +321,7 @@ Panel.propTypes = {
 Panel.defaultProps = {
   className: '',
   onTab: () => {},
+  onTabClicked: () => {},
   onClearAllFilters: () => {},
   onFocus: () => {},
   onBlur: () => {},

--- a/packages/dashboard-core-plugins/src/panels/Panel.jsx
+++ b/packages/dashboard-core-plugins/src/panels/Panel.jsx
@@ -75,6 +75,7 @@ class Panel extends PureComponent {
     glContainer.off('shown', this.handleShow);
     glContainer.off('hide', this.handleHide);
     glContainer.off('tab', this.handleTab);
+    glContainer.off('tabClicked', this.handleTabClicked);
     glEventHub.off(ConsoleEvent.SESSION_CLOSED, this.handleSessionClosed);
     glEventHub.off(ConsoleEvent.SESSION_OPENED, this.handleSessionOpened);
     glEventHub.off(TabEvent.focus, this.handleTabFocus);

--- a/packages/dashboard-core-plugins/src/panels/Panel.test.jsx
+++ b/packages/dashboard-core-plugins/src/panels/Panel.test.jsx
@@ -1,0 +1,122 @@
+/* eslint-disable no-unused-vars */
+/* eslint-disable react/prefer-stateless-function */
+/* eslint func-names: "off" */
+import React, { Component } from 'react';
+import GoldenLayout from '@deephaven/golden-layout';
+import { render } from '@testing-library/react';
+import Panel from './Panel';
+
+class TestComponentPanel extends Component {}
+
+function makeChildren() {
+  return <div>Test Children</div>;
+}
+
+function makeComponentPanel() {
+  return new TestComponentPanel();
+}
+
+function makeGlComponent({
+  on = jest.fn(),
+  off = jest.fn(),
+  emit = jest.fn(),
+} = {}) {
+  return { on, off, emit: jest.fn() };
+}
+
+function renderPanel({
+  children = makeChildren(),
+  componentPanel = makeComponentPanel(),
+  glContainer = makeGlComponent(),
+  glEventHub = makeGlComponent(),
+  onResize = jest.fn(),
+  onShow = jest.fn(),
+  onBeforeShow = jest.fn(),
+  onHide = jest.fn(),
+  onTab = jest.fn(),
+  onTabClicked = jest.fn(),
+} = {}) {
+  return render(
+    <Panel
+      componentPanel={componentPanel}
+      glContainer={glContainer}
+      glEventHub={glEventHub}
+      onResize={onResize}
+      onShow={onShow}
+      onBeforeShow={onBeforeShow}
+      onHide={onHide}
+      onTab={onTab}
+      onTabClicked={onTabClicked}
+    >
+      {children}
+    </Panel>
+  );
+}
+
+it('renders without crashing', () => {
+  renderPanel();
+});
+
+describe('adds and emits events correctly', () => {
+  it('emits a signal when the tab is clicked', () => {
+    const on = jest.fn();
+    const off = jest.fn();
+    const onResize = jest.fn();
+    const onShow = jest.fn();
+    const onBeforeShow = jest.fn();
+    const onHide = jest.fn();
+    const onTab = jest.fn();
+    const onTabClicked = jest.fn();
+
+    const glContainer = makeGlComponent({ on, off });
+    const { unmount } = renderPanel({
+      glContainer,
+      onResize,
+      onShow,
+      onBeforeShow,
+      onHide,
+      onTab,
+      onTabClicked,
+    });
+
+    // Map of event names to callbacks
+    const propCallbacks = new Map();
+    propCallbacks.set('resize', onResize);
+    propCallbacks.set('show', onBeforeShow);
+    propCallbacks.set('shown', onShow);
+    propCallbacks.set('hide', onHide);
+    propCallbacks.set('tab', onTab);
+    propCallbacks.set('tabClicked', onTabClicked);
+
+    const eventCallbacks = new Map();
+    for (let i = 0; i < on.mock.calls.length; i += 1) {
+      const call = on.mock.calls[i];
+      eventCallbacks.set(call[0], call[1]);
+    }
+
+    // If we start listening to something else in Panel, we want to add it to the tests as well, so check the size
+    expect(on).toHaveBeenCalledTimes(propCallbacks.size);
+    expect(off).not.toHaveBeenCalled();
+
+    const eventNames = [...propCallbacks.keys()];
+    for (let i = 0; i < eventNames.length; i += 1) {
+      const eventName = eventNames[i];
+      const testArg = { eventName };
+      const propCallback = propCallbacks.get(eventName);
+      expect(propCallback).not.toHaveBeenCalled();
+      eventCallbacks.get(eventName)(testArg);
+      expect(propCallback).toHaveBeenCalledWith(testArg);
+    }
+
+    unmount();
+
+    // Make sure we call `off` with the correct event names on unmount
+    for (let i = 0; i < eventNames.length; i += 1) {
+      const eventName = eventNames[i];
+      expect(off).toHaveBeenCalledWith(
+        eventName,
+        eventCallbacks.get(eventName)
+      );
+    }
+  });
+});

--- a/packages/dashboard-core-plugins/src/panels/WidgetPanel.jsx
+++ b/packages/dashboard-core-plugins/src/panels/WidgetPanel.jsx
@@ -109,6 +109,7 @@ class WidgetPanel extends PureComponent {
       onShow,
       onTabBlur,
       onTabFocus,
+      onTabClicked,
     } = this.props;
 
     const {
@@ -147,6 +148,7 @@ class WidgetPanel extends PureComponent {
         onSessionOpen={this.handleSessionOpened}
         onTabBlur={onTabBlur}
         onTabFocus={onTabFocus}
+        onTabClicked={onTabClicked}
         renderTabTooltip={doRenderTabTooltip}
         errorMessage={errorMessage}
         isLoaded={isLoaded}
@@ -191,6 +193,7 @@ WidgetPanel.propTypes = {
   onShow: PropTypes.func,
   onTabBlur: PropTypes.func,
   onTabFocus: PropTypes.func,
+  onTabClicked: PropTypes.func,
 };
 
 WidgetPanel.defaultProps = {
@@ -217,6 +220,7 @@ WidgetPanel.defaultProps = {
   onShow: () => {},
   onTabBlur: () => {},
   onTabFocus: () => {},
+  onTabClicked: () => {},
 };
 
 export default WidgetPanel;

--- a/packages/golden-layout/src/js/controls/Tab.js
+++ b/packages/golden-layout/src/js/controls/Tab.js
@@ -231,7 +231,13 @@ lm.utils.copy(lm.controls.Tab.prototype, {
           document.activeElement
         )
       ) {
+        // if no focus inside put focus onto the container
+        // so focusin always fires for tabclicks
         this.contentItem.container._contentElement.focus();
+
+        // still emit tab clicked event, so panels can also
+        // do it's own focus handling if desired
+        this.contentItem.container.emit('tabClicked');
       }
 
       // might have been called from the dropdown

--- a/packages/iris-grid/src/IrisGrid.jsx
+++ b/packages/iris-grid/src/IrisGrid.jsx
@@ -1472,6 +1472,10 @@ export class IrisGrid extends Component {
     );
   }
 
+  focus() {
+    if (this.grid) this.grid.focus();
+  }
+
   focusFilterBar(column) {
     const { model } = this.props;
     const { columnCount } = model;


### PR DESCRIPTION
- Resolves #416
- Moved tabclick event in golden-layout to always fire on click, and not just when tab first becomes active in stack (so if tab is clicked when already at top, it still focuses table)
- listen to existing onTabClicked in panel and widgetpanel
- irisgridpanel onTabClicked focus irisgrid (which focuses grid)