### PR TITLE
Fix layout utils react config

### DIFF
--- a/packages/dashboard/src/layout/LayoutUtils.ts
+++ b/packages/dashboard/src/layout/LayoutUtils.ts
@@ -35,12 +35,11 @@ export function isReactComponentConfig(
 ): config is ReactComponentConfig {
   const reactConfig = config as ReactComponentConfig;
   // Golden layout sets the type to 'component' and componentName to 'lm-react-component' in `createContentItem`, then changes it back in `toConfig`
-  // Check for both here, since for our purposes we just want the `component` and `props` part of the config
+  // Just check `componentName` instead of checking `component.type`.
   return (
-    reactConfig.type === 'react-component' ||
-    (isComponentConfig(config) &&
-      config.componentName === 'lm-react-component' &&
-      reactConfig.component !== undefined)
+    isComponentConfig(config) &&
+    config.componentName === 'lm-react-component' &&
+    reactConfig.component !== undefined
   );
 }
 

--- a/packages/dashboard/src/layout/LayoutUtils.ts
+++ b/packages/dashboard/src/layout/LayoutUtils.ts
@@ -26,30 +26,26 @@ export type StackItemConfig = ItemConfig & {
   activeItemIndex?: number;
 };
 
-export function isReactComponentConfig(
-  config: ItemConfigType
-): config is ReactComponentConfig {
-  const reactConfig = config as ReactComponentConfig;
-  return (
-    reactConfig.type === 'react-component' &&
-    reactConfig.component !== undefined
-  );
-}
-
 function isComponentConfig(config: ItemConfigType): config is ComponentConfig {
   return (config as ComponentConfig).componentName !== undefined;
 }
 
-function isHTMLElement(element: Element): element is HTMLElement {
-  return (element as HTMLElement).focus !== undefined;
+export function isReactComponentConfig(
+  config: ItemConfigType
+): config is ReactComponentConfig {
+  const reactConfig = config as ReactComponentConfig;
+  // Golden layout sets the type to 'component' and componentName to 'lm-react-component' in `createContentItem`, then changes it back in `toConfig`
+  // Check for both here, since for our purposes we just want the `component` and `props` part of the config
+  return (
+    reactConfig.type === 'react-component' ||
+    (isComponentConfig(config) &&
+      config.componentName === 'lm-react-component' &&
+      reactConfig.component !== undefined)
+  );
 }
 
-function assertReactComponentConfig(
-  config: ItemConfigType
-): asserts config is ReactComponentConfig {
-  if (!isReactComponentConfig(config)) {
-    throw new Error('config is not react component config');
-  }
+function isHTMLElement(element: Element): element is HTMLElement {
+  return (element as HTMLElement).focus !== undefined;
 }
 
 function isStackItemConfig(config: ItemConfigType): config is StackItemConfig {
@@ -776,9 +772,8 @@ class LayoutUtils {
   }): string | null {
     const { glContainer } = panel.props;
     const config = LayoutUtils.getComponentConfigFromContainer(glContainer);
-    if (config) {
-      assertReactComponentConfig(config);
-      return config.component;
+    if (config && isReactComponentConfig(config)) {
+      return config.component ?? null;
     }
     return null;
   }

--- a/packages/iris-grid/src/IrisGridProxyModel.ts
+++ b/packages/iris-grid/src/IrisGridProxyModel.ts
@@ -524,6 +524,14 @@ class IrisGridProxyModel extends IrisGridModel {
     this.setNextModel(modelPromise);
   }
 
+  get table(): Table | TreeTable | undefined {
+    if (isIrisGridTableModelTemplate(this.model)) {
+      return this.model.table;
+    }
+
+    return undefined;
+  }
+
   get totalsConfig(): UITotalsTableConfig | null {
     return this.model.totalsConfig;
   }


### PR DESCRIPTION
- Fix layout assertions for react components. Golden Layout switches the type in createContentItem and toConfig for some reason.
- Allow IrisGridProxyModel to pass through the table. This is necessary for FilterSetManager to work correctly
