### PR TITLE
DH-11788 Fix aggregation formatting when only one aggregation is applied

### DIFF
--- a/packages/iris-grid/src/IrisGridTableModel.js
+++ b/packages/iris-grid/src/IrisGridTableModel.js
@@ -630,10 +630,16 @@ class IrisGridTableModel extends IrisGridModel {
     const defaultOperation =
       this.totals?.defaultOperation ?? AggregationOperation.SUM;
     const tableColumn = this.columns[x];
+
+    // Find the matching totals table column for the operation
+    // When there are multiple aggregations, the column name will be the original name of the column with the operation appended afterward
+    // When the the operation is the default operation OR there is only one operation, then the totals column name is just the original column name
     return this.totalsTable.columns.find(
       column =>
         column.name === `${tableColumn.name}__${operation}` ||
-        (operation === defaultOperation && column.name === tableColumn.name)
+        ((operation === defaultOperation ||
+          this.totals.operationOrder.length === 1) &&
+          column.name === tableColumn.name)
     );
   }
 


### PR DESCRIPTION
When there is only one aggregation operation applied, it does not append the operation as a suffix to the column name in the totals table. Fix it up so it looks for the correct column name when there is only one operation.

This was noticed with the Count operation since the totals column format doesn't always match the source column format with Count, but happened with any type of operation.

Tested by running latest Jackson with `npm run start-community`, and with the `randomValuesWithNullNaN` table, applied one aggregation (`Count`), removed it, and then applied a bunch of different aggregations operations to test multiple aggregations.