### PR TITLE
Fix filter set capture failing on timestamp column advanced filters, DH-12754

### DIFF
--- a/packages/dashboard-core-plugins/src/panels/FilterSetManagerPanel.jsx
+++ b/packages/dashboard-core-plugins/src/panels/FilterSetManagerPanel.jsx
@@ -6,7 +6,6 @@ import {
   GLPropTypes,
   LayoutUtils,
 } from '@deephaven/dashboard';
-import { IrisGridUtils } from '@deephaven/iris-grid';
 import Log from '@deephaven/log';
 import {
   getFilterSetsForDashboard,
@@ -128,20 +127,13 @@ export class FilterSetManagerPanel extends Component {
       advancedFilters: indexedAdvancedFilters,
       quickFilters: indexedQuickFilters,
     } = irisGridState;
-    const dehydratedAdvancedFilters = IrisGridUtils.dehydrateAdvancedFilters(
-      table.columns,
-      indexedAdvancedFilters
-    );
     const advancedFilters = FilterSetManagerPanel.changeFilterIndexesToColumnNames(
       table,
-      dehydratedAdvancedFilters
-    );
-    const dehydratedQuickFilters = IrisGridUtils.dehydrateQuickFilters(
-      indexedQuickFilters
+      indexedAdvancedFilters
     );
     const quickFilters = FilterSetManagerPanel.changeFilterIndexesToColumnNames(
       table,
-      dehydratedQuickFilters
+      indexedQuickFilters
     );
     return {
       irisGridState: {


### PR DESCRIPTION
We were dehydrating the filters from the `irisGridState` that were already dehydrated. This worked fine in most cases, but failed on timestamp column advanced filters.