### PR TITLE
Version Bump v0.15.4

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,5 +2,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "0.15.3"
+  "version": "0.15.4"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -39133,7 +39133,7 @@
     },
     "packages/code-studio": {
       "name": "@deephaven/code-studio",
-      "version": "0.15.3",
+      "version": "0.15.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@deephaven/chart": "file:../chart",
@@ -39300,7 +39300,7 @@
     },
     "packages/dashboard-core-plugins": {
       "name": "@deephaven/dashboard-core-plugins",
-      "version": "0.15.3",
+      "version": "0.15.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@deephaven/chart": "file:../chart",
@@ -39358,7 +39358,7 @@
     },
     "packages/embed-grid": {
       "name": "@deephaven/embed-grid",
-      "version": "0.15.3",
+      "version": "0.15.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/core": "^7.16.0",
@@ -39529,7 +39529,7 @@
     },
     "packages/iris-grid": {
       "name": "@deephaven/iris-grid",
-      "version": "0.15.3",
+      "version": "0.15.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@deephaven/components": "file:../components",

--- a/packages/code-studio/package.json
+++ b/packages/code-studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/code-studio",
-  "version": "0.15.3",
+  "version": "0.15.4",
   "description": "Deephaven Code Studio",
   "author": "Deephaven Data Labs LLC",
   "license": "Apache-2.0",

--- a/packages/dashboard-core-plugins/package.json
+++ b/packages/dashboard-core-plugins/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/dashboard-core-plugins",
-  "version": "0.15.3",
+  "version": "0.15.4",
   "description": "Deephaven Dashboard Core Plugins",
   "author": "Deephaven Data Labs LLC",
   "license": "Apache-2.0",

--- a/packages/embed-grid/package.json
+++ b/packages/embed-grid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/embed-grid",
-  "version": "0.15.3",
+  "version": "0.15.4",
   "description": "Deephaven Embedded Grid",
   "author": "Deephaven Data Labs LLC",
   "license": "Apache-2.0",

--- a/packages/iris-grid/package.json
+++ b/packages/iris-grid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/iris-grid",
-  "version": "0.15.3",
+  "version": "0.15.4",
   "description": "Deephaven Iris Grid",
   "author": "Deephaven Data Labs LLC",
   "license": "Apache-2.0",


### PR DESCRIPTION

## v0.15.4 (2022-08-03)

#### :bug: Bug Fix
* `iris-grid`
  * [#704](https://github.com/deephaven/web-client-ui/pull/704) Fixed Linker throwing an error when clicking empty space with the linker active ([@SparkyFnay](https://github.com/SparkyFnay))

#### Committers: 1
- Tony Zhou ([@SparkyFnay](https://github.com/SparkyFnay))
