### PR TITLE
DH-10208 Fix arrow up at top of history loading empty history commands

### DIFF
--- a/packages/console/src/ConsoleInput.jsx
+++ b/packages/console/src/ConsoleInput.jsx
@@ -311,18 +311,20 @@ export class ConsoleInput extends PureComponent {
    * @param {number | null} index The index to load. Null to load command started in the editor and not in the history
    */
   loadCommand(index) {
-    let value = '';
-    if (index !== null && index < this.history.length) {
-      value = this.history[this.history.length - index - 1];
-
-      if (index > this.history.length - BUFFER_SIZE) {
-        this.loadMoreHistory();
-      }
+    if (index >= this.history.length) {
+      return;
     }
 
+    const modifiedValue = this.modifiedCommands.get(index);
+    const historyValue =
+      index === null ? '' : this.history[this.history.length - index - 1];
+
     this.commandHistoryIndex = index;
-    value = this.modifiedCommands.get(index) ?? value;
-    this.commandEditor.getModel().setValue(value);
+    this.commandEditor.getModel().setValue(modifiedValue ?? historyValue);
+
+    if (index > this.history.length - BUFFER_SIZE) {
+      this.loadMoreHistory();
+    }
   }
 
   async loadMoreHistory() {

--- a/packages/console/src/ConsoleInput.jsx
+++ b/packages/console/src/ConsoleInput.jsx
@@ -311,7 +311,7 @@ export class ConsoleInput extends PureComponent {
    * @param {number | null} index The index to load. Null to load command started in the editor and not in the history
    */
   loadCommand(index) {
-    if (index >= this.history.length) {
+    if (index !== null && index >= this.history.length) {
       return;
     }
 
@@ -322,7 +322,7 @@ export class ConsoleInput extends PureComponent {
     this.commandHistoryIndex = index;
     this.commandEditor.getModel().setValue(modifiedValue ?? historyValue);
 
-    if (index > this.history.length - BUFFER_SIZE) {
+    if (index !== null && index > this.history.length - BUFFER_SIZE) {
       this.loadMoreHistory();
     }
   }


### PR DESCRIPTION
Fixes #537. This was discovered as part of DH-10208 testing which is tangentially related to where the bug was actually introduced.

Now at the top of history in the console input, pressing arrow up should not move up to other commands

I tried to write a test for this w/ RTL, but was hitting obstacles w/ Monaco so I just skipped it for now