### PR TITLE
Refactor GridUtils move items

### DIFF
--- a/packages/grid/src/GridUtils.test.ts
+++ b/packages/grid/src/GridUtils.test.ts
@@ -1,6 +1,6 @@
 import GridMetrics, { ModelIndex, MoveOperation } from './GridMetrics';
 import GridRange, { GridRangeIndex } from './GridRange';
-import GridUtils, { AxisRange } from './GridUtils';
+import GridUtils from './GridUtils';
 
 function expectModelIndexes(
   movedItems: MoveOperation[],
@@ -166,18 +166,16 @@ describe('floating item checks', () => {
   });
 });
 
-describe('start/end range adjustment in one dimension', () => {
+describe('start/end range adjustment in one dimension visible to model', () => {
   function testRange(
     start: GridRangeIndex,
     end: GridRangeIndex,
     movedItems: MoveOperation[] = [],
     expectedResult = [[start, end]]
   ) {
-    expect(
-      GridUtils.getModelRangeIndexes(start, end, movedItems).sort(
-        (a, b) => (a as AxisRange)[0] - (b as AxisRange)[0]
-      )
-    ).toEqual(expectedResult);
+    expect(GridUtils.getModelRangeIndexes(start, end, movedItems)).toEqual(
+      expectedResult
+    );
   }
   it('handles no transforms', () => {
     testRange(0, 0);
@@ -190,15 +188,38 @@ describe('start/end range adjustment in one dimension', () => {
     testRange(10, 20, movedItems);
   });
   it('handles items moved into the range', () => {
-    const movedItems = GridUtils.moveItem(100, 7);
-    testRange(5, 10, movedItems, [
+    testRange(5, 10, GridUtils.moveItem(1, 7), [
+      [6, 10],
+      [1, 1],
+    ]);
+
+    testRange(5, 10, GridUtils.moveItem(100, 7), [
+      [5, 9],
+      [100, 100],
+    ]);
+
+    testRange(5, 10, GridUtils.moveItem(1, 5), [
+      [6, 10],
+      [1, 1],
+    ]);
+
+    testRange(5, 10, GridUtils.moveItem(1, 10), [
+      [6, 10],
+      [1, 1],
+    ]);
+
+    testRange(5, 10, GridUtils.moveItem(100, 5), [
+      [5, 9],
+      [100, 100],
+    ]);
+
+    testRange(5, 10, GridUtils.moveItem(100, 10), [
       [5, 9],
       [100, 100],
     ]);
   });
   it('handles items moved outside the range', () => {
-    const movedItems = GridUtils.moveItem(7, 100);
-    testRange(5, 10, movedItems, [
+    testRange(5, 10, GridUtils.moveItem(7, 100), [
       [5, 6],
       [8, 11],
     ]);
@@ -208,8 +229,7 @@ describe('start/end range adjustment in one dimension', () => {
     testRange(5, 10, movedItems, [[6, 11]]);
   });
   it('handles items moved from after to before range', () => {
-    const movedItems = GridUtils.moveItem(100, 1);
-    testRange(5, 10, movedItems, [[4, 9]]);
+    testRange(5, 10, GridUtils.moveItem(100, 1), [[4, 9]]);
   });
   it('handles multiple operations', () => {
     let movedItems = GridUtils.moveItem(1, 100);
@@ -226,9 +246,159 @@ describe('start/end range adjustment in one dimension', () => {
       [52, 52],
     ]);
   });
+  it('handles moves within the range', () => {
+    testRange(5, 10, GridUtils.moveItem(9, 6), [
+      [5, 5],
+      [9, 9],
+      [6, 8],
+      [10, 10],
+    ]);
+
+    testRange(5, 10, GridUtils.moveItem(6, 9), [
+      [5, 5],
+      [7, 9],
+      [6, 6],
+      [10, 10],
+    ]);
+
+    testRange(5, 10, GridUtils.moveItem(9, 5), [
+      [9, 9],
+      [5, 8],
+      [10, 10],
+    ]);
+
+    testRange(5, 10, GridUtils.moveItem(6, 10), [
+      [5, 5],
+      [7, 10],
+      [6, 6],
+    ]);
+
+    testRange(5, 10, GridUtils.moveItem(5, 10), [
+      [6, 10],
+      [5, 5],
+    ]);
+
+    testRange(5, 10, GridUtils.moveItem(10, 5), [
+      [10, 10],
+      [5, 9],
+    ]);
+  });
 });
 
-describe('grid range transforms with moved items in both dimensions', () => {
+describe('start/end range adjustment in one dimension model to visible', () => {
+  function testRange(
+    start: GridRangeIndex,
+    end: GridRangeIndex,
+    movedItems: MoveOperation[] = [],
+    expectedResult = [[start, end]]
+  ) {
+    expect(GridUtils.getVisibleRangeIndexes(start, end, movedItems)).toEqual(
+      expectedResult
+    );
+  }
+  it('handles no transforms', () => {
+    testRange(0, 0);
+    testRange(100, 100);
+  });
+  it('handles transforms outside of range', () => {
+    let movedItems = GridUtils.moveItem(2, 1);
+    movedItems = GridUtils.moveItem(100, 200, movedItems);
+    testRange(5, 10, movedItems);
+    testRange(10, 20, movedItems);
+  });
+  it('handles items moved into the range', () => {
+    testRange(5, 10, GridUtils.moveItem(1, 7), [
+      [4, 6],
+      [8, 10],
+    ]);
+
+    testRange(5, 10, GridUtils.moveItem(100, 7), [
+      [5, 6],
+      [8, 11],
+    ]);
+
+    testRange(5, 10, GridUtils.moveItem(1, 5), [
+      [4, 4],
+      [6, 10],
+    ]);
+
+    testRange(5, 10, GridUtils.moveItem(1, 10), [[4, 9]]);
+
+    testRange(5, 10, GridUtils.moveItem(100, 5), [[6, 11]]);
+
+    testRange(5, 10, GridUtils.moveItem(100, 10), [
+      [5, 9],
+      [11, 11],
+    ]);
+  });
+  it('handles items moved outside the range', () => {
+    testRange(5, 10, GridUtils.moveItem(7, 100), [
+      [5, 9],
+      [100, 100],
+    ]);
+  });
+  it('handles items moved from before to after range', () => {
+    testRange(5, 10, GridUtils.moveItem(1, 100), [[4, 9]]);
+  });
+  it('handles items moved from after to before range', () => {
+    testRange(5, 10, GridUtils.moveItem(100, 1), [[6, 11]]);
+  });
+  it('handles multiple operations', () => {
+    let movedItems = GridUtils.moveItem(1, 100);
+    testRange(5, 10, movedItems, [[4, 9]]);
+    movedItems = GridUtils.moveItem(7, 100, movedItems);
+    testRange(5, 10, movedItems, [
+      [4, 8],
+      [100, 100],
+    ]);
+    movedItems = GridUtils.moveItem(50, 8, movedItems);
+    testRange(5, 10, movedItems, [
+      [4, 7],
+      [9, 9],
+      [100, 100],
+    ]);
+  });
+
+  it('handles moves within the range', () => {
+    testRange(5, 10, GridUtils.moveItem(9, 6), [
+      [5, 5],
+      [7, 9],
+      [6, 6],
+      [10, 10],
+    ]);
+
+    testRange(5, 10, GridUtils.moveItem(6, 9), [
+      [5, 5],
+      [9, 9],
+      [6, 8],
+      [10, 10],
+    ]);
+
+    testRange(5, 10, GridUtils.moveItem(9, 5), [
+      [6, 9],
+      [5, 5],
+      [10, 10],
+    ]);
+
+    testRange(5, 10, GridUtils.moveItem(6, 10), [
+      [5, 5],
+      [10, 10],
+      [6, 9],
+    ]);
+
+    testRange(5, 10, GridUtils.moveItem(5, 10), [
+      [10, 10],
+      [5, 9],
+    ]);
+
+    testRange(5, 10, GridUtils.moveItem(10, 5), [
+      [6, 10],
+      [5, 5],
+    ]);
+  });
+});
+
+describe('grid range transforms with moved items in both dimensions visible to model', () => {
   function testRanges(
     ranges: GridRange[],
     movedColumns: MoveOperation[] = [],
@@ -285,6 +455,69 @@ describe('grid range transforms with moved items in both dimensions', () => {
         new GridRange(10, 27, 19, 27),
         new GridRange(25, 15, 25, 24),
         new GridRange(25, 27, 25, 27),
+        new GridRange(30, 35, 40, 45),
+      ]
+    );
+  });
+});
+
+describe('grid range transforms with moved items in both dimensions model to visible', () => {
+  function testRanges(
+    ranges: GridRange[],
+    movedColumns: MoveOperation[] = [],
+    movedRows: MoveOperation[] = [],
+    expectedRanges = ranges
+  ) {
+    expect(
+      GridUtils.getVisibleRanges(ranges, movedColumns, movedRows).sort((a, b) =>
+        a.startColumn !== b.startColumn
+          ? (a.startColumn as ModelIndex) - (b.startColumn as ModelIndex)
+          : (a.startRow as ModelIndex) - (b.endRow as ModelIndex)
+      )
+    ).toEqual(expectedRanges);
+  }
+  function testRange(
+    range: GridRange,
+    movedColumns: MoveOperation[] = [],
+    movedRows: MoveOperation[] = [],
+    expectedRanges = [range]
+  ) {
+    testRanges([range], movedColumns, movedRows, expectedRanges);
+  }
+  it('handles no transformations', () => {
+    testRange(new GridRange(0, 0, 0, 0));
+    testRange(new GridRange(1, 4, 2, 6));
+  });
+  it('handles transformations that do not affect the range', () => {
+    let movedItems: MoveOperation[] = GridUtils.moveItem(2, 1);
+    movedItems = GridUtils.moveItem(5, 0, movedItems);
+    movedItems = GridUtils.moveItem(100, 110, movedItems);
+    movedItems = GridUtils.moveItem(200, 220, movedItems);
+
+    testRange(new GridRange(50, 55, 60, 65), movedItems, movedItems);
+  });
+  it('handles moving items into the range', () => {
+    const movedColumns: MoveOperation[] = GridUtils.moveItem(25, 15);
+    const movedRows: MoveOperation[] = GridUtils.moveItem(27, 17);
+    testRange(new GridRange(10, 15, 20, 25), movedColumns, movedRows, [
+      new GridRange(10, 15, 14, 16),
+      new GridRange(10, 18, 14, 26),
+      new GridRange(16, 15, 21, 16),
+      new GridRange(16, 18, 21, 26),
+    ]);
+  });
+  it('handles multiple ranges', () => {
+    const movedColumns = GridUtils.moveItem(25, 15);
+    const movedRows = GridUtils.moveItem(27, 17);
+    testRanges(
+      [new GridRange(10, 15, 20, 25), new GridRange(30, 35, 40, 45)],
+      movedColumns,
+      movedRows,
+      [
+        new GridRange(10, 15, 14, 16),
+        new GridRange(10, 18, 14, 26),
+        new GridRange(16, 15, 21, 16),
+        new GridRange(16, 18, 21, 26),
         new GridRange(30, 35, 40, 45),
       ]
     );


### PR DESCRIPTION
Adds model -> visible range transform methods and refactors the moved item methods to utilize the same logic w/ an optional reverse flag for converting from visible -> model

The model -> visible transform is needed for column header groups