### PR TITLE
Fix broken advanced filter creator

### DIFF
--- a/packages/iris-grid/src/AdvancedFilterCreator.tsx
+++ b/packages/iris-grid/src/AdvancedFilterCreator.tsx
@@ -125,6 +125,7 @@ class AdvancedFilterCreator extends PureComponent<
     const { options } = props;
     let { filterOperators, invertSelection, selectedValues } = options;
 
+    // can be null or an empty array
     const filterItems: AdvancedFilterItem[] = options.filterItems?.map(
       ({ selectedType, value }) => ({
         selectedType,
@@ -132,6 +133,9 @@ class AdvancedFilterCreator extends PureComponent<
         key: shortid(),
       })
     ) ?? [AdvancedFilterCreator.makeFilterItem()];
+    if (filterItems.length === 0) {
+      filterItems.push(AdvancedFilterCreator.makeFilterItem());
+    }
     if (filterOperators == null) {
       filterOperators = [];
     }

--- a/packages/iris-grid/src/AdvancedFilterCreator.tsx
+++ b/packages/iris-grid/src/AdvancedFilterCreator.tsx
@@ -45,7 +45,7 @@ interface AdvancedFilterCreatorProps {
   column: Column;
   onFilterChange: (
     column: Column,
-    filter: FilterCondition,
+    filter: FilterCondition | null,
     options: AdvancedFilterOptions
   ) => void;
   onSortChange: (
@@ -121,19 +121,17 @@ class AdvancedFilterCreator extends PureComponent<
     this.handleUpdateTimeout = this.handleUpdateTimeout.bind(this);
 
     this.focusTrapContainer = React.createRef();
-    this.filterKey = 0;
 
     const { options } = props;
     let { filterOperators, invertSelection, selectedValues } = options;
 
-    let filterItems: AdvancedFilterItem[] = options.filterItems.map(
-      ({ selectedType, value }) => ({
+    let filterItems: AdvancedFilterItem[] =
+      options.filterItems?.map(({ selectedType, value }) => ({
         selectedType,
         value,
         key: shortid(),
-      })
-    );
-    if (filterItems == null) {
+      })) ?? [];
+    if (filterItems.length === 0) {
       filterItems = [AdvancedFilterCreator.makeFilterItem()];
     }
     if (filterOperators == null) {
@@ -179,8 +177,6 @@ class AdvancedFilterCreator extends PureComponent<
   focusTrapContainer: React.RefObject<HTMLFormElement>;
 
   debounceTimeout?: ReturnType<typeof setTimeout>;
-
-  filterKey: number;
 
   valuesTablePromise?: CancelablePromise<Table>;
 
@@ -592,19 +588,17 @@ class AdvancedFilterCreator extends PureComponent<
           {isValuesTableAvailable && !valuesTableError && (
             <>
               {!isBoolean && <hr />}
-              {valuesTable && (
-                <div className="form-group">
-                  <AdvancedFilterCreatorSelectValue<unknown>
-                    table={valuesTable}
-                    onChange={this.handleSelectValueChange}
-                    invertSelection={invertSelection}
-                    selectedValues={selectedValues}
-                    formatter={formatter}
-                    showSearch={!isDateType}
-                    timeZone={formatter.timeZone}
-                  />
-                </div>
-              )}
+              <div className="form-group">
+                <AdvancedFilterCreatorSelectValue<unknown>
+                  table={valuesTable}
+                  onChange={this.handleSelectValueChange}
+                  invertSelection={invertSelection}
+                  selectedValues={selectedValues}
+                  formatter={formatter}
+                  showSearch={!isDateType}
+                  timeZone={formatter.timeZone}
+                />
+              </div>
             </>
           )}
           <div className="form-row justify-content-end">

--- a/packages/iris-grid/src/AdvancedFilterCreator.tsx
+++ b/packages/iris-grid/src/AdvancedFilterCreator.tsx
@@ -126,13 +126,12 @@ class AdvancedFilterCreator extends PureComponent<
     let { filterOperators, invertSelection, selectedValues } = options;
 
     // can be null or an empty array
-    const filterItems: AdvancedFilterItem[] = options.filterItems?.map(
-      ({ selectedType, value }) => ({
+    const filterItems: AdvancedFilterItem[] =
+      options.filterItems?.map(({ selectedType, value }) => ({
         selectedType,
         value,
         key: shortid(),
-      })
-    ) ?? [AdvancedFilterCreator.makeFilterItem()];
+      })) ?? [];
     if (filterItems.length === 0) {
       filterItems.push(AdvancedFilterCreator.makeFilterItem());
     }
@@ -423,11 +422,25 @@ class AdvancedFilterCreator extends PureComponent<
     const { column, onFilterChange, model } = this.props;
     const { formatter } = model;
 
+    const items = filterItems.filter(
+      ({ selectedType, value }) =>
+        selectedType != null && value != null && value !== ''
+    ) as FilterItem[];
+
+    const operators = filterOperators
+      .filter(
+        (operator, i) =>
+          operator != null &&
+          filterItems[i].selectedType != null &&
+          filterItems[i].value != null &&
+          filterItems[i].value !== ''
+      )
+      .slice(0, items.length - 1);
+    // slice last operator, user may have set an operator but not a value
+
     const options = {
-      filterItems: filterItems.filter(
-        ({ selectedType, value }) => selectedType != null && value != null
-      ) as FilterItem[],
-      filterOperators,
+      filterItems: items,
+      filterOperators: operators,
       invertSelection,
       selectedValues,
     };

--- a/packages/iris-grid/src/AdvancedFilterCreator.tsx
+++ b/packages/iris-grid/src/AdvancedFilterCreator.tsx
@@ -125,15 +125,13 @@ class AdvancedFilterCreator extends PureComponent<
     const { options } = props;
     let { filterOperators, invertSelection, selectedValues } = options;
 
-    let filterItems: AdvancedFilterItem[] =
-      options.filterItems?.map(({ selectedType, value }) => ({
+    const filterItems: AdvancedFilterItem[] = options.filterItems?.map(
+      ({ selectedType, value }) => ({
         selectedType,
         value,
         key: shortid(),
-      })) ?? [];
-    if (filterItems.length === 0) {
-      filterItems = [AdvancedFilterCreator.makeFilterItem()];
-    }
+      })
+    ) ?? [AdvancedFilterCreator.makeFilterItem()];
     if (filterOperators == null) {
       filterOperators = [];
     }

--- a/packages/iris-grid/src/AdvancedFilterCreatorFilterItem.tsx
+++ b/packages/iris-grid/src/AdvancedFilterCreatorFilterItem.tsx
@@ -78,21 +78,20 @@ export class AdvancedFilterCreatorFilterItem extends PureComponent<
   }
 
   componentDidUpdate(prevProps: AdvancedFilterCreatorFilterItemProps): void {
-    const {
-      value = '',
-      filterTypes,
-      selectedType = filterTypes[0],
-    } = this.props;
-    if (prevProps.selectedType !== selectedType || prevProps.value !== value) {
-      this.setState({ selectedType, value });
+    const { value, selectedType } = this.props;
+    if (selectedType !== undefined && prevProps.selectedType !== selectedType) {
+      this.setState({ selectedType });
+    }
+    if (value !== undefined && prevProps.value !== value) {
+      this.setState({ value });
     }
   }
 
   typeDropdown: HTMLSelectElement | null;
 
   handleTypeChange(event: React.ChangeEvent<HTMLSelectElement>): void {
-    log.debug2('typeChange');
     const selectedType = event.target.value as FilterTypeValue;
+    log.debug2('typeChange', selectedType);
     this.setState({ selectedType });
 
     const { onChange } = this.props;

--- a/packages/iris-grid/src/AdvancedFilterCreatorSelectValue.tsx
+++ b/packages/iris-grid/src/AdvancedFilterCreatorSelectValue.tsx
@@ -11,7 +11,7 @@ import { ColumnName } from './CommonTypes';
 interface AdvancedFilterCreatorSelectValueProps<T> {
   invertSelection: boolean;
   selectedValues: T[];
-  table: Table;
+  table?: Table;
   formatter: Formatter;
   onChange: (selectedValues: T[], invertSelection: boolean) => void;
   showSearch: boolean;
@@ -34,7 +34,6 @@ class AdvancedFilterCreatorSelectValue<T = unknown> extends PureComponent<
   static searchDebounceTime = 250;
 
   static defaultProps = {
-    table: null,
     invertSelection: true,
     selectedValues: [],
     onChange: (): void => undefined,

--- a/packages/iris-grid/src/AdvancedFilterCreatorSelectValue.tsx
+++ b/packages/iris-grid/src/AdvancedFilterCreatorSelectValue.tsx
@@ -290,16 +290,14 @@ class AdvancedFilterCreatorSelectValue<T = unknown> extends PureComponent<
             />
           )}
         </div>
-        {table && (
-          <AdvancedFilterCreatorSelectValueList
-            table={table}
-            filters={filters}
-            invertSelection={invertSelection}
-            selectedValues={selectedValues}
-            formatter={formatter}
-            onChange={this.handleListChange}
-          />
-        )}
+        <AdvancedFilterCreatorSelectValueList
+          table={table}
+          filters={filters}
+          invertSelection={invertSelection}
+          selectedValues={selectedValues}
+          formatter={formatter}
+          onChange={this.handleListChange}
+        />
         <div className="advanced-filter-creator-select-meta-row">
           <div>
             <button

--- a/packages/iris-grid/src/AdvancedFilterCreatorSelectValueList.tsx
+++ b/packages/iris-grid/src/AdvancedFilterCreatorSelectValueList.tsx
@@ -113,7 +113,7 @@ class AdvancedFilterCreatorSelectValueList<T = unknown> extends PureComponent<
     }
 
     if (prevProps.filters !== filters) {
-      if (table) table.applyFilter(filters);
+      table?.applyFilter(filters);
       this.resetViewport();
     }
   }

--- a/packages/iris-grid/src/AdvancedFilterCreatorSelectValueList.tsx
+++ b/packages/iris-grid/src/AdvancedFilterCreatorSelectValueList.tsx
@@ -210,10 +210,12 @@ class AdvancedFilterCreatorSelectValueList<T = unknown> extends PureComponent<
   }
 
   startListening(table: Table): void {
+    if (!table) return;
     table.addEventListener(dh.Table.EVENT_UPDATED, this.handleTableUpdate);
   }
 
   stopListening(table: Table): void {
+    if (!table) return;
     table.removeEventListener(dh.Table.EVENT_UPDATED, this.handleTableUpdate);
   }
 

--- a/packages/iris-grid/src/AdvancedFilterCreatorSelectValueList.tsx
+++ b/packages/iris-grid/src/AdvancedFilterCreatorSelectValueList.tsx
@@ -14,7 +14,7 @@ const log = Log.module('AdvancedFilterCreatorSelectValueList');
 
 interface AdvancedFilterCreatorSelectValueListProps<T> {
   selectedValues: T[];
-  table: Table;
+  table?: Table;
   filters: FilterCondition[];
   invertSelection: boolean;
   onChange: (selectedValues: T[], invertSelection: boolean) => void;
@@ -37,7 +37,6 @@ class AdvancedFilterCreatorSelectValueList<T = unknown> extends PureComponent<
   AdvancedFilterCreatorSelectValueListState<T>
 > {
   static defaultProps = {
-    table: null,
     invertSelection: true,
     selectedValues: [],
     onChange: (): void => undefined,
@@ -92,7 +91,7 @@ class AdvancedFilterCreatorSelectValueList<T = unknown> extends PureComponent<
 
   componentDidMount(): void {
     const { table } = this.props;
-    this.startListening(table);
+    if (table) this.startListening(table);
   }
 
   componentDidUpdate(
@@ -100,8 +99,8 @@ class AdvancedFilterCreatorSelectValueList<T = unknown> extends PureComponent<
   ): void {
     const { filters, invertSelection, selectedValues, table } = this.props;
     if (prevProps.table !== table) {
-      this.stopListening(prevProps.table);
-      this.startListening(table);
+      if (prevProps.table) this.stopListening(prevProps.table);
+      if (table) this.startListening(table);
       this.resetViewport();
     }
 
@@ -114,14 +113,14 @@ class AdvancedFilterCreatorSelectValueList<T = unknown> extends PureComponent<
     }
 
     if (prevProps.filters !== filters) {
-      table.applyFilter(filters);
+      if (table) table.applyFilter(filters);
       this.resetViewport();
     }
   }
 
   componentWillUnmount(): void {
     const { table } = this.props;
-    this.stopListening(table);
+    if (table) this.stopListening(table);
   }
 
   list: SelectValueList<T> | null;
@@ -168,11 +167,12 @@ class AdvancedFilterCreatorSelectValueList<T = unknown> extends PureComponent<
   }
 
   handleTableUpdate(event: CustomEvent): void {
+    const { table, formatter } = this.props;
+    if (!table) return;
+
     const data = event.detail;
     const { offset } = data;
-
     const items = [];
-    const { table, formatter } = this.props;
     const column = table.columns[0];
     for (let r = 0; r < data.rows.length; r += 1) {
       const row = data.rows[r];
@@ -210,12 +210,10 @@ class AdvancedFilterCreatorSelectValueList<T = unknown> extends PureComponent<
   }
 
   startListening(table: Table): void {
-    if (!table) return;
     table.addEventListener(dh.Table.EVENT_UPDATED, this.handleTableUpdate);
   }
 
   stopListening(table: Table): void {
-    if (!table) return;
     table.removeEventListener(dh.Table.EVENT_UPDATED, this.handleTableUpdate);
   }
 

--- a/packages/iris-grid/src/IrisGrid.tsx
+++ b/packages/iris-grid/src/IrisGrid.tsx
@@ -1400,7 +1400,7 @@ export class IrisGrid extends Component<IrisGridProps, IrisGridState> {
 
   setAdvancedFilter(
     modelIndex: ModelIndex,
-    filter: FilterCondition,
+    filter: FilterCondition | null,
     options: AdvancedFilterOptions
   ): void {
     log.debug('Setting advanced filter', modelIndex, filter);
@@ -2438,7 +2438,7 @@ export class IrisGrid extends Component<IrisGridProps, IrisGridState> {
 
   handleAdvancedFilterChange(
     column: Column,
-    filter: FilterCondition,
+    filter: FilterCondition | null,
     options: AdvancedFilterOptions
   ): void {
     const { model } = this.props;

--- a/packages/jsapi-utils/src/TableUtils.ts
+++ b/packages/jsapi-utils/src/TableUtils.ts
@@ -1066,7 +1066,7 @@ export class TableUtils {
     column: Column,
     options: AdvancedFilterOptions,
     timeZone: string
-  ): FilterCondition {
+  ): FilterCondition | null {
     const {
       filterItems,
       filterOperators,
@@ -1133,9 +1133,6 @@ export class TableUtils {
       }
     }
 
-    if (filter === null) {
-      throw new Error('filter is null');
-    }
     return filter;
   }
 


### PR DESCRIPTION
Broke from typescript migration. Fixes #648.

- Allow filterCondition to be null, it is used to clear filters and fix things that break due to that
- Make value list still show if table is not yet set, so that it reserves space rather than pop in.