### PR TITLE
DH-9164 Fix title overlap on twin Y charts in Enterprise

### DIFF
--- a/packages/chart/src/ChartUtils.js
+++ b/packages/chart/src/ChartUtils.js
@@ -879,7 +879,9 @@ class ChartUtils {
     const isYAxis = axis.type === dh.plot.AxisType.Y;
     const axisSize = isYAxis ? yAxisSize : xAxisSize;
     const layoutAxis = layoutAxisParam;
-    layoutAxis.title.text = axis.label;
+    // Enterprise API returns null for empty axis labels
+    // Passing null title text to Plotly results in incorrect axis position, DH-9164
+    layoutAxis.title.text = axis.label ?? '';
     if (axis.log) {
       layoutAxis.type = 'log';
     }


### PR DESCRIPTION
While investigating DH-9164 I found that DHE API returns `null` for empty axis labels, while DHC returns an empty string.
Passing `null` title text to Plotly results in incorrect axis position on twin Y charts.
We could fix it up on the API side, or just cast `null` titles to an empty string on the client side.