### PR TITLE
Fix CSV download formatting

### DIFF
--- a/packages/iris-grid/src/FormatterUtils.test.ts
+++ b/packages/iris-grid/src/FormatterUtils.test.ts
@@ -1,0 +1,85 @@
+import Formatter from './Formatter';
+import FormatterUtils from './FormatterUtils';
+import {
+  TableColumnFormat,
+  TableColumnFormatter,
+  TableColumnFormatType,
+} from './formatters';
+import TableUtils from './TableUtils';
+
+function makeFormatter(...settings: ConstructorParameters<typeof Formatter>) {
+  return new Formatter(...settings);
+}
+
+function makeFormattingRule(
+  label: string,
+  formatString = '',
+  type: TableColumnFormatType = TableColumnFormatter.TYPE_CONTEXT_CUSTOM
+): TableColumnFormat {
+  return { label, formatString, type };
+}
+
+describe('isCustomColumnFormatDefined', () => {
+  const columnFormats = [
+    Formatter.makeColumnFormattingRule(
+      TableUtils.dataType.DECIMAL,
+      'Col 1',
+      makeFormattingRule('format 1 custom')
+    ),
+    Formatter.makeColumnFormattingRule(
+      TableUtils.dataType.DECIMAL,
+      'Col 2',
+      makeFormattingRule(
+        'format 2 preset',
+        '',
+        TableColumnFormatter.TYPE_CONTEXT_PRESET
+      )
+    ),
+    Formatter.makeColumnFormattingRule(
+      TableUtils.dataType.DECIMAL,
+      'Col 3',
+      makeFormattingRule(
+        'format 3 global',
+        '',
+        TableColumnFormatter.TYPE_GLOBAL
+      )
+    ),
+  ];
+
+  it('is true for columns with custom or preset formats', () => {
+    const formatter = makeFormatter(columnFormats);
+    expect(
+      FormatterUtils.isCustomColumnFormatDefined(
+        formatter,
+        'Col 1',
+        TableUtils.dataType.DECIMAL
+      )
+    ).toBe(true);
+    expect(
+      FormatterUtils.isCustomColumnFormatDefined(
+        formatter,
+        'Col 2',
+        TableUtils.dataType.DECIMAL
+      )
+    ).toBe(true);
+  });
+
+  it('is false for columns with global or no format', () => {
+    const formatter = makeFormatter(columnFormats);
+    expect(
+      FormatterUtils.isCustomColumnFormatDefined(
+        formatter,
+        'Col 3',
+        TableUtils.dataType.DECIMAL
+      )
+    ).toBe(false);
+    expect(
+      FormatterUtils.isCustomColumnFormatDefined(
+        formatter,
+        // No format defined for Col 4
+        'Col 4',
+        TableUtils.dataType.DECIMAL
+      )
+    ).toBe(false);
+  });
+});

--- a/packages/iris-grid/src/FormatterUtils.ts
+++ b/packages/iris-grid/src/FormatterUtils.ts
@@ -1,5 +1,6 @@
 import type { FormattingRule } from './Formatter';
-import { DateTimeColumnFormatter } from './formatters';
+import Formatter from './Formatter';
+import { DateTimeColumnFormatter, TableColumnFormatter } from './formatters';
 
 class FormatterUtils {
   static getColumnFormats(settings: {
@@ -27,6 +28,26 @@ class FormatterUtils {
       showTimeZone,
       showTSeparator,
     };
+  }
+
+  /**
+   * Check if the formatter has a custom format defined for the column name and type
+   * @param formatter Formatter to check
+   * @param columnName Column name
+   * @param columnType Column type
+   * @returns True, if a custom format is defined
+   */
+  static isCustomColumnFormatDefined(
+    formatter: Formatter,
+    columnName: string,
+    columnType: string
+  ): boolean {
+    const columnFormat = formatter.getColumnFormat(columnType, columnName);
+    return (
+      columnFormat != null &&
+      (columnFormat.type === TableColumnFormatter.TYPE_CONTEXT_PRESET ||
+        columnFormat.type === TableColumnFormatter.TYPE_CONTEXT_CUSTOM)
+    );
   }
 }
 

--- a/packages/iris-grid/src/IrisGridTableModel.js
+++ b/packages/iris-grid/src/IrisGridTableModel.js
@@ -7,7 +7,7 @@ import Log from '@deephaven/log';
 import { PromiseUtils } from '@deephaven/utils';
 import TableUtils from './TableUtils';
 import Formatter from './Formatter';
-import { TableColumnFormatter } from './formatters';
+import FormatterUtils from './FormatterUtils';
 import IrisGridModel from './IrisGridModel';
 import AggregationOperation from './sidebar/aggregations/AggregationOperation';
 import IrisGridUtils from './IrisGridUtils';
@@ -363,7 +363,6 @@ class IrisGridTableModel extends IrisGridModel {
       }
 
       const column = this.totalsColumn(x, y) ?? this.columns[x];
-      // TODO: formatting
       const hasCustomColumnFormat = this.getCachedCustomColumnFormatFlag(
         this.formatter,
         column.type,
@@ -692,7 +691,6 @@ class IrisGridTableModel extends IrisGridModel {
   }
 
   formatForCell(x, y) {
-    //
     return this.dataForCell(x, y)?.format;
   }
 
@@ -1208,14 +1206,7 @@ class IrisGridTableModel extends IrisGridModel {
   );
 
   getCachedCustomColumnFormatFlag = memoizeClear(
-    (formatter, columnType, columnName) => {
-      const columnFormat = formatter.getColumnFormat(columnType, columnName);
-      return (
-        columnFormat != null &&
-        (columnFormat.type === TableColumnFormatter.TYPE_CONTEXT_PRESET ||
-          columnFormat.type === TableColumnFormatter.TYPE_CONTEXT_CUSTOM)
-      );
-    },
+    FormatterUtils.isCustomColumnFormatDefined,
     { max: 10000 }
   );
 

--- a/packages/iris-grid/src/IrisGridTableModel.js
+++ b/packages/iris-grid/src/IrisGridTableModel.js
@@ -363,6 +363,7 @@ class IrisGridTableModel extends IrisGridModel {
       }
 
       const column = this.totalsColumn(x, y) ?? this.columns[x];
+      // TODO: formatting
       const hasCustomColumnFormat = this.getCachedCustomColumnFormatFlag(
         this.formatter,
         column.type,
@@ -691,6 +692,7 @@ class IrisGridTableModel extends IrisGridModel {
   }
 
   formatForCell(x, y) {
+    //
     return this.dataForCell(x, y)?.format;
   }
 

--- a/packages/iris-grid/src/sidebar/TableSaver.jsx
+++ b/packages/iris-grid/src/sidebar/TableSaver.jsx
@@ -370,7 +370,8 @@ export default class TableSaver extends PureComponent {
         const cellData = formatter.getFormattedString(
           snapshot.getData(rowIdx, this.columns[j]),
           this.columns[j].type,
-          this.columns[j].name
+          this.columns[j].name,
+          snapshot.getFormat(rowIdx, this.columns[j])?.formatString
         );
         csvString += TableSaver.csvEscapeString(cellData);
         csvString += j === this.columns.length - 1 ? '\n' : ',';


### PR DESCRIPTION
Pass cell format as override to `getFormatterString` if custom format for column is not defined.