### PR TITLE
Improve copy button alignment in widget panel tooltip

### DIFF
--- a/packages/dashboard-core-plugins/src/panels/WidgetPanelTooltip.jsx
+++ b/packages/dashboard-core-plugins/src/panels/WidgetPanelTooltip.jsx
@@ -15,7 +15,7 @@ const WidgetPanelTooltip = props => {
 
   return (
     <div className="tab-tooltip-container">
-      <div className="row">
+      <div className="row flex-nowrap align-items-start">
         <span className="tab-tooltip-title">
           <b>{widgetType} Name </b>
         </span>


### PR DESCRIPTION
Wrapping was weird for long names, added no-wrap and alignment classes.

Before:
![image](https://user-images.githubusercontent.com/1576283/181641063-0233de4b-a65f-4b9c-8804-a3a2cc114808.png)

After:
![image](https://user-images.githubusercontent.com/1576283/181641090-d6ab0205-4f2e-4b63-bf9e-13d71ee0dbe2.png)
