### PR TITLE
Only collect code coverage in CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ We are still using node 16.x and npm 8.x. If you are [using nvm](https://github.
 
   Note that log messages from other sources such as react prop types will still be printed since they do not go through our logger.
 
+  If you want to collect coverage locally, run `npm test -- --coverage`
+
 - `npm run build`: Create a production build of all packages. Mainly used by CI when packaging up a production version of the app.
 
 ## Package Overview

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -10,6 +10,6 @@ module.exports = {
     'jest-watch-typeahead/testname',
     'jest-watch-select-projects',
   ],
-  collectCoverage: true,
+  collectCoverage: process.env.CI === 'true',
   collectCoverageFrom: ['./src/**/*.{js,ts,jsx,tsx}'], // This is relative to individual project root due to how Jest handles it
 };


### PR DESCRIPTION
Fixes #662 

`npm run test` locally will not collect coverage now. This is nicer because when you start the tests and then want to quit early to run a specific test, Jest does not calculate coverage for files

CI will still collect coverage as normal