### PR TITLE
Fix grid resizing automatically when outer parent size not specified

### DIFF
--- a/packages/code-studio/src/styleguide/Grids.jsx
+++ b/packages/code-studio/src/styleguide/Grids.jsx
@@ -31,7 +31,7 @@ class Grids extends PureComponent {
       <div>
         <ThemeContext.Provider value={contextTheme}>
           <h2 className="ui-title">Grid</h2>
-          <div style={{ height: 500 }}>
+          <div>
             <Grid model={model} theme={theme} />
           </div>
           <h2 className="ui-title">Static Data</h2>

--- a/packages/grid/src/Grid.scss
+++ b/packages/grid/src/Grid.scss
@@ -1,3 +1,6 @@
+.grid-canvas {
+  display: block;
+}
 .grid-canvas:focus {
   outline: none;
 }
@@ -25,7 +28,6 @@
 .grid-cursor-pointer {
   cursor: pointer;
 }
-
 .grid-block-events {
   pointer-events: none;
 }

--- a/packages/grid/src/Grid.tsx
+++ b/packages/grid/src/Grid.tsx
@@ -774,11 +774,13 @@ class Grid extends PureComponent<GridProps, GridState> {
     // we don't want to stretch the canvas to 100%, to avoid fractional pixels.
     // A wrapper element must be used for sizing, and canvas size must be
     // set manually to a floored value in css and a scaled value in width/height
-    const { width, height } = canvas.parentElement.getBoundingClientRect();
-    canvas.style.width = `${Math.floor(width)}px`;
-    canvas.style.height = `${Math.floor(height)}px`;
-    canvas.width = Math.floor(width) * scale;
-    canvas.height = Math.floor(height) * scale;
+    const rect = canvas.parentElement.getBoundingClientRect();
+    const width = Math.floor(rect.width);
+    const height = Math.floor(rect.height);
+    canvas.style.width = `${width}px`;
+    canvas.style.height = `${height}px`;
+    canvas.width = width * scale;
+    canvas.height = height * scale;
     canvasContext.scale(scale, scale);
   }
 


### PR DESCRIPTION
Canvas renders a new line after the element (apparently). Set it to display: block so it doesn't.
See https://stackoverflow.com/questions/15807833/div-containing-canvas-have-got-a-strange-bottom-margin-of-5px

Fixes #602
