### PR TITLE
Add support for moving ranges within grids

### DIFF
--- a/packages/grid/src/GridMetrics.ts
+++ b/packages/grid/src/GridMetrics.ts
@@ -1,3 +1,5 @@
+import type { AxisRange } from './GridUtils';
+
 /** A grid coordinate value */
 export type Coordinate = number;
 
@@ -29,7 +31,7 @@ export type IndexModelMap = Map<VisibleIndex, ModelIndex>;
 
 /** Represents a move operation from one index to another */
 export type MoveOperation = {
-  from: VisibleIndex;
+  from: VisibleIndex | AxisRange;
   to: VisibleIndex;
 };
 

--- a/packages/grid/src/GridMetrics.ts
+++ b/packages/grid/src/GridMetrics.ts
@@ -1,4 +1,4 @@
-import type { AxisRange } from './GridUtils';
+import type { BoundedAxisRange } from './GridUtils';
 
 /** A grid coordinate value */
 export type Coordinate = number;
@@ -31,7 +31,7 @@ export type IndexModelMap = Map<VisibleIndex, ModelIndex>;
 
 /** Represents a move operation from one index to another */
 export type MoveOperation = {
-  from: VisibleIndex | AxisRange;
+  from: VisibleIndex | BoundedAxisRange;
   to: VisibleIndex;
 };
 

--- a/packages/grid/src/GridUtils.ts
+++ b/packages/grid/src/GridUtils.ts
@@ -741,6 +741,11 @@ export class GridUtils {
 
   /**
    * Move a visible range in the grid
+   *
+   * This will effectively slice the range out of the grid,
+   * re-index the remaining columns,
+   * then insert the range with the first element at the provided index
+   *
    * @param from The visible axis range to move
    * @param to The visible index to move the start of the range to
    * @param oldMovedItems The old reordered items
@@ -856,14 +861,14 @@ export class GridUtils {
                 // Current range in moved range
                 movedRange = [s + moveDistance, e + moveDistance];
                 return movedRange;
-          }
+              }
 
               if (fromEnd < s) {
                 // Current range is after moved range
                 return [s - length, e - length];
-          }
+              }
               return range;
-          }
+            }
           )
           .map((range): Range<number>[] => {
             const [s, e] = range;
@@ -873,17 +878,17 @@ export class GridUtils {
                 [s, toStart - 1],
                 [toStart + length, e + length],
               ];
-          }
+            }
 
             if (range === movedRange) {
               // Moved range has already been shifted
               return [range];
-        }
+            }
 
             if (toStart <= s) {
               // Moved range shifts this range right
               return [[s + length, e + length]];
-        }
+            }
             return [range];
           })
           .flat();

--- a/packages/grid/src/GridUtils.ts
+++ b/packages/grid/src/GridUtils.ts
@@ -17,11 +17,35 @@ import { GridWheelEvent } from './GridMouseHandler';
 
 type Range<T> = [start: T, end: T];
 
-export type AxisRange = Range<VisibleIndex>;
+export type AxisRange = Range<GridRangeIndex>;
+export type BoundedAxisRange = Range<VisibleIndex>;
 
-export type BoundedAxisRange = Range<number>;
+export function isAxisRange(range: unknown): range is AxisRange {
+  return (
+    Array.isArray(range) &&
+    range.length === 2 &&
+    (range[0] === null || typeof range[0] === 'number') &&
+    (range[1] === null || typeof range[1] === 'number')
+  );
+}
 
-export type GridAxisRange = Range<GridRangeIndex>;
+export function assertAxisRange(range: unknown): asserts range is AxisRange {
+  if (!isAxisRange(range)) {
+    throw new Error(`Expected axis range. Received: ${range}`);
+  }
+}
+
+export function isBoundedAxisRange(range: unknown): range is BoundedAxisRange {
+  return isAxisRange(range) && range[0] != null && range[1] != null;
+}
+
+export function assertBoundedAxisRange(
+  range: unknown
+): asserts range is BoundedAxisRange {
+  if (!isBoundedAxisRange(range)) {
+    throw new Error(`Expected bounded axis range. Received: ${range}`);
+  }
+}
 
 export type GridPoint = {
   x: Coordinate;
@@ -752,7 +776,7 @@ export class GridUtils {
    * @returns The new reordered items
    */
   static moveRange(
-    from: AxisRange,
+    from: BoundedAxisRange,
     to: VisibleIndex,
     oldMovedItems: MoveOperation[] = []
   ): MoveOperation[] {
@@ -763,8 +787,7 @@ export class GridUtils {
     const movedItems: MoveOperation[] = [...oldMovedItems];
     const lastMovedItem = movedItems[movedItems.length - 1];
     if (
-      lastMovedItem &&
-      Array.isArray(lastMovedItem.from) &&
+      isBoundedAxisRange(lastMovedItem.from) &&
       lastMovedItem.from[1] - lastMovedItem.from[0] === from[1] - from[0] &&
       lastMovedItem.to === from[0]
     ) {
@@ -823,7 +846,7 @@ export class GridUtils {
       const { from: fromItemOrRange, to: toItem } = movedItems[i];
       let length = 1;
       let fromItem: number;
-      if (Array.isArray(fromItemOrRange)) {
+      if (isBoundedAxisRange(fromItemOrRange)) {
         length = fromItemOrRange[1] - fromItemOrRange[0] + 1; // Ranges are inclusive
         [fromItem] = fromItemOrRange;
       } else {
@@ -955,7 +978,7 @@ export class GridUtils {
     start: GridRangeIndex,
     end: GridRangeIndex,
     movedItems: MoveOperation[]
-  ): GridAxisRange[] {
+  ): AxisRange[] {
     return GridUtils.applyItemMoves(start, end, movedItems, true);
   }
 
@@ -1012,7 +1035,7 @@ export class GridUtils {
     start: GridRangeIndex,
     end: GridRangeIndex,
     movedItems: MoveOperation[]
-  ): GridAxisRange[] {
+  ): AxisRange[] {
     return GridUtils.applyItemMoves(start, end, movedItems, false);
   }
 

--- a/packages/grid/src/GridUtils.ts
+++ b/packages/grid/src/GridUtils.ts
@@ -787,6 +787,7 @@ export class GridUtils {
     const movedItems: MoveOperation[] = [...oldMovedItems];
     const lastMovedItem = movedItems[movedItems.length - 1];
     if (
+      lastMovedItem &&
       isBoundedAxisRange(lastMovedItem.from) &&
       lastMovedItem.from[1] - lastMovedItem.from[0] === from[1] - from[0] &&
       lastMovedItem.to === from[0]


### PR DESCRIPTION
This adds support for moving an entire range within a grid

The operation is to slice the range from the current grid, re-index the remaining columns as if the range was not there, and then insert with the first element in the range at the position specified