### PR TITLE
Fix cell overflow button overlapping scroll bar and not truncating text with row header

### DIFF
--- a/packages/iris-grid/src/IrisGridRenderer.js
+++ b/packages/iris-grid/src/IrisGridRenderer.js
@@ -81,8 +81,12 @@ class IrisGridRenderer extends GridRenderer {
   drawCanvas(state) {
     super.drawCanvas(state);
 
-    this.drawCellOverflowButton(state);
     this.drawScrim(state);
+  }
+
+  drawGrid(context, state) {
+    super.drawGrid(context, state);
+    this.drawCellOverflowButton(state);
   }
 
   drawGridLines(context, state) {
@@ -715,7 +719,7 @@ class IrisGridRenderer extends GridRenderer {
     if (column === mouseColumn && row === mouseRow) {
       const { left } = this.getCellOverflowButtonPosition(state);
       if (this.shouldRenderOverflowButton(state)) {
-        textMetrics.width = left - textMetrics.x;
+        textMetrics.width = left - metrics.gridX - textMetrics.x;
       }
     }
     return textMetrics;


### PR DESCRIPTION
This fixes 2 small issues with the cell overflow button.

1. Cell overflow button was overlapping the horizontal scroll bar. Now it draws under the scroll bar. It should still show even if the scroll bar partially covers a row because you can have the row covered by 1-2 pixels and you will see all content in the cell still. The overflow not appearing because the border is overlapped by the scroll bar could be frustrating to a user.
2. Cells were not truncating properly when `IrisGridTheme.rowHeaderWidth` was non-zero. The header width was not accounted for