### PR TITLE
Go to row UX cleanup

### DIFF
--- a/packages/grid/src/Grid.tsx
+++ b/packages/grid/src/Grid.tsx
@@ -1050,16 +1050,15 @@ class Grid extends PureComponent<GridProps, GridState> {
     const metricState = this.getMetricState();
     const newTop = this.metricCalculator.getLastTop(
       metricState,
-      focusedRow,
+      focusedRow + 1,
       halfViewportHeight
     );
-
     this.setState({
       top: Math.min(lastTop, newTop),
-      selectedRanges: [
-        new GridRange(null, focusedRow - 1, null, focusedRow - 1),
-      ],
+      selectedRanges: [new GridRange(null, focusedRow, null, focusedRow)],
     });
+    const { cursorColumn } = this.state;
+    this.moveCursorToPosition(cursorColumn, focusedRow, false, false);
   }
 
   /**

--- a/packages/iris-grid/src/GotoRow.scss
+++ b/packages/iris-grid/src/GotoRow.scss
@@ -12,15 +12,15 @@
   padding: $spacer-2;
   border-top: $border-width solid black;
   gap: $spacer-2;
-  // overflow: hidden;
 
-  input {
-    max-width: calc($input-padding-x + 12ch + $input-padding-x);
-  }
   .goto-row-wrapper {
     display: flex;
     align-items: center;
     gap: $spacer-2;
     flex-wrap: wrap;
+  }
+
+  input {
+    max-width: calc($input-padding-x + 12ch + $input-padding-x);
   }
 }

--- a/packages/iris-grid/src/GotoRow.scss
+++ b/packages/iris-grid/src/GotoRow.scss
@@ -1,33 +1,26 @@
 @import '../../components/scss/custom.scss';
 
+.iris-grid-bottom-bar.goto-row {
+  height: auto;
+}
+
 .goto-row {
-  display: inline-block;
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
   background-color: $content-bg;
-  padding: 3px;
-  border-style: solid;
-  border-width: $border-width;
-  border-color: $black;
+  padding: $spacer-2;
+  border-top: $border-width solid black;
+  gap: $spacer-2;
+  // overflow: hidden;
 
-  .goto-row-text {
-    padding: 5px;
-    display: inline-block;
+  input {
+    max-width: calc($input-padding-x + 12ch + $input-padding-x);
   }
-
-  .goto-row-input {
-    padding: 5px;
-    display: inline-block;
-    width: 180px;
-  }
-
-  .goto-row-error {
-    padding: 5px;
-    display: inline-block;
-    max-width: 200px;
-    color: $red;
-  }
-
-  .goto-row-close {
-    padding: 5px;
-    float: right;
+  .goto-row-wrapper {
+    display: flex;
+    align-items: center;
+    gap: $spacer-2;
+    flex-wrap: wrap;
   }
 }

--- a/packages/iris-grid/src/GotoRow.tsx
+++ b/packages/iris-grid/src/GotoRow.tsx
@@ -19,7 +19,6 @@ const DEFAULT_FORMAT_STRING = '###,##0';
 interface GotoRowProps {
   gotoRow: string;
   gotoRowError: string;
-  selectGotoRowInput: boolean;
   onSubmit: () => void;
   model: IrisGridModel;
   onGotoRowNumberChanged: (event: ChangeEvent<HTMLInputElement>) => void;
@@ -34,7 +33,6 @@ interface GotoRowProps {
 const GotoRow = ({
   gotoRow,
   gotoRowError,
-  selectGotoRowInput,
   onSubmit,
   isShown,
   onEntering,
@@ -52,10 +50,12 @@ const GotoRow = ({
   const { rowCount } = model;
 
   useEffect(() => {
-    if (selectGotoRowInput) {
+    // when row changes without focus (i.e. via context menu), re-select input
+    if (document.activeElement !== inputRef.current) {
       inputRef.current?.select();
     }
-  }, [selectGotoRowInput]);
+  }, [gotoRow]);
+
   return (
     <IrisGridBottomBar
       isShown={isShown}
@@ -63,7 +63,7 @@ const GotoRow = ({
       onEntering={onEntering}
       onEntered={() => {
         onEntered();
-        inputRef.current?.focus();
+        inputRef.current?.select();
       }}
       onExiting={onExiting}
       onExited={onExited}
@@ -77,6 +77,8 @@ const GotoRow = ({
               type="number"
               onKeyDown={e => {
                 if (e.key === 'Enter') {
+                  e.stopPropagation();
+                  e.preventDefault();
                   onSubmit();
                 }
               }}

--- a/packages/iris-grid/src/GotoRow.tsx
+++ b/packages/iris-grid/src/GotoRow.tsx
@@ -20,6 +20,7 @@ interface GotoRowProps {
   gotoRow: string;
   gotoRowError: string;
   selectGotoRowInput: boolean;
+  onSubmit: () => void;
   model: IrisGridModel;
   onGotoRowNumberChanged: (event: ChangeEvent<HTMLInputElement>) => void;
   onClose: () => void;
@@ -34,6 +35,7 @@ const GotoRow = ({
   gotoRow,
   gotoRowError,
   selectGotoRowInput,
+  onSubmit,
   isShown,
   onEntering,
   onEntered,
@@ -73,6 +75,11 @@ const GotoRow = ({
             <input
               ref={inputRef}
               type="number"
+              onKeyDown={e => {
+                if (e.key === 'Enter') {
+                  onSubmit();
+                }
+              }}
               className={classNames('form-control', {
                 'is-invalid': gotoRowError !== '',
               })}

--- a/packages/iris-grid/src/GotoRow.tsx
+++ b/packages/iris-grid/src/GotoRow.tsx
@@ -1,6 +1,6 @@
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { vsClose } from '@deephaven/icons';
-import React, { ReactElement, useState } from 'react';
+import React, { ReactElement, useRef, useState } from 'react';
 import { Button } from '@deephaven/components';
 import classNames from 'classnames';
 import './GotoRow.scss';
@@ -39,6 +39,7 @@ const GotoRow = ({
 }: GotoRowProps): ReactElement => {
   const [row, setRow] = useState('');
   const [error, setError] = useState('');
+  const inputRef = useRef<HTMLInputElement>(null);
 
   const res = 'Row number';
 
@@ -49,55 +50,53 @@ const GotoRow = ({
       isShown={isShown}
       className={classNames('goto-row')}
       onEntering={onEntering}
-      onEntered={onEntered}
+      onEntered={() => {
+        onEntered();
+        inputRef.current?.focus();
+      }}
       onExiting={onExiting}
       onExited={onExited}
     >
       <>
-        <div className="goto-row-text">
-          <h6>Go to row</h6>
-        </div>
-        <div className="goto-row-input">
-          <input
-            type="number"
-            className={classNames('form-control', {
-              'is-invalid': error !== '',
-            })}
-            placeholder={res}
-            onChange={event => {
-              const rowNumber = event.target.value;
-              setRow(rowNumber);
-              if (rowNumber === '') {
-                setError('');
-                return;
-              }
-              const rowInt = parseInt(event.target.value, 10);
-              if (rowInt > rowCount || rowInt < -rowCount) {
-                setError('Invalid row index');
-              } else if (rowInt === 0) {
-                onGotoRowNumberChanged(1);
-                setError('');
-              } else if (rowInt < 0) {
-                onGotoRowNumberChanged(rowInt + rowCount + 1);
-                setError('');
-              } else {
-                onGotoRowNumberChanged(parseInt(event.target.value, 10));
-                setError('');
-              }
-            }}
-            value={row}
-          />
-        </div>
-        <div className="goto-row-text">
-          <h6>
-            of {dh.i18n.NumberFormat.format(DEFAULT_FORMAT_STRING, rowCount)}
-          </h6>
-        </div>
-        {error && (
-          <div className="goto-row-error">
-            <h6>{error}</h6>
+        <div className="goto-row-wrapper">
+          <div className="goto-row-text">Go to row</div>
+          <div className="goto-row-input">
+            <input
+              ref={inputRef}
+              type="number"
+              className={classNames('form-control', {
+                'is-invalid': error !== '',
+              })}
+              placeholder={res}
+              onChange={event => {
+                const rowNumber = event.target.value;
+                setRow(rowNumber);
+                if (rowNumber === '') {
+                  setError('');
+                  return;
+                }
+                const rowInt = parseInt(event.target.value, 10);
+                if (rowInt > rowCount || rowInt < -rowCount) {
+                  setError('Invalid row index');
+                } else if (rowInt === 0) {
+                  onGotoRowNumberChanged(1);
+                  setError('');
+                } else if (rowInt < 0) {
+                  onGotoRowNumberChanged(rowInt + rowCount + 1);
+                  setError('');
+                } else {
+                  onGotoRowNumberChanged(parseInt(event.target.value, 10));
+                  setError('');
+                }
+              }}
+              value={row}
+            />
           </div>
-        )}
+          <div className="goto-row-text">
+            of {dh.i18n.NumberFormat.format(DEFAULT_FORMAT_STRING, rowCount)}
+          </div>
+          {error && <div className="goto-row-error text-danger">{error}</div>}
+        </div>
         <div className="goto-row-close">
           <Button kind="ghost" onClick={onClose}>
             <FontAwesomeIcon icon={vsClose} style={{ marginRight: '0' }} />

--- a/packages/iris-grid/src/GotoRow.tsx
+++ b/packages/iris-grid/src/GotoRow.tsx
@@ -1,6 +1,6 @@
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { vsClose } from '@deephaven/icons';
-import React, { ReactElement, useRef, useState } from 'react';
+import React, { ChangeEvent, ReactElement, useEffect, useRef } from 'react';
 import { Button } from '@deephaven/components';
 import classNames from 'classnames';
 import './GotoRow.scss';
@@ -17,8 +17,11 @@ export function isIrisGridProxyModel(
 const DEFAULT_FORMAT_STRING = '###,##0';
 
 interface GotoRowProps {
+  gotoRow: string;
+  gotoRowError: string;
+  selectGotoRowInput: boolean;
   model: IrisGridModel;
-  onGotoRowNumberChanged: (rowValue: number) => void;
+  onGotoRowNumberChanged: (event: ChangeEvent<HTMLInputElement>) => void;
   onClose: () => void;
   isShown: boolean;
   onEntering: () => void;
@@ -28,6 +31,9 @@ interface GotoRowProps {
 }
 
 const GotoRow = ({
+  gotoRow,
+  gotoRowError,
+  selectGotoRowInput,
   isShown,
   onEntering,
   onEntered,
@@ -37,14 +43,17 @@ const GotoRow = ({
   onGotoRowNumberChanged,
   onClose,
 }: GotoRowProps): ReactElement => {
-  const [row, setRow] = useState('');
-  const [error, setError] = useState('');
   const inputRef = useRef<HTMLInputElement>(null);
 
   const res = 'Row number';
 
   const { rowCount } = model;
 
+  useEffect(() => {
+    if (selectGotoRowInput) {
+      inputRef.current?.select();
+    }
+  }, [selectGotoRowInput]);
   return (
     <IrisGridBottomBar
       isShown={isShown}
@@ -65,37 +74,21 @@ const GotoRow = ({
               ref={inputRef}
               type="number"
               className={classNames('form-control', {
-                'is-invalid': error !== '',
+                'is-invalid': gotoRowError !== '',
               })}
               placeholder={res}
               onChange={event => {
-                const rowNumber = event.target.value;
-                setRow(rowNumber);
-                if (rowNumber === '') {
-                  setError('');
-                  return;
-                }
-                const rowInt = parseInt(event.target.value, 10);
-                if (rowInt > rowCount || rowInt < -rowCount) {
-                  setError('Invalid row index');
-                } else if (rowInt === 0) {
-                  onGotoRowNumberChanged(1);
-                  setError('');
-                } else if (rowInt < 0) {
-                  onGotoRowNumberChanged(rowInt + rowCount + 1);
-                  setError('');
-                } else {
-                  onGotoRowNumberChanged(parseInt(event.target.value, 10));
-                  setError('');
-                }
+                onGotoRowNumberChanged(event);
               }}
-              value={row}
+              value={gotoRow}
             />
           </div>
           <div className="goto-row-text">
             of {dh.i18n.NumberFormat.format(DEFAULT_FORMAT_STRING, rowCount)}
           </div>
-          {error && <div className="goto-row-error text-danger">{error}</div>}
+          {gotoRowError && (
+            <div className="goto-row-error text-danger">{gotoRowError}</div>
+          )}
         </div>
         <div className="goto-row-close">
           <Button kind="ghost" onClick={onClose}>

--- a/packages/iris-grid/src/IrisGrid.tsx
+++ b/packages/iris-grid/src/IrisGrid.tsx
@@ -389,7 +389,6 @@ export interface IrisGridState {
   overflowText: string;
   overflowButtonTooltipProps: CSSProperties | null;
 
-  selectGotoRowInput: boolean;
   gotoRow: string;
   gotoRowError: string;
   isGotoRowShown: boolean;
@@ -599,7 +598,7 @@ export class IrisGrid extends Component<IrisGridProps, IrisGridState> {
     };
 
     this.toggleGotoRowAction = {
-      action: () => this.toggleGotoRow(''),
+      action: () => this.toggleGotoRow(),
       shortcut: SHORTCUTS.TABLE.GOTO_ROW,
     };
 
@@ -784,7 +783,6 @@ export class IrisGrid extends Component<IrisGridProps, IrisGridState> {
       isGotoRowShown: false,
       gotoRow: '',
       gotoRowError: '',
-      selectGotoRowInput: false,
     };
   }
 
@@ -2341,22 +2339,21 @@ export class IrisGrid extends Component<IrisGridProps, IrisGridState> {
     );
   }
 
-  toggleGotoRow(row: string): void {
+  toggleGotoRow(row = ''): void {
     const { isGotoRowShown } = this.state;
-    if (!isGotoRowShown) {
+    if (row) {
+      // if invoked with a row, keep open instead of toggle
       this.setState({
-        isGotoRowShown: !isGotoRowShown,
+        isGotoRowShown: true,
         gotoRow: row,
         gotoRowError: '',
-        selectGotoRowInput: true,
       });
       return;
     }
     this.setState({
       isGotoRowShown: !isGotoRowShown,
-      gotoRow: row,
+      gotoRow: '',
       gotoRowError: '',
-      selectGotoRowInput: false,
     });
   }
 
@@ -3244,7 +3241,7 @@ export class IrisGrid extends Component<IrisGridProps, IrisGridState> {
   focusRowInGrid(rowNumber: string): void {
     const { model } = this.props;
     const { rowCount } = model;
-    this.setState({ gotoRow: rowNumber, selectGotoRowInput: false });
+    this.setState({ gotoRow: rowNumber });
     if (rowNumber === '') {
       this.setState({ gotoRowError: '' });
       return;
@@ -3453,7 +3450,6 @@ export class IrisGrid extends Component<IrisGridProps, IrisGridState> {
       isGotoRowShown,
       gotoRow,
       gotoRowError,
-      selectGotoRowInput,
     } = this.state;
     if (!isReady) {
       return null;
@@ -4056,7 +4052,6 @@ export class IrisGrid extends Component<IrisGridProps, IrisGridState> {
             model={model}
             isShown={isGotoRowShown}
             gotoRow={gotoRow}
-            selectGotoRowInput={selectGotoRowInput}
             gotoRowError={gotoRowError}
             onSubmit={this.handleGotoRowSelectedRowNumberSubmit}
             onGotoRowNumberChanged={this.handleGotoRowSelectedRowNumberChanged}

--- a/packages/iris-grid/src/IrisGrid.tsx
+++ b/packages/iris-grid/src/IrisGrid.tsx
@@ -548,7 +548,10 @@ export class IrisGrid extends Component<IrisGridProps, IrisGridState> {
     this.handlePendingDiscardClicked = this.handlePendingDiscardClicked.bind(
       this
     );
-
+    this.handleGotoRowSelectedRowNumberSubmit = this.handleGotoRowSelectedRowNumberSubmit.bind(
+      this
+    );
+    this.focusRowInGrid = this.focusRowInGrid.bind(this);
     this.handleDownloadTable = this.handleDownloadTable.bind(this);
     this.handleDownloadTableStart = this.handleDownloadTableStart.bind(this);
     this.handleCancelDownloadTable = this.handleCancelDownloadTable.bind(this);
@@ -2344,6 +2347,7 @@ export class IrisGrid extends Component<IrisGridProps, IrisGridState> {
       this.setState({
         isGotoRowShown: !isGotoRowShown,
         gotoRow: row,
+        gotoRowError: '',
         selectGotoRowInput: true,
       });
       return;
@@ -2351,6 +2355,7 @@ export class IrisGrid extends Component<IrisGridProps, IrisGridState> {
     this.setState({
       isGotoRowShown: !isGotoRowShown,
       gotoRow: row,
+      gotoRowError: '',
       selectGotoRowInput: false,
     });
   }
@@ -3231,18 +3236,20 @@ export class IrisGrid extends Component<IrisGridProps, IrisGridState> {
     }
   );
 
-  handleGotoRowSelectedRowNumberChanged(
-    event: ChangeEvent<HTMLInputElement>
-  ): void {
+  handleGotoRowSelectedRowNumberSubmit(): void {
+    const { gotoRow: rowNumber } = this.state;
+    this.focusRowInGrid(rowNumber);
+  }
+
+  focusRowInGrid(rowNumber: string): void {
     const { model } = this.props;
     const { rowCount } = model;
-    const rowNumber = event.target.value;
     this.setState({ gotoRow: rowNumber, selectGotoRowInput: false });
     if (rowNumber === '') {
       this.setState({ gotoRowError: '' });
       return;
     }
-    const rowInt = parseInt(event.target.value, 10);
+    const rowInt = parseInt(rowNumber, 10);
     if (rowInt > rowCount || rowInt < -rowCount) {
       this.setState({ gotoRowError: 'Invalid row index' });
     } else if (rowInt === 0) {
@@ -3255,6 +3262,13 @@ export class IrisGrid extends Component<IrisGridProps, IrisGridState> {
       this.grid?.setFocusRow(rowInt - 1);
       this.setState({ gotoRowError: '' });
     }
+  }
+
+  handleGotoRowSelectedRowNumberChanged(
+    event: ChangeEvent<HTMLInputElement>
+  ): void {
+    const rowNumber = event.target.value;
+    this.focusRowInGrid(rowNumber);
   }
 
   getColumnTooltip(
@@ -4044,6 +4058,7 @@ export class IrisGrid extends Component<IrisGridProps, IrisGridState> {
             gotoRow={gotoRow}
             selectGotoRowInput={selectGotoRowInput}
             gotoRowError={gotoRowError}
+            onSubmit={this.handleGotoRowSelectedRowNumberSubmit}
             onGotoRowNumberChanged={this.handleGotoRowSelectedRowNumberChanged}
             onClose={this.handleGotoRowClosed}
             onEntering={this.handleAnimationStart}

--- a/packages/iris-grid/src/IrisGrid.tsx
+++ b/packages/iris-grid/src/IrisGrid.tsx
@@ -4000,7 +4000,10 @@ export class IrisGrid extends Component<IrisGridProps, IrisGridState> {
             onClose={this.handleGotoRowClosed}
             onEntering={this.handleAnimationStart}
             onEntered={this.handleAnimationEnd}
-            onExiting={this.handleAnimationStart}
+            onExiting={() => {
+              this.handleAnimationStart();
+              this.focus();
+            }}
             onExited={this.handleAnimationEnd}
           />
 

--- a/packages/iris-grid/src/IrisGrid.tsx
+++ b/packages/iris-grid/src/IrisGrid.tsx
@@ -2340,10 +2340,18 @@ export class IrisGrid extends Component<IrisGridProps, IrisGridState> {
 
   toggleGotoRow(row: string): void {
     const { isGotoRowShown } = this.state;
+    if (!isGotoRowShown) {
+      this.setState({
+        isGotoRowShown: !isGotoRowShown,
+        gotoRow: row,
+        selectGotoRowInput: true,
+      });
+      return;
+    }
     this.setState({
       isGotoRowShown: !isGotoRowShown,
       gotoRow: row,
-      selectGotoRowInput: true,
+      selectGotoRowInput: false,
     });
   }
 

--- a/packages/iris-grid/src/mousehandlers/IrisGridContextMenuHandler.tsx
+++ b/packages/iris-grid/src/mousehandlers/IrisGridContextMenuHandler.tsx
@@ -440,7 +440,7 @@ class IrisGridContextMenuHandler extends GridMouseHandler {
           shortcut: SHORTCUTS.TABLE.GOTO_ROW,
           group: IrisGridContextMenuHandler.GROUP_GOTO,
           order: 10,
-          action: () => this.irisGrid.toggleGotoRow(),
+          action: () => this.irisGrid.toggleGotoRow(`${rowIndex + 1}`),
         };
 
         if (value != null) {

--- a/packages/iris-grid/src/mousehandlers/IrisGridContextMenuHandler.tsx
+++ b/packages/iris-grid/src/mousehandlers/IrisGridContextMenuHandler.tsx
@@ -6,7 +6,6 @@ import {
   vsRemove,
   vsCheck,
   vsFilter,
-  vsReply,
   IconDefinition,
 } from '@deephaven/icons';
 import debounce from 'lodash.debounce';
@@ -438,12 +437,10 @@ class IrisGridContextMenuHandler extends GridMouseHandler {
 
         const gotoRow = {
           title: 'Go to',
-          icon: vsReply,
-          iconColor: filterIconColor,
           shortcut: SHORTCUTS.TABLE.GOTO_ROW,
           group: IrisGridContextMenuHandler.GROUP_GOTO,
           order: 10,
-          action: () => this.irisGrid.handleGotoRowOpened(),
+          action: () => this.irisGrid.toggleGotoRow(),
         };
 
         if (value != null) {


### PR DESCRIPTION
I missed reviewing PR #638 before merge, here is some minor cleanup

- Simplified CSS using flex box, allowing for better wrapping and narrow panel sizes
- Use $spacer variables instead of fixed px sizes for spacing, ensures globally consistent paddings.
- Removed icon from context menu (per spec), and changed behaviour to toggle
- Focus on open, return focus on grid

Issue I need help with:
1. ctrl-g
2. type a row like 100
3. ctrl-g to close, which now correctly returns keyboard focus to grid
4. arrow down.

expected:
row is on 101
actual:
row jumps to row 2

So not sure what's being set incorrectly?

Assigning @SparkyFnay to fix the remaining issues:
Todo:
- [x] fix the above value
- [x] clear value on close
- [x] when opened via context menu, populate the input with the row that contextmenu was opened from