### PR TITLE
DH-10111 Fix missing horizontal scroll bar for single column tables

### DIFF
--- a/packages/grid/src/Grid.tsx
+++ b/packages/grid/src/Grid.tsx
@@ -1739,7 +1739,13 @@ class Grid extends PureComponent<GridProps, GridState> {
 
     if (!metrics) throw new Error('metrics not set');
 
-    const { lastTop, lastLeft } = metrics;
+    const {
+      lastTop,
+      lastLeft,
+      columnCount,
+      scrollableContentWidth,
+      scrollableViewportWidth,
+    } = metrics;
     let { top, left, topOffset, leftOffset } = metrics;
 
     const theme = this.getTheme();
@@ -1758,13 +1764,27 @@ class Grid extends PureComponent<GridProps, GridState> {
       leftOffset += deltaX;
       deltaX = 0;
 
-      // no scrolling needed, at directional edge
-      if (
-        (leftOffset > 0 && left >= lastLeft) ||
-        (leftOffset < 0 && left <= 0)
-      ) {
-        leftOffset = 0;
-        break;
+      if (columnCount > 1) {
+        // no scrolling needed, at directional edge
+        if (
+          (leftOffset > 0 && left >= lastLeft) ||
+          (leftOffset < 0 && left <= 0)
+        ) {
+          leftOffset = 0;
+          break;
+        }
+      } else {
+        // single column at edge
+        if (leftOffset <= 0) {
+          leftOffset = 0;
+          break;
+        }
+
+        const maxLeftOffset = scrollableContentWidth - scrollableViewportWidth;
+        if (leftOffset >= maxLeftOffset) {
+          leftOffset = maxLeftOffset;
+          break;
+        }
       }
 
       if (leftOffset > 0) {

--- a/packages/grid/src/Grid.tsx
+++ b/packages/grid/src/Grid.tsx
@@ -1743,8 +1743,11 @@ class Grid extends PureComponent<GridProps, GridState> {
       lastTop,
       lastLeft,
       columnCount,
+      rowCount,
       scrollableContentWidth,
       scrollableViewportWidth,
+      scrollableContentHeight,
+      scrollableViewportHeight,
     } = metrics;
     let { top, left, topOffset, leftOffset } = metrics;
 
@@ -1800,7 +1803,7 @@ class Grid extends PureComponent<GridProps, GridState> {
           deltaX = leftOffset - columnWidth;
           leftOffset = 0;
           left += 1;
-        } else if (theme.scrollSnapToColumn) {
+        } else if (theme.scrollSnapToColumn && columnCount > 1) {
           // if there's still a balance to travel but its less then a column and snapping is on
           leftOffset = 0;
           left += 1;
@@ -1813,7 +1816,11 @@ class Grid extends PureComponent<GridProps, GridState> {
           metrics.visibleColumnWidths.get(left - 1) ??
           metricCalculator.getVisibleColumnWidth(left - 1, metricState);
 
-        if (Math.abs(leftOffset) <= columnWidth && theme.scrollSnapToColumn) {
+        if (
+          Math.abs(leftOffset) <= columnWidth &&
+          theme.scrollSnapToColumn &&
+          columnCount > 1
+        ) {
           // if there's still a balance to travel but its less then a column and snapping is on
           leftOffset = 0;
           left -= 1;
@@ -1832,10 +1839,24 @@ class Grid extends PureComponent<GridProps, GridState> {
       topOffset += deltaY;
       deltaY = 0;
 
-      // no scrolling needed, at directional edge
-      if ((topOffset > 0 && top >= lastTop) || (topOffset < 0 && top <= 0)) {
-        topOffset = 0;
-        break;
+      if (rowCount > 1) {
+        // no scrolling needed, at directional edge
+        if ((topOffset > 0 && top >= lastTop) || (topOffset < 0 && top <= 0)) {
+          topOffset = 0;
+          break;
+        }
+      } else {
+        // single row at edge
+        if (topOffset <= 0) {
+          topOffset = 0;
+          break;
+        }
+
+        const maxTopOffset = scrollableContentHeight - scrollableViewportHeight;
+        if (topOffset >= maxTopOffset) {
+          topOffset = maxTopOffset;
+          break;
+        }
       }
 
       if (topOffset > 0) {
@@ -1851,7 +1872,7 @@ class Grid extends PureComponent<GridProps, GridState> {
           deltaY = topOffset - rowHeight;
           topOffset = 0;
           top += 1;
-        } else if (theme.scrollSnapToRow) {
+        } else if (theme.scrollSnapToRow && rowCount > 1) {
           // if there's still a balance to travel but its less then a row and snapping is on
           topOffset = 0;
           top += 1;
@@ -1864,7 +1885,11 @@ class Grid extends PureComponent<GridProps, GridState> {
           metrics.visibleRowHeights.get(top - 1) ??
           metricCalculator.getVisibleRowHeight(top - 1, metricState);
 
-        if (Math.abs(topOffset) <= rowHeight && theme.scrollSnapToRow) {
+        if (
+          Math.abs(topOffset) <= rowHeight &&
+          theme.scrollSnapToRow &&
+          rowCount > 1
+        ) {
           // if there's still a balance to travel but its less then a row and snapping is on
           topOffset = 0;
           top -= 1;

--- a/packages/grid/src/GridMetricCalculator.ts
+++ b/packages/grid/src/GridMetricCalculator.ts
@@ -303,7 +303,7 @@ export class GridMetricCalculator {
     const maxY = rowHeightValues.reduce((y, h) => y + h, 0) - topOffset;
 
     // Visible space available in the canvas viewport
-    const viewportWidth = width - gridX - rowHeaderWidth;
+    const viewportWidth = width - gridX;
 
     // How much total space the content will take
     const contentWidth = leftOffset + maxX + rowFooterWidth;

--- a/packages/grid/src/GridMetricCalculator.ts
+++ b/packages/grid/src/GridMetricCalculator.ts
@@ -303,10 +303,10 @@ export class GridMetricCalculator {
     const maxY = rowHeightValues.reduce((y, h) => y + h, 0) - topOffset;
 
     // Visible space available in the canvas viewport
-    const viewportWidth = width - gridX;
+    const scrollableViewportWidth = width - gridX;
 
     // How much total space the content will take
-    const contentWidth = leftOffset + maxX + rowFooterWidth;
+    const scrollableContentWidth = leftOffset + maxX + rowFooterWidth;
 
     const floatingBottomHeight = this.getFloatingBottomHeight(
       state,
@@ -325,7 +325,8 @@ export class GridMetricCalculator {
     );
 
     // Calculate some metrics for the scroll bars
-    const hasHorizontalBar = lastLeft > 0 || contentWidth > viewportWidth;
+    const hasHorizontalBar =
+      lastLeft > 0 || scrollableContentWidth > scrollableViewportWidth;
     const hasVerticalBar = lastTop > 0;
     const horizontalBarHeight = hasHorizontalBar ? scrollBarSize : 0;
     const verticalBarWidth = hasVerticalBar ? scrollBarSize : 0;
@@ -335,7 +336,7 @@ export class GridMetricCalculator {
     // How big the horizontal is relative to the horizontal bar
     const horizontalHandlePercent =
       columnCount === 1
-        ? barWidth / contentWidth
+        ? barWidth / scrollableContentWidth
         : (columnCount - lastLeft) / columnCount;
 
     const handleWidth = hasHorizontalBar
@@ -363,7 +364,7 @@ export class GridMetricCalculator {
     // How much of the available space has been scrolled
     const horizontalScrollPercent =
       columnCount === 1
-        ? leftOffset / (contentWidth - viewportWidth)
+        ? leftOffset / (scrollableContentWidth - scrollableViewportWidth)
         : (left + leftOffsetPercent) / lastLeft;
     const verticalScrollPercent = (top + topOffsetPercent) / lastTop;
 
@@ -546,6 +547,9 @@ export class GridMetricCalculator {
       // The vertical x/y scroll amount
       scrollX,
       scrollY,
+
+      scrollableContentWidth,
+      scrollableViewportWidth,
 
       // Array of visible rows/columns, by grid index
       visibleRows,

--- a/packages/grid/src/GridMetrics.ts
+++ b/packages/grid/src/GridMetrics.ts
@@ -105,11 +105,13 @@ export type GridMetrics = {
   scrollX: number;
   scrollY: number;
 
-  // The width of all known content in the scrollable area (includes footer, not header which is 'frozen')
+  // The size of all known content in the scrollable area
   scrollableContentWidth: number;
+  scrollableContentHeight: number;
 
   // The visible space for scrollable content to display
   scrollableViewportWidth: number;
+  scrollableViewportHeight: number;
 
   // Array of visible rows/columns, by grid index
   visibleRows: VisibleIndex[];

--- a/packages/grid/src/GridMetrics.ts
+++ b/packages/grid/src/GridMetrics.ts
@@ -105,6 +105,12 @@ export type GridMetrics = {
   scrollX: number;
   scrollY: number;
 
+  // The width of all known content in the scrollable area (includes footer, not header which is 'frozen')
+  scrollableContentWidth: number;
+
+  // The visible space for scrollable content to display
+  scrollableViewportWidth: number;
+
   // Array of visible rows/columns, by grid index
   visibleRows: VisibleIndex[];
   visibleColumns: VisibleIndex[];

--- a/packages/grid/src/mouse-handlers/GridHorizontalScrollBarMouseHandler.ts
+++ b/packages/grid/src/mouse-handlers/GridHorizontalScrollBarMouseHandler.ts
@@ -79,16 +79,12 @@ class GridHorizontalScrollBarMouseHandler extends GridMouseHandler {
       handleWidth,
       lastLeft,
       rowHeaderWidth,
-      leftOffset,
-      maxX,
-      rowFooterWidth,
-      width,
-      gridX,
       columnCount,
+      scrollableContentWidth,
+      scrollableViewportWidth,
     } = metrics;
 
     const mouseBarX = x - rowHeaderWidth;
-    const maxWidth = leftOffset + maxX + rowFooterWidth;
     const scrollPercent = clamp(
       (mouseBarX - (this.dragOffset ?? 0)) / (barWidth - handleWidth),
       0,
@@ -98,7 +94,8 @@ class GridHorizontalScrollBarMouseHandler extends GridMouseHandler {
     if (columnCount === 1) {
       return {
         left: 0,
-        leftOffset: scrollPercent * (maxWidth - (width - gridX)),
+        leftOffset:
+          scrollPercent * (scrollableContentWidth - scrollableViewportWidth),
       };
     }
 

--- a/packages/grid/src/mouse-handlers/GridHorizontalScrollBarMouseHandler.ts
+++ b/packages/grid/src/mouse-handlers/GridHorizontalScrollBarMouseHandler.ts
@@ -127,6 +127,7 @@ class GridHorizontalScrollBarMouseHandler extends GridMouseHandler {
         columnCount,
         maxX,
         width,
+        gridX,
         leftOffset,
       } = metrics;
 
@@ -140,7 +141,7 @@ class GridHorizontalScrollBarMouseHandler extends GridMouseHandler {
 
       if (columnCount === 1) {
         grid.setViewState({
-          leftOffset: scrollPercent * (maxWidth - width),
+          leftOffset: scrollPercent * (maxWidth - (width - gridX)),
           isDraggingHorizontalScrollBar: true,
           isDragging: true,
         });

--- a/packages/grid/src/mouse-handlers/GridHorizontalScrollBarMouseHandler.ts
+++ b/packages/grid/src/mouse-handlers/GridHorizontalScrollBarMouseHandler.ts
@@ -46,22 +46,16 @@ class GridHorizontalScrollBarMouseHandler extends GridMouseHandler {
     if (!metrics) throw new Error('metrics not set');
 
     const { x, y } = gridPoint;
-    const {
-      lastTop,
-      rowHeaderWidth,
-      width,
-      height,
-      hasHorizontalBar,
-    } = metrics;
+    const { gridX, width, height, hasHorizontalBar, hasVerticalBar } = metrics;
 
-    const scrollBarWidth = lastTop > 0 ? width - scrollBarSize : width;
+    const scrollBarWidth = hasVerticalBar ? width - scrollBarSize : width;
 
     return (
       hasHorizontalBar &&
       scrollBarSize > 0 &&
       y >= height - scrollBarHoverSize &&
       y < height &&
-      x > rowHeaderWidth &&
+      x > gridX &&
       x < scrollBarWidth
     );
   }
@@ -78,13 +72,13 @@ class GridHorizontalScrollBarMouseHandler extends GridMouseHandler {
       barWidth,
       handleWidth,
       lastLeft,
-      rowHeaderWidth,
+      gridX,
       columnCount,
       scrollableContentWidth,
       scrollableViewportWidth,
     } = metrics;
 
-    const mouseBarX = x - rowHeaderWidth;
+    const mouseBarX = x - gridX;
     const scrollPercent = clamp(
       (mouseBarX - (this.dragOffset ?? 0)) / (barWidth - handleWidth),
       0,
@@ -111,12 +105,12 @@ class GridHorizontalScrollBarMouseHandler extends GridMouseHandler {
     if (!metrics) throw new Error('metrics not set');
 
     const { x } = gridPoint;
-    const { handleWidth, rowHeaderWidth, scrollX } = metrics;
+    const { handleWidth, gridX, scrollX } = metrics;
     if (!this.isInScrollBar(gridPoint, grid)) {
       return false;
     }
 
-    const mouseBarX = x - rowHeaderWidth;
+    const mouseBarX = x - gridX;
     if (mouseBarX >= scrollX && mouseBarX <= scrollX + handleWidth) {
       // Grabbed the horizontal handle
       this.dragOffset = mouseBarX - scrollX;

--- a/packages/grid/src/mouse-handlers/GridVerticalScrollBarMouseHandler.ts
+++ b/packages/grid/src/mouse-handlers/GridVerticalScrollBarMouseHandler.ts
@@ -110,8 +110,6 @@ class GridVerticalScrollBarMouseHandler extends GridMouseHandler {
       return false;
     }
 
-    console.log(gridY);
-
     const mouseBarY = y - gridY;
     if (mouseBarY >= scrollY && mouseBarY <= scrollY + handleHeight) {
       // Grabbed the vertical handle


### PR DESCRIPTION
Fixes #446 and related to DH-10111 test failure

This adds a horizontal scroll bar for any single column table which does not fit in the panel fully

Example Python to test with
```python
from deephaven import new_table
from deephaven.column import string_col
import random
import string

letters = string.printable
strings = [''.join(random.choice(letters) for i in range(random.randint(0, 1000))) for j in range(0, 100)]
table1 = new_table([string_col("Random", strings)])
```

Also tested with changing `IrisGridTheme.rowHeaderWidth` to be non-zero