### PR TITLE
Don't scroll columns into view on click

### DIFF
--- a/packages/grid/src/mouse-handlers/GridSelectionMouseHandler.ts
+++ b/packages/grid/src/mouse-handlers/GridSelectionMouseHandler.ts
@@ -61,7 +61,7 @@ class GridSelectionMouseHandler extends GridMouseHandler {
         column,
         row,
         isShiftKey,
-        true,
+        false,
         isShiftKey && isModifierKey
       );
     }


### PR DESCRIPTION
Fixes Click to focus column is more annoying than useful #567