### PR TITLE
Allow copying the widget name from tab context menu

### DIFF
--- a/packages/dashboard-core-plugins/src/panels/Panel.jsx
+++ b/packages/dashboard-core-plugins/src/panels/Panel.jsx
@@ -208,7 +208,7 @@ class Panel extends PureComponent {
     return {
       title: 'Rename',
       order: 10,
-      group: ContextActions.groups.high,
+      group: ContextActions.groups.medium,
       action: this.handleShowRenameDialog,
     };
   }

--- a/packages/dashboard-core-plugins/src/panels/WidgetPanel.jsx
+++ b/packages/dashboard-core-plugins/src/panels/WidgetPanel.jsx
@@ -2,6 +2,7 @@ import React, { Component, PureComponent } from 'react';
 import classNames from 'classnames';
 import memoize from 'memoize-one';
 import PropTypes from 'prop-types';
+import { ContextActions, ContextActionUtils } from '@deephaven/components';
 import { GLPropTypes } from '@deephaven/dashboard';
 import Panel from './Panel';
 import WidgetPanelTooltip from './WidgetPanelTooltip';
@@ -16,6 +17,7 @@ class WidgetPanel extends PureComponent {
 
     this.handleSessionClosed = this.handleSessionClosed.bind(this);
     this.handleSessionOpened = this.handleSessionOpened.bind(this);
+    this.handleCopyName = this.handleCopyName.bind(this);
 
     this.state = {
       isClientDisconnected: false,
@@ -24,6 +26,11 @@ class WidgetPanel extends PureComponent {
       isWaitingForReconnect: false,
       isPanelInactive: false,
     };
+  }
+
+  handleCopyName() {
+    const { widgetName } = this.props;
+    ContextActionUtils.copyToClipboard(widgetName);
   }
 
   getErrorMessage() {
@@ -128,6 +135,15 @@ class WidgetPanel extends PureComponent {
         description
       );
 
+    const additionalActions = [
+      {
+        title: `Copy ${widgetType} Name`,
+        group: ContextActions.groups.medium,
+        order: 20,
+        action: this.handleCopyName,
+      },
+    ];
+
     return (
       <Panel
         className={classNames(className, {
@@ -155,6 +171,7 @@ class WidgetPanel extends PureComponent {
         isLoading={isLoading}
         isClonable={isClonable}
         isRenamable={isRenamable}
+        additionalActions={additionalActions}
       >
         {children}
         {isPanelInactive && <div className="fill-parent-absolute" />}

--- a/packages/dashboard-core-plugins/src/panels/WidgetPanelTooltip.jsx
+++ b/packages/dashboard-core-plugins/src/panels/WidgetPanelTooltip.jsx
@@ -1,11 +1,17 @@
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
+import { Button, ContextActionUtils } from '@deephaven/components';
+import { vsCopy, vsPassFilled } from '@deephaven/icons';
 import { GLPropTypes, LayoutUtils } from '@deephaven/dashboard';
+import Log from '@deephaven/log';
 import './WidgetPanelTooltip.scss';
+
+const log = Log.module('WidgetPanelTooltip');
 
 const WidgetPanelTooltip = props => {
   const { widgetType, widgetName, glContainer, description, children } = props;
   const panelTitle = LayoutUtils.getTitleFromContainer(glContainer);
+  const [copied, setCopied] = useState(false);
 
   return (
     <div className="tab-tooltip-container">
@@ -14,6 +20,18 @@ const WidgetPanelTooltip = props => {
           <b>{widgetType} Name </b>
         </span>
         <span className="tab-tooltip-name">{widgetName}</span>
+
+        <Button
+          kind="ghost"
+          className="tab-tooltip-copy"
+          icon={copied ? vsPassFilled : vsCopy}
+          onClick={() => {
+            ContextActionUtils.copyToClipboard(widgetName)
+              .then(setCopied(true))
+              .catch(e => log.error('Unable to column name', e));
+          }}
+          tooltip={copied ? 'Copied text' : 'Copy name'}
+        />
       </div>
       {widgetName !== panelTitle && (
         <div className="row">

--- a/packages/dashboard-core-plugins/src/panels/WidgetPanelTooltip.scss
+++ b/packages/dashboard-core-plugins/src/panels/WidgetPanelTooltip.scss
@@ -15,4 +15,9 @@ $tooltip-title-width: 110px;
     word-break: break-word;
     padding-left: 5px;
   }
+
+  .tab-tooltip-copy {
+    margin-left: 2px;
+    margin-top: -4px;
+  }
 }


### PR DESCRIPTION
Adds a context menu options when right clicking on a widget to "copy {widgettype} name". Think the order makes sense?

Adds a click to copy button to the tooltip for widget panels.

![image](https://user-images.githubusercontent.com/1576283/180315801-6691b4e4-6c50-4bad-b436-05b1f94c1654.png)

![image](https://user-images.githubusercontent.com/1576283/180315783-40462c3d-7aef-481c-bf99-b9e6abc1b255.png)
