### PR TITLE
Use session type provided by the server instead of hardcoding python

### DIFF
--- a/packages/embed-grid/src/App.tsx
+++ b/packages/embed-grid/src/App.tsx
@@ -72,9 +72,21 @@ function App(): JSX.Element {
       log.debug(`Starting connection...`);
       const connection = new dh.IdeConnection(websocketUrl);
 
-      // Start a code session. For this example, we use python.
-      log.debug(`Starting session...`);
-      const session = await connection.startSession('python');
+      log.debug('Getting console types...');
+
+      const types = await connection.getConsoleTypes();
+
+      log.debug('Available types:', types);
+
+      if (types.length === 0) {
+        throw new Error('No console types available');
+      }
+
+      const type = types[0];
+
+      log.debug('Starting session with type', type);
+
+      const session = await connection.startSession(type);
 
       // Get the table name from the query param `name`.
       const name = searchParams.get('name');


### PR DESCRIPTION
Now you can embed grids from Groovy sessions as well

Fixes #573
