### PR TITLE
Version Bump v0.13.5

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,5 +2,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "0.13.4"
+  "version": "0.13.5"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -39067,7 +39067,7 @@
     },
     "packages/chart": {
       "name": "@deephaven/chart",
-      "version": "0.13.0",
+      "version": "0.13.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@deephaven/icons": "file:../icons",
@@ -39095,7 +39095,7 @@
     },
     "packages/code-studio": {
       "name": "@deephaven/code-studio",
-      "version": "0.13.4",
+      "version": "0.13.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@deephaven/chart": "file:../chart",
@@ -39156,7 +39156,7 @@
     },
     "packages/components": {
       "name": "@deephaven/components",
-      "version": "0.13.4",
+      "version": "0.13.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@deephaven/icons": "file:../icons",
@@ -39195,7 +39195,7 @@
     },
     "packages/console": {
       "name": "@deephaven/console",
-      "version": "0.13.4",
+      "version": "0.13.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@deephaven/components": "file:../components",
@@ -39229,7 +39229,7 @@
     },
     "packages/dashboard": {
       "name": "@deephaven/dashboard",
-      "version": "0.13.4",
+      "version": "0.13.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@deephaven/components": "file:../components",
@@ -39259,7 +39259,7 @@
     },
     "packages/dashboard-core-plugins": {
       "name": "@deephaven/dashboard-core-plugins",
-      "version": "0.13.4",
+      "version": "0.13.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@deephaven/chart": "file:../chart",
@@ -39304,7 +39304,7 @@
     },
     "packages/embed-grid": {
       "name": "@deephaven/embed-grid",
-      "version": "0.13.4",
+      "version": "0.13.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/core": "^7.16.0",
@@ -39374,7 +39374,7 @@
     },
     "packages/file-explorer": {
       "name": "@deephaven/file-explorer",
-      "version": "0.13.4",
+      "version": "0.13.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@deephaven/components": "file:../components",
@@ -39456,7 +39456,7 @@
     },
     "packages/iris-grid": {
       "name": "@deephaven/iris-grid",
-      "version": "0.13.4",
+      "version": "0.13.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@deephaven/components": "file:../components",

--- a/packages/chart/package.json
+++ b/packages/chart/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/chart",
-  "version": "0.13.0",
+  "version": "0.13.5",
   "description": "Deephaven Chart",
   "author": "Deephaven Data Labs LLC",
   "license": "Apache-2.0",

--- a/packages/code-studio/package.json
+++ b/packages/code-studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/code-studio",
-  "version": "0.13.4",
+  "version": "0.13.5",
   "description": "Deephaven Code Studio",
   "author": "Deephaven Data Labs LLC",
   "license": "Apache-2.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/components",
-  "version": "0.13.4",
+  "version": "0.13.5",
   "description": "Deephaven React component library",
   "author": "Deephaven Data Labs LLC",
   "license": "Apache-2.0",

--- a/packages/console/package.json
+++ b/packages/console/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/console",
-  "version": "0.13.4",
+  "version": "0.13.5",
   "description": "Deephaven Console",
   "author": "Deephaven Data Labs LLC",
   "license": "Apache-2.0",

--- a/packages/dashboard-core-plugins/package.json
+++ b/packages/dashboard-core-plugins/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/dashboard-core-plugins",
-  "version": "0.13.4",
+  "version": "0.13.5",
   "description": "Deephaven Dashboard Core Plugins",
   "author": "Deephaven Data Labs LLC",
   "license": "Apache-2.0",

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/dashboard",
-  "version": "0.13.4",
+  "version": "0.13.5",
   "description": "Deephaven Dashboard",
   "author": "Deephaven Data Labs LLC",
   "license": "Apache-2.0",

--- a/packages/embed-grid/package.json
+++ b/packages/embed-grid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/embed-grid",
-  "version": "0.13.4",
+  "version": "0.13.5",
   "description": "Deephaven Embedded Grid",
   "author": "Deephaven Data Labs LLC",
   "license": "Apache-2.0",

--- a/packages/file-explorer/package.json
+++ b/packages/file-explorer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/file-explorer",
-  "version": "0.13.4",
+  "version": "0.13.5",
   "description": "Deephaven File Explorer React component",
   "author": "Deephaven Data Labs LLC",
   "license": "Apache-2.0",

--- a/packages/iris-grid/package.json
+++ b/packages/iris-grid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/iris-grid",
-  "version": "0.13.4",
+  "version": "0.13.5",
   "description": "Deephaven Iris Grid",
   "author": "Deephaven Data Labs LLC",
   "license": "Apache-2.0",


### PR DESCRIPTION
- DH-9164 Fix title overlap on twin Y charts in Enterprise (#687)
- Version Bump v0.13.5