### PR TITLE
Provide the `outsidetextfont` for treemap charts

### DIFF
--- a/packages/chart/src/ChartUtils.js
+++ b/packages/chart/src/ChartUtils.js
@@ -546,6 +546,7 @@ class ChartUtils {
         pad: 0,
       };
       seriesData.textposition = 'middle center';
+      seriesData.outsidetextfont = { color: theme.title_color };
     }
 
     if (lineColor != null) {


### PR DESCRIPTION
Fixes #708

Tested following the steps in the description.

![image](https://user-images.githubusercontent.com/4505624/182935778-088ca432-e466-4e03-8b63-95ac3d0def23.png)
