### PR TITLE
Fix various layout hint issues

### DIFF
--- a/packages/grid/src/mouse-handlers/GridColumnMoveMouseHandler.ts
+++ b/packages/grid/src/mouse-handlers/GridColumnMoveMouseHandler.ts
@@ -30,7 +30,7 @@ class GridColumnMoveMouseHandler extends GridMouseHandler {
     if (
       column != null &&
       y <= columnHeaderHeight &&
-      model.isColumnMovable(column)
+      model.isColumnMovable(grid.getModelColumn(column))
     ) {
       const columnX = getOrThrow(visibleColumnXs, column);
       this.draggingOffset = x - columnX - rowHeaderWidth;
@@ -68,7 +68,10 @@ class GridColumnMoveMouseHandler extends GridMouseHandler {
 
     if (draggingColumn == null) {
       const { column } = grid.getGridPointFromXY(mouseX, mouseY);
-      if (column != null && !model.isColumnMovable(column)) {
+      if (
+        column != null &&
+        !model.isColumnMovable(grid.getModelColumn(column))
+      ) {
         return false;
       }
 
@@ -121,7 +124,7 @@ class GridColumnMoveMouseHandler extends GridMouseHandler {
     if (
       mouseX < minX &&
       draggingColumn > 0 &&
-      model.isColumnMovable(draggingColumn - 1)
+      model.isColumnMovable(grid.getModelColumn(draggingColumn - 1))
     ) {
       movedColumns = GridUtils.moveItem(
         draggingColumn,
@@ -132,7 +135,7 @@ class GridColumnMoveMouseHandler extends GridMouseHandler {
     } else if (
       maxX < mouseX &&
       draggingColumn < columnCount - 1 &&
-      model.isColumnMovable(draggingColumn + 1)
+      model.isColumnMovable(grid.getModelColumn(draggingColumn + 1))
     ) {
       movedColumns = GridUtils.moveItem(
         draggingColumn,

--- a/packages/iris-grid/src/IrisGrid.jsx
+++ b/packages/iris-grid/src/IrisGrid.jsx
@@ -1173,29 +1173,26 @@ export class IrisGrid extends Component {
     (
       alwaysFetchColumns,
       columns,
+      movedColumns,
       floatingLeftColumnCount,
       floatingRightColumnCount
     ) => {
-      let floatingLeftColumns = [];
-      let floatingRightColumns = [];
+      const floatingColumns = [];
 
-      if (floatingLeftColumnCount) {
-        floatingLeftColumns = columns
-          .slice(0, floatingLeftColumnCount)
-          .map(col => col.name);
+      for (let i = 0; i < floatingLeftColumnCount; i++) {
+        floatingColumns.push(
+          columns[GridUtils.getModelIndex(i, movedColumns)].name
+        );
       }
 
-      if (floatingRightColumnCount) {
-        floatingRightColumns = columns
-          .slice(-floatingRightColumnCount)
-          .map(col => col.name);
+      for (let i = 0; i < floatingRightColumnCount; i++) {
+        floatingColumns.push(
+          columns[GridUtils.getModelIndex(columns.length - 1 - i, movedColumns)]
+            .name
+        );
       }
 
-      const columnSet = new Set([
-        ...alwaysFetchColumns,
-        ...floatingLeftColumns,
-        ...floatingRightColumns,
-      ]);
+      const columnSet = new Set([...alwaysFetchColumns, ...floatingColumns]);
 
       return [...columnSet];
     }
@@ -3316,6 +3313,7 @@ export class IrisGrid extends Component {
                 alwaysFetchColumns={this.getAlwaysFetchColumns(
                   alwaysFetchColumns,
                   model.columns,
+                  movedColumns,
                   model.floatingLeftColumnCount,
                   model.floatingRightColumnCount
                 )}

--- a/packages/iris-grid/src/IrisGrid.jsx
+++ b/packages/iris-grid/src/IrisGrid.jsx
@@ -1179,13 +1179,13 @@ export class IrisGrid extends Component {
     ) => {
       const floatingColumns = [];
 
-      for (let i = 0; i < floatingLeftColumnCount; i++) {
+      for (let i = 0; i < floatingLeftColumnCount; i += 1) {
         floatingColumns.push(
           columns[GridUtils.getModelIndex(i, movedColumns)].name
         );
       }
 
-      for (let i = 0; i < floatingRightColumnCount; i++) {
+      for (let i = 0; i < floatingRightColumnCount; i += 1) {
         floatingColumns.push(
           columns[GridUtils.getModelIndex(columns.length - 1 - i, movedColumns)]
             .name

--- a/packages/iris-grid/src/IrisGrid.jsx
+++ b/packages/iris-grid/src/IrisGrid.jsx
@@ -1545,7 +1545,7 @@ export class IrisGrid extends Component {
 
     const allFrozenColumns =
       frozenColumns == null
-        ? new Set(model.layoutHints?.frozenColumns)
+        ? new Set(model.frozenColumns)
         : new Set(frozenColumns);
 
     allFrozenColumns.add(columnName);
@@ -1571,7 +1571,7 @@ export class IrisGrid extends Component {
 
     const allFrozenColumns =
       frozenColumns == null
-        ? new Set(model.layoutHints?.frozenColumns)
+        ? new Set(model.frozenColumns)
         : new Set(frozenColumns);
 
     allFrozenColumns.delete(columnName);

--- a/packages/iris-grid/src/IrisGridModel.ts
+++ b/packages/iris-grid/src/IrisGridModel.ts
@@ -4,6 +4,7 @@ import {
   GridModel,
   GridRange,
   ModelIndex,
+  MoveOperation,
   VisibleIndex,
 } from '@deephaven/grid';
 import type {
@@ -131,6 +132,16 @@ abstract class IrisGridModel<
     return this.columns;
   }
 
+  /** List of column movements defined by the model. Used as initial movements for IrisGrid */
+  get movedColumns(): MoveOperation[] {
+    return [];
+  }
+
+  /** List of row movements defined by the model. Used as initial movements for IrisGrid */
+  get movedRows(): MoveOperation[] {
+    return [];
+  }
+
   /**
    * Retrieve the grouped columns for this model
    * @returns The columns that are grouped
@@ -245,6 +256,27 @@ abstract class IrisGridModel<
    */
   get layoutHints(): LayoutHints | null {
     return null;
+  }
+
+  /**
+   * @returns Names of columns which should be locked to the front, but not floating
+   */
+  get frontColumns(): string[] {
+    return [];
+  }
+
+  /**
+   * @returns Names of columns which should be locked to the back, but not floating
+   */
+  get backColumns(): string[] {
+    return [];
+  }
+
+  /**
+   * @returns Names of columns which should be frozen to the front and floating
+   */
+  get frozenColumns(): string[] {
+    return [];
   }
 
   /**

--- a/packages/iris-grid/src/IrisGridProxyModel.js
+++ b/packages/iris-grid/src/IrisGridProxyModel.js
@@ -292,8 +292,28 @@ class IrisGridProxyModel extends IrisGridModel {
     return this.model.columns;
   }
 
+  get movedColumns() {
+    return this.model.movedColumns;
+  }
+
+  get movedRows() {
+    return this.model.movedRows;
+  }
+
   get layoutHints() {
     return this.model.layoutHints;
+  }
+
+  get frontColumns() {
+    return this.model.frontColumns;
+  }
+
+  get backColumns() {
+    return this.model.backColumns;
+  }
+
+  get frozenColumns() {
+    return this.model.frozenColumns;
   }
 
   updateFrozenColumns(...args) {

--- a/packages/iris-grid/src/IrisGridTableModel.js
+++ b/packages/iris-grid/src/IrisGridTableModel.js
@@ -1,7 +1,7 @@
 /* eslint class-methods-use-this: "off" */
 import memoize from 'memoize-one';
 import throttle from 'lodash.throttle';
-import { GridRange, memoizeClear } from '@deephaven/grid';
+import { GridRange, GridUtils, memoizeClear } from '@deephaven/grid';
 import dh from '@deephaven/jsapi-shim';
 import Log from '@deephaven/log';
 import { PromiseUtils } from '@deephaven/utils';
@@ -481,68 +481,59 @@ class IrisGridTableModel extends IrisGridModel {
     return '';
   }
 
-  getColumnsWithLayoutHints = memoize(
-    (columnMap, frontColumns, backColumns, frozenColumns) => {
-      const columns = [...columnMap.values()];
-      if (frontColumns.length || backColumns.length || frozenColumns.length) {
-        let finalFrontColumns = [];
-        let finalBackColumns = [];
-        let finalFrozenColumns = [];
-
-        if (frontColumns.length) {
-          finalFrontColumns = frontColumns
-            .map(name => columnMap.get(name))
-            .filter(Boolean);
-        }
-        if (backColumns.length) {
-          finalBackColumns = backColumns
-            .map(name => columnMap.get(name))
-            .filter(Boolean);
-        }
-        if (frozenColumns.length) {
-          finalFrozenColumns = frozenColumns
-            .map(name => columnMap.get(name))
-            .filter(Boolean);
-        }
-
-        if (
-          finalFrontColumns.length !== frontColumns.length ||
-          finalBackColumns.length !== backColumns.length ||
-          finalFrozenColumns.length !== frozenColumns.length
-        ) {
-          throw new Error(
-            'Layout hints are invalid (contain invalid column names)'
-          );
-        }
-
-        const frontColumnSet = new Set(finalFrontColumns);
-        const backColumnSet = new Set(finalBackColumns);
-        const frozenColumnSet = new Set(finalFrozenColumns);
-        const middleColumns = columns.filter(
-          col =>
-            !frontColumnSet.has(col) &&
-            !backColumnSet.has(col) &&
-            !frozenColumnSet.has(col)
-        );
-
-        return [
-          ...finalFrozenColumns,
-          ...finalFrontColumns,
-          ...middleColumns,
-          ...finalBackColumns,
-        ];
-      }
-      return columns;
-    }
-  );
-
+  /**
+   * Returns an array of the columns in the model
+   * The order of model columns should never change once established
+   */
   get columns() {
-    return this.getColumnsWithLayoutHints(
-      this.columnMap,
-      this.frontColumns,
-      this.backColumns,
-      this.frozenColumns
-    );
+    return this.table.columns;
+  }
+
+  /**
+   * Used to get the initial moved columns based on layout hints
+   */
+  get movedColumns() {
+    let movedColumns = [];
+
+    if (
+      this.frontColumns.length ||
+      this.backColumns.length ||
+      this.frozenColumns.length
+    ) {
+      const usedColumns = new Set();
+
+      const moveColumn = (name, index) => {
+        if (usedColumns.has(name)) {
+          throw new Error(`Column specified in multiple layout hints: ${name}`);
+        }
+        const modelIndex = this.getColumnIndexByName(name);
+        if (!modelIndex) {
+          throw new Error(`Unknown layout hint column: ${name}`);
+        }
+        const visibleIndex = GridUtils.getVisibleIndex(
+          modelIndex,
+          movedColumns
+        );
+        movedColumns = GridUtils.moveItem(visibleIndex, index, movedColumns);
+      };
+
+      let frontIndex = 0;
+      this.frozenColumns.forEach(name => {
+        moveColumn(name, frontIndex);
+        frontIndex += 1;
+      });
+      this.frontColumns.forEach(name => {
+        moveColumn(name, frontIndex);
+        frontIndex += 1;
+      });
+
+      let backIndex = this.columnMap.size - 1;
+      this.backColumns.forEach(name => {
+        moveColumn(name, backIndex);
+        backIndex -= 1;
+      });
+    }
+    return movedColumns;
   }
 
   getMemoizedColumnMap = memoize(tableColumns => {
@@ -755,8 +746,9 @@ class IrisGridTableModel extends IrisGridModel {
   }
 
   /**
-   * Use this as the canonical column index since things like layoutHints could have
-   * changed the column order.
+   * Gets the model index for a column from its name
+   * @param {string} name The column name
+   * @returns {number | undefined} The ModelIndex if it exists
    */
   getColumnIndexByName(name) {
     return this.getColumnIndicesByNameMap(this.columns).get(name);
@@ -1241,20 +1233,20 @@ class IrisGridTableModel extends IrisGridModel {
     }
   );
 
-  isColumnMovable(x) {
-    const columnName = this.columns[x].name;
+  isColumnMovable(modelIndex) {
+    const columnName = this.columns[modelIndex].name;
     if (
-      this.layoutHints?.frontColumns?.includes(columnName) ||
-      this.layoutHints?.backColumns?.includes(columnName) ||
+      this.frontColumns.includes(columnName) ||
+      this.backColumns.includes(columnName) ||
       this.frozenColumns.includes(columnName)
     ) {
       return false;
     }
-    return !this.isKeyColumn(x);
+    return !this.isKeyColumn(modelIndex);
   }
 
-  isColumnFrozen(x) {
-    return this.frozenColumns.includes(this.columns[x].name);
+  isColumnFrozen(modelIndex) {
+    return this.frozenColumns.includes(this.columns[modelIndex].name);
   }
 
   isKeyColumn(x) {

--- a/packages/iris-grid/src/mousehandlers/IrisGridContextMenuHandler.jsx
+++ b/packages/iris-grid/src/mousehandlers/IrisGridContextMenuHandler.jsx
@@ -213,7 +213,7 @@ class IrisGridContextMenuHandler extends GridMouseHandler {
         const isColumnHidden = [...userColumnWidths.values()].some(
           columnWidth => columnWidth === 0
         );
-        const isColumnFrozen = model.isColumnFrozen(columnIndex);
+        const isColumnFrozen = model.isColumnFrozen(modelColumn);
         actions.push({
           title: 'Hide Column',
           group: IrisGridContextMenuHandler.GROUP_HIDE_COLUMNS,
@@ -232,6 +232,7 @@ class IrisGridContextMenuHandler extends GridMouseHandler {
             }
           },
           order: 10,
+          disabled: !model.isColumnMovable(modelColumn) && !isColumnFrozen,
         });
         actions.push({
           title: 'Show All Columns',


### PR DESCRIPTION
Fixes #560. Also disables context menu freeze option on other locked columns (front/back). Added a check for columns listed in multiple layout hints which will display an error. 

Instead of modifying the model columns (which caused the initial issue), the model now defines a starting list of moved columns. The list is derived from the layout hints. If a user makes more changes, they are simply added to the moved columns list. The model column order is left untouched. The model base moved columns will be useful for column groups via layout hints

When a user unfreezes a column, it is moved to just after the remaining frozen columns + front locked columns. 

This may cause odd behavior in DHE PQs if the underlying table changes (but the original implementation would too). We should probably have some way of versioning PQ tables like we do for shared dashboards (if we don't already), because all other user modifications to a table would be incorrect if the underlying table changed.