### PR TITLE
Fix 'Unknown columnType' warnings

### DIFF
--- a/packages/iris-grid/src/Formatter.ts
+++ b/packages/iris-grid/src/Formatter.ts
@@ -1,4 +1,3 @@
-import { Log } from '@deephaven/log';
 import TableUtils, { DataType } from './TableUtils';
 import {
   BooleanColumnFormatter,
@@ -11,8 +10,6 @@ import {
   TableColumnFormatter,
 } from './formatters';
 import StringColumnFormatter from './formatters/StringColumnFormatter';
-
-const log = Log.module('Formatter');
 
 type ColumnName = string;
 

--- a/packages/iris-grid/src/Formatter.ts
+++ b/packages/iris-grid/src/Formatter.ts
@@ -136,7 +136,6 @@ class Formatter {
   ): Map<string, TableColumnFormat> | undefined {
     const dataType = TableUtils.getNormalizedType(columnType);
     if (dataType === null) {
-      log.warn(`Unknown columnType ${columnType}`);
       return undefined;
     }
 


### PR DESCRIPTION
Remove warnings for `TableUtils.getNormalizedType(...) === null`.
This is a valid case for column types rendered with the default formatter, no warning needed.