### PR TITLE
Fixed Linker throwing an error when clicking empty space with the linker active

### DIFF
--- a/packages/iris-grid/src/mousehandlers/IrisGridColumnSelectMouseHandler.ts
+++ b/packages/iris-grid/src/mousehandlers/IrisGridColumnSelectMouseHandler.ts
@@ -5,7 +5,6 @@ import {
   EventHandlerResult,
 } from '@deephaven/grid';
 import type { Column } from '@deephaven/jsapi-shim';
-import { assertNotNull } from '@deephaven/utils';
 import { IrisGrid } from '../IrisGrid';
 
 /**
@@ -120,8 +119,7 @@ class IrisGridColumnSelectMouseHandler extends GridMouseHandler {
 
     const { column } = gridPoint;
     const tableColumn = this.getTableColumn(column);
-    assertNotNull(tableColumn);
-    if (this.isValidColumn(tableColumn)) {
+    if (tableColumn != null && this.isValidColumn(tableColumn)) {
       this.irisGrid.selectColumn(tableColumn);
     }
 


### PR DESCRIPTION
To reproduce:
1. run this snippet of code:
```
from deephaven import empty_table
t1 = empty_table(100).update_view('Col1 = ii')
t2 = t1.update_view('Col2 = Col1 * Col1').sum_by('Col1')
```

2. select the linker tool and select an exist column
3. now click any where that's not a column

Expected behaviour:
The link does not get set, and waits for selection of a column

Actual behaviour:
Program throws an assertNotNull error


The bug is fixed in this pr