### PR TITLE
Clean up treemap in web UI

### DIFF
--- a/packages/chart/src/ChartUtils.js
+++ b/packages/chart/src/ChartUtils.js
@@ -181,7 +181,7 @@ class ChartUtils {
 
   static getPlotlySeriesOrientation(series) {
     const { sources } = series;
-    if (sources.length === 2 && sources[0].axis.type === dh.plot.AxisType.Y) {
+    if (sources.length === 2 && sources[0]?.axis?.type === dh.plot.AxisType.Y) {
       return ChartUtils.ORIENTATION.HORIZONTAL;
     }
 

--- a/packages/chart/src/FigureChartModel.js
+++ b/packages/chart/src/FigureChartModel.js
@@ -566,6 +566,13 @@ class FigureChartModel extends ChartModel {
       if (yLow && yHigh && yLow !== y) {
         seriesData.error_y = ChartUtils.getPlotlyErrorBars(y, yLow, yHigh);
       }
+    } else if (plotStyle === dh.plot.SeriesPlotStyle.TREEMAP) {
+      const { ids, labels } = seriesData;
+      if (ids && !labels) {
+        // If the user only provided IDs, we assign the IDs to the labels property as well automatically
+        // Plotly uses the labels primarily, which from our API perspective seems kind of backwards
+        seriesData.labels = ids;
+      }
     }
   }
 

--- a/packages/chart/src/FigureChartModel.js
+++ b/packages/chart/src/FigureChartModel.js
@@ -568,7 +568,7 @@ class FigureChartModel extends ChartModel {
       }
     } else if (plotStyle === dh.plot.SeriesPlotStyle.TREEMAP) {
       const { ids, labels } = seriesData;
-      if (ids && !labels) {
+      if (ids !== undefined && labels === undefined) {
         // If the user only provided IDs, we assign the IDs to the labels property as well automatically
         // Plotly uses the labels primarily, which from our API perspective seems kind of backwards
         seriesData.labels = ids;


### PR DESCRIPTION
- Automatically fill in labels with IDs if labels are blank
- Fix a possible null axis check

Tested with https://github.com/deephaven/deephaven-core/pull/2678
Was able to open and interact with Treemaps correctly