### PR TITLE
Fix invalid format custom columns created from row formats based on different columns

### DIFF
--- a/packages/iris-grid/src/sidebar/conditional-formatting/ConditionalFormattingUtils.test.ts
+++ b/packages/iris-grid/src/sidebar/conditional-formatting/ConditionalFormattingUtils.test.ts
@@ -195,4 +195,23 @@ describe('getFormatColumns', () => {
       `[row] 0 - ${FormatStyleType.WARN} : 0 - ${FormatStyleType.POSITIVE} : null`,
     ]);
   });
+
+  it('returns a single condition for row rules on different columns', () => {
+    expect(
+      getFormatColumns(makeColumns(), [
+        makeFormatRule({
+          columnName: '0',
+          formatterType: FormatterType.ROWS,
+          styleType: FormatStyleType.POSITIVE,
+        }),
+        makeFormatRule({
+          columnName: '1',
+          formatterType: FormatterType.ROWS,
+          styleType: FormatStyleType.WARN,
+        }),
+      ])
+    ).toEqual([
+      `[row] 1 - ${FormatStyleType.WARN} : 0 - ${FormatStyleType.POSITIVE} : null`,
+    ]);
+  });
 });

--- a/packages/iris-grid/src/sidebar/conditional-formatting/ConditionalFormattingUtils.ts
+++ b/packages/iris-grid/src/sidebar/conditional-formatting/ConditionalFormattingUtils.ts
@@ -655,7 +655,7 @@ export function getFormatColumns(
   const result: CustomColumn[] = [];
   // There can be only one row format custom column
   // and multiple column format custom columns (one per column)
-  let rowFormatConfig = undefined as [string, CustomColumn] | undefined;
+  let rowFormatConfig: [string, CustomColumn];
   const columnFormatConfigMap = new Map<string, [string, CustomColumn]>();
   rules.forEach(({ config, type: formatterType }) => {
     const { column } = config;


### PR DESCRIPTION
Applying custom columns with more than one row format column crashes the grid panel. Fixed by stacking all row formats into a single rule. Added unit test.