### PR TITLE
DH-12387 Unable to override query formatting via the custom format menu

### DIFF
--- a/packages/iris-grid/src/IrisGridTableModel.js
+++ b/packages/iris-grid/src/IrisGridTableModel.js
@@ -365,8 +365,8 @@ class IrisGridTableModel extends IrisGridModel {
       const column = this.totalsColumn(x, y) ?? this.columns[x];
       const hasCustomColumnFormat = this.getCachedCustomColumnFormatFlag(
         this.formatter,
-        column.type,
-        column.name
+        column.name,
+        column.type
       );
       let formatOverride = null;
       if (!hasCustomColumnFormat) {

--- a/packages/iris-grid/src/sidebar/TableSaver.jsx
+++ b/packages/iris-grid/src/sidebar/TableSaver.jsx
@@ -377,8 +377,8 @@ export default class TableSaver extends PureComponent {
         const { type, name } = this.columns[j];
         const hasCustomColumnFormat = this.getCachedCustomColumnFormatFlag(
           formatter,
-          type,
-          name
+          name,
+          type
         );
         let formatOverride = null;
         if (!hasCustomColumnFormat) {


### PR DESCRIPTION
Fix wrong order of the args passed to `isCustomColumnFormatDefined` resulting in inability to override query formatting via the UI custom format menu.