### PR TITLE
Don't check outside of min/max column bounds for groupings

### DIFF
--- a/packages/grid/src/GridRenderer.ts
+++ b/packages/grid/src/GridRenderer.ts
@@ -1657,6 +1657,7 @@ export class GridRenderer {
       let columnIndex = startIndex;
 
       while (columnIndex <= endIndex) {
+        const { columnCount } = metrics;
         const modelColumn = getOrThrow(modelColumns, columnIndex);
         const columnGroupName = model.textForColumnHeader(modelColumn, depth);
         const columnGroupColor = model.colorForColumnHeader(modelColumn, depth);
@@ -1670,8 +1671,9 @@ export class GridRenderer {
           // The group will be drawn as if it were a column with a max width of the bounds width
           let prevColumnIndex = columnIndex - 1;
           while (
-            columnGroupRight - columnGroupLeft < visibleWidth ||
-            columnGroupLeft > minX
+            prevColumnIndex >= 0 &&
+            (columnGroupRight - columnGroupLeft < visibleWidth ||
+              columnGroupLeft > minX)
           ) {
             const prevModelIndex =
               modelColumns.get(prevColumnIndex) ??
@@ -1697,8 +1699,9 @@ export class GridRenderer {
 
           let nextColumnIndex = columnIndex + 1;
           while (
-            columnGroupRight - columnGroupLeft < visibleWidth ||
-            columnGroupRight < maxX
+            nextColumnIndex < columnCount &&
+            (columnGroupRight - columnGroupLeft < visibleWidth ||
+              columnGroupRight < maxX)
           ) {
             const nextModelIndex =
               modelColumns.get(nextColumnIndex) ??


### PR DESCRIPTION
- Was checking column indices < 0 and >= columnCount for groups which is invalid

Tested with this snippet (added `table5` which doesn't have frozen columns):
```
from deephaven import new_table
from deephaven.column import string_col, char_col, int_col

groups = [
    {'name': 'MyShorts', 'children': ['Short', 'Short2', 'Short3']},
    {'name': 'MyInts', 'children': ['Int2', 'Int3'], 'color': 'blue'}
]

groups2 = [
    {'name': 'MegaGroup', 'children': ['MyShorts', 'MyInts', 'Char5']},
    {'name': 'MyShorts', 'children': ['Short', 'Short2', 'Short3']},
    {'name': 'MyInts', 'children': ['Int2', 'Int3'], 'color': 'blue'}
]

groups3 = [
    {'name': 'MegaGroup', 'children': ['MyShorts', 'MyInts', 'Char5']},
    {'name': 'MyShorts', 'children': ['Short', 'Short2', 'Short3']},
    {'name': 'MyInts', 'children': ['Int2', 'Int3'], 'color': 'blue'},
    {'name': 'MoreInts', 'children': ['Int4', 'Int6'], 'color': 'blue'},
    {'name': 'SuperMegaGroup', 'children': ['MegaGroup', 'Char9', 'MoreInts']},
]

table = new_table([
    string_col("Short", ["A" , "B", "C", "D"]),
    char_col("Char", "ABCD"),
    int_col("Int", [123456789, 234567890, 42, 8675309]),
    string_col("Short2", ["A" , "B", "C", "D"]),
    char_col("Char2", "ABCD"),
    int_col("Int2", [123456789, 234567890, 42, 8675309]),
    string_col("Short3", ["A" , "B", "C", "D"]),
    char_col("Char3", "ABCD"),
    int_col("Int3", [123456789, 234567890, 42, 8675309]),
    string_col("Short4", ["A" , "B", "C", "D"]),
    char_col("Char4", "ABCD"),
    int_col("Int4", [123456789, 234567890, 42, 8675309]),
    string_col("Short5", ["A" , "B", "C", "D"]),
    char_col("Char5", "ABCD"),
    int_col("Int5", [123456789, 234567890, 42, 8675309]),
    string_col("Short6", ["A" , "B", "C", "D"]),
    char_col("Char6", "ABCD"),
    int_col("Int6", [123456789, 234567890, 42, 8675309]),
    string_col("Short7", ["A" , "B", "C", "D"]),
    char_col("Char7", "ABCD"),
    int_col("Int7", [123456789, 234567890, 42, 8675309]),
    string_col("Short8", ["A" , "B", "C", "D"]),
    char_col("Char8", "ABCD"),
    int_col("Int8", [123456789, 234567890, 42, 8675309]),
    string_col("Short9", ["A" , "B", "C", "D"]),
    char_col("Char9", "ABCD"),
    int_col("Int9", [123456789, 234567890, 42, 8675309]),
    string_col("Short10", ["A" , "B", "C", "D"]),
    char_col("Char10", "ABCD"),
    int_col("Int10", [123456789, 234567890, 42, 8675309]),
    string_col("Short11", ["A" , "B", "C", "D"]),
    char_col("Char11", "ABCD"),
    int_col("Int11", [123456789, 234567890, 42, 8675309]),
    string_col("Short12", ["A" , "B", "C", "D"]),
    char_col("Char12", "ABCD"),
    int_col("Int12", [123456789, 234567890, 42, 8675309]),
])

table2 = table.layout_hints(freeze=["Char", "Int"], column_groups=groups)
table3 = table2.layout_hints(freeze=["Char", "Int"], column_groups=groups2)
table4 = table3.layout_hints(freeze=["Char", "Int"], column_groups=groups3)
table5 = table.layout_hints(column_groups=groups)
```

NOTE: I was checking where calls were returning undefined when calling `textForColumnHeader` to hit a debugger if it gets asked for an invalid column:
```
  textForColumnHeader(x: ModelIndex, depth = 0): string | undefined {
    const column = this.columnAtDepth(x, depth);
    if (column == null) {
      debugger;
      return undefined;
    }
    return column.name ?? undefined;
  }
```