### PR TITLE
Remove @deephaven peer dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38748,6 +38748,7 @@
         "@deephaven/icons": "file:../icons",
         "@deephaven/jsapi-shim": "file:../jsapi-shim",
         "@deephaven/jsapi-utils": "file:../jsapi-utils",
+        "@deephaven/log": "file:../log",
         "deep-equal": "^2.0.5",
         "lodash.debounce": "^4.0.8",
         "memoize-one": "^5.1.1",
@@ -38757,7 +38758,6 @@
         "react-plotly.js": "^2.4.0"
       },
       "devDependencies": {
-        "@deephaven/log": "file:../log",
         "@deephaven/mocks": "file:../mocks",
         "@deephaven/tsconfig": "file:../tsconfig"
       },
@@ -38765,7 +38765,6 @@
         "node": ">=16"
       },
       "peerDependencies": {
-        "@deephaven/log": "^0.12",
         "react": "^17.x"
       }
     },
@@ -38836,6 +38835,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@deephaven/icons": "file:../icons",
+        "@deephaven/log": "file:../log",
         "@deephaven/react-hooks": "file:../react-hooks",
         "@deephaven/utils": "file:../utils",
         "@fortawesome/fontawesome-svg-core": "1.2.36",
@@ -38857,7 +38857,6 @@
         "shortid": "^2.2.16"
       },
       "devDependencies": {
-        "@deephaven/log": "file:../log",
         "@deephaven/mocks": "file:../mocks",
         "@deephaven/tsconfig": "file:../tsconfig"
       },
@@ -38865,7 +38864,6 @@
         "node": ">=10"
       },
       "peerDependencies": {
-        "@deephaven/log": "^0.12",
         "react": "^17.x",
         "react-dom": "^17.x"
       }
@@ -38875,8 +38873,10 @@
       "version": "0.12.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "@deephaven/components": "file:../components",
         "@deephaven/icons": "file:../icons",
         "@deephaven/jsapi-shim": "file:../jsapi-shim",
+        "@deephaven/log": "file:../log",
         "@deephaven/storage": "file:../storage",
         "@deephaven/utils": "file:../utils",
         "@fortawesome/react-fontawesome": "^0.1.15",
@@ -38891,7 +38891,6 @@
         "shell-quote": "^1.7.2"
       },
       "devDependencies": {
-        "@deephaven/log": "file:../log",
         "@deephaven/mocks": "file:../mocks",
         "@deephaven/tsconfig": "file:../tsconfig"
       },
@@ -38899,8 +38898,6 @@
         "node": ">=16"
       },
       "peerDependencies": {
-        "@deephaven/components": "^0.12",
-        "@deephaven/log": "^0.12",
         "react": "^17.x",
         "react-dom": "^17.x"
       }
@@ -38910,8 +38907,11 @@
       "version": "0.12.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "@deephaven/components": "file:../components",
         "@deephaven/golden-layout": "file:../golden-layout",
+        "@deephaven/log": "file:../log",
         "@deephaven/react-hooks": "file:../react-hooks",
+        "@deephaven/redux": "file:../redux",
         "deep-equal": "^2.0.5",
         "jquery": "^3.6.0",
         "lodash.ismatch": "^4.1.1",
@@ -38920,18 +38920,13 @@
         "shortid": "^2.2.16"
       },
       "devDependencies": {
-        "@deephaven/log": "file:../log",
         "@deephaven/mocks": "file:../mocks",
-        "@deephaven/redux": "file:../redux",
         "@deephaven/tsconfig": "file:../tsconfig"
       },
       "engines": {
         "node": ">=16"
       },
       "peerDependencies": {
-        "@deephaven/components": "^0.12",
-        "@deephaven/log": "^0.12",
-        "@deephaven/redux": "^0.12",
         "react": "^17.0.0",
         "react-dom": "^17.0.0",
         "react-redux": "^7.2.4"
@@ -38943,6 +38938,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@deephaven/chart": "file:../chart",
+        "@deephaven/components": "file:../components",
         "@deephaven/console": "file:../console",
         "@deephaven/dashboard": "file:../dashboard",
         "@deephaven/file-explorer": "file:../file-explorer",
@@ -38951,6 +38947,8 @@
         "@deephaven/iris-grid": "file:../iris-grid",
         "@deephaven/jsapi-shim": "file:../jsapi-shim",
         "@deephaven/jsapi-utils": "file:../jsapi-utils",
+        "@deephaven/log": "file:../log",
+        "@deephaven/redux": "file:../redux",
         "@deephaven/utils": "file:../utils",
         "@fortawesome/react-fontawesome": "^0.1.15",
         "classnames": "^2.3.1",
@@ -38967,18 +38965,13 @@
         "shortid": "^2.2.16"
       },
       "devDependencies": {
-        "@deephaven/log": "file:../log",
         "@deephaven/mocks": "file:../mocks",
-        "@deephaven/redux": "file:../redux",
         "@deephaven/tsconfig": "file:../tsconfig"
       },
       "engines": {
         "node": ">=16"
       },
       "peerDependencies": {
-        "@deephaven/components": "^0.12",
-        "@deephaven/log": "^0.12",
-        "@deephaven/redux": "^0.12",
         "react": "^17.0.0",
         "react-dom": "^17.0.0",
         "react-redux": "^7.2.4"
@@ -39059,7 +39052,9 @@
       "version": "0.12.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "@deephaven/components": "file:../components",
         "@deephaven/icons": "file:../icons",
+        "@deephaven/log": "file:../log",
         "@deephaven/storage": "file:../storage",
         "@deephaven/utils": "file:../utils",
         "@fortawesome/fontawesome-svg-core": "1.2.36",
@@ -39071,15 +39066,12 @@
         "webdav": "^4.6.1"
       },
       "devDependencies": {
-        "@deephaven/log": "file:../log",
         "@deephaven/tsconfig": "file:../tsconfig"
       },
       "engines": {
         "node": ">=16"
       },
       "peerDependencies": {
-        "@deephaven/components": "^0.12",
-        "@deephaven/log": "^0.12",
         "react": "^17.0.0"
       }
     },
@@ -39142,12 +39134,14 @@
       "version": "0.12.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "@deephaven/components": "file:../components",
         "@deephaven/console": "file:../console",
         "@deephaven/filters": "file:../filters",
         "@deephaven/grid": "file:../grid",
         "@deephaven/icons": "file:../icons",
         "@deephaven/jsapi-shim": "file:../jsapi-shim",
         "@deephaven/jsapi-utils": "file:../jsapi-utils",
+        "@deephaven/log": "file:../log",
         "@deephaven/react-hooks": "file:../react-hooks",
         "@deephaven/storage": "file:../storage",
         "@deephaven/utils": "file:../utils",
@@ -39168,7 +39162,6 @@
         "web-streams-polyfill": "^2.1.0"
       },
       "devDependencies": {
-        "@deephaven/log": "file:../log",
         "@deephaven/mocks": "file:../mocks",
         "@deephaven/tsconfig": "file:../tsconfig"
       },
@@ -39176,8 +39169,6 @@
         "node": ">=10"
       },
       "peerDependencies": {
-        "@deephaven/components": "^0.12",
-        "@deephaven/log": "^0.12",
         "react": "^17.x"
       }
     },
@@ -39262,6 +39253,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@deephaven/jsapi-utils": "file:../jsapi-utils",
+        "@deephaven/log": "file:../log",
         "deep-equal": "^2.0.5",
         "redux-thunk": "^2.3.0"
       },
@@ -39272,7 +39264,6 @@
         "node": ">=16"
       },
       "peerDependencies": {
-        "@deephaven/log": "^0.12",
         "redux": "^4.0.5"
       }
     },
@@ -39281,18 +39272,17 @@
       "version": "0.12.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "@deephaven/filters": "file:../filters",
+        "@deephaven/log": "file:../log",
         "lodash.throttle": "^4.1.1"
       },
       "devDependencies": {
-        "@deephaven/filters": "file:../filters",
         "@deephaven/tsconfig": "file:../tsconfig"
       },
       "engines": {
         "node": ">=16"
       },
       "peerDependencies": {
-        "@deephaven/filters": "^0.12",
-        "@deephaven/log": "^0.12",
         "react": "^17.0.0"
       }
     },
@@ -40662,6 +40652,7 @@
     "@deephaven/console": {
       "version": "file:packages/console",
       "requires": {
+        "@deephaven/components": "file:../components",
         "@deephaven/icons": "file:../icons",
         "@deephaven/jsapi-shim": "file:../jsapi-shim",
         "@deephaven/log": "file:../log",
@@ -40684,6 +40675,7 @@
     "@deephaven/dashboard": {
       "version": "file:packages/dashboard",
       "requires": {
+        "@deephaven/components": "file:../components",
         "@deephaven/golden-layout": "file:../golden-layout",
         "@deephaven/log": "file:../log",
         "@deephaven/mocks": "file:../mocks",
@@ -40702,6 +40694,7 @@
       "version": "file:packages/dashboard-core-plugins",
       "requires": {
         "@deephaven/chart": "file:../chart",
+        "@deephaven/components": "file:../components",
         "@deephaven/console": "file:../console",
         "@deephaven/dashboard": "file:../dashboard",
         "@deephaven/file-explorer": "file:../file-explorer",
@@ -40789,6 +40782,7 @@
     "@deephaven/file-explorer": {
       "version": "file:packages/file-explorer",
       "requires": {
+        "@deephaven/components": "file:../components",
         "@deephaven/icons": "file:../icons",
         "@deephaven/log": "file:../log",
         "@deephaven/storage": "file:../storage",
@@ -40837,6 +40831,7 @@
     "@deephaven/iris-grid": {
       "version": "file:packages/iris-grid",
       "requires": {
+        "@deephaven/components": "file:../components",
         "@deephaven/console": "file:../console",
         "@deephaven/filters": "file:../filters",
         "@deephaven/grid": "file:../grid",
@@ -40908,6 +40903,7 @@
       "version": "file:packages/redux",
       "requires": {
         "@deephaven/jsapi-utils": "file:../jsapi-utils",
+        "@deephaven/log": "file:../log",
         "@deephaven/tsconfig": "file:../tsconfig",
         "deep-equal": "^2.0.5",
         "redux-thunk": "^2.3.0"
@@ -40917,6 +40913,7 @@
       "version": "file:packages/storage",
       "requires": {
         "@deephaven/filters": "file:../filters",
+        "@deephaven/log": "file:../log",
         "@deephaven/tsconfig": "file:../tsconfig",
         "lodash.throttle": "^4.1.1"
       }

--- a/packages/chart/package.json
+++ b/packages/chart/package.json
@@ -33,6 +33,7 @@
     "@deephaven/icons": "file:../icons",
     "@deephaven/jsapi-shim": "file:../jsapi-shim",
     "@deephaven/jsapi-utils": "file:../jsapi-utils",
+    "@deephaven/log": "file:../log",
     "deep-equal": "^2.0.5",
     "lodash.debounce": "^4.0.8",
     "memoize-one": "^5.1.1",
@@ -42,11 +43,9 @@
     "react-plotly.js": "^2.4.0"
   },
   "peerDependencies": {
-    "@deephaven/log": "^0.12",
     "react": "^17.x"
   },
   "devDependencies": {
-    "@deephaven/log": "file:../log",
     "@deephaven/mocks": "file:../mocks",
     "@deephaven/tsconfig": "file:../tsconfig"
   },

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -31,6 +31,7 @@
   },
   "dependencies": {
     "@deephaven/icons": "file:../icons",
+    "@deephaven/log": "file:../log",
     "@deephaven/react-hooks": "file:../react-hooks",
     "@deephaven/utils": "file:../utils",
     "@fortawesome/fontawesome-svg-core": "1.2.36",
@@ -52,12 +53,10 @@
     "shortid": "^2.2.16"
   },
   "peerDependencies": {
-    "@deephaven/log": "^0.12",
     "react": "^17.x",
     "react-dom": "^17.x"
   },
   "devDependencies": {
-    "@deephaven/log": "file:../log",
     "@deephaven/mocks": "file:../mocks",
     "@deephaven/tsconfig": "file:../tsconfig"
   },

--- a/packages/console/package.json
+++ b/packages/console/package.json
@@ -30,8 +30,10 @@
     "start": "cross-env NODE_ENV=development npm run watch"
   },
   "dependencies": {
+    "@deephaven/components": "file:../components",
     "@deephaven/icons": "file:../icons",
     "@deephaven/jsapi-shim": "file:../jsapi-shim",
+    "@deephaven/log": "file:../log",
     "@deephaven/storage": "file:../storage",
     "@deephaven/utils": "file:../utils",
     "@fortawesome/react-fontawesome": "^0.1.15",
@@ -46,13 +48,10 @@
     "shell-quote": "^1.7.2"
   },
   "peerDependencies": {
-    "@deephaven/components": "^0.12",
-    "@deephaven/log": "^0.12",
     "react": "^17.x",
     "react-dom": "^17.x"
   },
   "devDependencies": {
-    "@deephaven/log": "file:../log",
     "@deephaven/mocks": "file:../mocks",
     "@deephaven/tsconfig": "file:../tsconfig"
   },

--- a/packages/dashboard-core-plugins/package.json
+++ b/packages/dashboard-core-plugins/package.json
@@ -31,6 +31,7 @@
   },
   "dependencies": {
     "@deephaven/chart": "file:../chart",
+    "@deephaven/components": "file:../components",
     "@deephaven/console": "file:../console",
     "@deephaven/dashboard": "file:../dashboard",
     "@deephaven/file-explorer": "file:../file-explorer",
@@ -39,6 +40,8 @@
     "@deephaven/iris-grid": "file:../iris-grid",
     "@deephaven/jsapi-shim": "file:../jsapi-shim",
     "@deephaven/jsapi-utils": "file:../jsapi-utils",
+    "@deephaven/log": "file:../log",
+    "@deephaven/redux": "file:../redux",
     "@deephaven/utils": "file:../utils",
     "@fortawesome/react-fontawesome": "^0.1.15",
     "classnames": "^2.3.1",
@@ -55,17 +58,12 @@
     "shortid": "^2.2.16"
   },
   "peerDependencies": {
-    "@deephaven/components": "^0.12",
-    "@deephaven/log": "^0.12",
-    "@deephaven/redux": "^0.12",
     "react": "^17.0.0",
     "react-dom": "^17.0.0",
     "react-redux": "^7.2.4"
   },
   "devDependencies": {
-    "@deephaven/log": "file:../log",
     "@deephaven/mocks": "file:../mocks",
-    "@deephaven/redux": "file:../redux",
     "@deephaven/tsconfig": "file:../tsconfig"
   },
   "files": [

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -30,8 +30,11 @@
     "start": "cross-env NODE_ENV=development npm run watch"
   },
   "dependencies": {
+    "@deephaven/components": "file:../components",
     "@deephaven/golden-layout": "file:../golden-layout",
+    "@deephaven/log": "file:../log",
     "@deephaven/react-hooks": "file:../react-hooks",
+    "@deephaven/redux": "file:../redux",
     "deep-equal": "^2.0.5",
     "jquery": "^3.6.0",
     "lodash.ismatch": "^4.1.1",
@@ -40,17 +43,12 @@
     "shortid": "^2.2.16"
   },
   "peerDependencies": {
-    "@deephaven/components": "^0.12",
-    "@deephaven/log": "^0.12",
-    "@deephaven/redux": "^0.12",
     "react": "^17.0.0",
     "react-dom": "^17.0.0",
     "react-redux": "^7.2.4"
   },
   "devDependencies": {
-    "@deephaven/log": "file:../log",
     "@deephaven/mocks": "file:../mocks",
-    "@deephaven/redux": "file:../redux",
     "@deephaven/tsconfig": "file:../tsconfig"
   },
   "files": [

--- a/packages/file-explorer/package.json
+++ b/packages/file-explorer/package.json
@@ -30,7 +30,9 @@
     "start": "cross-env NODE_ENV=development npm run watch"
   },
   "dependencies": {
+    "@deephaven/components": "file:../components",
     "@deephaven/icons": "file:../icons",
+    "@deephaven/log": "file:../log",
     "@deephaven/storage": "file:../storage",
     "@deephaven/utils": "file:../utils",
     "@fortawesome/fontawesome-svg-core": "1.2.36",
@@ -42,12 +44,9 @@
     "webdav": "^4.6.1"
   },
   "peerDependencies": {
-    "@deephaven/components": "^0.12",
-    "@deephaven/log": "^0.12",
     "react": "^17.0.0"
   },
   "devDependencies": {
-    "@deephaven/log": "file:../log",
     "@deephaven/tsconfig": "file:../tsconfig"
   },
   "files": [

--- a/packages/iris-grid/package.json
+++ b/packages/iris-grid/package.json
@@ -30,12 +30,14 @@
     "start": "cross-env NODE_ENV=development npm run watch"
   },
   "dependencies": {
+    "@deephaven/components": "file:../components",
     "@deephaven/console": "file:../console",
     "@deephaven/filters": "file:../filters",
     "@deephaven/grid": "file:../grid",
     "@deephaven/icons": "file:../icons",
     "@deephaven/jsapi-shim": "file:../jsapi-shim",
     "@deephaven/jsapi-utils": "file:../jsapi-utils",
+    "@deephaven/log": "file:../log",
     "@deephaven/react-hooks": "file:../react-hooks",
     "@deephaven/storage": "file:../storage",
     "@deephaven/utils": "file:../utils",
@@ -56,12 +58,9 @@
     "web-streams-polyfill": "^2.1.0"
   },
   "peerDependencies": {
-    "@deephaven/components": "^0.12",
-    "@deephaven/log": "^0.12",
     "react": "^17.x"
   },
   "devDependencies": {
-    "@deephaven/log": "file:../log",
     "@deephaven/mocks": "file:../mocks",
     "@deephaven/tsconfig": "file:../tsconfig"
   },

--- a/packages/redux/package.json
+++ b/packages/redux/package.json
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "@deephaven/jsapi-utils": "file:../jsapi-utils",
+    "@deephaven/log": "file:../log",
     "deep-equal": "^2.0.5",
     "redux-thunk": "^2.3.0"
   },
@@ -35,7 +36,6 @@
     "@deephaven/tsconfig": "file:../tsconfig"
   },
   "peerDependencies": {
-    "@deephaven/log": "^0.12",
     "redux": "^4.0.5"
   },
   "files": [

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -27,15 +27,14 @@
     "start": "cross-env NODE_ENV=development npm run watch"
   },
   "dependencies": {
+    "@deephaven/filters": "file:../filters",
+    "@deephaven/log": "file:../log",
     "lodash.throttle": "^4.1.1"
   },
   "peerDependencies": {
-    "@deephaven/filters": "^0.12",
-    "@deephaven/log": "^0.12",
     "react": "^17.0.0"
   },
   "devDependencies": {
-    "@deephaven/filters": "file:../filters",
     "@deephaven/tsconfig": "file:../tsconfig"
   },
   "files": [


### PR DESCRIPTION
Just set them as regular dependencies. Peer dependencies need to be defined as explicit version numbers, and we're just using file:... notation for all dev/dependencies. 