### PR TITLE
Fix broken conditional formatting sidebar

### DIFF
--- a/packages/iris-grid/src/IrisGrid.tsx
+++ b/packages/iris-grid/src/IrisGrid.tsx
@@ -353,7 +353,7 @@ export interface IrisGridState {
 
   conditionalFormats: SidebarFormattingRule[];
   conditionalFormatEditIndex: number | null;
-  conditionalFormatPreview?: SidebarFormattingRule | undefined;
+  conditionalFormatPreview?: SidebarFormattingRule;
 
   // Column user is hovering over for selection
   hoverSelectColumn: GridRangeIndex;

--- a/packages/iris-grid/src/IrisGrid.tsx
+++ b/packages/iris-grid/src/IrisGrid.tsx
@@ -353,7 +353,7 @@ export interface IrisGridState {
 
   conditionalFormats: SidebarFormattingRule[];
   conditionalFormatEditIndex: number | null;
-  conditionalFormatPreview?: SidebarFormattingRule | null;
+  conditionalFormatPreview?: SidebarFormattingRule | undefined;
 
   // Column user is hovering over for selection
   hoverSelectColumn: GridRangeIndex;
@@ -531,6 +531,9 @@ export class IrisGrid extends Component<IrisGridProps, IrisGridState> {
       this
     );
     this.handleConditionalFormatEditorSave = this.handleConditionalFormatEditorSave.bind(
+      this
+    );
+    this.handleConditionalFormatEditorCancel = this.handleConditionalFormatEditorCancel.bind(
       this
     );
     this.handleUpdateCustomColumns = this.handleUpdateCustomColumns.bind(this);
@@ -745,7 +748,7 @@ export class IrisGrid extends Component<IrisGridProps, IrisGridState> {
 
       conditionalFormats,
       conditionalFormatEditIndex: null,
-      conditionalFormatPreview: null,
+      conditionalFormatPreview: undefined,
 
       // Column user is hovering over for selection
       hoverSelectColumn: null,
@@ -3796,7 +3799,6 @@ export class IrisGrid extends Component<IrisGridProps, IrisGridState> {
           );
         case OptionType.CONDITIONAL_FORMATTING_EDIT:
           assertNotNull(model.columns);
-          assertNotNull(conditionalFormatPreview);
           assertNotNull(this.handleConditionalFormatEditorUpdate);
           return (
             <ConditionalFormatEditor
@@ -4001,9 +4003,7 @@ export class IrisGrid extends Component<IrisGridProps, IrisGridState> {
                 formatColumns={this.getCachedPreviewFormatColumns(
                   this.getCachedModelColumns(model, customColumns),
                   conditionalFormats,
-                  conditionalFormatPreview === null
-                    ? undefined
-                    : conditionalFormatPreview,
+                  conditionalFormatPreview,
                   // Disable the preview format when we press Back on the format edit page
                   openOptions[openOptions.length - 1]?.type ===
                     OptionType.CONDITIONAL_FORMATTING_EDIT

--- a/packages/iris-grid/src/sidebar/conditional-formatting/ConditionalFormatEditor.tsx
+++ b/packages/iris-grid/src/sidebar/conditional-formatting/ConditionalFormatEditor.tsx
@@ -24,7 +24,7 @@ export type CancelCallback = () => void;
 
 export interface ConditionalFormatEditorProps {
   columns: ModelColumn[];
-  rule?: FormattingRule;
+  rule?: FormattingRule | undefined;
   onCancel?: CancelCallback;
   onSave?: SaveCallback;
   onUpdate?: UpdateCallback;

--- a/packages/iris-grid/src/sidebar/conditional-formatting/ConditionalFormatEditor.tsx
+++ b/packages/iris-grid/src/sidebar/conditional-formatting/ConditionalFormatEditor.tsx
@@ -24,7 +24,7 @@ export type CancelCallback = () => void;
 
 export interface ConditionalFormatEditorProps {
   columns: ModelColumn[];
-  rule?: FormattingRule | undefined;
+  rule?: FormattingRule;
   onCancel?: CancelCallback;
   onSave?: SaveCallback;
   onUpdate?: UpdateCallback;


### PR DESCRIPTION
Allow rule to be undefined, as that is how an empty rule is initialized. Fixes #676.