### PR TITLE
Fix grabbing scroll bar when filter bar is visible

### DIFF
--- a/packages/grid/src/GridMetricCalculator.ts
+++ b/packages/grid/src/GridMetricCalculator.ts
@@ -337,6 +337,8 @@ export class GridMetricCalculator {
     const verticalBarWidth = hasVerticalBar ? scrollBarSize : 0;
     const barWidth = width - rowHeaderWidth - verticalBarWidth;
     const barHeight = height - columnHeaderHeight - horizontalBarHeight;
+    const barLeft = rowHeaderWidth;
+    const barTop = columnHeaderHeight;
 
     // How big the scroll handle is relative to the bar
     const horizontalHandlePercent =
@@ -548,7 +550,9 @@ export class GridMetricCalculator {
 
       // Scroll bar metrics
       barHeight,
+      barTop,
       barWidth,
+      barLeft,
       handleHeight,
       handleWidth,
       hasHorizontalBar,

--- a/packages/grid/src/GridMetrics.ts
+++ b/packages/grid/src/GridMetrics.ts
@@ -94,7 +94,9 @@ export type GridMetrics = {
 
   // Scroll bar metrics
   barHeight: number;
-  barWidth: number;
+  barTop: number; // Relative to canvas dimensions
+  barWidth: number; // Relative to canvas dimensions
+  barLeft: number;
   handleHeight: number;
   handleWidth: number;
   hasHorizontalBar: boolean;

--- a/packages/grid/src/GridMetrics.ts
+++ b/packages/grid/src/GridMetrics.ts
@@ -95,8 +95,8 @@ export type GridMetrics = {
   // Scroll bar metrics
   barHeight: number;
   barTop: number; // Relative to canvas dimensions
-  barWidth: number; // Relative to canvas dimensions
-  barLeft: number;
+  barWidth: number;
+  barLeft: number; // Relative to canvas dimensions
   handleHeight: number;
   handleWidth: number;
   hasHorizontalBar: boolean;

--- a/packages/grid/src/mouse-handlers/GridHorizontalScrollBarMouseHandler.ts
+++ b/packages/grid/src/mouse-handlers/GridHorizontalScrollBarMouseHandler.ts
@@ -46,17 +46,15 @@ class GridHorizontalScrollBarMouseHandler extends GridMouseHandler {
     if (!metrics) throw new Error('metrics not set');
 
     const { x, y } = gridPoint;
-    const { gridX, width, height, hasHorizontalBar, hasVerticalBar } = metrics;
-
-    const scrollBarWidth = hasVerticalBar ? width - scrollBarSize : width;
+    const { barLeft, barWidth, height, hasHorizontalBar } = metrics;
 
     return (
       hasHorizontalBar &&
       scrollBarSize > 0 &&
       y >= height - scrollBarHoverSize &&
       y < height &&
-      x > gridX &&
-      x < scrollBarWidth
+      x > barLeft &&
+      x < barLeft + barWidth
     );
   }
 
@@ -72,13 +70,13 @@ class GridHorizontalScrollBarMouseHandler extends GridMouseHandler {
       barWidth,
       handleWidth,
       lastLeft,
-      gridX,
+      barLeft,
       columnCount,
       scrollableContentWidth,
       scrollableViewportWidth,
     } = metrics;
 
-    const mouseBarX = x - gridX;
+    const mouseBarX = x - barLeft;
     const scrollPercent = clamp(
       (mouseBarX - (this.dragOffset ?? 0)) / (barWidth - handleWidth),
       0,
@@ -105,12 +103,12 @@ class GridHorizontalScrollBarMouseHandler extends GridMouseHandler {
     if (!metrics) throw new Error('metrics not set');
 
     const { x } = gridPoint;
-    const { handleWidth, gridX, scrollX } = metrics;
+    const { handleWidth, barLeft, scrollX } = metrics;
     if (!this.isInScrollBar(gridPoint, grid)) {
       return false;
     }
 
-    const mouseBarX = x - gridX;
+    const mouseBarX = x - barLeft;
     if (mouseBarX >= scrollX && mouseBarX <= scrollX + handleWidth) {
       // Grabbed the horizontal handle
       this.dragOffset = mouseBarX - scrollX;

--- a/packages/grid/src/mouse-handlers/GridScrollBarCornerMouseHandler.ts
+++ b/packages/grid/src/mouse-handlers/GridScrollBarCornerMouseHandler.ts
@@ -15,11 +15,11 @@ class GridScrollBarCornerMouseHandler extends GridMouseHandler {
     if (!metrics) throw new Error('metrics not set');
 
     const { x, y } = gridPoint;
-    const { lastLeft, lastTop, width, height } = metrics;
+    const { width, height, hasVerticalBar, hasHorizontalBar } = metrics;
     return (
       scrollBarSize > 0 &&
-      lastTop > 0 &&
-      lastLeft > 0 &&
+      hasVerticalBar &&
+      hasHorizontalBar &&
       x >= width - scrollBarSize &&
       y >= height - scrollBarSize &&
       x <= width &&

--- a/packages/grid/src/mouse-handlers/GridVerticalScrollBarMouseHandler.ts
+++ b/packages/grid/src/mouse-handlers/GridVerticalScrollBarMouseHandler.ts
@@ -46,17 +46,15 @@ class GridVerticalScrollBarMouseHandler extends GridMouseHandler {
     if (!metrics) throw new Error('metrics not set');
 
     const { x, y } = gridPoint;
-    const { gridY, height, width, hasHorizontalBar, hasVerticalBar } = metrics;
-
-    const scrollBarHeight = hasHorizontalBar ? height - scrollBarSize : height;
+    const { barTop, barHeight, width, hasVerticalBar } = metrics;
 
     return (
       hasVerticalBar &&
       scrollBarSize > 0 &&
       x >= width - scrollBarHoverSize &&
       x < width &&
-      y > gridY &&
-      y < scrollBarHeight
+      y > barTop &&
+      y < barTop + barHeight
     );
   }
 
@@ -72,13 +70,13 @@ class GridVerticalScrollBarMouseHandler extends GridMouseHandler {
       barHeight,
       handleHeight,
       lastTop,
-      gridY,
+      barTop,
       rowCount,
       scrollableContentHeight,
       scrollableViewportHeight,
     } = metrics;
 
-    const mouseBarY = y - gridY;
+    const mouseBarY = y - barTop;
     const scrollPercent = clamp(
       (mouseBarY - (this.dragOffset ?? 0)) / (barHeight - handleHeight),
       0,
@@ -105,12 +103,12 @@ class GridVerticalScrollBarMouseHandler extends GridMouseHandler {
     if (!metrics) throw new Error('metrics not set');
 
     const { y } = gridPoint;
-    const { handleHeight, gridY, scrollY } = metrics;
+    const { handleHeight, barTop, scrollY } = metrics;
     if (!this.isInScrollBar(gridPoint, grid)) {
       return false;
     }
 
-    const mouseBarY = y - gridY;
+    const mouseBarY = y - barTop;
     if (mouseBarY >= scrollY && mouseBarY <= scrollY + handleHeight) {
       // Grabbed the vertical handle
       this.dragOffset = mouseBarY - scrollY;


### PR DESCRIPTION
Fixes #619 

Also tested w/ setting a rowHeaderWidth in `IrisGridTheme` for horizontal scroll bar