### PR TITLE
Fix vertical scroll bar when FileExplorer tab shown

### DIFF
--- a/packages/file-explorer/src/FileExplorer.scss
+++ b/packages/file-explorer/src/FileExplorer.scss
@@ -6,8 +6,6 @@ $file-explorer-bg: $gray-900;
   background: $file-explorer-bg;
   position: relative;
   flex-grow: 1;
-  width: 100%;
-  height: 100%;
 
   .single-click-item-list-scroll-pane {
     flex-grow: 1;

--- a/packages/file-explorer/src/FileExplorer.scss
+++ b/packages/file-explorer/src/FileExplorer.scss
@@ -6,6 +6,8 @@ $file-explorer-bg: $gray-900;
   background: $file-explorer-bg;
   position: relative;
   flex-grow: 1;
+  width: 100%;
+  height: 100%;
 
   .single-click-item-list-scroll-pane {
     flex-grow: 1;

--- a/packages/file-explorer/src/FileExplorerToolbar.scss
+++ b/packages/file-explorer/src/FileExplorerToolbar.scss
@@ -3,7 +3,7 @@
 $toolbar-padding: $spacer-1;
 $toolbar-font-size: 17px;
 $toolbar-btn-width: $input-height;
-$toolbar-height: calc(#{$input-height} + 2 * #{$toolbar-padding});
+$toolbar-height: 42px;
 $toolbar-bg: $content-bg;
 $file-list-search-bg: $gray-800;
 $item-list-color: $foreground;
@@ -20,7 +20,7 @@ $item-list-color: $foreground;
   position: relative;
   align-items: center;
   padding: $toolbar-padding;
-  min-height: 0;
+  min-height: $toolbar-height;
   .file-explorer-toolbar-buttons {
     display: flex;
     padding-right: $toolbar-padding;


### PR DESCRIPTION
- There was a vertical scroll bar shown when the FileExplorer tab was the full height of the dashboard
- Add height/width 100% so it fills the container
