### PR TITLE
DH-12182: Column Grouping

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -10,6 +10,6 @@ module.exports = {
     'jest-watch-typeahead/testname',
     'jest-watch-select-projects',
   ],
-  collectCoverage: false,
+  collectCoverage: true,
   collectCoverageFrom: ['./src/**/*.{js,ts,jsx,tsx}'], // This is relative to individual project root due to how Jest handles it
 };

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -10,6 +10,6 @@ module.exports = {
     'jest-watch-typeahead/testname',
     'jest-watch-select-projects',
   ],
-  collectCoverage: true,
+  collectCoverage: false,
   collectCoverageFrom: ['./src/**/*.{js,ts,jsx,tsx}'], // This is relative to individual project root due to how Jest handles it
 };

--- a/packages/code-studio/src/styleguide/MockIrisGridTreeModel.ts
+++ b/packages/code-studio/src/styleguide/MockIrisGridTreeModel.ts
@@ -113,8 +113,8 @@ class MockIrisGridTreeModel
     return this.model.textForRowHeader(row);
   }
 
-  textForColumnHeader(column: ModelIndex): string {
-    return this.model.textForColumnHeader(column);
+  textForColumnHeader(column: ModelIndex, depth: number): string {
+    return this.model.textForColumnHeader(column, depth);
   }
 
   get hasExpandableRows(): boolean {
@@ -150,7 +150,7 @@ class MockIrisGridTreeModel
     const columns = [];
     for (let i = 0; i < count; i += 1) {
       columns.push({
-        name: this.model.textForColumnHeader(i),
+        name: this.model.textForColumnHeader(i, 0),
         type: 'java.lang.String',
         description: `Mock column ${i}`,
       });

--- a/packages/dashboard-core-plugins/src/panels/IrisGridPanel.jsx
+++ b/packages/dashboard-core-plugins/src/panels/IrisGridPanel.jsx
@@ -633,6 +633,7 @@ export class IrisGridPanel extends PureComponent {
       visibleColumnXs,
       visibleColumnWidths,
       right,
+      columnHeaderMaxDepth,
     } = metrics;
     const visibleIndex = irisGrid.getVisibleColumn(
       model.getColumnIndexByName(columnName)
@@ -649,7 +650,7 @@ export class IrisGridPanel extends PureComponent {
         rect.right
       )
     );
-    const y = rect.top + columnHeaderHeight;
+    const y = rect.top + columnHeaderHeight * columnHeaderMaxDepth;
 
     return [x, y];
   }

--- a/packages/grid/src/ColumnHeaderGroup.ts
+++ b/packages/grid/src/ColumnHeaderGroup.ts
@@ -1,0 +1,9 @@
+import { MoveOperation } from './GridMetrics';
+import { BoundedAxisRange } from './GridAxisRange';
+
+export interface IColumnHeaderGroup {
+  name: string;
+  depth: number;
+  color?: string;
+  getVisibleRange(movedColumns: MoveOperation[]): BoundedAxisRange;
+}

--- a/packages/grid/src/Grid.tsx
+++ b/packages/grid/src/Grid.tsx
@@ -27,6 +27,7 @@ import {
   GridScrollBarCornerMouseHandler,
   GridVerticalScrollBarMouseHandler,
   EditMouseHandler,
+  GridSeparator,
 } from './mouse-handlers';
 import './Grid.scss';
 import KeyHandler, { GridKeyboardEvent } from './KeyHandler';
@@ -53,6 +54,7 @@ import {
 import { EventHandlerResultOptions } from './EventHandlerResult';
 import { assertIsDefined } from './errors';
 import ThemeContext from './ThemeContext';
+import { DraggingColumn } from './mouse-handlers/GridColumnMoveMouseHandler';
 
 type LegacyCanvasRenderingContext2D = CanvasRenderingContext2D & {
   webkitBackingStorePixelRatio?: number;
@@ -126,7 +128,7 @@ export type GridState = {
   leftOffset: number; // Should be less than the width of the column
 
   // current column/row that user is dragging
-  draggingColumn: VisibleIndex | null;
+  draggingColumn: DraggingColumn | null;
   draggingRow: VisibleIndex | null;
 
   // Offset when dragging a column/row
@@ -134,8 +136,9 @@ export type GridState = {
   draggingRowOffset: number | null;
 
   // When drawing header separators for resizing
-  draggingColumnSeparator: VisibleIndex | null;
-  draggingRowSeparator: VisibleIndex | null;
+  // Keeps hover style when mouse is in buffer before resize starts
+  draggingColumnSeparator: GridSeparator | null;
+  draggingRowSeparator: GridSeparator | null;
 
   // Dragging a scroll bar status
   isDraggingHorizontalScrollBar: boolean;

--- a/packages/grid/src/Grid.tsx
+++ b/packages/grid/src/Grid.tsx
@@ -131,8 +131,7 @@ export type GridState = {
   draggingColumn: DraggingColumn | null;
   draggingRow: VisibleIndex | null;
 
-  // Offset when dragging a column/row
-  draggingColumnOffset: number | null;
+  // Offset when dragging a row
   draggingRowOffset: number | null;
 
   // When drawing header separators for resizing
@@ -374,8 +373,7 @@ class Grid extends PureComponent<GridProps, GridState> {
       draggingColumn: null,
       draggingRow: null,
 
-      // Offset when dragging a column/row
-      draggingColumnOffset: null,
+      // Offset when dragging a row
       draggingRowOffset: null,
 
       // When drawing header separators for resizing
@@ -614,6 +612,7 @@ class Grid extends PureComponent<GridProps, GridState> {
       movedRows,
       isDraggingHorizontalScrollBar,
       isDraggingVerticalScrollBar,
+      draggingColumn,
     } = state;
 
     return {
@@ -630,6 +629,7 @@ class Grid extends PureComponent<GridProps, GridState> {
       movedRows,
       isDraggingHorizontalScrollBar,
       isDraggingVerticalScrollBar,
+      draggingColumn,
       ...stateOverride,
     };
   }
@@ -1528,7 +1528,6 @@ class Grid extends PureComponent<GridProps, GridState> {
       cursorColumn,
       cursorRow,
       draggingColumn,
-      draggingColumnOffset,
       draggingColumnSeparator,
       draggingRow,
       draggingRowOffset,
@@ -1560,7 +1559,6 @@ class Grid extends PureComponent<GridProps, GridState> {
       mouseY,
       selectedRanges,
       draggingColumn,
-      draggingColumnOffset,
       draggingColumnSeparator,
       draggingRow,
       draggingRowOffset,

--- a/packages/grid/src/GridAxisRange.ts
+++ b/packages/grid/src/GridAxisRange.ts
@@ -1,4 +1,5 @@
-import { GridRangeIndex, VisibleIndex } from '.';
+import type { GridRangeIndex } from './GridRange';
+import type { VisibleIndex } from './GridMetrics';
 
 export type Range<T> = [start: T, end: T];
 

--- a/packages/grid/src/GridAxisRange.ts
+++ b/packages/grid/src/GridAxisRange.ts
@@ -1,0 +1,33 @@
+import { GridRangeIndex, VisibleIndex } from '.';
+
+export type Range<T> = [start: T, end: T];
+
+export type AxisRange = Range<GridRangeIndex>;
+export type BoundedAxisRange = Range<VisibleIndex>;
+
+export function isAxisRange(range: unknown): range is AxisRange {
+  return (
+    Array.isArray(range) &&
+    range.length === 2 &&
+    (range[0] === null || typeof range[0] === 'number') &&
+    (range[1] === null || typeof range[1] === 'number')
+  );
+}
+
+export function assertAxisRange(range: unknown): asserts range is AxisRange {
+  if (!isAxisRange(range)) {
+    throw new Error(`Expected axis range. Received: ${range}`);
+  }
+}
+
+export function isBoundedAxisRange(range: unknown): range is BoundedAxisRange {
+  return isAxisRange(range) && range[0] != null && range[1] != null;
+}
+
+export function assertBoundedAxisRange(
+  range: unknown
+): asserts range is BoundedAxisRange {
+  if (!isBoundedAxisRange(range)) {
+    throw new Error(`Expected bounded axis range. Received: ${range}`);
+  }
+}

--- a/packages/grid/src/GridMetricCalculator.ts
+++ b/packages/grid/src/GridMetricCalculator.ts
@@ -299,15 +299,27 @@ export class GridMetricCalculator {
       visibleColumnWidths
     );
 
-    const columnWidthValues = Array.from(visibleColumnWidths.values());
-    const rowHeightValues = Array.from(visibleRowHeights.values());
-    const maxX = columnWidthValues.reduce((x, w) => x + w, 0) - leftOffset;
-    const maxY = rowHeightValues.reduce((y, h) => y + h, 0) - topOffset;
-
+    const floatingTopHeight = this.getFloatingTopHeight(
+      state,
+      visibleRowHeights
+    );
     const floatingBottomHeight = this.getFloatingBottomHeight(
       state,
       visibleRowHeights
     );
+    const floatingLeftWidth = this.getFloatingLeftWidth(
+      state,
+      visibleColumnWidths
+    );
+    const floatingRightWidth = this.getFloatingRightWidth(
+      state,
+      visibleColumnWidths
+    );
+
+    const columnWidthValues = Array.from(visibleColumnWidths.values());
+    const rowHeightValues = Array.from(visibleRowHeights.values());
+    const maxX = columnWidthValues.reduce((x, w) => x + w, 0) - leftOffset;
+    const maxY = rowHeightValues.reduce((y, h) => y + h, 0) - topOffset;
 
     const lastLeft = this.getLastLeft(
       state,
@@ -469,19 +481,6 @@ export class GridMetricCalculator {
             gridX
           )
         : right;
-
-    const floatingTopHeight = this.getFloatingTopHeight(
-      state,
-      visibleRowHeights
-    );
-    const floatingLeftWidth = this.getFloatingLeftWidth(
-      state,
-      visibleColumnWidths
-    );
-    const floatingRightWidth = this.getFloatingRightWidth(
-      state,
-      visibleColumnWidths
-    );
 
     const {
       fontWidths,

--- a/packages/grid/src/GridMetricCalculator.ts
+++ b/packages/grid/src/GridMetricCalculator.ts
@@ -230,6 +230,7 @@ export class GridMetricCalculator {
       floatingBottomRowCount,
       floatingLeftColumnCount,
       floatingRightColumnCount,
+      columnHeaderMaxDepth,
     } = model;
 
     // Get some basic metrics
@@ -617,6 +618,8 @@ export class GridMetricCalculator {
       // Map of calculated row/column height/width
       calculatedRowHeights,
       calculatedColumnWidths,
+
+      columnHeaderMaxDepth,
     };
   }
 
@@ -640,9 +643,9 @@ export class GridMetricCalculator {
   getGridY(state: GridMetricState): Coordinate {
     const { theme, model } = state;
     const { columnHeaderHeight } = theme;
-    const { columnHeaderDepth } = model;
+    const { columnHeaderMaxDepth } = model;
 
-    return columnHeaderDepth * columnHeaderHeight;
+    return columnHeaderMaxDepth * columnHeaderHeight;
   }
 
   /**

--- a/packages/grid/src/GridMetricCalculator.ts
+++ b/packages/grid/src/GridMetricCalculator.ts
@@ -15,6 +15,7 @@ import type {
 import GridUtils from './GridUtils';
 import { GridFont, GridTheme } from './GridTheme';
 import { isExpandableGridModel } from './ExpandableGridModel';
+import { DraggingColumn } from './mouse-handlers/GridColumnMoveMouseHandler';
 
 /* eslint class-methods-use-this: "off" */
 /* eslint react/destructuring-assignment: "off" */
@@ -48,6 +49,8 @@ export interface GridMetricState {
   // Whether the scrollbars are currently being dragged
   isDraggingHorizontalScrollBar: boolean;
   isDraggingVerticalScrollBar: boolean;
+
+  draggingColumn: DraggingColumn | null;
 }
 
 /**
@@ -202,6 +205,7 @@ export class GridMetricCalculator {
       model,
       movedRows,
       movedColumns,
+      draggingColumn,
     } = state;
     const {
       rowHeight,
@@ -437,8 +441,28 @@ export class GridMetricCalculator {
       ]);
     }
 
+    const draggingColumns: VisibleIndex[] = [];
+    if (draggingColumn) {
+      for (
+        let i = draggingColumn.range[0];
+        i <= draggingColumn.range[1];
+        i += 1
+      ) {
+        draggingColumns.push(i);
+        if (!visibleColumnWidths.has(i)) {
+          visibleColumnWidths.set(i, this.getVisibleColumnWidth(i, state));
+        }
+
+        if (!visibleColumnXs.has(i)) {
+          visibleColumnXs.set(i, 0);
+        }
+      }
+    }
+
     const allRows = visibleRows.concat(floatingRows);
-    const allColumns = visibleColumns.concat(floatingColumns);
+    const allColumns = visibleColumns
+      .concat(floatingColumns)
+      .concat(draggingColumns);
     const modelRows = this.getModelRows(allRows, state);
     const modelColumns = this.getModelColumns(allColumns, state);
 

--- a/packages/grid/src/GridMetricCalculator.ts
+++ b/packages/grid/src/GridMetricCalculator.ts
@@ -638,10 +638,11 @@ export class GridMetricCalculator {
    * @returns y value of the top side of the first cell
    */
   getGridY(state: GridMetricState): Coordinate {
-    const { theme } = state;
+    const { theme, model } = state;
     const { columnHeaderHeight } = theme;
+    const { columnHeaderDepth } = model;
 
-    return columnHeaderHeight;
+    return columnHeaderDepth * columnHeaderHeight;
   }
 
   /**
@@ -1665,7 +1666,7 @@ export class GridMetricCalculator {
     const { model, theme } = state;
     const { headerFont, headerHorizontalPadding } = theme;
 
-    const headerText = model.textForColumnHeader(modelColumn);
+    const headerText = model.textForColumnHeader(modelColumn, 0);
     if (headerText) {
       const headerFontWidth = this.getWidthForFont(headerFont, state);
       return headerText.length * headerFontWidth + headerHorizontalPadding * 2;

--- a/packages/grid/src/GridMetricCalculator.ts
+++ b/packages/grid/src/GridMetricCalculator.ts
@@ -6,7 +6,7 @@ import type {
   Coordinate,
   CoordinateMap,
   VisibleIndex,
-  IndexModelMap,
+  VisibleToModelMap,
   ModelIndex,
   ModelSizeMap,
   MoveOperation,
@@ -150,10 +150,10 @@ export class GridMetricCalculator {
   protected fontWidths: Map<string, number>;
 
   /** Map from visible index to model index for rows (e.g. reversing movedRows operations) */
-  protected modelRows: IndexModelMap;
+  protected modelRows: VisibleToModelMap;
 
   /** Map from visible index to model index for columns (e.g. reversing movedColumns operations) */
-  protected modelColumns: IndexModelMap;
+  protected modelColumns: VisibleToModelMap;
 
   /** List of moved row operations. Need to track the previous value so we know if modelRows needs to be cleared. */
   protected movedRows: MoveOperation[];
@@ -603,6 +603,9 @@ export class GridMetricCalculator {
       // Mapping from visible row indexes to the model row/columns they pull from
       modelRows,
       modelColumns,
+
+      movedRows,
+      movedColumns,
 
       // Map of the width of the fonts
       fontWidths,
@@ -1140,7 +1143,7 @@ export class GridMetricCalculator {
    */
   getVisibleRowTreeBoxes(
     visibleRowHeights: SizeMap,
-    modelRows: IndexModelMap,
+    modelRows: VisibleToModelMap,
     state: GridMetricState
   ): Map<VisibleIndex, BoxCoordinates> {
     const visibleRowTreeBoxes = new Map();
@@ -1506,15 +1509,15 @@ export class GridMetricCalculator {
   }
 
   /**
-   * Get a map of ModelIndex to Index
+   * Get a map of VisibleIndex to ModelIndex
    * @param visibleRows Array of visible row indexes
    * @param state The grid metric state
-   * @returns Map of Index to ModelIndex
+   * @returns Map of VisibleIndex to ModelIndex
    */
   getModelRows(
     visibleRows: VisibleIndex[],
     state: GridMetricState
-  ): IndexModelMap {
+  ): VisibleToModelMap {
     const modelRows = new Map();
     for (let i = 0; i < visibleRows.length; i += 1) {
       const visibleRow = visibleRows[i];
@@ -1549,7 +1552,7 @@ export class GridMetricCalculator {
   getModelColumns(
     visibleColumns: VisibleIndex[],
     state: GridMetricState
-  ): IndexModelMap {
+  ): VisibleToModelMap {
     const modelColumns = new Map();
     for (let i = 0; i < visibleColumns.length; i += 1) {
       const visibleColumn = visibleColumns[i];

--- a/packages/grid/src/GridMetrics.ts
+++ b/packages/grid/src/GridMetrics.ts
@@ -162,6 +162,8 @@ export type GridMetrics = {
   // Map of calculated row/column height/width
   calculatedRowHeights: ModelSizeMap;
   calculatedColumnWidths: ModelSizeMap;
+
+  columnHeaderMaxDepth: number;
 };
 
 export default GridMetrics;

--- a/packages/grid/src/GridMetrics.ts
+++ b/packages/grid/src/GridMetrics.ts
@@ -1,3 +1,5 @@
+import type { BoundedAxisRange } from './GridAxisRange';
+
 /** A grid coordinate value */
 export type Coordinate = number;
 
@@ -30,7 +32,7 @@ export type VisibleToModelMap = Map<VisibleIndex, ModelIndex>;
 // TODO #620
 /** Represents a move operation from one index to another */
 export type MoveOperation = {
-  from: VisibleIndex;
+  from: VisibleIndex | BoundedAxisRange;
   to: VisibleIndex;
 };
 

--- a/packages/grid/src/GridMetrics.ts
+++ b/packages/grid/src/GridMetrics.ts
@@ -164,6 +164,7 @@ export type GridMetrics = {
   calculatedRowHeights: ModelSizeMap;
   calculatedColumnWidths: ModelSizeMap;
 
+  // Max depth of column headers. Depth of 1 for a table without column groups
   columnHeaderMaxDepth: number;
 };
 

--- a/packages/grid/src/GridMetrics.ts
+++ b/packages/grid/src/GridMetrics.ts
@@ -29,7 +29,6 @@ export type ModelSizeMap = Map<ModelIndex, number>;
 /** Map from visible Index to ModelIndex */
 export type VisibleToModelMap = Map<VisibleIndex, ModelIndex>;
 
-// TODO #620
 /** Represents a move operation from one index to another */
 export type MoveOperation = {
   from: VisibleIndex | BoundedAxisRange;

--- a/packages/grid/src/GridMetrics.ts
+++ b/packages/grid/src/GridMetrics.ts
@@ -25,7 +25,7 @@ export type SizeMap = Map<VisibleIndex, number>;
 export type ModelSizeMap = Map<ModelIndex, number>;
 
 /** Map from visible Index to ModelIndex */
-export type IndexModelMap = Map<VisibleIndex, ModelIndex>;
+export type VisibleToModelMap = Map<VisibleIndex, ModelIndex>;
 
 // TODO #620
 /** Represents a move operation from one index to another */
@@ -146,8 +146,11 @@ export type GridMetrics = {
   visibleRowTreeBoxes: Map<VisibleIndex, BoxCoordinates>;
 
   // Mapping from visible row indexes to the model row/columns they pull from
-  modelRows: IndexModelMap;
-  modelColumns: IndexModelMap;
+  modelRows: VisibleToModelMap;
+  modelColumns: VisibleToModelMap;
+
+  movedRows: MoveOperation[];
+  movedColumns: MoveOperation[];
 
   // Map of the width of the fonts
   fontWidths: Map<string, number>;

--- a/packages/grid/src/GridModel.ts
+++ b/packages/grid/src/GridModel.ts
@@ -1,5 +1,5 @@
 import { EventTarget, Event } from 'event-target-shim';
-import { IColumnHeaderGroup } from '.';
+import type { IColumnHeaderGroup } from './ColumnHeaderGroup';
 import { ModelIndex } from './GridMetrics';
 import { GridColor, GridTheme, NullableGridColor } from './GridTheme';
 

--- a/packages/grid/src/GridModel.ts
+++ b/packages/grid/src/GridModel.ts
@@ -48,7 +48,7 @@ abstract class GridModel<
    * Used for column grouping where columns at depth 0 are the base columns
    *
    * A grid with 1-level grouping would have a columnHeaderDepth of 2
-   * and columns at depths 0 and 1
+   * and column headers at depths 0 and 1
    */
   get columnHeaderMaxDepth(): number {
     return 1;

--- a/packages/grid/src/GridModel.ts
+++ b/packages/grid/src/GridModel.ts
@@ -156,7 +156,36 @@ abstract class GridModel<
    * @param column Column to check
    * @returns True if the column is movable
    */
-  isColumnMovable(column: ModelIndex): boolean {
+  isColumnMovable(column: ModelIndex, depth = 0): boolean {
+    return true;
+  }
+
+  /**
+   * Checks if a column can be moved to a specific index
+   * @param fromIndex The index to move from
+   * @param toIndex The index to move to
+   * @param depth The depth the movement is occurring at
+   * @returns If the column can be moved to the given index at the given depth
+   */
+  isColumnMovableTo(column: ModelIndex, to: ModelIndex, depth = 0): boolean {
+    return true;
+  }
+
+  /**
+   * Checks if a column can be dropped between 2 columns
+   * Assumes the left and right indexes are adjacent to each other
+   * @param fromIndex The index to move from
+   * @param leftIndex The index on the left of the drop spot
+   * @param rightIndex The index on the right of the drop spot
+   * @param depth The depth the movement is occurring at
+   * @returns If the column can be dropped between the given indexes at the given depth
+   */
+  isColumnDroppableBetween(
+    column: ModelIndex,
+    left: ModelIndex | null,
+    right: ModelIndex | null,
+    depth = 0
+  ): boolean {
     return true;
   }
 

--- a/packages/grid/src/GridModel.ts
+++ b/packages/grid/src/GridModel.ts
@@ -1,4 +1,5 @@
 import { EventTarget, Event } from 'event-target-shim';
+import { IColumnHeaderGroup } from '.';
 import { ModelIndex } from './GridMetrics';
 import { GridColor, GridTheme, NullableGridColor } from './GridTheme';
 
@@ -121,9 +122,10 @@ abstract class GridModel<
    * @param depth Depth to get the header text for. 0 is base columns
    * @returns Text to put in the column header
    */
-  textForColumnHeader(column: ModelIndex, depth = 0): string {
-    return '';
-  }
+  abstract textForColumnHeader(
+    column: ModelIndex,
+    depth?: number
+  ): string | undefined;
 
   /** Color for column header
    * @param column Column to get the color for
@@ -195,6 +197,13 @@ abstract class GridModel<
    */
   isRowMovable(row: ModelIndex): boolean {
     return true;
+  }
+
+  getColumnHeaderGroup(
+    modelIndex: ModelIndex,
+    depth: number
+  ): IColumnHeaderGroup | null {
+    return null;
   }
 }
 

--- a/packages/grid/src/GridModel.ts
+++ b/packages/grid/src/GridModel.ts
@@ -163,35 +163,6 @@ abstract class GridModel<
   }
 
   /**
-   * Checks if a column can be moved to a specific index
-   * @param fromIndex The index to move from
-   * @param toIndex The index to move to
-   * @param depth The depth the movement is occurring at
-   * @returns If the column can be moved to the given index at the given depth
-   */
-  isColumnMovableTo(column: ModelIndex, to: ModelIndex, depth = 0): boolean {
-    return true;
-  }
-
-  /**
-   * Checks if a column can be dropped between 2 columns
-   * Assumes the left and right indexes are adjacent to each other
-   * @param fromIndex The index to move from
-   * @param leftIndex The index on the left of the drop spot
-   * @param rightIndex The index on the right of the drop spot
-   * @param depth The depth the movement is occurring at
-   * @returns If the column can be dropped between the given indexes at the given depth
-   */
-  isColumnDroppableBetween(
-    column: ModelIndex,
-    left: ModelIndex | null,
-    right: ModelIndex | null,
-    depth = 0
-  ): boolean {
-    return true;
-  }
-
-  /**
    * @param row Row to check
    * @returns True if the row is movable
    */
@@ -202,8 +173,15 @@ abstract class GridModel<
   getColumnHeaderGroup(
     modelIndex: ModelIndex,
     depth: number
-  ): IColumnHeaderGroup | null {
-    return null;
+  ): IColumnHeaderGroup | undefined {
+    return undefined;
+  }
+
+  getColumnHeaderParentGroup(
+    modelIndex: ModelIndex,
+    depth: number
+  ): IColumnHeaderGroup | undefined {
+    return undefined;
   }
 }
 

--- a/packages/grid/src/GridModel.ts
+++ b/packages/grid/src/GridModel.ts
@@ -43,6 +43,17 @@ abstract class GridModel<
   }
 
   /**
+   * How many columns header levels are in the grid
+   * Used for column grouping where columns at depth 0 are the base columns
+   *
+   * A grid with 1-level grouping would have a columnHeaderDepth of 2
+   * and columns at depths 0 and 1
+   */
+  get columnHeaderDepth(): number {
+    return 1;
+  }
+
+  /**
    * Get the text for the specified cell
    * @param column Column to get the text for
    * @param row Row to get the text for
@@ -107,10 +118,20 @@ abstract class GridModel<
   /**
    * Text for the column header
    * @param column Column to get the header for
+   * @param depth Depth to get the header text for. 0 is base columns
    * @returns Text to put in the column header
    */
-  textForColumnHeader(column: ModelIndex): string {
+  textForColumnHeader(column: ModelIndex, depth = 0): string {
     return '';
+  }
+
+  /** Color for column header
+   * @param column Column to get the color for
+   * @param depth Header depth to get the color for
+   * @returns Color for the header at the depth or null
+   */
+  colorForColumnHeader(column: ModelIndex, depth = 0): string | null {
+    return null;
   }
 
   /**

--- a/packages/grid/src/GridModel.ts
+++ b/packages/grid/src/GridModel.ts
@@ -49,7 +49,7 @@ abstract class GridModel<
    * A grid with 1-level grouping would have a columnHeaderDepth of 2
    * and columns at depths 0 and 1
    */
-  get columnHeaderDepth(): number {
+  get columnHeaderMaxDepth(): number {
     return 1;
   }
 

--- a/packages/grid/src/GridRenderer.ts
+++ b/packages/grid/src/GridRenderer.ts
@@ -1433,7 +1433,10 @@ export class GridRenderer {
       headerSeparatorHoverColor,
     } = theme;
     const hiddenSeparatorHeight = columnHeaderHeight * 0.5;
-    const hiddenY = columnHeaderHeight * 0.5 - hiddenSeparatorHeight * 0.5;
+    const hiddenY =
+      columnHeaderHeight * (columnHeaderMaxDepth - 1) +
+      columnHeaderHeight * 0.5 -
+      hiddenSeparatorHeight * 0.5;
     const containsFrozenColumns = floatingLeftColumnCount > 0;
 
     context.save();
@@ -1523,10 +1526,6 @@ export class GridRenderer {
         depth != null &&
         (!isDragging || draggingColumnSeparator != null)
       ) {
-        context.translate(
-          0,
-          (columnHeaderMaxDepth - depth - 1) * columnHeaderHeight
-        );
         context.strokeStyle = headerSeparatorHoverColor;
 
         const columnX = getOrThrow(visibleColumnXs, highlightedSeparator);
@@ -1566,13 +1565,15 @@ export class GridRenderer {
 
         // column seperator hover line
         context.beginPath();
-        context.moveTo(x, 0);
-        context.lineTo(x, columnHeaderHeight - 1);
-        context.stroke();
-        context.translate(
-          0,
-          -1 * (columnHeaderMaxDepth - depth - 1) * columnHeaderHeight
+        context.moveTo(
+          x,
+          (columnHeaderMaxDepth - depth - 1) * columnHeaderHeight
         );
+        context.lineTo(
+          x,
+          (columnHeaderMaxDepth - depth) * columnHeaderHeight - 1
+        );
+        context.stroke();
       }
     }
 
@@ -1825,9 +1826,6 @@ export class GridRenderer {
 
     const maxWidth = columnWidth - headerHorizontalPadding * 2;
     const maxLength = maxWidth / fontWidth;
-    if (maxLength <= 0) {
-      return;
-    }
 
     const { backgroundColor, textColor = '#ffffff', separatorColor } =
       style ?? {};
@@ -1868,7 +1866,9 @@ export class GridRenderer {
 
     let renderText = columnText;
 
-    if (renderText.length > maxLength) {
+    if (maxLength <= 0) {
+      renderText = '';
+    } else if (renderText.length > maxLength) {
       renderText = `${renderText.substring(0, maxLength - 1)}…`;
     }
 

--- a/packages/grid/src/GridRenderer.ts
+++ b/packages/grid/src/GridRenderer.ts
@@ -20,7 +20,8 @@ import { getOrThrow } from './GridMetricCalculator';
 import { isEditableGridModel } from './EditableGridModel';
 import type { GridSeparator } from './mouse-handlers/GridSeparatorMouseHandler';
 import { DraggingColumn } from './mouse-handlers/GridColumnMoveMouseHandler';
-import { BoundedAxisRange, GridColumnSeparatorMouseHandler } from '.';
+import GridColumnSeparatorMouseHandler from './mouse-handlers/GridColumnSeparatorMouseHandler';
+import { BoundedAxisRange } from './GridAxisRange';
 
 export type EditingCellTextSelectionRange = [start: number, end: number];
 
@@ -2298,7 +2299,7 @@ export class GridRenderer {
       height,
     } = metrics;
     const {
-      left = metrics.leftVisible,
+      left = metrics.left,
       top = metrics.top,
       right = metrics.right,
       bottom = metrics.bottom,
@@ -2523,7 +2524,6 @@ export class GridRenderer {
       columnHeaderMaxDepth,
       columnHeaderHeight,
       movedColumns,
-      left,
       modelColumns,
     } = metrics;
 
@@ -2542,8 +2542,7 @@ export class GridRenderer {
 
     const [startIndex, endIndex] = draggingColumnVisibleRange;
 
-    const xLeft =
-      startIndex >= left ? getOrThrow(visibleColumnXs, startIndex) : 0;
+    const xLeft = getOrThrow(visibleColumnXs, startIndex, 0);
     const xRight =
       getOrThrow(visibleColumnXs, endIndex, xLeft) +
       getOrThrow(visibleColumnWidths, endIndex, 0);

--- a/packages/grid/src/GridRenderer.ts
+++ b/packages/grid/src/GridRenderer.ts
@@ -20,7 +20,7 @@ import { getOrThrow } from './GridMetricCalculator';
 import { isEditableGridModel } from './EditableGridModel';
 import type { GridSeparator } from './mouse-handlers/GridSeparatorMouseHandler';
 import { DraggingColumn } from './mouse-handlers/GridColumnMoveMouseHandler';
-import { BoundedAxisRange } from '.';
+import { BoundedAxisRange, GridColumnSeparatorMouseHandler } from '.';
 
 export type EditingCellTextSelectionRange = [start: number, end: number];
 
@@ -1491,15 +1491,14 @@ export class GridRenderer {
         draggingColumnSeparator ?? {};
 
       if (highlightedSeparator == null && mouseX != null && mouseY != null) {
-        highlightedSeparator =
-          GridUtils.getColumnSeparatorIndex(mouseX, mouseY, metrics, theme) ??
-          undefined;
-
-        ({ columnHeaderDepth: depth } = GridUtils.getGridPointFromXY(
-          mouseX,
-          mouseY,
-          metrics
-        ));
+        const separator = GridColumnSeparatorMouseHandler.getColumnSeparator(
+          GridUtils.getGridPointFromXY(mouseX, mouseY, metrics),
+          metrics,
+          model,
+          theme
+        );
+        highlightedSeparator = separator?.index;
+        depth = separator?.depth;
       }
 
       let shouldDrawSeparator: boolean;

--- a/packages/grid/src/GridRenderer.ts
+++ b/packages/grid/src/GridRenderer.ts
@@ -2510,7 +2510,7 @@ export class GridRenderer {
     }
 
     const {
-      index: draggingColumnIndex,
+      range: draggingColumnVisibleRange,
       depth: draggingColumnDepth,
     } = draggingColumn;
 
@@ -2520,16 +2520,16 @@ export class GridRenderer {
       visibleColumnXs,
       visibleColumnWidths,
       height,
-      width,
       columnHeaderMaxDepth,
       columnHeaderHeight,
       movedColumns,
       left,
-      right,
       modelColumns,
     } = metrics;
 
-    const draggingModelIndex = getOrThrow(modelColumns, draggingColumnIndex);
+    const draggingModelIndex =
+      modelColumns.get(draggingColumnVisibleRange[0]) ??
+      GridUtils.getModelIndex(draggingColumnVisibleRange[0], movedColumns);
 
     const draggingGroup = model.getColumnHeaderGroup(
       draggingModelIndex,
@@ -2540,19 +2540,14 @@ export class GridRenderer {
       return;
     }
 
-    const [startIndex, endIndex] = draggingGroup?.getVisibleRange(
-      movedColumns
-    ) ?? [draggingColumnIndex, draggingColumnIndex];
+    const [startIndex, endIndex] = draggingColumnVisibleRange;
 
     const xLeft =
       startIndex >= left ? getOrThrow(visibleColumnXs, startIndex) : 0;
     const xRight =
-      endIndex <= right
-        ? getOrThrow(visibleColumnXs, endIndex) +
-          getOrThrow(visibleColumnWidths, endIndex)
-        : width;
-    // const columnWidth =
-    //   getOrThrow(visibleColumnWidths, draggingColumnIndex) + 1;
+      getOrThrow(visibleColumnXs, endIndex, xLeft) +
+      getOrThrow(visibleColumnWidths, endIndex, 0);
+
     const columnWidth = xRight - xLeft;
     const {
       backgroundColor,
@@ -2609,8 +2604,8 @@ export class GridRenderer {
     context.font = headerFont;
 
     this.drawColumnHeadersForRange(context, state, [startIndex, endIndex], {
-      minX: 0,
-      maxX: width,
+      minX: xLeft,
+      maxX: xRight,
     });
 
     context.restore();

--- a/packages/grid/src/GridRenderer.ts
+++ b/packages/grid/src/GridRenderer.ts
@@ -1435,14 +1435,14 @@ export class GridRenderer {
     context.save();
 
     // Make sure base column header background always goes to the right edge
-    context.translate(0, (model.columnHeaderDepth - 1) * columnHeaderHeight);
+    context.translate(0, (model.columnHeaderMaxDepth - 1) * columnHeaderHeight);
     this.drawColumnHeader(context, state, '', 0, width, {
       backgroundColor: headerBackgroundColor,
       separatorColor: headerSeparatorColor,
     });
     context.translate(
       0,
-      -1 * (model.columnHeaderDepth - 1) * columnHeaderHeight
+      -1 * (model.columnHeaderMaxDepth - 1) * columnHeaderHeight
     );
 
     this.drawColumnHeadersForRange(context, state, visibleColumns, {
@@ -1554,13 +1554,13 @@ export class GridRenderer {
     bounds: { minX: number; maxX: number }
   ): void {
     const { model } = state;
-    const { columnHeaderDepth } = model;
+    const { columnHeaderMaxDepth } = model;
 
-    if (columnHeaderDepth === 0) {
+    if (columnHeaderMaxDepth === 0) {
       return;
     }
 
-    for (let d = 0; d <= columnHeaderDepth; d += 1) {
+    for (let d = 0; d <= columnHeaderMaxDepth; d += 1) {
       this.drawColumnHeadersAtDepth(context, state, range, bounds, d);
     }
   }
@@ -1589,16 +1589,19 @@ export class GridRenderer {
       columnHeaderHeight,
       columnWidth,
     } = theme;
-    const { columnHeaderDepth } = model;
+    const { columnHeaderMaxDepth } = model;
     const { minX, maxX } = bounds;
     const visibleWidth = maxX - minX;
 
-    if (columnHeaderDepth === 0) {
+    if (columnHeaderMaxDepth === 0) {
       return;
     }
 
     context.save();
-    context.translate(0, (columnHeaderDepth - depth - 1) * columnHeaderHeight);
+    context.translate(
+      0,
+      (columnHeaderMaxDepth - depth - 1) * columnHeaderHeight
+    );
 
     if (depth === 0) {
       // Draw base column headers

--- a/packages/grid/src/GridUtils.test.ts
+++ b/packages/grid/src/GridUtils.test.ts
@@ -23,7 +23,7 @@ function expectVisibleIndexes(
 
 describe('move items', () => {
   it('returns the proper model/visible index when one column is moved', () => {
-    const movedItems = GridUtils.moveItem(2, 1);
+    const movedItems = GridUtils.moveItem(2, 1, []);
 
     expectModelIndexes(movedItems, [0, 2, 1, 3]);
     expectVisibleIndexes(movedItems, [0, 2, 1, 3]);
@@ -83,14 +83,14 @@ describe('move items', () => {
 
 describe('move ranges', () => {
   it('returns the proper model/visible index when one range is moved', () => {
-    const movedItems = GridUtils.moveRange([3, 5], 1);
+    const movedItems = GridUtils.moveRange([3, 5], 1, []);
 
     expectModelIndexes(movedItems, [0, 3, 4, 5, 1, 2]);
     expectVisibleIndexes(movedItems, [0, 4, 5, 1, 2, 3]);
   });
 
   it('returns the proper model/visible index when two ranges are moved', () => {
-    let movedItems = GridUtils.moveRange([3, 5], 1);
+    let movedItems = GridUtils.moveRange([3, 5], 1, []);
     movedItems = GridUtils.moveRange([2, 4], 5, movedItems);
 
     expectModelIndexes(movedItems, [0, 3, 2, 6, 7, 4, 5, 1]);
@@ -236,59 +236,59 @@ describe('start/end range adjustment in one dimension visible to model', () => {
     testRange(100, 100);
   });
   it('handles transforms outside of range', () => {
-    let movedItems = GridUtils.moveItem(2, 1);
+    let movedItems = GridUtils.moveItem(2, 1, []);
     movedItems = GridUtils.moveItem(100, 200, movedItems);
     testRange(5, 10, movedItems);
     testRange(10, 20, movedItems);
   });
   it('handles items moved into the range', () => {
-    testRange(5, 10, GridUtils.moveItem(1, 7), [
+    testRange(5, 10, GridUtils.moveItem(1, 7, []), [
       [6, 7],
       [1, 1],
       [8, 10],
     ]);
 
-    testRange(5, 10, GridUtils.moveItem(100, 7), [
+    testRange(5, 10, GridUtils.moveItem(100, 7, []), [
       [5, 6],
       [100, 100],
       [7, 9],
     ]);
 
-    testRange(5, 10, GridUtils.moveItem(1, 5), [
+    testRange(5, 10, GridUtils.moveItem(1, 5, []), [
       [1, 1],
       [6, 10],
     ]);
 
-    testRange(5, 10, GridUtils.moveItem(1, 10), [
+    testRange(5, 10, GridUtils.moveItem(1, 10, []), [
       [6, 10],
       [1, 1],
     ]);
 
-    testRange(5, 10, GridUtils.moveItem(100, 5), [
+    testRange(5, 10, GridUtils.moveItem(100, 5, []), [
       [100, 100],
       [5, 9],
     ]);
 
-    testRange(5, 10, GridUtils.moveItem(100, 10), [
+    testRange(5, 10, GridUtils.moveItem(100, 10, []), [
       [5, 9],
       [100, 100],
     ]);
   });
   it('handles items moved outside the range', () => {
-    testRange(5, 10, GridUtils.moveItem(7, 100), [
+    testRange(5, 10, GridUtils.moveItem(7, 100, []), [
       [5, 6],
       [8, 11],
     ]);
   });
   it('handles items moved from before to after range', () => {
-    const movedItems = GridUtils.moveItem(1, 100);
+    const movedItems = GridUtils.moveItem(1, 100, []);
     testRange(5, 10, movedItems, [[6, 11]]);
   });
   it('handles items moved from after to before range', () => {
-    testRange(5, 10, GridUtils.moveItem(100, 1), [[4, 9]]);
+    testRange(5, 10, GridUtils.moveItem(100, 1, []), [[4, 9]]);
   });
   it('handles multiple operations', () => {
-    let movedItems = GridUtils.moveItem(1, 100);
+    let movedItems = GridUtils.moveItem(1, 100, []);
     testRange(5, 10, movedItems, [[6, 11]]);
     movedItems = GridUtils.moveItem(7, 100, movedItems);
     testRange(5, 10, movedItems, [
@@ -304,52 +304,52 @@ describe('start/end range adjustment in one dimension visible to model', () => {
     ]);
   });
   it('handles moves within the range', () => {
-    testRange(5, 10, GridUtils.moveItem(9, 6), [
+    testRange(5, 10, GridUtils.moveItem(9, 6, []), [
       [5, 5],
       [9, 9],
       [6, 8],
       [10, 10],
     ]);
 
-    testRange(5, 10, GridUtils.moveItem(6, 9), [
+    testRange(5, 10, GridUtils.moveItem(6, 9, []), [
       [5, 5],
       [7, 9],
       [6, 6],
       [10, 10],
     ]);
 
-    testRange(5, 10, GridUtils.moveItem(9, 5), [
+    testRange(5, 10, GridUtils.moveItem(9, 5, []), [
       [9, 9],
       [5, 8],
       [10, 10],
     ]);
 
-    testRange(5, 10, GridUtils.moveItem(6, 10), [
+    testRange(5, 10, GridUtils.moveItem(6, 10, []), [
       [5, 5],
       [7, 10],
       [6, 6],
     ]);
 
-    testRange(5, 10, GridUtils.moveItem(5, 10), [
+    testRange(5, 10, GridUtils.moveItem(5, 10, []), [
       [6, 10],
       [5, 5],
     ]);
 
-    testRange(5, 10, GridUtils.moveItem(10, 5), [
+    testRange(5, 10, GridUtils.moveItem(10, 5, []), [
       [10, 10],
       [5, 9],
     ]);
   });
 
   it('handles transforms with infinite ranges', () => {
-    testRange(null, null, GridUtils.moveItem(1, 10), [
+    testRange(null, null, GridUtils.moveItem(1, 10, []), [
       [null, 0],
       [2, 10],
       [1, 1],
       [11, null],
     ]);
 
-    testRange(null, null, GridUtils.moveItem(0, 10), [
+    testRange(null, null, GridUtils.moveItem(0, 10, []), [
       // We don't normally think of using negative indexes, but this is valid
       // We go from the start (null) to the element before index 0 since 0 is moved
       [null, -1],
@@ -358,23 +358,23 @@ describe('start/end range adjustment in one dimension visible to model', () => {
       [11, null],
     ]);
 
-    testRange(5, null, GridUtils.moveItem(1, 10), [
+    testRange(5, null, GridUtils.moveItem(1, 10, []), [
       [6, 10],
       [1, 1],
       [11, null],
     ]);
 
-    testRange(5, null, GridUtils.moveItem(10, 1), [
+    testRange(5, null, GridUtils.moveItem(10, 1, []), [
       [4, 9],
       [11, null],
     ]);
 
-    testRange(null, 10, GridUtils.moveItem(1, 15), [
+    testRange(null, 10, GridUtils.moveItem(1, 15, []), [
       [null, 0],
       [2, 11],
     ]);
 
-    testRange(null, 10, GridUtils.moveItem(15, 1), [
+    testRange(null, 10, GridUtils.moveItem(15, 1, []), [
       [null, 0],
       [15, 15],
       [1, 9],
@@ -398,57 +398,57 @@ describe('start/end range adjustment in one dimension model to visible', () => {
     testRange(100, 100);
   });
   it('handles transforms outside of range', () => {
-    let movedItems = GridUtils.moveItem(2, 1);
+    let movedItems = GridUtils.moveItem(2, 1, []);
     movedItems = GridUtils.moveItem(100, 200, movedItems);
     testRange(5, 10, movedItems);
     testRange(10, 20, movedItems);
   });
   it('handles items moved into the range', () => {
-    testRange(5, 10, GridUtils.moveItem(1, 7), [
+    testRange(5, 10, GridUtils.moveItem(1, 7, []), [
       [4, 6],
       [8, 10],
     ]);
 
-    testRange(5, 10, GridUtils.moveItem(100, 7), [
+    testRange(5, 10, GridUtils.moveItem(100, 7, []), [
       [5, 6],
       [8, 11],
     ]);
 
-    testRange(5, 10, GridUtils.moveItem(1, 5), [
+    testRange(5, 10, GridUtils.moveItem(1, 5, []), [
       [4, 4],
       [6, 10],
     ]);
 
-    testRange(5, 10, GridUtils.moveItem(1, 10), [[4, 9]]);
+    testRange(5, 10, GridUtils.moveItem(1, 10, []), [[4, 9]]);
 
-    testRange(5, 10, GridUtils.moveItem(100, 5), [[6, 11]]);
+    testRange(5, 10, GridUtils.moveItem(100, 5, []), [[6, 11]]);
 
-    testRange(5, 10, GridUtils.moveItem(100, 10), [
+    testRange(5, 10, GridUtils.moveItem(100, 10, []), [
       [5, 9],
       [11, 11],
     ]);
   });
   it('handles items moved outside the range', () => {
-    testRange(5, 10, GridUtils.moveItem(7, 100), [
+    testRange(5, 10, GridUtils.moveItem(7, 100, []), [
       [5, 6],
       [100, 100],
       [7, 9],
     ]);
 
-    testRange(5, 10, GridUtils.moveItem(7, 1), [
+    testRange(5, 10, GridUtils.moveItem(7, 1, []), [
       [6, 7],
       [1, 1],
       [8, 10],
     ]);
   });
   it('handles items moved from before to after range', () => {
-    testRange(5, 10, GridUtils.moveItem(1, 100), [[4, 9]]);
+    testRange(5, 10, GridUtils.moveItem(1, 100, []), [[4, 9]]);
   });
   it('handles items moved from after to before range', () => {
-    testRange(5, 10, GridUtils.moveItem(100, 1), [[6, 11]]);
+    testRange(5, 10, GridUtils.moveItem(100, 1, []), [[6, 11]]);
   });
   it('handles multiple operations', () => {
-    let movedItems = GridUtils.moveItem(1, 100);
+    let movedItems = GridUtils.moveItem(1, 100, []);
     testRange(5, 10, movedItems, [[4, 9]]);
     movedItems = GridUtils.moveItem(7, 100, movedItems);
     testRange(5, 10, movedItems, [
@@ -466,52 +466,52 @@ describe('start/end range adjustment in one dimension model to visible', () => {
   });
 
   it('handles moves within the range', () => {
-    testRange(5, 10, GridUtils.moveItem(9, 6), [
+    testRange(5, 10, GridUtils.moveItem(9, 6, []), [
       [5, 5],
       [7, 9],
       [6, 6],
       [10, 10],
     ]);
 
-    testRange(5, 10, GridUtils.moveItem(6, 9), [
+    testRange(5, 10, GridUtils.moveItem(6, 9, []), [
       [5, 5],
       [9, 9],
       [6, 8],
       [10, 10],
     ]);
 
-    testRange(5, 10, GridUtils.moveItem(9, 5), [
+    testRange(5, 10, GridUtils.moveItem(9, 5, []), [
       [6, 9],
       [5, 5],
       [10, 10],
     ]);
 
-    testRange(5, 10, GridUtils.moveItem(6, 10), [
+    testRange(5, 10, GridUtils.moveItem(6, 10, []), [
       [5, 5],
       [10, 10],
       [6, 9],
     ]);
 
-    testRange(5, 10, GridUtils.moveItem(5, 10), [
+    testRange(5, 10, GridUtils.moveItem(5, 10, []), [
       [10, 10],
       [5, 9],
     ]);
 
-    testRange(5, 10, GridUtils.moveItem(10, 5), [
+    testRange(5, 10, GridUtils.moveItem(10, 5, []), [
       [6, 10],
       [5, 5],
     ]);
   });
 
   it('handles transforms with infinite ranges', () => {
-    testRange(null, null, GridUtils.moveItem(1, 10), [
+    testRange(null, null, GridUtils.moveItem(1, 10, []), [
       [null, 0],
       [10, 10],
       [1, 9],
       [11, null],
     ]);
 
-    testRange(null, null, GridUtils.moveItem(0, 10), [
+    testRange(null, null, GridUtils.moveItem(0, 10, []), [
       // We don't normally think of using negative indexes, but this is valid
       // We go from the start (null) to the element before index 0 since 0 is moved
       [null, -1],
@@ -520,24 +520,24 @@ describe('start/end range adjustment in one dimension model to visible', () => {
       [11, null],
     ]);
 
-    testRange(5, null, GridUtils.moveItem(1, 10), [
+    testRange(5, null, GridUtils.moveItem(1, 10, []), [
       [4, 9],
       [11, null],
     ]);
 
-    testRange(5, null, GridUtils.moveItem(10, 1), [
+    testRange(5, null, GridUtils.moveItem(10, 1, []), [
       [6, 10],
       [1, 1],
       [11, null],
     ]);
 
-    testRange(null, 10, GridUtils.moveItem(1, 15), [
+    testRange(null, 10, GridUtils.moveItem(1, 15, []), [
       [null, 0],
       [15, 15],
       [1, 9],
     ]);
 
-    testRange(null, 10, GridUtils.moveItem(15, 1), [
+    testRange(null, 10, GridUtils.moveItem(15, 1, []), [
       [null, 0],
       [2, 11],
     ]);
@@ -568,7 +568,7 @@ describe('Move ranges of items', () => {
   }
 
   it('handles transforms outside of range', () => {
-    let movedItems = GridUtils.moveRange([2, 3], 1);
+    let movedItems = GridUtils.moveRange([2, 3], 1, []);
     movedItems = GridUtils.moveRange([100, 104], 200, movedItems);
     testModelToVisible(5, 10, movedItems);
     testVisibleToModel(5, 10, movedItems);
@@ -576,7 +576,7 @@ describe('Move ranges of items', () => {
 
   it('handles items moved into the range', () => {
     // Before to start
-    let movedItems = GridUtils.moveRange([1, 3], 5);
+    let movedItems = GridUtils.moveRange([1, 3], 5, []);
     // 0 1 2 3 4 5 6 7 8 9 10 Before/Visible
     // 0 4 5 6 7 1 2 3 8 9 10 After/Model
     testModelToVisible(5, 10, movedItems, [
@@ -589,7 +589,7 @@ describe('Move ranges of items', () => {
     ]);
 
     // Before to within
-    movedItems = GridUtils.moveRange([1, 3], 6);
+    movedItems = GridUtils.moveRange([1, 3], 6, []);
     // 0 1 2 3 4 5 6 7 8 9 10 Before/Visible
     // 0 4 5 6 7 8 1 2 3 9 10 After/Model
     testModelToVisible(5, 10, movedItems, [
@@ -603,7 +603,7 @@ describe('Move ranges of items', () => {
     ]);
 
     // Before to end
-    movedItems = GridUtils.moveRange([1, 3], 8);
+    movedItems = GridUtils.moveRange([1, 3], 8, []);
     // 0 1 2 3 4 5 6 7  8 9 10 Before/Visible
     // 0 4 5 6 7 8 9 10 1 2 3 After/Model
     testModelToVisible(5, 10, movedItems, [[2, 7]]);
@@ -613,7 +613,7 @@ describe('Move ranges of items', () => {
     ]);
 
     // Before to partially in start
-    movedItems = GridUtils.moveRange([1, 3], 4);
+    movedItems = GridUtils.moveRange([1, 3], 4, []);
     // 0 1 2 3 4 5 6 7 8 9 10 Before/Visible
     // 0 4 5 6 1 2 3 7 8 9 10 After/Model
     testModelToVisible(5, 10, movedItems, [
@@ -626,7 +626,7 @@ describe('Move ranges of items', () => {
     ]);
 
     // Before to partially in end
-    movedItems = GridUtils.moveRange([1, 3], 9);
+    movedItems = GridUtils.moveRange([1, 3], 9, []);
     // 0 1 2 3 4 5 6 7  8  9 10 11 Before/Visible
     // 0 4 5 6 7 8 9 10 11 1 2  3 After/Model
     testModelToVisible(5, 10, movedItems, [[2, 7]]);
@@ -636,7 +636,7 @@ describe('Move ranges of items', () => {
     ]);
 
     // After to end
-    movedItems = GridUtils.moveRange([12, 14], 8);
+    movedItems = GridUtils.moveRange([12, 14], 8, []);
     // 5 6 7  8  9  10 11 12 13 Before/Visible
     // 5 6 7  12 13 14 8  9  10  After/Model
     testModelToVisible(5, 10, movedItems, [
@@ -649,7 +649,7 @@ describe('Move ranges of items', () => {
     ]);
 
     // After to within
-    movedItems = GridUtils.moveRange([12, 14], 7);
+    movedItems = GridUtils.moveRange([12, 14], 7, []);
     // 5 6 7  8  9  10 11 12 13 Before/Visible
     // 5 6 12 13 14 7  8  9  10 After/Model
     testModelToVisible(5, 10, movedItems, [
@@ -665,7 +665,7 @@ describe('Move ranges of items', () => {
 
   it('handles items moved outside the range', () => {
     // Within to before
-    let movedItems = GridUtils.moveRange([6, 8], 2);
+    let movedItems = GridUtils.moveRange([6, 8], 2, []);
     // 0 1 2 3 4 5 6 7 8 9 10 Before/Visible
     // 0 1 6 7 8 2 3 4 5 9 10 After/Model
     testModelToVisible(5, 10, movedItems, [
@@ -679,7 +679,7 @@ describe('Move ranges of items', () => {
     ]);
 
     // Start to before
-    movedItems = GridUtils.moveRange([5, 7], 2);
+    movedItems = GridUtils.moveRange([5, 7], 2, []);
     // 0 1 2 3 4 5 6 7 8 9 10 Before/Visible
     // 0 1 5 6 7 2 3 4 8 9 10 After/Model
     testModelToVisible(5, 10, movedItems, [
@@ -692,7 +692,7 @@ describe('Move ranges of items', () => {
     ]);
 
     // End to before
-    movedItems = GridUtils.moveRange([8, 10], 2);
+    movedItems = GridUtils.moveRange([8, 10], 2, []);
     // 0 1 2 3 4  5 6 7 8 9 10 Before/Visible
     // 0 1 8 9 10 2 3 4 5 6 7 After/Model
     testModelToVisible(5, 10, movedItems, [
@@ -702,7 +702,7 @@ describe('Move ranges of items', () => {
     testVisibleToModel(5, 10, movedItems, [[2, 7]]);
 
     // Within to after
-    movedItems = GridUtils.moveRange([6, 8], 11);
+    movedItems = GridUtils.moveRange([6, 8], 11, []);
     // 5 6 7  8  9  10 11 12 13 Before/Visible
     // 5 9 10 11 12 13 6  7  8 After/Model
     testModelToVisible(5, 10, movedItems, [
@@ -716,7 +716,7 @@ describe('Move ranges of items', () => {
     ]);
 
     // Start to after
-    movedItems = GridUtils.moveRange([5, 7], 11);
+    movedItems = GridUtils.moveRange([5, 7], 11, []);
     // 5 6 7  8  9  10 11 12 13 Before/Visible
     // 8 9 10 11 12 13 5  6  7 After/Model
     testModelToVisible(5, 10, movedItems, [
@@ -726,7 +726,7 @@ describe('Move ranges of items', () => {
     testVisibleToModel(5, 10, movedItems, [[8, 13]]);
 
     // End to after
-    movedItems = GridUtils.moveRange([8, 10], 11);
+    movedItems = GridUtils.moveRange([8, 10], 11, []);
     // 5 6 7 8  9  10 11 12 13 Before/Visible
     // 5 6 7 11 12 13 8  9  10 After/Model
     testModelToVisible(5, 10, movedItems, [
@@ -741,14 +741,14 @@ describe('Move ranges of items', () => {
 
   it('handles ranges moved from before to after range', () => {
     // Before to after
-    let movedItems = GridUtils.moveRange([2, 4], 11);
+    let movedItems = GridUtils.moveRange([2, 4], 11, []);
     // 2 3 4 5 6 7  8  9  10 11 12 13 Before/Visible
     // 5 6 7 8 9 10 11 12 13 2  3  4 After/Model
     testModelToVisible(5, 10, movedItems, [[2, 7]]);
     testVisibleToModel(5, 10, movedItems, [[8, 13]]);
 
     // After to before
-    movedItems = GridUtils.moveRange([11, 13], 4);
+    movedItems = GridUtils.moveRange([11, 13], 4, []);
     // 4  5  6  7 8 9 10 11 12 13 Before/Visible
     // 11 12 13 4 5 6 7  8  9  10 After/Model
     testModelToVisible(5, 10, movedItems, [[8, 13]]);
@@ -759,7 +759,7 @@ describe('Move ranges of items', () => {
   });
 
   it('handles ranges moved that contain the target range', () => {
-    let movedItems = GridUtils.moveRange([4, 11], 6);
+    let movedItems = GridUtils.moveRange([4, 11], 6, []);
     // 2 3 4  5  6 7 8 9 10 11 12 13 Before/Visible
     // 2 3 12 13 4 5 6 7 8  9  10 11 After/Model
     testModelToVisible(5, 10, movedItems, [[7, 12]]);
@@ -768,7 +768,7 @@ describe('Move ranges of items', () => {
       [4, 8],
     ]);
 
-    movedItems = GridUtils.moveRange([5, 10], 3);
+    movedItems = GridUtils.moveRange([5, 10], 3, []);
     // 2 3 4 5 6 7 8  9 10 11 Before/Visible
     // 2 5 6 7 8 9 10 3 4  11 After/Model
     testModelToVisible(5, 10, movedItems, [[3, 8]]);
@@ -778,8 +778,8 @@ describe('Move ranges of items', () => {
     ]);
   });
   it('handles multiple operations', () => {
-    let movedItems = GridUtils.moveRange([2, 4], 11);
-    movedItems = GridUtils.moveRange([5, 10], 3);
+    let movedItems = GridUtils.moveRange([2, 4], 11, []);
+    movedItems = GridUtils.moveRange([5, 10], 3, []);
     // 2 3 4 5 6 7  8  9  10 11 12 13 Before/Visible
     // 5 6 7 8 9 10 11 12 13 2  3  4 After 1st
     // 2 5 6 7 8 9  10 3  4  11 12 13 After 2nd/Model
@@ -816,7 +816,7 @@ describe('grid range transforms with moved items in both dimensions visible to m
     testRange(new GridRange(1, 4, 2, 6));
   });
   it('handles transformations that do not affect the range', () => {
-    let movedItems: MoveOperation[] = GridUtils.moveItem(2, 1);
+    let movedItems: MoveOperation[] = GridUtils.moveItem(2, 1, []);
     movedItems = GridUtils.moveItem(5, 0, movedItems);
     movedItems = GridUtils.moveItem(100, 110, movedItems);
     movedItems = GridUtils.moveItem(200, 220, movedItems);
@@ -824,8 +824,8 @@ describe('grid range transforms with moved items in both dimensions visible to m
     testRange(new GridRange(50, 55, 60, 65), movedItems, movedItems);
   });
   it('handles moving items into the range', () => {
-    const movedColumns: MoveOperation[] = GridUtils.moveItem(25, 15);
-    const movedRows: MoveOperation[] = GridUtils.moveItem(27, 17);
+    const movedColumns: MoveOperation[] = GridUtils.moveItem(25, 15, []);
+    const movedRows: MoveOperation[] = GridUtils.moveItem(27, 17, []);
     testRange(new GridRange(10, 15, 20, 25), movedColumns, movedRows, [
       new GridRange(10, 15, 14, 16),
       new GridRange(10, 27, 14, 27),
@@ -839,8 +839,8 @@ describe('grid range transforms with moved items in both dimensions visible to m
     ]);
   });
   it('handles multiple ranges', () => {
-    const movedColumns = GridUtils.moveItem(25, 15);
-    const movedRows = GridUtils.moveItem(27, 17);
+    const movedColumns = GridUtils.moveItem(25, 15, []);
+    const movedRows = GridUtils.moveItem(27, 17, []);
     testRanges(
       [new GridRange(10, 15, 20, 25), new GridRange(30, 35, 40, 45)],
       movedColumns,
@@ -885,7 +885,7 @@ describe('grid range transforms with moved items in both dimensions model to vis
     testRange(new GridRange(1, 4, 2, 6));
   });
   it('handles transformations that do not affect the range', () => {
-    let movedItems: MoveOperation[] = GridUtils.moveItem(2, 1);
+    let movedItems: MoveOperation[] = GridUtils.moveItem(2, 1, []);
     movedItems = GridUtils.moveItem(5, 0, movedItems);
     movedItems = GridUtils.moveItem(100, 110, movedItems);
     movedItems = GridUtils.moveItem(200, 220, movedItems);
@@ -893,8 +893,8 @@ describe('grid range transforms with moved items in both dimensions model to vis
     testRange(new GridRange(50, 55, 60, 65), movedItems, movedItems);
   });
   it('handles moving items into the range', () => {
-    const movedColumns: MoveOperation[] = GridUtils.moveItem(25, 15);
-    const movedRows: MoveOperation[] = GridUtils.moveItem(27, 17);
+    const movedColumns: MoveOperation[] = GridUtils.moveItem(25, 15, []);
+    const movedRows: MoveOperation[] = GridUtils.moveItem(27, 17, []);
     testRange(new GridRange(10, 15, 20, 25), movedColumns, movedRows, [
       new GridRange(10, 15, 14, 16),
       new GridRange(10, 18, 14, 26),
@@ -903,8 +903,8 @@ describe('grid range transforms with moved items in both dimensions model to vis
     ]);
   });
   it('handles multiple ranges', () => {
-    const movedColumns = GridUtils.moveItem(25, 15);
-    const movedRows = GridUtils.moveItem(27, 17);
+    const movedColumns = GridUtils.moveItem(25, 15, []);
+    const movedRows = GridUtils.moveItem(27, 17, []);
     testRanges(
       [new GridRange(10, 15, 20, 25), new GridRange(30, 35, 40, 45)],
       movedColumns,

--- a/packages/grid/src/GridUtils.test.ts
+++ b/packages/grid/src/GridUtils.test.ts
@@ -225,7 +225,7 @@ describe('start/end range adjustment in one dimension visible to model', () => {
     start: GridRangeIndex,
     end: GridRangeIndex,
     movedItems: MoveOperation[] = [],
-    expectedResult = [[start, end]]
+    expectedResult: AxisRange[] = [[start, end]]
   ) {
     expect(GridUtils.getModelRangeIndexes(start, end, movedItems)).toEqual(
       expectedResult
@@ -387,7 +387,7 @@ describe('start/end range adjustment in one dimension model to visible', () => {
     start: GridRangeIndex,
     end: GridRangeIndex,
     movedItems: MoveOperation[] = [],
-    expectedResult = [[start, end]]
+    expectedResult: AxisRange[] = [[start, end]]
   ) {
     expect(GridUtils.getVisibleRangeIndexes(start, end, movedItems)).toEqual(
       expectedResult
@@ -549,7 +549,7 @@ describe('Move ranges of items', () => {
     start: GridRangeIndex,
     end: GridRangeIndex,
     movedItems: MoveOperation[] = [],
-    expectedResult = [[start, end]]
+    expectedResult: AxisRange[] = [[start, end]]
   ) {
     expect(GridUtils.getVisibleRangeIndexes(start, end, movedItems)).toEqual(
       expectedResult
@@ -560,7 +560,7 @@ describe('Move ranges of items', () => {
     start: GridRangeIndex,
     end: GridRangeIndex,
     movedItems: MoveOperation[] = [],
-    expectedResult = [[start, end]]
+    expectedResult: AxisRange[] = [[start, end]]
   ) {
     expect(GridUtils.getModelRangeIndexes(start, end, movedItems)).toEqual(
       expectedResult

--- a/packages/grid/src/GridUtils.test.ts
+++ b/packages/grid/src/GridUtils.test.ts
@@ -1,4 +1,4 @@
-import { AxisRange } from '.';
+import { AxisRange } from './GridAxisRange';
 import GridMetrics, { ModelIndex, MoveOperation } from './GridMetrics';
 import GridRange, { GridRangeIndex } from './GridRange';
 import GridUtils, { BoundedAxisRange } from './GridUtils';

--- a/packages/grid/src/GridUtils.ts
+++ b/packages/grid/src/GridUtils.ts
@@ -782,8 +782,7 @@ export class GridUtils {
         to,
       };
     } else {
-      // TODO #620
-      movedItems.push({ from: (from as unknown) as number, to });
+      movedItems.push({ from, to });
     }
 
     return movedItems;

--- a/packages/grid/src/GridUtils.ts
+++ b/packages/grid/src/GridUtils.ts
@@ -730,13 +730,15 @@ export class GridUtils {
     }
 
     const movedItems: MoveOperation[] = [...oldMovedItems];
+    const lastMovedItem = movedItems[movedItems.length - 1];
 
     if (
-      movedItems.length > 0 &&
-      movedItems[movedItems.length - 1].to === from
+      lastMovedItem &&
+      !isBoundedAxisRange(lastMovedItem.from) &&
+      lastMovedItem.to === from
     ) {
       movedItems[movedItems.length - 1] = {
-        ...movedItems[movedItems.length - 1],
+        ...lastMovedItem,
         to,
       };
     } else {
@@ -776,7 +778,7 @@ export class GridUtils {
       lastMovedItem.to === from[0]
     ) {
       movedItems[movedItems.length - 1] = {
-        ...movedItems[movedItems.length - 1],
+        ...lastMovedItem,
         to,
       };
     } else {
@@ -795,7 +797,7 @@ export class GridUtils {
    * @param reverse If the moved items should be applied in reverse (this reverses the effects of the moves)
    * @returns A list of AxisRanges in the translated space. Possibly multiple non-continuous ranges
    */
-  private static applyItemMoves<T extends number | GridRangeIndex>(
+  static applyItemMoves<T extends number | GridRangeIndex>(
     start: T,
     end: T,
     movedItems: MoveOperation[],

--- a/packages/grid/src/GridUtils.ts
+++ b/packages/grid/src/GridUtils.ts
@@ -736,7 +736,7 @@ export class GridUtils {
   static moveItem(
     from: VisibleIndex,
     to: VisibleIndex,
-    oldMovedItems: MoveOperation[] = []
+    oldMovedItems: MoveOperation[]
   ): MoveOperation[] {
     if (from === to) {
       return oldMovedItems;
@@ -783,7 +783,7 @@ export class GridUtils {
   static moveRange(
     from: BoundedAxisRange,
     to: VisibleIndex,
-    oldMovedItems: MoveOperation[] = []
+    oldMovedItems: MoveOperation[]
   ): MoveOperation[] {
     if (from[0] === to) {
       return oldMovedItems;

--- a/packages/grid/src/GridUtils.ts
+++ b/packages/grid/src/GridUtils.ts
@@ -253,20 +253,23 @@ export class GridUtils {
     floatingEnd: number,
     items: VisibleIndex[],
     itemCoordinates: CoordinateMap,
-    itemSizes: SizeMap
+    itemSizes: SizeMap,
+    ignoreFloating = false
   ): VisibleIndex | null {
-    const floatingItem = GridUtils.iterateFloating(
-      floatingStart,
-      floatingEnd,
-      itemCount,
-      item => {
-        if (GridUtils.isInItem(item, itemCoordinates, itemSizes, offset)) {
-          return item;
-        }
-        return undefined;
-      }
-    );
-    if (floatingItem !== undefined) {
+    const floatingItem = ignoreFloating
+      ? undefined
+      : GridUtils.iterateFloating(
+          floatingStart,
+          floatingEnd,
+          itemCount,
+          item => {
+            if (GridUtils.isInItem(item, itemCoordinates, itemSizes, offset)) {
+              return item;
+            }
+            return undefined;
+          }
+        );
+    if (!ignoreFloating && floatingItem !== undefined) {
       return floatingItem;
     }
 
@@ -288,7 +291,8 @@ export class GridUtils {
    */
   static getColumnAtX(
     x: Coordinate,
-    metrics: GridMetrics
+    metrics: GridMetrics,
+    ignoreFloating = false
   ): VisibleIndex | null {
     const {
       columnCount,
@@ -311,7 +315,8 @@ export class GridUtils {
       floatingRightColumnCount,
       visibleColumns,
       visibleColumnXs,
-      visibleColumnWidths
+      visibleColumnWidths,
+      ignoreFloating
     );
   }
 
@@ -1039,7 +1044,7 @@ export class GridUtils {
   }
 
   /**
-   * Translate the provided UI range into model range, using the `movedColumns` and `movedRows` to apply the necessary transforms.
+   * Translate the provided UI range into visible range, using the `movedColumns` and `movedRows` to apply the necessary transforms.
    * `movedColumns` and `movedRows` are array of operations done to the UI indexes to re-order items
    *
    * @param uiRange The currently selected UI ranges

--- a/packages/grid/src/GridUtils.ts
+++ b/packages/grid/src/GridUtils.ts
@@ -1,4 +1,5 @@
 import React from 'react';
+import clamp from 'lodash.clamp';
 import GridRange, { GridRangeIndex } from './GridRange';
 import {
   BoxCoordinates,
@@ -110,7 +111,11 @@ export class GridUtils {
     const { columnHeaderHeight, columnHeaderMaxDepth } = metrics;
 
     if (row === null && y <= columnHeaderHeight * columnHeaderMaxDepth) {
-      return columnHeaderMaxDepth - Math.ceil(y / columnHeaderHeight);
+      return clamp(
+        columnHeaderMaxDepth - Math.ceil(y / columnHeaderHeight),
+        0,
+        columnHeaderMaxDepth - 1
+      );
     }
 
     return undefined;

--- a/packages/grid/src/GridUtils.ts
+++ b/packages/grid/src/GridUtils.ts
@@ -5,7 +5,7 @@ import {
   Coordinate,
   CoordinateMap,
   VisibleIndex,
-  IndexModelMap,
+  VisibleToModelMap,
   ModelIndex,
   ModelSizeMap,
   MoveOperation,
@@ -375,7 +375,7 @@ export class GridUtils {
    */
   static getNextShownItem(
     startIndex: VisibleIndex,
-    modelIndexes: IndexModelMap,
+    modelIndexes: VisibleToModelMap,
     visibleItems: VisibleIndex[],
     userSizes: ModelSizeMap
   ): VisibleIndex | null {
@@ -733,7 +733,7 @@ export class GridUtils {
   /**
    * Set a new order for items in the grid
    * @param from The visible index to move from
-   * @param to The visible index to move the itme to
+   * @param to The visible index to move the item to
    * @param oldMovedItems The old reordered items
    * @returns The new reordered items
    */

--- a/packages/grid/src/GridUtils.ts
+++ b/packages/grid/src/GridUtils.ts
@@ -52,6 +52,7 @@ export type GridPoint = {
   y: Coordinate;
   column: GridRangeIndex;
   row: GridRangeIndex;
+  columnHeaderDepth?: number;
 };
 
 export interface CellInfo {
@@ -86,8 +87,15 @@ export class GridUtils {
   ): GridPoint {
     const column = GridUtils.getColumnAtX(x, metrics);
     const row = GridUtils.getRowAtY(y, metrics);
+    const { columnHeaderHeight, columnHeaderMaxDepth } = metrics;
 
-    return { x, y, row, column };
+    let columnHeaderDepth: number | undefined;
+    if (row === null) {
+      columnHeaderDepth =
+        columnHeaderMaxDepth - Math.ceil(y / columnHeaderHeight);
+    }
+
+    return { x, y, row, column, columnHeaderDepth };
   }
 
   static getCellInfoFromXY(

--- a/packages/grid/src/MockGridModel.ts
+++ b/packages/grid/src/MockGridModel.ts
@@ -88,7 +88,7 @@ class MockGridModel extends GridModel implements EditableGridModel {
     return theme.textColor;
   }
 
-  textForColumnHeader(column: ModelIndex): string {
+  textForColumnHeader(column: ModelIndex, depth = 0): string {
     return `${column}`;
   }
 

--- a/packages/grid/src/index.ts
+++ b/packages/grid/src/index.ts
@@ -1,3 +1,4 @@
+export * from './ColumnHeaderGroup';
 export * from './EditableGridModel';
 export * from './ExpandableGridModel';
 export { default as Grid } from './Grid';

--- a/packages/grid/src/index.ts
+++ b/packages/grid/src/index.ts
@@ -7,6 +7,7 @@ export * from './GridMetrics';
 export { default as GridModel } from './GridModel';
 export * from './GridMouseHandler';
 export * from './GridRange';
+export * from './GridAxisRange';
 export * from './GridRenderer';
 export { default as GridTestUtils } from './GridTestUtils';
 export { default as GridTheme } from './GridTheme';

--- a/packages/grid/src/mouse-handlers/GridColumnMoveMouseHandler.ts
+++ b/packages/grid/src/mouse-handlers/GridColumnMoveMouseHandler.ts
@@ -1,10 +1,68 @@
 import Grid from '../Grid';
 import GridUtils, { GridPoint } from '../GridUtils';
-import GridMouseHandler from '../GridMouseHandler';
+import GridMouseHandler, { GridMouseEvent } from '../GridMouseHandler';
 import { getOrThrow } from '../GridMetricCalculator';
 import { EventHandlerResult } from '../EventHandlerResult';
+import type { VisibleIndex, ModelIndex, GridMetrics } from '../GridMetrics';
+import type GridModel from '../GridModel';
 
 const SLOPPY_CLICK_DISTANCE = 5;
+const SCROLL_INTERVAL = 250;
+
+export interface DraggingColumn {
+  index: VisibleIndex;
+  depth: number;
+}
+
+interface ColumnInfo {
+  visibleIndex: VisibleIndex;
+  modelIndex: ModelIndex;
+  left: number;
+  right: number;
+}
+
+function getColumnInfo(
+  visibleIndex: VisibleIndex | null,
+  metrics: GridMetrics
+): ColumnInfo | null {
+  const {
+    modelColumns,
+    movedColumns,
+    visibleColumnXs,
+    columnCount,
+    visibleColumnWidths,
+    userColumnWidths,
+    calculatedColumnWidths,
+  } = metrics;
+
+  if (visibleIndex == null || visibleIndex > columnCount || visibleIndex < 0) {
+    return null;
+  }
+
+  const modelIndex =
+    modelColumns.get(visibleIndex) ??
+    GridUtils.getModelIndex(visibleIndex, movedColumns);
+
+  const left = visibleColumnXs.get(visibleIndex);
+
+  if (left == null) {
+    return null;
+  }
+
+  const right =
+    left +
+    (visibleColumnWidths.get(visibleIndex) ??
+      userColumnWidths.get(modelIndex) ??
+      calculatedColumnWidths.get(modelIndex) ??
+      0);
+
+  return {
+    visibleIndex,
+    modelIndex,
+    left,
+    right,
+  };
+}
 
 class GridColumnMoveMouseHandler extends GridMouseHandler {
   cursor: string | null = null;
@@ -15,22 +73,74 @@ class GridColumnMoveMouseHandler extends GridMouseHandler {
 
   private sloppyClickThreshold = false;
 
+  private scrollingInterval?: number;
+
+  private scrollingDirection?: 'left' | 'right';
+
+  private setScrollInterval(grid: Grid, direction: 'left' | 'right'): void {
+    if (
+      this.scrollingInterval != null &&
+      direction === this.scrollingDirection
+    ) {
+      return;
+    }
+
+    this.scrollingDirection = direction;
+    this.scrollingInterval = window.setInterval(() => {
+      const { metrics } = grid;
+      if (!metrics) {
+        return;
+      }
+
+      const { left, lastLeft } = metrics;
+
+      if (
+        (direction === 'left' && left === 0) ||
+        (direction === 'right' && left === lastLeft)
+      ) {
+        if (left === 0) {
+          grid.setState({ leftOffset: 0 });
+        }
+        this.clearScrollInterval();
+        return;
+      }
+
+      grid.setState({ left: direction === 'left' ? left - 1 : left + 1 });
+    }, SCROLL_INTERVAL);
+  }
+
+  private clearScrollInterval(): void {
+    this.scrollingDirection = undefined;
+    window.clearInterval(this.scrollingInterval);
+    this.scrollingInterval = undefined;
+  }
+
+  onLeave(): EventHandlerResult {
+    this.clearScrollInterval();
+    return false;
+  }
+
   onDown(gridPoint: GridPoint, grid: Grid): EventHandlerResult {
     const { model } = grid.props;
-    const { x, y, column } = gridPoint;
+    const { x, column, columnHeaderDepth } = gridPoint;
     const { metrics } = grid;
     if (!metrics) throw new Error('Metrics not set');
 
-    const { columnHeaderHeight, rowHeaderWidth, visibleColumnXs } = metrics;
+    const { rowHeaderWidth, visibleColumnXs, modelColumns } = metrics;
+
+    if (column == null || columnHeaderDepth !== 0) {
+      return false;
+    }
 
     this.startingGridPoint = gridPoint;
     this.sloppyClickThreshold = false;
     this.cursor = null;
+    const modelColumn = modelColumns.get(column);
 
     if (
-      column != null &&
-      y <= columnHeaderHeight &&
-      model.isColumnMovable(grid.getModelColumn(column))
+      modelColumn != null &&
+      columnHeaderDepth != null &&
+      model.isColumnMovable(modelColumn, columnHeaderDepth)
     ) {
       const columnX = getOrThrow(visibleColumnXs, column);
       this.draggingOffset = x - columnX - rowHeaderWidth;
@@ -39,7 +149,11 @@ class GridColumnMoveMouseHandler extends GridMouseHandler {
     return false;
   }
 
-  onDrag(gridPoint: GridPoint, grid: Grid): EventHandlerResult {
+  onDrag(
+    gridPoint: GridPoint,
+    grid: Grid,
+    event: GridMouseEvent
+  ): EventHandlerResult {
     if (
       this.draggingOffset === undefined ||
       this.startingGridPoint === undefined
@@ -47,10 +161,43 @@ class GridColumnMoveMouseHandler extends GridMouseHandler {
       return false;
     }
 
+    const {
+      x: mouseX,
+      y: mouseY,
+      column: visibleIndex,
+      columnHeaderDepth,
+    } = gridPoint;
+
     const { model } = grid.props;
-    let { draggingColumn } = grid.state;
-    const { mouseX, mouseY, isDragging } = grid.state;
-    if (mouseX == null || mouseY == null) {
+    let { draggingColumn, movedColumns } = grid.state;
+    const { isDragging } = grid.state;
+    const { metrics } = grid;
+
+    if (!metrics) throw new Error('Metrics not set');
+
+    const {
+      leftVisible,
+      width,
+      rightVisible,
+      columnCount,
+      rowHeaderWidth,
+      visibleColumnWidths,
+      userColumnWidths,
+      calculatedColumnWidths,
+      visibleColumnXs,
+      modelColumns,
+      floatingLeftWidth,
+    } = metrics;
+
+    const modelIndex =
+      visibleIndex != null ? modelColumns.get(visibleIndex) : null;
+
+    if (
+      mouseX == null ||
+      mouseY == null ||
+      visibleIndex == null ||
+      modelIndex == null
+    ) {
       return false;
     }
 
@@ -67,15 +214,28 @@ class GridColumnMoveMouseHandler extends GridMouseHandler {
     }
 
     if (draggingColumn == null) {
-      const { column } = grid.getGridPointFromXY(mouseX, mouseY);
+      const startColumnInfo = getColumnInfo(
+        this.startingGridPoint.column,
+        metrics
+      );
+      if (!startColumnInfo) {
+        return false;
+      }
+
       if (
-        column != null &&
-        !model.isColumnMovable(grid.getModelColumn(column))
+        startColumnInfo.visibleIndex != null &&
+        !model.isColumnMovable(startColumnInfo.modelIndex)
       ) {
         return false;
       }
 
-      draggingColumn = column;
+      draggingColumn = null;
+      if (startColumnInfo.visibleIndex != null && columnHeaderDepth != null) {
+        draggingColumn = {
+          index: startColumnInfo.visibleIndex,
+          depth: columnHeaderDepth,
+        };
+      }
 
       grid.setState({ draggingColumn, isDragging: true });
 
@@ -85,84 +245,123 @@ class GridColumnMoveMouseHandler extends GridMouseHandler {
     }
 
     this.cursor = 'move';
-    const { metrics } = grid;
-    if (!metrics) throw new Error('Metrics not set');
 
-    const {
-      left,
-      lastLeft,
-      right,
-      rightVisible,
-      columnCount,
-      rowHeaderWidth,
-      visibleColumnWidths,
-      visibleColumnXs,
-      width,
-    } = metrics;
-    let minX = rowHeaderWidth;
-    if (left < draggingColumn) {
-      const leftColumn = draggingColumn - 1;
-      minX =
-        getOrThrow(visibleColumnXs, leftColumn) +
-        getOrThrow(visibleColumnWidths, leftColumn) * 0.5 +
-        this.draggingOffset +
-        rowHeaderWidth;
+    const draggingColumnInfo = getColumnInfo(draggingColumn.index, metrics);
+    if (!draggingColumnInfo) {
+      return false;
+    }
+    const { depth: draggingColumnDepth } = draggingColumn;
+    let draggingVisibleIndex = draggingColumnInfo.visibleIndex;
+    const draggingModelIndex = draggingColumnInfo.modelIndex;
+
+    const draggingColumnLeft = mouseX - this.draggingOffset;
+    const draggingColumnRight =
+      draggingColumnLeft +
+      (visibleColumnWidths.get(draggingVisibleIndex) ??
+        userColumnWidths.get(draggingModelIndex) ??
+        calculatedColumnWidths.get(draggingModelIndex) ??
+        0);
+
+    const isDraggingLeft = draggingColumnLeft < draggingColumnInfo.left;
+    const isDraggingRight = draggingColumnRight > draggingColumnInfo.right;
+    if (!isDraggingLeft && !isDraggingRight) {
+      return true;
+    }
+    const swapColumnInfo = getColumnInfo(
+      isDraggingLeft ? draggingVisibleIndex - 1 : draggingVisibleIndex + 1,
+      metrics
+    );
+
+    if (!swapColumnInfo) {
+      return true;
     }
 
-    let maxX = width;
-    if (draggingColumn < right) {
-      const rightColumn = draggingColumn + 1;
-      maxX =
-        getOrThrow(visibleColumnXs, rightColumn) +
-        getOrThrow(visibleColumnWidths, rightColumn) * 0.5 -
-        getOrThrow(visibleColumnWidths, draggingColumn) +
-        this.draggingOffset +
-        rowHeaderWidth;
+    const switchPoint =
+      getOrThrow(visibleColumnXs, swapColumnInfo.visibleIndex) +
+      getOrThrow(visibleColumnWidths, swapColumnInfo.visibleIndex) * 0.5 +
+      rowHeaderWidth;
+
+    if (visibleIndex === draggingVisibleIndex) {
+      return true;
     }
 
-    let { movedColumns } = grid.state;
     if (
-      mouseX < minX &&
-      draggingColumn > 0 &&
-      model.isColumnMovable(grid.getModelColumn(draggingColumn - 1))
+      !model.isColumnMovableTo(draggingModelIndex, modelIndex)
+      // !model.isColumnMovableTo(draggingModelIndex, swapColumnInfo.modelIndex)
     ) {
-      movedColumns = GridUtils.moveItem(
-        draggingColumn,
-        draggingColumn - 1,
-        movedColumns
-      );
-      draggingColumn -= 1;
-    } else if (
-      maxX < mouseX &&
-      draggingColumn < columnCount - 1 &&
-      model.isColumnMovable(grid.getModelColumn(draggingColumn + 1))
-    ) {
-      movedColumns = GridUtils.moveItem(
-        draggingColumn,
-        draggingColumn + 1,
-        movedColumns
-      );
-      draggingColumn += 1;
-    }
-    grid.setState({ movedColumns, draggingColumn });
+      this.clearScrollInterval();
 
-    const minMoveX =
-      rowHeaderWidth + getOrThrow(visibleColumnWidths, left) * 0.5;
-    const maxMoveX =
-      rowHeaderWidth +
-      getOrThrow(visibleColumnXs, rightVisible) +
-      getOrThrow(visibleColumnWidths, rightVisible) * 0.5;
-    if (mouseX < minMoveX && left > 0) {
-      grid.setState({ left: left - 1 });
-    } else if (mouseX > maxMoveX && left < lastLeft) {
-      grid.setState({ left: left + 1 });
+      this.draggingOffset +=
+        draggingColumnLeft - (visibleColumnXs.get(draggingVisibleIndex) ?? 0);
+
+      grid.setState({ draggingColumnOffset: this.draggingOffset });
+      return true;
     }
+
+    if (draggingColumnLeft < floatingLeftWidth) {
+      this.setScrollInterval(grid, 'left');
+    } else if (draggingColumnRight > width) {
+      this.setScrollInterval(grid, 'right');
+    } else {
+      this.clearScrollInterval();
+    }
+
+    if (
+      isDraggingLeft &&
+      draggingVisibleIndex > leftVisible &&
+      draggingColumnLeft < switchPoint &&
+      model.isColumnDroppableBetween(
+        draggingModelIndex,
+        visibleIndex > 0
+          ? modelColumns.get(visibleIndex - 1) ??
+              GridUtils.getModelIndex(visibleIndex - 1, movedColumns)
+          : null,
+        modelIndex,
+        draggingColumnDepth
+      )
+    ) {
+      movedColumns = GridUtils.moveItem(
+        draggingVisibleIndex,
+        visibleIndex,
+        movedColumns
+      );
+      draggingVisibleIndex = visibleIndex;
+    } else if (
+      !isDraggingLeft &&
+      draggingVisibleIndex < rightVisible &&
+      draggingColumnRight > switchPoint &&
+      model.isColumnDroppableBetween(
+        draggingModelIndex,
+        modelIndex,
+        visibleIndex < columnCount + 1
+          ? modelColumns.get(visibleIndex + 1) ??
+              GridUtils.getModelIndex(visibleIndex + 1, movedColumns)
+          : null,
+        draggingColumnDepth
+      )
+    ) {
+      movedColumns = GridUtils.moveItem(
+        draggingVisibleIndex,
+        visibleIndex,
+        movedColumns
+      );
+      draggingVisibleIndex = visibleIndex;
+    }
+    grid.setState({
+      movedColumns,
+      draggingColumn: {
+        index: draggingVisibleIndex,
+        depth: draggingColumnDepth,
+      },
+    });
 
     return true;
   }
 
   onUp(gridPoint: GridPoint, grid: Grid): EventHandlerResult {
     this.cursor = null;
+
+    this.clearScrollInterval();
 
     if (this.draggingOffset != null) {
       this.draggingOffset = undefined;

--- a/packages/grid/src/mouse-handlers/GridColumnMoveMouseHandler.ts
+++ b/packages/grid/src/mouse-handlers/GridColumnMoveMouseHandler.ts
@@ -137,8 +137,6 @@ class GridColumnMoveMouseHandler extends GridMouseHandler {
 
   private draggingColumn: DraggingColumn | null = null;
 
-  private updateDraggingColumn(column: DraggingColumn, grid: Grid): void {}
-
   private setScrollInterval(grid: Grid, direction: 'left' | 'right'): void {
     if (
       this.scrollingInterval != null &&

--- a/packages/grid/src/mouse-handlers/GridColumnMoveMouseHandler.ts
+++ b/packages/grid/src/mouse-handlers/GridColumnMoveMouseHandler.ts
@@ -186,19 +186,16 @@ class GridColumnMoveMouseHandler extends GridMouseHandler {
         nextOffset += SCROLL_DELTA;
         let leftColumnWidth = visibleColumnWidths.get(left);
         while (leftColumnWidth !== undefined && nextOffset > leftColumnWidth) {
-          if (nextLeft === lastLeft) {
+          nextLeft += 1;
+          nextOffset -= leftColumnWidth;
+          const modelIndex = GridUtils.getModelIndex(left + 1, movedColumns);
+          leftColumnWidth =
+            userColumnWidths.get(modelIndex) ??
+            calculatedColumnWidths.get(modelIndex);
+
+          if (nextLeft > lastLeft) {
             nextOffset = 0;
-          } else {
-            if (nextLeft === lastLeft) {
-              nextOffset = 0;
-            } else {
-              nextLeft += 1;
-              nextOffset -= leftColumnWidth;
-            }
-            const modelIndex = GridUtils.getModelIndex(left + 1, movedColumns);
-            leftColumnWidth =
-              userColumnWidths.get(modelIndex) ??
-              calculatedColumnWidths.get(modelIndex);
+            nextLeft = lastLeft;
           }
         }
       }

--- a/packages/grid/src/mouse-handlers/GridColumnMoveMouseHandler.ts
+++ b/packages/grid/src/mouse-handlers/GridColumnMoveMouseHandler.ts
@@ -127,13 +127,9 @@ class GridColumnMoveMouseHandler extends GridMouseHandler {
 
   private initialGridPoint?: GridPoint;
 
-  private isDragging = false;
-
   private scrollingInterval?: number;
 
   private scrollingDirection?: 'left' | 'right';
-
-  private draggingDirection?: 'left' | 'right';
 
   private draggingColumn: DraggingColumn | null = null;
 
@@ -255,7 +251,6 @@ class GridColumnMoveMouseHandler extends GridMouseHandler {
     const { rowHeaderWidth } = metrics;
 
     this.initialGridPoint = gridPoint;
-    this.isDragging = false;
     this.draggingColumn = null;
     this.cursor = null;
 
@@ -363,11 +358,6 @@ class GridColumnMoveMouseHandler extends GridMouseHandler {
      * At this point, we have determined we are actually dragging a column
      */
     this.cursor = 'move';
-    if (event.movementX !== 0) {
-      this.draggingDirection = event.movementX < 0 ? 'left' : 'right';
-    } else {
-      this.draggingDirection = undefined;
-    }
 
     this.moveDraggingColumn(gridPoint, grid, event.movementX);
 
@@ -511,16 +501,19 @@ class GridColumnMoveMouseHandler extends GridMouseHandler {
       return;
     }
 
-    movedColumns = [...movedColumns, columnMove];
+    movedColumns =
+      typeof columnMove.from === 'number'
+        ? GridUtils.moveItem(columnMove.from, columnMove.to, movedColumns)
+        : GridUtils.moveRange(columnMove.from, columnMove.to, movedColumns);
 
-    const newDraggingRange = GridUtils.applyItemMoves(
-      draggingColumn.range[0],
-      draggingColumn.range[1],
-      [columnMove]
-    );
+    const moveDistance = columnMove.to - draggingColumn.range[0];
+    const newDraggingRange: BoundedAxisRange = [
+      draggingColumn.range[0] + moveDistance,
+      draggingColumn.range[1] + moveDistance,
+    ];
 
     this.draggingColumn = {
-      range: newDraggingRange[0],
+      range: newDraggingRange,
       depth: this.draggingColumn.depth,
     };
 

--- a/packages/grid/src/mouse-handlers/GridColumnSeparatorMouseHandler.ts
+++ b/packages/grid/src/mouse-handlers/GridColumnSeparatorMouseHandler.ts
@@ -31,7 +31,7 @@ class GridColumnSeparatorMouseHandler extends GridSeparatorMouseHandler {
       theme
     );
 
-    // TODO: Allow resizing of column groups as well. Right now just allow resizing from base columns
+    // TODO #695: Allow resizing of column groups as well. Right now just allow resizing from base columns
     if (
       separatorIndex == null ||
       columnHeaderDepth == null ||

--- a/packages/grid/src/mouse-handlers/GridColumnSeparatorMouseHandler.ts
+++ b/packages/grid/src/mouse-handlers/GridColumnSeparatorMouseHandler.ts
@@ -1,7 +1,9 @@
 /* eslint class-methods-use-this: "off" */
 import Grid from '../Grid';
 import GridMetricCalculator from '../GridMetricCalculator';
-import { ModelIndex } from '../GridMetrics';
+import type { ModelIndex, GridMetrics } from '../GridMetrics';
+import type GridModel from '../GridModel';
+import type { GridTheme } from '../GridTheme';
 import GridUtils, { GridPoint } from '../GridUtils';
 import GridSeparatorMouseHandler, {
   GridSeparator,
@@ -10,18 +12,15 @@ import GridSeparatorMouseHandler, {
 class GridColumnSeparatorMouseHandler extends GridSeparatorMouseHandler {
   static getColumnSeparator(
     gridPoint: GridPoint,
-    grid: Grid,
-    checkAllowResize = true
+    metrics: GridMetrics,
+    model: GridModel,
+    theme: GridTheme
   ): GridSeparator | null {
-    const theme = grid.getTheme();
-    if (checkAllowResize && !theme.allowColumnResize) {
+    if (!theme.allowColumnResize) {
       return null;
     }
 
     const { x, y, columnHeaderDepth } = gridPoint;
-    const { metrics, props } = grid;
-    const { model } = props;
-    if (!metrics) throw new Error('metrics not set');
 
     const { modelColumns } = metrics;
 

--- a/packages/grid/src/mouse-handlers/GridColumnSeparatorMouseHandler.ts
+++ b/packages/grid/src/mouse-handlers/GridColumnSeparatorMouseHandler.ts
@@ -31,6 +31,7 @@ class GridColumnSeparatorMouseHandler extends GridSeparatorMouseHandler {
       theme
     );
 
+    // TODO: Allow resizing of column groups as well. Right now just allow resizing from base columns
     if (
       separatorIndex == null ||
       columnHeaderDepth == null ||
@@ -40,16 +41,8 @@ class GridColumnSeparatorMouseHandler extends GridSeparatorMouseHandler {
     }
 
     const columnIndex = modelColumns.get(separatorIndex);
-    const nextColumnIndex = modelColumns.get(separatorIndex + 1);
-    if (columnIndex == null || nextColumnIndex == null) {
-      return null;
-    }
-
-    if (
-      model.textForColumnHeader(columnIndex, columnHeaderDepth) !==
-      model.textForColumnHeader(nextColumnIndex, columnHeaderDepth)
-    ) {
-      return { index: separatorIndex, depth: columnHeaderDepth };
+    if (columnIndex != null) {
+      return { index: separatorIndex, depth: 0 };
     }
 
     return null;

--- a/packages/grid/src/mouse-handlers/GridColumnSeparatorMouseHandler.ts
+++ b/packages/grid/src/mouse-handlers/GridColumnSeparatorMouseHandler.ts
@@ -1,26 +1,59 @@
 /* eslint class-methods-use-this: "off" */
 import Grid from '../Grid';
 import GridMetricCalculator from '../GridMetricCalculator';
-import { ModelIndex, VisibleIndex } from '../GridMetrics';
+import { ModelIndex } from '../GridMetrics';
 import GridUtils, { GridPoint } from '../GridUtils';
-import GridSeparatorMouseHandler from './GridSeparatorMouseHandler';
+import GridSeparatorMouseHandler, {
+  GridSeparator,
+} from './GridSeparatorMouseHandler';
 
 class GridColumnSeparatorMouseHandler extends GridSeparatorMouseHandler {
-  static getColumnSeparatorIndex(
+  static getColumnSeparator(
     gridPoint: GridPoint,
     grid: Grid,
     checkAllowResize = true
-  ): VisibleIndex | null {
+  ): GridSeparator | null {
     const theme = grid.getTheme();
     if (checkAllowResize && !theme.allowColumnResize) {
       return null;
     }
 
-    const { x, y } = gridPoint;
-    const { metrics } = grid;
+    const { x, y, columnHeaderDepth } = gridPoint;
+    const { metrics, props } = grid;
+    const { model } = props;
     if (!metrics) throw new Error('metrics not set');
 
-    return GridUtils.getColumnSeparatorIndex(x, y, metrics, theme);
+    const { modelColumns } = metrics;
+
+    const separatorIndex = GridUtils.getColumnSeparatorIndex(
+      x,
+      y,
+      metrics,
+      theme
+    );
+
+    if (
+      separatorIndex == null ||
+      columnHeaderDepth == null ||
+      columnHeaderDepth > 0
+    ) {
+      return null;
+    }
+
+    const columnIndex = modelColumns.get(separatorIndex);
+    const nextColumnIndex = modelColumns.get(separatorIndex + 1);
+    if (columnIndex == null || nextColumnIndex == null) {
+      return null;
+    }
+
+    if (
+      model.textForColumnHeader(columnIndex, columnHeaderDepth) !==
+      model.textForColumnHeader(nextColumnIndex, columnHeaderDepth)
+    ) {
+      return { index: separatorIndex, depth: columnHeaderDepth };
+    }
+
+    return null;
   }
 
   hiddenCursor = 'e-resize';
@@ -64,14 +97,14 @@ class GridColumnSeparatorMouseHandler extends GridSeparatorMouseHandler {
     metricCalculator.resetColumnWidth(modelIndex);
   }
 
-  updateSeparator(grid: Grid, separatorIndex: VisibleIndex | null): void {
+  updateSeparator(grid: Grid, separator: GridSeparator | null): void {
     grid.setState({
-      draggingColumnSeparator: separatorIndex,
-      isDragging: separatorIndex !== null,
+      draggingColumnSeparator: separator,
+      isDragging: separator !== null,
     });
   }
 
-  getSeparatorIndex = GridColumnSeparatorMouseHandler.getColumnSeparatorIndex;
+  getSeparator = GridColumnSeparatorMouseHandler.getColumnSeparator;
 }
 
 export default GridColumnSeparatorMouseHandler;

--- a/packages/grid/src/mouse-handlers/GridRowSeparatorMouseHandler.ts
+++ b/packages/grid/src/mouse-handlers/GridRowSeparatorMouseHandler.ts
@@ -1,7 +1,9 @@
 /* eslint class-methods-use-this: "off" */
 import Grid from '../Grid';
 import GridMetricCalculator from '../GridMetricCalculator';
-import { ModelIndex, VisibleIndex } from '../GridMetrics';
+import type { ModelIndex, GridMetrics } from '../GridMetrics';
+import type GridModel from '../GridModel';
+import { GridTheme } from '../GridTheme';
 import GridUtils, { GridPoint } from '../GridUtils';
 import GridSeparatorMouseHandler, {
   GridSeparator,
@@ -10,17 +12,15 @@ import GridSeparatorMouseHandler, {
 class GridRowSeparatorMouseHandler extends GridSeparatorMouseHandler {
   static getRowSeparator(
     gridPoint: GridPoint,
-    grid: Grid,
-    checkAllowResize = true
+    metrics: GridMetrics,
+    model: GridModel,
+    theme: GridTheme
   ): GridSeparator | null {
-    const theme = grid.getTheme();
-    if (checkAllowResize && !theme.allowRowResize) {
+    if (!theme.allowRowResize) {
       return null;
     }
 
     const { x, y } = gridPoint;
-    const { metrics } = grid;
-    if (!metrics) throw new Error('metrics not set');
 
     const index = GridUtils.getRowSeparatorIndex(x, y, metrics, theme);
 

--- a/packages/grid/src/mouse-handlers/GridRowSeparatorMouseHandler.ts
+++ b/packages/grid/src/mouse-handlers/GridRowSeparatorMouseHandler.ts
@@ -3,14 +3,16 @@ import Grid from '../Grid';
 import GridMetricCalculator from '../GridMetricCalculator';
 import { ModelIndex, VisibleIndex } from '../GridMetrics';
 import GridUtils, { GridPoint } from '../GridUtils';
-import GridSeparatorMouseHandler from './GridSeparatorMouseHandler';
+import GridSeparatorMouseHandler, {
+  GridSeparator,
+} from './GridSeparatorMouseHandler';
 
 class GridRowSeparatorMouseHandler extends GridSeparatorMouseHandler {
-  static getRowSeparatorIndex(
+  static getRowSeparator(
     gridPoint: GridPoint,
     grid: Grid,
     checkAllowResize = true
-  ): VisibleIndex | null {
+  ): GridSeparator | null {
     const theme = grid.getTheme();
     if (checkAllowResize && !theme.allowRowResize) {
       return null;
@@ -20,7 +22,9 @@ class GridRowSeparatorMouseHandler extends GridSeparatorMouseHandler {
     const { metrics } = grid;
     if (!metrics) throw new Error('metrics not set');
 
-    return GridUtils.getRowSeparatorIndex(x, y, metrics, theme);
+    const index = GridUtils.getRowSeparatorIndex(x, y, metrics, theme);
+
+    return index != null ? { index, depth: 0 } : null;
   }
 
   hiddenCursor = 's-resize';
@@ -64,14 +68,14 @@ class GridRowSeparatorMouseHandler extends GridSeparatorMouseHandler {
     metricCalculator.resetRowHeight(modelIndex);
   }
 
-  updateSeparator(grid: Grid, separatorIndex: VisibleIndex | null): void {
+  updateSeparator(grid: Grid, separator: GridSeparator | null): void {
     grid.setState({
-      draggingRowSeparator: separatorIndex,
-      isDragging: separatorIndex !== null,
+      draggingRowSeparator: separator,
+      isDragging: separator !== null,
     });
   }
 
-  getSeparatorIndex = GridRowSeparatorMouseHandler.getRowSeparatorIndex;
+  getSeparator = GridRowSeparatorMouseHandler.getRowSeparator;
 }
 
 export default GridRowSeparatorMouseHandler;

--- a/packages/grid/src/mouse-handlers/GridSeparatorMouseHandler.ts
+++ b/packages/grid/src/mouse-handlers/GridSeparatorMouseHandler.ts
@@ -1,11 +1,12 @@
 /* eslint class-methods-use-this: "off" */
 /* eslint no-unused-vars: "off" */
-import { Grid, GridMetricCalculator } from '..';
+import type { Grid, GridMetricCalculator, GridModel } from '..';
 import { EventHandlerResult } from '../EventHandlerResult';
 import { getOrThrow } from '../GridMetricCalculator';
 import GridMetrics, { ModelIndex, VisibleIndex } from '../GridMetrics';
 import GridMouseHandler from '../GridMouseHandler';
-import { GridPoint } from '../GridUtils';
+import type { GridTheme } from '../GridTheme';
+import type { GridPoint } from '../GridUtils';
 
 // The different properties that can be used by implementing classes, whether for rows or columns
 export type PointProperty = 'x' | 'y';
@@ -91,17 +92,20 @@ abstract class GridSeparatorMouseHandler extends GridMouseHandler {
 
   abstract getSeparator(
     gridPoint: GridPoint,
-    grid: Grid,
-    checkAllowResize?: boolean
+    metrics: GridMetrics,
+    model: GridModel,
+    theme: GridTheme
   ): GridSeparator | null;
   // End of overrides
 
   onDown(gridPoint: GridPoint, grid: Grid): EventHandlerResult {
-    const separator = this.getSeparator(gridPoint, grid);
-    if (separator != null) {
-      const { metrics } = grid;
-      if (!metrics) throw new Error('metrics not set');
+    const { metrics } = grid;
+    const { model } = grid.props;
+    const theme = grid.getTheme();
+    if (!metrics) throw new Error('metrics not set');
 
+    const separator = this.getSeparator(gridPoint, metrics, model, theme);
+    if (separator != null) {
       const separatorIndex = separator.index;
 
       this.dragOffset = 0;
@@ -122,11 +126,14 @@ abstract class GridSeparatorMouseHandler extends GridMouseHandler {
   }
 
   onMove(gridPoint: GridPoint, grid: Grid): EventHandlerResult {
-    const separator = this.getSeparator(gridPoint, grid);
-    if (separator != null) {
-      const { metrics } = grid;
-      if (!metrics) throw new Error('metrics not set');
+    const { metrics } = grid;
+    const { model } = grid.props;
+    const theme = grid.getTheme();
+    if (!metrics) throw new Error('metrics not set');
 
+    const separator = this.getSeparator(gridPoint, metrics, model, theme);
+
+    if (separator != null) {
       this.updateCursor(metrics, separator.index);
       return true;
     }
@@ -255,12 +262,14 @@ abstract class GridSeparatorMouseHandler extends GridMouseHandler {
   }
 
   onDoubleClick(gridPoint: GridPoint, grid: Grid): EventHandlerResult {
-    const separator = this.getSeparator(gridPoint, grid);
+    const { metrics, metricCalculator } = grid;
+    const { model } = grid.props;
+    const theme = grid.getTheme();
+    if (!metrics) throw new Error('metrics not set');
+
+    const separator = this.getSeparator(gridPoint, metrics, model, theme);
 
     if (separator != null) {
-      const { metricCalculator, metrics } = grid;
-      if (!metrics) throw new Error('metrics not set');
-
       const modelIndexes = metrics[this.modelIndexesProperty];
       const modelIndex = getOrThrow(modelIndexes, separator.index);
 

--- a/packages/grid/src/mouse-handlers/GridSeparatorMouseHandler.ts
+++ b/packages/grid/src/mouse-handlers/GridSeparatorMouseHandler.ts
@@ -1,6 +1,6 @@
-/* eslint class-methods-use-this: "off" */
-/* eslint no-unused-vars: "off" */
-import type { Grid, GridMetricCalculator, GridModel } from '..';
+import type Grid from '../Grid';
+import type { GridMetricCalculator } from '../GridMetricCalculator';
+import type GridModel from '../GridModel';
 import { EventHandlerResult } from '../EventHandlerResult';
 import { getOrThrow } from '../GridMetricCalculator';
 import GridMetrics, { ModelIndex, VisibleIndex } from '../GridMetrics';

--- a/packages/grid/src/mouse-handlers/index.js
+++ b/packages/grid/src/mouse-handlers/index.js
@@ -8,3 +8,4 @@ export { default as GridRowTreeMouseHandler } from './GridRowTreeMouseHandler';
 export { default as GridScrollBarCornerMouseHandler } from './GridScrollBarCornerMouseHandler';
 export { default as GridVerticalScrollBarMouseHandler } from './GridVerticalScrollBarMouseHandler';
 export { default as EditMouseHandler } from './EditMouseHandler';
+export * from './GridSeparatorMouseHandler';

--- a/packages/iris-grid/src/ColumnHeaderGroup.ts
+++ b/packages/iris-grid/src/ColumnHeaderGroup.ts
@@ -1,0 +1,29 @@
+import { MoveOperation, AxisRange } from '@deephaven/grid';
+
+export default class ColumnHeaderGroup {
+  name: string;
+
+  children: string[];
+
+  color?: string;
+
+  private movedItems: MoveOperation[] = [];
+
+  constructor({
+    name,
+    children,
+    color,
+  }: {
+    name: string;
+    children: string[];
+    color?: string;
+  }) {
+    this.name = name;
+    this.children = children;
+    this.color = color;
+  }
+
+  // getVisibleRange(movedItems: MoveOperation[]): AxisRange {
+
+  // }
+}

--- a/packages/iris-grid/src/ColumnHeaderGroup.ts
+++ b/packages/iris-grid/src/ColumnHeaderGroup.ts
@@ -20,23 +20,26 @@ export default class ColumnHeaderGroup implements IColumnHeaderGroup {
 
   color?: string;
 
-  childIndexes: (ModelIndex | ModelIndex[])[] = [];
+  childIndexes: (ModelIndex | ModelIndex[])[];
 
   constructor({
     name,
     children,
     color,
     depth,
+    childIndexes,
   }: {
     name: string;
     children: string[];
     color?: string;
     depth: number;
+    childIndexes: (ModelIndex | ModelIndex[])[];
   }) {
     this.name = name;
     this.children = children;
     this.color = color;
     this.depth = depth;
+    this.childIndexes = childIndexes;
   }
 
   getVisibleRange = memoizeOne(

--- a/packages/iris-grid/src/ColumnHeaderGroup.ts
+++ b/packages/iris-grid/src/ColumnHeaderGroup.ts
@@ -6,6 +6,9 @@ import {
   IColumnHeaderGroup,
 } from '@deephaven/grid';
 import memoizeOne from 'memoize-one';
+import Log from '@deephaven/log';
+
+const log = Log.module('ColumnHeaderGroup');
 
 export function isColumnHeaderGroup(x: unknown): x is ColumnHeaderGroup {
   return x instanceof ColumnHeaderGroup;
@@ -54,7 +57,7 @@ export default class ColumnHeaderGroup implements IColumnHeaderGroup {
       const end = Math.max(...visibleIndexes);
 
       if (end - start !== flattenedIndexes.length - 1) {
-        throw new Error(`Column header group ${this.name} is not contiguous`);
+        log.warn(`Column header group ${this.name} is not contiguous`);
       }
 
       return [start, end];

--- a/packages/iris-grid/src/IrisGrid.scss
+++ b/packages/iris-grid/src/IrisGrid.scss
@@ -88,20 +88,23 @@ $cell-invalid-box-shadow: 0 0 0 2px $danger, 0 0 0 5px rgba($danger, 0.25);
       position: absolute;
       top: 0;
       right: 0;
-      background-image: linear-gradient(
-        to left,
-        $iris-grid-bg 19px,
-        transparent
-      );
-      background-size: 100% 23px; // header height - reversebar height
-      background-repeat: no-repeat;
-      margin: 1px 0;
+      height: $header-height;
+      width: $header-height;
+      background-color: $header-bg;
+      border-bottom: 1px solid $header-separator-color;
       transition: transform $transition-mid ease-out,
         opacity $transition-mid ease-out;
 
       .btn {
-        padding: 4px 8px 1px 8px;
-        // remove extra bottom padding that was covering up table indicator bars
+        height: 100%;
+        width: 100%;
+        &::after {
+          border-radius: 0;
+        }
+
+        &:focus::after {
+          box-shadow: none;
+        }
       }
 
       &.is-menu-shown {

--- a/packages/iris-grid/src/IrisGrid.tsx
+++ b/packages/iris-grid/src/IrisGrid.tsx
@@ -3172,6 +3172,7 @@ export class IrisGrid extends Component<IrisGridProps, IrisGridState> {
       visibleColumnXs,
       visibleColumnWidths,
       width,
+      columnHeaderMaxDepth,
     } = metrics;
     const columnX = visibleColumnXs.get(shownColumnTooltip);
     const columnWidth = visibleColumnWidths.get(shownColumnTooltip);
@@ -3184,9 +3185,11 @@ export class IrisGrid extends Component<IrisGridProps, IrisGridState> {
       clamp(columnX + columnWidth / 2, popperMargin, width - popperMargin);
 
     return {
-      top: gridRect.top,
-      left,
-      bottom: gridRect.top + columnHeaderHeight,
+      top: gridRect.top + (columnHeaderMaxDepth - 1) * columnHeaderHeight,
+      left:
+        gridRect.left +
+        clamp(columnX + columnWidth / 2, popperMargin, width - popperMargin),
+      bottom: gridRect.top + columnHeaderMaxDepth * columnHeaderHeight,
       right:
         gridRect.left +
         clamp(columnX + columnWidth / 2, popperMargin, width - popperMargin) +
@@ -3278,6 +3281,7 @@ export class IrisGrid extends Component<IrisGridProps, IrisGridState> {
   ): ReactNode {
     const {
       columnHeaderHeight,
+      columnHeaderMaxDepth,
       visibleColumnXs,
       visibleColumnWidths,
       width,
@@ -3308,7 +3312,7 @@ export class IrisGrid extends Component<IrisGridProps, IrisGridState> {
 
     const wrapperStyle: CSSProperties = {
       position: 'absolute',
-      top: 0,
+      top: (columnHeaderMaxDepth - 1) * columnHeaderHeight,
       left: boundedLeft,
       width: boundedWidth,
       height: columnHeaderHeight,

--- a/packages/iris-grid/src/IrisGrid.tsx
+++ b/packages/iris-grid/src/IrisGrid.tsx
@@ -41,6 +41,7 @@ import {
   VisibleIndex,
   GridState,
   isEditableGridModel,
+  BoundedAxisRange,
 } from '@deephaven/grid';
 import {
   dhEye,
@@ -1665,7 +1666,8 @@ export class IrisGrid extends Component<IrisGridProps, IrisGridState> {
       columns: Column[],
       movedColumns: MoveOperation[],
       floatingLeftColumnCount: number,
-      floatingRightColumnCount: number
+      floatingRightColumnCount: number,
+      draggingRange?: BoundedAxisRange
     ) => {
       const floatingColumns: ColumnName[] = [];
 
@@ -1680,6 +1682,14 @@ export class IrisGrid extends Component<IrisGridProps, IrisGridState> {
           columns[GridUtils.getModelIndex(columns.length - 1 - i, movedColumns)]
             .name
         );
+      }
+
+      if (draggingRange) {
+        for (let i = draggingRange[0]; i <= draggingRange[1]; i += 1) {
+          floatingColumns.push(
+            columns[GridUtils.getModelIndex(i, movedColumns)].name
+          );
+        }
       }
 
       const columnSet = new Set([...alwaysFetchColumns, ...floatingColumns]);
@@ -4005,7 +4015,8 @@ export class IrisGrid extends Component<IrisGridProps, IrisGridState> {
                   model.columns,
                   movedColumns,
                   model.floatingLeftColumnCount,
-                  model.floatingRightColumnCount
+                  model.floatingRightColumnCount,
+                  this.grid?.state.draggingColumn?.range
                 )}
                 formatColumns={this.getCachedPreviewFormatColumns(
                   this.getCachedModelColumns(model, customColumns),

--- a/packages/iris-grid/src/IrisGrid.tsx
+++ b/packages/iris-grid/src/IrisGrid.tsx
@@ -1221,7 +1221,8 @@ export class IrisGrid extends Component<IrisGridProps, IrisGridState> {
       advancedFilters,
       sorts,
       reverseType,
-      rollupConfig
+      rollupConfig,
+      isMenuShown
     ) => ({
       hoverSelectColumn,
       isFilterBarShown,
@@ -1232,6 +1233,7 @@ export class IrisGrid extends Component<IrisGridProps, IrisGridState> {
       sorts,
       reverseType,
       rollupConfig,
+      isMenuShown,
     }),
     { max: 1 }
   );
@@ -3482,7 +3484,8 @@ export class IrisGrid extends Component<IrisGridProps, IrisGridState> {
       advancedFilters,
       sorts,
       reverseType,
-      rollupConfig
+      rollupConfig,
+      isMenuShown
     );
     const top = metrics ? metrics.top : 0;
     const bottom = metrics ? metrics.bottomViewport : 0;
@@ -4030,20 +4033,18 @@ export class IrisGrid extends Component<IrisGridProps, IrisGridState> {
                 frozenColumns={frozenColumns}
               />
             )}
-            <div
-              className={classNames('grid-settings-button', {
-                'is-menu-shown': isMenuShown,
-              })}
-            >
-              <button
-                type="button"
-                data-testid={`btn-iris-grid-settings-button-${name}`}
-                className="btn btn-link btn-link-icon"
-                onClick={this.handleMenu}
-              >
-                <FontAwesomeIcon icon={vsMenu} transform="up-1" />
-              </button>
-            </div>
+            {!isMenuShown && (
+              <div className="grid-settings-button">
+                <button
+                  type="button"
+                  data-testid={`btn-iris-grid-settings-button-${name}`}
+                  className="btn btn-link btn-link-icon"
+                  onClick={this.handleMenu}
+                >
+                  <FontAwesomeIcon icon={vsMenu} transform="up-1" />
+                </button>
+              </div>
+            )}
             {focusField}
             {loadingElement}
             {filterBar}

--- a/packages/iris-grid/src/IrisGridMetricCalculator.ts
+++ b/packages/iris-grid/src/IrisGridMetricCalculator.ts
@@ -18,8 +18,6 @@ export interface IrisGridMetricState extends GridMetricState {
   reverseType: string;
 }
 
-/* eslint class-methods-use-this: "off" */
-/* eslint react/destructuring-assignment: "off" */
 /**
  * Class to calculate all the metrics for a grid.
  * Call getMetrics() with the state to get metrics
@@ -45,7 +43,7 @@ class IrisGridMetricCalculator extends GridMetricCalculator {
     const hasUserSetWidth = this.userColumnWidths.has(modelColumn);
     if (
       !hasUserSetWidth &&
-      hiddenColumns.includes(model.columns[modelColumn].name)
+      hiddenColumns.includes(model.columns[modelColumn]?.name)
     ) {
       return 0;
     }

--- a/packages/iris-grid/src/IrisGridProxyModel.ts
+++ b/packages/iris-grid/src/IrisGridProxyModel.ts
@@ -21,7 +21,6 @@ import {
 } from '@deephaven/jsapi-shim';
 import {
   EditableGridModel,
-  IColumnHeaderGroup,
   isEditableGridModel,
   isExpandableGridModel,
   ModelIndex,

--- a/packages/iris-grid/src/IrisGridProxyModel.ts
+++ b/packages/iris-grid/src/IrisGridProxyModel.ts
@@ -21,6 +21,7 @@ import {
 } from '@deephaven/jsapi-shim';
 import {
   EditableGridModel,
+  IColumnHeaderGroup,
   isEditableGridModel,
   isExpandableGridModel,
   ModelIndex,
@@ -244,6 +245,9 @@ class IrisGridProxyModel extends IrisGridModel {
   textForColumnHeader: IrisGridModel['textForColumnHeader'] = (...args) =>
     this.model.textForColumnHeader(...args);
 
+  colorForColumnHeader: IrisGridModel['colorForColumnHeader'] = (...args) =>
+    this.model.colorForColumnHeader(...args);
+
   textForRowHeader: IrisGridModel['textForRowHeader'] = (...args) =>
     this.model.textForRowHeader(...args);
 
@@ -255,6 +259,13 @@ class IrisGridProxyModel extends IrisGridModel {
 
   isColumnMovable: IrisGridModel['isColumnMovable'] = (...args) =>
     this.model.isColumnMovable(...args);
+
+  isColumnMovableTo: IrisGridModel['isColumnMovableTo'] = (...args) =>
+    this.model.isColumnMovableTo(...args);
+
+  isColumnDroppableBetween: IrisGridModel['isColumnDroppableBetween'] = (
+    ...args
+  ) => this.model.isColumnDroppableBetween(...args);
 
   isColumnFrozen(x: ModelIndex): boolean {
     return this.model.isColumnFrozen(x);
@@ -373,6 +384,13 @@ class IrisGridProxyModel extends IrisGridModel {
 
   get frozenColumns(): ColumnName[] {
     return this.model.frozenColumns;
+  }
+
+  getColumnHeaderGroup: IrisGridModel['getColumnHeaderGroup'] = (...args) =>
+    this.model.getColumnHeaderGroup(...args);
+
+  get columnHeaderMaxDepth(): number {
+    return this.model.columnHeaderMaxDepth;
   }
 
   updateFrozenColumns(columns: ColumnName[]): void {

--- a/packages/iris-grid/src/IrisGridProxyModel.ts
+++ b/packages/iris-grid/src/IrisGridProxyModel.ts
@@ -259,13 +259,6 @@ class IrisGridProxyModel extends IrisGridModel {
   isColumnMovable: IrisGridModel['isColumnMovable'] = (...args) =>
     this.model.isColumnMovable(...args);
 
-  isColumnMovableTo: IrisGridModel['isColumnMovableTo'] = (...args) =>
-    this.model.isColumnMovableTo(...args);
-
-  isColumnDroppableBetween: IrisGridModel['isColumnDroppableBetween'] = (
-    ...args
-  ) => this.model.isColumnDroppableBetween(...args);
-
   isColumnFrozen(x: ModelIndex): boolean {
     return this.model.isColumnFrozen(x);
   }
@@ -387,6 +380,10 @@ class IrisGridProxyModel extends IrisGridModel {
 
   getColumnHeaderGroup: IrisGridModel['getColumnHeaderGroup'] = (...args) =>
     this.model.getColumnHeaderGroup(...args);
+
+  getColumnHeaderParentGroup: IrisGridModel['getColumnHeaderParentGroup'] = (
+    ...args
+  ) => this.model.getColumnHeaderParentGroup(...args);
 
   get columnHeaderMaxDepth(): number {
     return this.model.columnHeaderMaxDepth;

--- a/packages/iris-grid/src/IrisGridRenderer.ts
+++ b/packages/iris-grid/src/IrisGridRenderer.ts
@@ -10,6 +10,7 @@ import {
   IconDefinition,
 } from '@deephaven/icons';
 import {
+  BoundedAxisRange,
   BoxCoordinates,
   Coordinate,
   getOrThrow,
@@ -356,7 +357,7 @@ class IrisGridRenderer extends GridRenderer {
     barHeight: number,
     interior = true
   ): void {
-    const { theme, metrics } = state;
+    const { theme, metrics, model } = state;
     const { columnHeaderHeight, width } = metrics;
     // Draw casing with 1 pixel above and below the bar,
     // 1px falls on the existing split between grid/headers
@@ -368,7 +369,7 @@ class IrisGridRenderer extends GridRenderer {
     context.fillStyle = theme.headerBarCasingColor;
     context.fillRect(
       0,
-      columnHeaderHeight - barHeight - 2 + offset,
+      model.columnHeaderDepth * columnHeaderHeight - barHeight - 2 + offset,
       width,
       barHeight + 2
     );
@@ -376,25 +377,54 @@ class IrisGridRenderer extends GridRenderer {
     context.fillStyle = color;
     context.fillRect(
       0,
-      columnHeaderHeight - barHeight - 1 + offset,
+      model.columnHeaderDepth * columnHeaderHeight - barHeight - 1 + offset,
       width,
       barHeight
     );
   }
 
-  drawColumnHeader(
+  drawColumnHeadersAtDepth(
     context: CanvasRenderingContext2D,
     state: IrisGridRenderState,
-    column: VisibleIndex,
-    columnX: Coordinate,
-    columnWidth: number
+    range: BoundedAxisRange,
+    boundsProp: { minX: number; maxX: number },
+    depth: number
   ): void {
-    super.drawColumnHeader(context, state, column, columnX, columnWidth);
+    const { metrics, model } = state;
+    const { columnHeaderDepth } = model;
+    const { width } = metrics;
+    const bounds = {
+      ...boundsProp,
+      // Account for the menu button
+      maxX:
+        depth === columnHeaderDepth - 1 && boundsProp.maxX === width
+          ? width - 30
+          : boundsProp.maxX,
+    };
+    super.drawColumnHeadersAtDepth(context, state, range, bounds, depth);
+  }
 
+  drawColumnHeaderAtIndex(
+    context: CanvasRenderingContext2D,
+    state: IrisGridRenderState,
+    index: VisibleIndex,
+    bounds: { minX: number; maxX: number }
+  ): void {
+    super.drawColumnHeaderAtIndex(context, state, index, bounds);
     const { metrics, model, theme } = state;
-    const { modelColumns } = metrics;
-    const modelColumn = getOrThrow(modelColumns, column);
+    const {
+      modelColumns,
+      visibleColumnWidths,
+      visibleColumnXs,
+      gridX,
+      columnHeaderHeight,
+      fontWidths,
+    } = metrics;
 
+    const { headerHorizontalPadding } = theme;
+    const columnWidth = getOrThrow(visibleColumnWidths, index);
+    const columnX = getOrThrow(visibleColumnXs, index) + gridX;
+    const modelColumn = modelColumns.get(index);
     const sort = TableUtils.getSortForColumn(model.sort, modelColumn);
 
     if (!sort) {
@@ -406,32 +436,26 @@ class IrisGridRenderer extends GridRenderer {
       return;
     }
 
-    const { columnHeaderHeight, gridX } = metrics;
+    const text = model.textForColumnHeader(modelColumn);
+    const fontWidth =
+      fontWidths.get(context.font) || GridRenderer.DEFAULT_FONT_WIDTH;
+    const textWidth = text.length * fontWidth;
+    const textRight = gridX + columnX + textWidth + headerHorizontalPadding;
+    let { maxX } = bounds;
+    maxX -= headerHorizontalPadding;
+    const defaultX =
+      gridX + columnX + columnWidth - headerHorizontalPadding - 1;
 
-    const x = gridX + columnX + columnWidth - 13;
+    const x = textRight > maxX ? textRight + 1 : Math.min(maxX, defaultX);
     const yOffset =
       sort.direction === TableUtils.sortDirection.ascending ? -6 : -12;
     const y = columnHeaderHeight * 0.5 + yOffset;
-    const gradientWidth = 12;
-    const gradientX = x - 3;
 
     context.save();
 
     context.beginPath();
     context.rect(columnX, 0, columnWidth, columnHeaderHeight);
     context.clip();
-
-    const gradient = context.createLinearGradient(
-      gradientX,
-      0,
-      gradientX + 5,
-      0
-    );
-    gradient.addColorStop(0, `${theme.headerBackgroundColor}00`);
-    gradient.addColorStop(1, `${theme.headerBackgroundColor}CD`);
-
-    context.fillStyle = gradient;
-    context.fillRect(gradientX, 0, gradientWidth, columnHeaderHeight);
 
     context.fillStyle = theme.headerSortBarColor;
     context.translate(x, y);

--- a/packages/iris-grid/src/IrisGridRenderer.ts
+++ b/packages/iris-grid/src/IrisGridRenderer.ts
@@ -442,7 +442,7 @@ class IrisGridRenderer extends GridRenderer {
     }
 
     const text = model.textForColumnHeader(modelColumn);
-    if (!text) {
+    if (text === undefined) {
       return;
     }
 

--- a/packages/iris-grid/src/IrisGridRenderer.ts
+++ b/packages/iris-grid/src/IrisGridRenderer.ts
@@ -425,6 +425,11 @@ class IrisGridRenderer extends GridRenderer {
     const columnWidth = getOrThrow(visibleColumnWidths, index);
     const columnX = getOrThrow(visibleColumnXs, index) + gridX;
     const modelColumn = modelColumns.get(index);
+
+    if (modelColumn == null) {
+      return;
+    }
+
     const sort = TableUtils.getSortForColumn(model.sort, modelColumn);
 
     if (!sort) {
@@ -437,6 +442,10 @@ class IrisGridRenderer extends GridRenderer {
     }
 
     const text = model.textForColumnHeader(modelColumn);
+    if (!text) {
+      return;
+    }
+
     const fontWidth =
       fontWidths.get(context.font) || GridRenderer.DEFAULT_FONT_WIDTH;
     const textWidth = text.length * fontWidth;
@@ -892,10 +901,11 @@ class IrisGridRenderer extends GridRenderer {
       return textMetrics;
     }
 
-    const {
-      visibleIndex: mouseColumn,
-      row: mouseRow,
-    } = GridUtils.getGridPointFromXY(mouseX, mouseY, metrics);
+    const { column: mouseColumn, row: mouseRow } = GridUtils.getGridPointFromXY(
+      mouseX,
+      mouseY,
+      metrics
+    );
 
     if (column === mouseColumn && row === mouseRow) {
       const { left } = this.getCellOverflowButtonPosition(state);

--- a/packages/iris-grid/src/IrisGridRenderer.ts
+++ b/packages/iris-grid/src/IrisGridRenderer.ts
@@ -369,7 +369,7 @@ class IrisGridRenderer extends GridRenderer {
     context.fillStyle = theme.headerBarCasingColor;
     context.fillRect(
       0,
-      model.columnHeaderDepth * columnHeaderHeight - barHeight - 2 + offset,
+      model.columnHeaderMaxDepth * columnHeaderHeight - barHeight - 2 + offset,
       width,
       barHeight + 2
     );
@@ -377,7 +377,7 @@ class IrisGridRenderer extends GridRenderer {
     context.fillStyle = color;
     context.fillRect(
       0,
-      model.columnHeaderDepth * columnHeaderHeight - barHeight - 1 + offset,
+      model.columnHeaderMaxDepth * columnHeaderHeight - barHeight - 1 + offset,
       width,
       barHeight
     );
@@ -391,13 +391,13 @@ class IrisGridRenderer extends GridRenderer {
     depth: number
   ): void {
     const { metrics, model } = state;
-    const { columnHeaderDepth } = model;
+    const { columnHeaderMaxDepth } = model;
     const { width } = metrics;
     const bounds = {
       ...boundsProp,
       // Account for the menu button
       maxX:
-        depth === columnHeaderDepth - 1 && boundsProp.maxX === width
+        depth === columnHeaderMaxDepth - 1 && boundsProp.maxX === width
           ? width - 30
           : boundsProp.maxX,
     };

--- a/packages/iris-grid/src/IrisGridRenderer.ts
+++ b/packages/iris-grid/src/IrisGridRenderer.ts
@@ -154,9 +154,12 @@ class IrisGridRenderer extends GridRenderer {
     const { metrics, model } = state;
     const { modelColumns, modelRows } = metrics;
     const modelRow = getOrThrow(modelRows, row);
-    const modelColumn = getOrThrow(modelColumns, column);
+    const modelColumn = modelColumns.get(column);
+    if (modelColumn === undefined) {
+      return;
+    }
     const value = model.valueForCell(modelColumn, modelRow);
-    if (TableUtils.isTextType(model.columns[modelColumn].type)) {
+    if (TableUtils.isTextType(model.columns[modelColumn]?.type)) {
       if (value === null || value === '') {
         const originalFont = context.font;
         context.font = `italic ${originalFont}`;
@@ -422,7 +425,7 @@ class IrisGridRenderer extends GridRenderer {
     } = metrics;
 
     const { headerHorizontalPadding } = theme;
-    const columnWidth = getOrThrow(visibleColumnWidths, index);
+    const columnWidth = getOrThrow(visibleColumnWidths, index, 0);
     const columnX = getOrThrow(visibleColumnXs, index) + gridX;
     const modelColumn = modelColumns.get(index);
 

--- a/packages/iris-grid/src/IrisGridRenderer.ts
+++ b/packages/iris-grid/src/IrisGridRenderer.ts
@@ -892,11 +892,10 @@ class IrisGridRenderer extends GridRenderer {
       return textMetrics;
     }
 
-    const { column: mouseColumn, row: mouseRow } = GridUtils.getGridPointFromXY(
-      mouseX,
-      mouseY,
-      metrics
-    );
+    const {
+      visibleIndex: mouseColumn,
+      row: mouseRow,
+    } = GridUtils.getGridPointFromXY(mouseX, mouseY, metrics);
 
     if (column === mouseColumn && row === mouseRow) {
       const { left } = this.getCellOverflowButtonPosition(state);

--- a/packages/iris-grid/src/IrisGridRenderer.ts
+++ b/packages/iris-grid/src/IrisGridRenderer.ts
@@ -54,6 +54,7 @@ export type IrisGridRenderState = GridRenderState & {
   isFilterBarShown: boolean;
   advancedFilters: AdvancedFilterMap;
   quickFilters: QuickFilterMap;
+  isMenuShown: boolean;
 };
 /**
  * Handles rendering some of the Iris specific features, such as sorting icons, sort bar display
@@ -390,15 +391,14 @@ class IrisGridRenderer extends GridRenderer {
     boundsProp: { minX: number; maxX: number },
     depth: number
   ): void {
-    const { metrics, model } = state;
+    const { metrics, model, isMenuShown } = state;
     const { columnHeaderMaxDepth } = model;
     const { width } = metrics;
     const bounds = {
       ...boundsProp,
-      // Account for the menu button
       maxX:
         depth === columnHeaderMaxDepth - 1 && boundsProp.maxX === width
-          ? width - 30
+          ? width - (isMenuShown ? 0 : 30) // Account for the menu button
           : boundsProp.maxX,
     };
     super.drawColumnHeadersAtDepth(context, state, range, bounds, depth);

--- a/packages/iris-grid/src/IrisGridTableModel.ts
+++ b/packages/iris-grid/src/IrisGridTableModel.ts
@@ -1,12 +1,6 @@
 /* eslint class-methods-use-this: "off" */
 import memoize from 'memoize-one';
-import {
-  GridRange,
-  GridUtils,
-  ModelIndex,
-  MoveOperation,
-  VisibleIndex,
-} from '@deephaven/grid';
+import { GridRange, ModelIndex } from '@deephaven/grid';
 import {
   Column,
   ColumnStatistics,
@@ -83,53 +77,6 @@ class IrisGridTableModel extends IrisGridTableModelTemplate<Table, UIRow> {
 
   get isFormatColumnsAvailable(): boolean {
     return this.table.applyCustomColumns != null;
-  }
-
-  /**
-   * Used to get the initial moved columns based on layout hints
-   */
-  get movedColumns(): MoveOperation[] {
-    let movedColumns: MoveOperation[] = [];
-
-    if (
-      this.frontColumns.length ||
-      this.backColumns.length ||
-      this.frozenColumns.length
-    ) {
-      const usedColumns = new Set();
-
-      const moveColumn = (name: string, toIndex: VisibleIndex) => {
-        if (usedColumns.has(name)) {
-          throw new Error(`Column specified in multiple layout hints: ${name}`);
-        }
-        const modelIndex = this.getColumnIndexByName(name);
-        if (!modelIndex) {
-          throw new Error(`Unknown layout hint column: ${name}`);
-        }
-        const visibleIndex = GridUtils.getVisibleIndex(
-          modelIndex,
-          movedColumns
-        );
-        movedColumns = GridUtils.moveItem(visibleIndex, toIndex, movedColumns);
-      };
-
-      let frontIndex = 0;
-      this.frozenColumns.forEach(name => {
-        moveColumn(name, frontIndex);
-        frontIndex += 1;
-      });
-      this.frontColumns.forEach(name => {
-        moveColumn(name, frontIndex);
-        frontIndex += 1;
-      });
-
-      let backIndex = this.columnMap.size - 1;
-      this.backColumns.forEach(name => {
-        moveColumn(name, backIndex);
-        backIndex -= 1;
-      });
-    }
-    return movedColumns;
   }
 
   getMemoizedFrontColumns = memoize(

--- a/packages/iris-grid/src/IrisGridTableModelTemplate.ts
+++ b/packages/iris-grid/src/IrisGridTableModelTemplate.ts
@@ -664,7 +664,7 @@ class IrisGridTableModelTemplate<
 
     const moveColumn = (name: string, toIndex: VisibleIndex) => {
       const modelIndex = this.getColumnIndexByName(name);
-      if (!modelIndex) {
+      if (modelIndex == null) {
         throw new Error(`Unknown layout hint column: ${name}`);
       }
       const visibleIndex = GridUtils.getVisibleIndex(modelIndex, movedColumns);

--- a/packages/iris-grid/src/IrisGridTheme.module.scss
+++ b/packages/iris-grid/src/IrisGridTheme.module.scss
@@ -7,13 +7,17 @@ $selection-outline-casing-color: $gray-900;
 $font-size: 12px;
 $row-height: 19px;
 $row-hover-bg: mix($gray-600, $gray-700, 50%);
+$header-bg: $content-bg;
+$header-separator-color: $gray-900;
+$header-height: 30px;
 
 :export {
   grid-bg: $gray-900;
   font: $font-size Fira Sans, sans-serif; // must be preloaded
-  header-bg: $content-bg;
+  header-bg: $header-bg;
   header-color: $gray-200;
-  header-separator-color: $gray-900;
+  header-height: $header-height;
+  header-separator-color: $header-separator-color;
   header-separator-hover-color: $gray-400;
   header-hidden-separator-hover-color: $primary;
   header-sort-bar-color: $purple;

--- a/packages/iris-grid/src/IrisGridTheme.ts
+++ b/packages/iris-grid/src/IrisGridTheme.ts
@@ -104,7 +104,7 @@ const theme: Partial<IrisGridThemeType> = Object.freeze({
   columnWidth: 100,
   rowHeaderWidth: 0,
   rowFooterWidth: 60,
-  columnHeaderHeight: 30,
+  columnHeaderHeight: parseInt(IrisGridTheme['header-height'], 10) || 30,
   filterBarHeight: 30, // includes 1px casing at bottom
   filterBarCollapsedHeight: 5, // includes 1px casing at bottom
   sortHeaderBarHeight: 2,

--- a/packages/iris-grid/src/IrisGridUtils.test.ts
+++ b/packages/iris-grid/src/IrisGridUtils.test.ts
@@ -1,6 +1,6 @@
 import { GridUtils, GridRange, MoveOperation } from '@deephaven/grid';
 import dh, { Column, Table, Sort } from '@deephaven/jsapi-shim';
-import { AdvancedFilter } from '.';
+import type { AdvancedFilter } from './CommonTypes';
 import IrisGridTestUtils from './IrisGridTestUtils';
 import IrisGridUtils from './IrisGridUtils';
 
@@ -267,7 +267,7 @@ describe('remove columns in moved columns', () => {
       movedColumns,
       ['3']
     );
-    expect(newMovedColumns).toEqual(GridUtils.moveItem(3, 1)); // new move should be {from: 3, to: 1}
+    expect(newMovedColumns).toEqual(GridUtils.moveItem(3, 1, [])); // new move should be {from: 3, to: 1}
   });
 
   it('delete the move when the move origin column is removed & alter move origin when a column is removed', () => {
@@ -284,7 +284,7 @@ describe('remove columns in moved columns', () => {
     // columns after move should be [4,0,1,2,5,...]; after columns '3' is removed;
     // move {from: 3, to: 0} is deleted because it is origin column is removed,
     // move {from: 4, to: 1 } is changed into {from: 3, to: 0};
-    expect(newMovedColumns).toEqual(GridUtils.moveItem(3, 0));
+    expect(newMovedColumns).toEqual(GridUtils.moveItem(3, 0, []));
   });
 
   it('delete the move when the origin and destination column is the same after the removal of a column', () => {
@@ -312,7 +312,7 @@ describe('remove columns in moved columns', () => {
     // columns' original state should be [0,1,4,5,...] after '2' & '3' are removed;
     // columns after move should be [0,1,4,5,...]; after columns '2' & '3' are removed;
     // move {from: 4, to: 1 } is changed into {from: 2, to: 1};
-    expect(newMovedColumns).toEqual(GridUtils.moveItem(2, 1));
+    expect(newMovedColumns).toEqual(GridUtils.moveItem(2, 1, []));
   });
 
   it('remove multiple columns - 2', () => {
@@ -327,7 +327,7 @@ describe('remove columns in moved columns', () => {
     // columns' original state should be [0,1,4,5,...] after '2' & '3' are removed;
     // columns after move should be [0,4,1,5,...]; after columns '2' & '3' are removed;
     // move {from: 1, to: 4 } is changed into {from: 1, to: 2};
-    expect(newMovedColumns).toEqual(GridUtils.moveItem(1, 2));
+    expect(newMovedColumns).toEqual(GridUtils.moveItem(1, 2, []));
   });
 
   it('remove multiple columns - 3', () => {
@@ -344,7 +344,7 @@ describe('remove columns in moved columns', () => {
     // columns after moves should be [0,4,1,6,5...]; after columns '2' & '3' are removed;
     // move {from: 4, to: 1 } is changed into {from: 2, to: 1};
     // move {from: 5, to: 6 } is changed into {from: 3, to: 4};
-    let expectMovedColumns = GridUtils.moveItem(2, 1);
+    let expectMovedColumns = GridUtils.moveItem(2, 1, []);
     expectMovedColumns = GridUtils.moveItem(3, 4, expectMovedColumns);
     expect(newMovedColumns).toEqual(expectMovedColumns);
   });

--- a/packages/iris-grid/src/IrisGridUtils.test.ts
+++ b/packages/iris-grid/src/IrisGridUtils.test.ts
@@ -1,5 +1,5 @@
-import { GridUtils, GridRange } from '@deephaven/grid';
-import dh, { Column, Table } from '@deephaven/jsapi-shim';
+import { GridUtils, GridRange, MoveOperation } from '@deephaven/grid';
+import dh, { Column, Table, Sort } from '@deephaven/jsapi-shim';
 import { AdvancedFilter } from '.';
 import IrisGridTestUtils from './IrisGridTestUtils';
 import IrisGridUtils from './IrisGridUtils';
@@ -10,7 +10,7 @@ function makeFilter() {
 }
 
 function makeColumns(count = 30) {
-  const columns = [];
+  const columns: Column[] = [];
 
   for (let i = 0; i < count; i += 1) {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -21,7 +21,10 @@ function makeColumns(count = 30) {
   return columns;
 }
 
-function makeTable({ columns = makeColumns(), sort = [] } = {}): Table {
+function makeTable({
+  columns = makeColumns(),
+  sort = [] as Sort[],
+} = {}): Table {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return new (dh as any).Table({ columns, sort });
 }
@@ -234,18 +237,18 @@ describe('pendingDataMap hydration/dehydration', () => {
       dehydratedMap
     );
     expect(hydratedMap.size).toBe(2);
-    expect(hydratedMap.get(1).data.size).toBe(2);
-    expect(hydratedMap.get(1).data.get(3)).toEqual('Foo');
-    expect(hydratedMap.get(1).data.get(4)).toEqual('Bar');
-    expect(hydratedMap.get(10).data.size).toBe(1);
-    expect(hydratedMap.get(10).data.get(7)).toEqual('Baz');
+    expect(hydratedMap.get(1)?.data.size).toBe(2);
+    expect(hydratedMap.get(1)?.data.get(3)).toEqual('Foo');
+    expect(hydratedMap.get(1)?.data.get(4)).toEqual('Bar');
+    expect(hydratedMap.get(10)?.data.size).toBe(1);
+    expect(hydratedMap.get(10)?.data.get(7)).toEqual('Baz');
   });
 });
 
 describe('remove columns in moved columns', () => {
   it('delete the move when the move origin column is removed', () => {
     const table = makeTable();
-    let movedColumns = [];
+    let movedColumns: MoveOperation[] = [];
     movedColumns = GridUtils.moveItem(3, 0, movedColumns); // move column '3' to '0'
     const newMovedColumns = IrisGridUtils.removeColumnFromMovedColumns(
       table.columns,
@@ -257,7 +260,7 @@ describe('remove columns in moved columns', () => {
 
   it('alter move origin when a column is removed', () => {
     const table = makeTable();
-    let movedColumns = [];
+    let movedColumns: MoveOperation[] = [];
     movedColumns = GridUtils.moveItem(4, 1, movedColumns); // move column '4' to '1'
     const newMovedColumns = IrisGridUtils.removeColumnFromMovedColumns(
       table.columns,
@@ -269,7 +272,7 @@ describe('remove columns in moved columns', () => {
 
   it('delete the move when the move origin column is removed & alter move origin when a column is removed', () => {
     const table = makeTable();
-    let movedColumns = [];
+    let movedColumns: MoveOperation[] = [];
     movedColumns = GridUtils.moveItem(3, 0, movedColumns); // move column '3' to '0', columns should be [3,0,1,2,4,5,...] after the move;
     movedColumns = GridUtils.moveItem(4, 1, movedColumns); // move column '4' to '1', columns should be [3,4,1,2,5,...] after the move;
     const newMovedColumns = IrisGridUtils.removeColumnFromMovedColumns(
@@ -286,7 +289,7 @@ describe('remove columns in moved columns', () => {
 
   it('delete the move when the origin and destination column is the same after the removal of a column', () => {
     const table = makeTable();
-    let movedColumns = [];
+    let movedColumns: MoveOperation[] = [];
     movedColumns = GridUtils.moveItem(3, 4, movedColumns); // move a column from 3 to 4
     const newMovedColumns = IrisGridUtils.removeColumnFromMovedColumns(
       table.columns,
@@ -299,7 +302,7 @@ describe('remove columns in moved columns', () => {
 
   it('remove multiple columns - 1', () => {
     const table = makeTable();
-    let movedColumns = [];
+    let movedColumns: MoveOperation[] = [];
     movedColumns = GridUtils.moveItem(4, 1, movedColumns); // move column '4' to '1', columns should be [0,4,1,2,3,5,...] after the move;
     const newMovedColumns = IrisGridUtils.removeColumnFromMovedColumns(
       table.columns,
@@ -314,7 +317,7 @@ describe('remove columns in moved columns', () => {
 
   it('remove multiple columns - 2', () => {
     const table = makeTable();
-    let movedColumns = [];
+    let movedColumns: MoveOperation[] = [];
     movedColumns = GridUtils.moveItem(1, 4, movedColumns); // move column '1' to '4', columns should be [0,2,3,1,4,5,...] after the move;
     const newMovedColumns = IrisGridUtils.removeColumnFromMovedColumns(
       table.columns,
@@ -329,7 +332,7 @@ describe('remove columns in moved columns', () => {
 
   it('remove multiple columns - 3', () => {
     const table = makeTable();
-    let movedColumns = [];
+    let movedColumns: MoveOperation[] = [];
     movedColumns = GridUtils.moveItem(4, 1, movedColumns); // move column '4' to '1', columns should be [0,4,1,2,3,5,6,...] after the move;
     movedColumns = GridUtils.moveItem(5, 6, movedColumns); // move column '3' to '0', columns should be [0,4,1,2,3,6,5...];
     const newMovedColumns = IrisGridUtils.removeColumnFromMovedColumns(

--- a/packages/iris-grid/src/IrisGridUtils.ts
+++ b/packages/iris-grid/src/IrisGridUtils.ts
@@ -123,6 +123,7 @@ class IrisGridUtils {
     } = gridState;
 
     const { columns } = model;
+
     return {
       isStuckToBottom,
       isStuckToRight,
@@ -130,7 +131,7 @@ class IrisGridUtils {
         .filter(
           ({ to, from }) =>
             isValidIndex(to, columns) &&
-            ((typeof from === 'string' && isValidIndex(from, columns)) ||
+            ((typeof from === 'number' && isValidIndex(from, columns)) ||
               (Array.isArray(from) &&
                 isValidIndex(from[0], columns) &&
                 isValidIndex(from[1], columns)))
@@ -202,7 +203,7 @@ class IrisGridUtils {
         .filter(
           ({ to, from }) =>
             isValidIndex(to, columnNames) &&
-            ((typeof from === 'string' && isValidIndex(from, columnNames)) ||
+            ((typeof from === 'number' && isValidIndex(from, columnNames)) ||
               (Array.isArray(from) &&
                 isValidIndex(from[0], columnNames) &&
                 isValidIndex(from[1], columnNames)))

--- a/packages/iris-grid/src/mousehandlers/IrisGridColumnTooltipMouseHandler.ts
+++ b/packages/iris-grid/src/mousehandlers/IrisGridColumnTooltipMouseHandler.ts
@@ -78,19 +78,11 @@ class IrisGridColumnTooltipMouseHandler extends GridMouseHandler {
   }
 
   onMove(gridPoint: GridPoint): EventHandlerResult {
-    const { y, column, row } = gridPoint;
+    const { column, row, columnHeaderDepth } = gridPoint;
     const { shownColumnTooltip } = this.irisGrid.state;
-    const theme = this.irisGrid.getTheme();
     let newTooltip = null;
-    if (column !== null && row === null) {
-      /**
-       * one would expect at y == theme.columnHeaderHeight, row == null
-       * however, gridY also == theme.columnHeaderHeight, so row still has a value
-       * so this tooltip won't actually show until row is null at columnHeaderHeight - 1
-       */
-      if (theme.columnHeaderHeight && y >= 0 && y <= theme.columnHeaderHeight) {
-        newTooltip = column;
-      }
+    if (column !== null && row === null && columnHeaderDepth === 0) {
+      newTooltip = column;
     }
 
     if (newTooltip !== shownColumnTooltip) {

--- a/packages/iris-grid/src/mousehandlers/IrisGridContextMenuHandler.tsx
+++ b/packages/iris-grid/src/mousehandlers/IrisGridContextMenuHandler.tsx
@@ -348,7 +348,7 @@ class IrisGridContextMenuHandler extends GridMouseHandler {
       group: IrisGridContextMenuHandler.GROUP_COPY,
       action: () => {
         ContextActionUtils.copyToClipboard(
-          model.textForColumnHeader(modelColumn)
+          model.textForColumnHeader(modelColumn) ?? ''
         ).catch(e => log.error('Unable to copy header', e));
       },
     });
@@ -585,7 +585,12 @@ class IrisGridContextMenuHandler extends GridMouseHandler {
     event: React.MouseEvent<Element, MouseEvent>
   ): EventHandlerResult {
     const { irisGrid } = this;
-    const { y, column: columnIndex, row: rowIndex } = gridPoint;
+    const {
+      y,
+      column: columnIndex,
+      row: rowIndex,
+      columnHeaderDepth,
+    } = gridPoint;
     const modelColumn = irisGrid.getModelColumn(columnIndex);
     const modelRow = irisGrid.getModelRow(rowIndex);
 
@@ -602,7 +607,7 @@ class IrisGridContextMenuHandler extends GridMouseHandler {
 
     assertNotNull(metrics);
 
-    const { columnHeaderHeight, gridY } = metrics;
+    const { columnHeaderHeight, gridY, columnHeaderMaxDepth } = metrics;
 
     const actions = [] as ContextAction[];
 
@@ -646,7 +651,12 @@ class IrisGridContextMenuHandler extends GridMouseHandler {
       });
     }
 
-    if (isFilterBarShown ? y <= gridY : y <= columnHeaderHeight) {
+    if (
+      isFilterBarShown
+        ? y <= gridY
+        : y <= columnHeaderHeight * columnHeaderMaxDepth &&
+          columnHeaderDepth === 0
+    ) {
       // grid header context menu options
       if (modelColumn != null) {
         actions.push(...this.getHeaderActions(modelColumn, gridPoint));

--- a/packages/iris-grid/src/mousehandlers/IrisGridFilterMouseHandler.ts
+++ b/packages/iris-grid/src/mousehandlers/IrisGridFilterMouseHandler.ts
@@ -21,14 +21,19 @@ class IrisGridFilterMouseHandler extends GridMouseHandler {
   onDown(gridPoint: GridPoint): EventHandlerResult {
     const { y, column, row } = gridPoint;
     if (column !== null && row === null) {
-      const { isFilterBarShown } = this.irisGrid.state;
+      const { isFilterBarShown, metrics } = this.irisGrid.state;
+      if (!metrics) throw new Error('Metrics not set');
+
+      const { columnHeaderMaxDepth } = metrics;
       const theme = this.irisGrid.getTheme();
       if (
         isFilterBarShown &&
         theme.columnHeaderHeight &&
         theme.filterBarHeight &&
-        y > theme.columnHeaderHeight &&
-        y <= theme.columnHeaderHeight + theme.filterBarHeight
+        y > theme.columnHeaderHeight * columnHeaderMaxDepth &&
+        y <=
+          theme.columnHeaderHeight * columnHeaderMaxDepth +
+            theme.filterBarHeight
       ) {
         this.irisGrid.focusFilterBar(column);
         return true;
@@ -40,16 +45,24 @@ class IrisGridFilterMouseHandler extends GridMouseHandler {
 
   onMove(gridPoint: GridPoint): EventHandlerResult {
     const { y, column } = gridPoint;
-    const { isFilterBarShown, hoverAdvancedFilter } = this.irisGrid.state;
+    const {
+      isFilterBarShown,
+      hoverAdvancedFilter,
+      metrics,
+    } = this.irisGrid.state;
+    if (!metrics) throw new Error('Metrics not set');
+    const { columnHeaderMaxDepth } = metrics;
     const theme = this.irisGrid.getTheme();
+
     let newHoverAdvancedFilter = null;
     if (
       isFilterBarShown &&
       theme.columnHeaderHeight &&
       theme.filterBarHeight &&
       column !== null &&
-      y >= theme.columnHeaderHeight &&
-      y <= theme.columnHeaderHeight + theme.filterBarHeight
+      y >= theme.columnHeaderHeight * columnHeaderMaxDepth &&
+      y <=
+        theme.columnHeaderHeight * columnHeaderMaxDepth + theme.filterBarHeight
     ) {
       newHoverAdvancedFilter = column;
     }

--- a/packages/iris-grid/src/mousehandlers/IrisGridSortMouseHandler.ts
+++ b/packages/iris-grid/src/mousehandlers/IrisGridSortMouseHandler.ts
@@ -26,12 +26,9 @@ class IrisGridSortMouseHandler extends GridMouseHandler {
   column: GridRangeIndex;
 
   getColumnFromGridPoint(gridPoint: GridPoint): GridRangeIndex {
-    const { y, column, row } = gridPoint;
-    if (column !== null && row === null) {
-      const theme = this.irisGrid.getTheme();
-      if (theme.columnHeaderHeight && y <= theme.columnHeaderHeight) {
-        return column;
-      }
+    const { column, row, columnHeaderDepth } = gridPoint;
+    if (column !== null && row === null && columnHeaderDepth === 0) {
+      return column;
     }
 
     return null;

--- a/packages/jsapi-shim/src/dh.types.ts
+++ b/packages/jsapi-shim/src/dh.types.ts
@@ -454,7 +454,11 @@ export interface OneClick {
 }
 
 export interface Column {
+  /**
+   * @deprecated
+   */
   readonly index: number;
+
   readonly type: string;
   readonly name: string;
   readonly description: string;
@@ -543,6 +547,11 @@ export interface InputTable {
   deleteTables(tables: Table[]): Promise<InputTable>;
   table: Table;
 }
+export interface ColumnGroup {
+  name: string;
+  children: string[];
+  color?: string;
+}
 
 export interface LayoutHints {
   areSavedLayoutsAllowed: boolean;
@@ -550,6 +559,7 @@ export interface LayoutHints {
   backColumns: string[];
   hiddenColumns: string[];
   frozenColumns: string[];
+  columnGroups: ColumnGroup[];
   searchDisplayMode?: keyof SearchDisplayModeStatic;
 }
 

--- a/packages/tsconfig/tsconfig.json
+++ b/packages/tsconfig/tsconfig.json
@@ -7,6 +7,10 @@
       "dom.iterable",
       "esnext"
     ],
+    "types": [
+      "node",
+      "jest"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "esModuleInterop": true,


### PR DESCRIPTION
Fixes #620 

Need to build core from [my branch](https://github.com/mattrunyon/deephaven-core/tree/column-grouping) currently

Todo
- [x] Fix hydrate/dehydrate
- [x] Fix types for `MoveOperation` (related to above)
- [x] Make sure dragging outside the canvas scrolls properly

Followup PRs
- [ ] Side panel group management
- [ ] Context menu specific to groups?
- [ ] Resizing groups in the UI/Hide button from spec
- [ ] Make dragging a column outside the canvas scroll at different speeds depending how far outside the column is

Example Python code

```python
from deephaven import new_table
from deephaven.column import string_col, char_col, int_col

groups = [
    {'name': 'MyShorts', 'children': ['Short', 'Short2', 'Short3']},
    {'name': 'MyInts', 'children': ['Int2', 'Int3'], 'color': 'blue'}
]

groups2 = [
    {'name': 'MegaGroup', 'children': ['MyShorts', 'MyInts', 'Char5']},
    {'name': 'MyShorts', 'children': ['Short', 'Short2', 'Short3']},
    {'name': 'MyInts', 'children': ['Int2', 'Int3'], 'color': 'blue'}
]

groups3 = [
    {'name': 'MegaGroup', 'children': ['MyShorts', 'MyInts', 'Char5']},
    {'name': 'MyShorts', 'children': ['Short', 'Short2', 'Short3']},
    {'name': 'MyInts', 'children': ['Int2', 'Int3'], 'color': 'blue'},
    {'name': 'MoreInts', 'children': ['Int4', 'Int6'], 'color': 'blue'},
    {'name': 'SuperMegaGroup', 'children': ['MegaGroup', 'Char9', 'MoreInts']},
]

table = new_table([
    string_col("Short", ["A" , "B", "C", "D"]),
    char_col("Char", "ABCD"),
    int_col("Int", [123456789, 234567890, 42, 8675309]),
    string_col("Short2", ["A" , "B", "C", "D"]),
    char_col("Char2", "ABCD"),
    int_col("Int2", [123456789, 234567890, 42, 8675309]),
    string_col("Short3", ["A" , "B", "C", "D"]),
    char_col("Char3", "ABCD"),
    int_col("Int3", [123456789, 234567890, 42, 8675309]),
    string_col("Short4", ["A" , "B", "C", "D"]),
    char_col("Char4", "ABCD"),
    int_col("Int4", [123456789, 234567890, 42, 8675309]),
    string_col("Short5", ["A" , "B", "C", "D"]),
    char_col("Char5", "ABCD"),
    int_col("Int5", [123456789, 234567890, 42, 8675309]),
    string_col("Short6", ["A" , "B", "C", "D"]),
    char_col("Char6", "ABCD"),
    int_col("Int6", [123456789, 234567890, 42, 8675309]),
    string_col("Short7", ["A" , "B", "C", "D"]),
    char_col("Char7", "ABCD"),
    int_col("Int7", [123456789, 234567890, 42, 8675309]),
    string_col("Short8", ["A" , "B", "C", "D"]),
    char_col("Char8", "ABCD"),
    int_col("Int8", [123456789, 234567890, 42, 8675309]),
    string_col("Short9", ["A" , "B", "C", "D"]),
    char_col("Char9", "ABCD"),
    int_col("Int9", [123456789, 234567890, 42, 8675309]),
    string_col("Short10", ["A" , "B", "C", "D"]),
    char_col("Char10", "ABCD"),
    int_col("Int10", [123456789, 234567890, 42, 8675309]),
    string_col("Short11", ["A" , "B", "C", "D"]),
    char_col("Char11", "ABCD"),
    int_col("Int11", [123456789, 234567890, 42, 8675309]),
    string_col("Short12", ["A" , "B", "C", "D"]),
    char_col("Char12", "ABCD"),
    int_col("Int12", [123456789, 234567890, 42, 8675309]),
])

table2 = table.layout_hints(freeze=["Char", "Int"], column_groups=groups)
table3 = table2.layout_hints(freeze=["Char", "Int"], column_groups=groups2)
table4 = table3.layout_hints(freeze=["Char", "Int"], column_groups=groups3)
```

