### PR TITLE
Fix filters in IrisGrid

### DIFF
--- a/packages/iris-grid/src/IrisGrid.tsx
+++ b/packages/iris-grid/src/IrisGrid.tsx
@@ -1205,11 +1205,11 @@ export class IrisGrid extends Component<IrisGridProps, IrisGridState> {
       partitionFilters,
       searchFilter
     ) => [
-      ...(customFilters ? [customFilters] : []), // null check
-      ...(partitionFilters ? [partitionFilters] : []), // null check
+      ...(customFilters ?? []),
+      ...(partitionFilters ?? []),
       ...IrisGridUtils.getFiltersFromFilterMap(quickFilters),
       ...IrisGridUtils.getFiltersFromFilterMap(advancedFilters),
-      ...(searchFilter ? [searchFilter] : []), // null check
+      ...(searchFilter ?? []),
     ],
     { max: 1 }
   );

--- a/packages/iris-grid/src/IrisGridRenderer.ts
+++ b/packages/iris-grid/src/IrisGridRenderer.ts
@@ -553,7 +553,7 @@ class IrisGridRenderer extends GridRenderer {
     } = theme;
     const columnHeaderHeight = gridY - filterBarHeight;
     const modelColumn = modelColumns.get(column);
-    if (!modelColumn) return;
+    if (modelColumn === undefined) return;
     const quickFilter = quickFilters.get(modelColumn);
     const advancedFilter = advancedFilters.get(modelColumn);
     if (quickFilter == null && advancedFilter == null) {


### PR DESCRIPTION
- Was building the cached array of filters incorrectly, adding a nested array incorrectly. This caused the filters to error when being applied.
