### PR TITLE
fixed copy cell unformatted not working in Long cells

### DIFF
--- a/packages/components/src/context-actions/ContextActionUtils.ts
+++ b/packages/components/src/context-actions/ContextActionUtils.ts
@@ -116,6 +116,11 @@ class ContextActionUtils {
    * @returns Promise Resolved on success, rejected on failure
    */
   static copyToClipboard(text: string): Promise<void> {
+    const { clipboard } = navigator;
+    if (clipboard === undefined) {
+      ContextActionUtils.copyToClipboardExecCommand(text);
+      return Promise.resolve();
+    }
     return navigator.clipboard.writeText(text).catch(() => {
       ContextActionUtils.copyToClipboardExecCommand(text);
     });


### PR DESCRIPTION
This potentially Fixes #660 
I was not able to reproduce the error, so I cannot verify that this resolved the issue. I tried reproducing using chrome/safari on `localhost:4000`, `localhost:10000/ide`, as well as the demo app on our website.

However, looking at the error stack trace, it seems that navigator.clipboard is returning undefined in some cases, thus when we call the writeText function, the error is thrown. 
I tried added a check for navigator.clipboard === undefined so that it goes straight to the fallback copy function.

