### PR TITLE
Plotly API integration

### DIFF
--- a/packages/chart/src/Chart.jsx
+++ b/packages/chart/src/Chart.jsx
@@ -74,6 +74,7 @@ export class Chart extends Component {
     this.state = {
       data: null,
       downsamplingError: null,
+      frames: undefined,
       isDownsampleFinished: false,
       isDownsampleInProgress: false,
       isDownsamplingDisabled: false,
@@ -188,6 +189,7 @@ export class Chart extends Component {
         ...layout,
         ...model.getLayout(),
       },
+      frames: model.getFrames(),
     });
   }
 
@@ -260,8 +262,10 @@ export class Chart extends Component {
       }
       case ChartModel.EVENT_LOADFINISHED: {
         const { onUpdate } = this.props;
-        this.isLoadedFired = true;
-        onUpdate({ isLoading: false });
+        if (!this.isLoadedFired) {
+          this.isLoadedFired = true;
+          onUpdate({ isLoading: false });
+        }
         break;
       }
       case ChartModel.EVENT_DISCONNECT: {
@@ -442,6 +446,7 @@ export class Chart extends Component {
     const {
       data,
       downsamplingError,
+      frames,
       isDownsampleFinished,
       isDownsampleInProgress,
       isDownsamplingDisabled,
@@ -462,6 +467,7 @@ export class Chart extends Component {
             ref={this.plot}
             data={data}
             layout={layout}
+            frames={frames}
             revision={revision}
             config={config}
             onAfterPlot={this.handleAfterPlot}

--- a/packages/chart/src/ChartModel.js
+++ b/packages/chart/src/ChartModel.js
@@ -42,6 +42,10 @@ class ChartModel {
     return {};
   }
 
+  getFrames() {
+    return undefined;
+  }
+
   getFilterColumnMap() {
     return new Map();
   }

--- a/packages/chart/src/ChartTheme.js
+++ b/packages/chart/src/ChartTheme.js
@@ -1,4 +1,5 @@
 import ChartTheme from './ChartTheme.module.scss';
+import ChartUtils from './ChartUtils';
 
 export default Object.freeze({
   paper_bgcolor: ChartTheme['paper-bgcolor'],

--- a/packages/chart/src/PlotlyChartModel.js
+++ b/packages/chart/src/PlotlyChartModel.js
@@ -1,0 +1,53 @@
+/* eslint class-methods-use-this: "off" */
+/* eslint no-unused-vars: "off" */
+
+import Log from '@deephaven/log';
+import ChartModel from './ChartModel';
+
+const log = Log.module('PlotlyChartModel');
+
+/**
+ * Model for a Plotly Chart
+ * All of these methods should return very quickly.
+ * If data needs to be loaded asynchronously, return something immediately, then trigger an event for the chart to refresh.
+ */
+class PlotlyChartModel extends ChartModel {
+  /**
+   * @param {Object} settings Chart settings
+   * @param {Object} settings.data Plotly chart data
+   * @param {Object} settings.layout Plotly chart layout
+   * @param {Object} settings.frames Plotly chart frames
+   */
+  constructor({ data, layout, frames }) {
+    super();
+
+    this.data = data;
+    this.frames = frames;
+    this.layout = layout;
+
+    // Fixed size charts not supported
+    ['width', 'height'].forEach(prop => {
+      delete this.layout[prop];
+    });
+    this.layout.autosize = true;
+  }
+
+  getData() {
+    return this.data;
+  }
+
+  getLayout() {
+    return this.layout;
+  }
+
+  getFrames() {
+    return this.frames;
+  }
+
+  subscribe(...args) {
+    super.subscribe(...args);
+    this.fireLoadFinished();
+  }
+}
+
+export default PlotlyChartModel;

--- a/packages/chart/src/index.ts
+++ b/packages/chart/src/index.ts
@@ -5,3 +5,4 @@ export { default as ChartUtils } from './ChartUtils';
 export { default as FigureChartModel } from './FigureChartModel';
 export { default as MockChartModel } from './MockChartModel';
 export { default as Plot } from './plotly/Plot';
+export { default as PlotlyChartModel } from './PlotlyChartModel';

--- a/packages/chart/src/plotly/Plotly.js
+++ b/packages/chart/src/plotly/Plotly.js
@@ -1,15 +1,3 @@
-/* eslint-disable global-require */
-// Create a partial plot with only the kinds of charts we need
-// https://github.com/plotly/plotly.js/#modules
-
-import Plotly from 'plotly.js/lib/core.js';
-import bar from 'plotly.js/lib/bar.js';
-import histogram from 'plotly.js/lib/histogram.js';
-import pie from 'plotly.js/lib/pie.js';
-import ohlc from 'plotly.js/lib/ohlc.js';
-import scattergl from 'plotly.js/lib/scattergl.js';
-
-// Load in the trace types we need/support
-Plotly.register([bar, histogram, pie, ohlc, scattergl]);
+import Plotly from 'plotly.js';
 
 export default Plotly;

--- a/packages/code-studio/src/main/AppMainContainer.jsx
+++ b/packages/code-studio/src/main/AppMainContainer.jsx
@@ -32,6 +32,7 @@ import {
   NotebookEvent,
   MarkdownPlugin,
   PandasPlugin,
+  PlotlyChartPlugin,
   getDashboardSessionWrapper,
   UIPropTypes,
   ControlType,
@@ -556,6 +557,15 @@ export class AppMainContainer extends Component {
     };
   }
 
+  // eslint-disable-next-line class-methods-use-this
+  hydratePlotlyChart(props, id) {
+    return {
+      ...props,
+      localDashboardId: id,
+      makeModel: () => Promise.reject(new Error('Chart data not available')),
+    };
+  }
+
   /**
    * Open a widget up, using a drag event if specified.
    * @param {VariableDefinition} widget The widget to open
@@ -685,6 +695,7 @@ export class AppMainContainer extends Component {
           <ConsolePlugin hydrateConsole={AppMainContainer.hydrateConsole} />
           <FilterPlugin />
           <PandasPlugin />
+          <PlotlyChartPlugin hydrate={this.hydratePlotlyChart} />
           <MarkdownPlugin />
           <LinkerPlugin />
           {dashboardPlugins}

--- a/packages/dashboard-core-plugins/src/PlotlyChartPlugin.tsx
+++ b/packages/dashboard-core-plugins/src/PlotlyChartPlugin.tsx
@@ -1,0 +1,104 @@
+import React, { useCallback, useEffect } from 'react';
+import { PlotlyChartModel } from '@deephaven/chart';
+import {
+  assertIsDashboardPluginProps,
+  DashboardPluginComponentProps,
+  LayoutUtils,
+  PanelEvent,
+  PanelHydrateFunction,
+  useListener,
+} from '@deephaven/dashboard';
+import Log from '@deephaven/log';
+import { Figure, VariableDefinition } from '@deephaven/jsapi-shim';
+import shortid from 'shortid';
+import { ChartPanel } from './panels';
+
+const log = Log.module('PlotlyChartPlugin');
+
+const PANEL_COMPONENT = 'PlotlyChartPanel';
+
+const PLOTLY_WIDGET_TYPE = 'plotly.figure';
+
+export type JsWidget = {
+  type: string;
+  getDataAsBase64: () => string;
+};
+
+export type PlotlyChartPluginProps = Partial<DashboardPluginComponentProps> & {
+  hydrate: PanelHydrateFunction;
+};
+
+export const PlotlyChartPlugin = (
+  props: PlotlyChartPluginProps
+): JSX.Element => {
+  assertIsDashboardPluginProps(props);
+  const { id, layout, registerComponent, hydrate } = props;
+  const handlePanelOpen = useCallback(
+    ({
+      dragEvent,
+      fetch,
+      panelId = shortid.generate(),
+      widget,
+    }: {
+      dragEvent?: DragEvent;
+      fetch: () => Promise<Figure>;
+      panelId?: string;
+      widget: VariableDefinition;
+    }) => {
+      const { name, type } = widget;
+
+      if ((type as string) !== PLOTLY_WIDGET_TYPE) {
+        return;
+      }
+
+      const makeModel = async () => {
+        const resolved = ((await fetch()) as unknown) as JsWidget;
+        const dataBase64 = resolved.getDataAsBase64();
+        try {
+          const json = JSON.parse(atob(dataBase64));
+          return new PlotlyChartModel(json);
+        } catch (e) {
+          log.error(e);
+          throw new Error('Unable to parse plot JSON');
+        }
+      };
+
+      const metadata = { name, figure: name };
+
+      const config = {
+        type: 'react-component',
+        component: PANEL_COMPONENT,
+        props: {
+          localDashboardId: id,
+          id: panelId,
+          metadata,
+          makeModel,
+        },
+        title: name,
+        id: panelId,
+      };
+
+      const { root } = layout;
+      LayoutUtils.openComponent({ root, config, dragEvent });
+    },
+    [id, layout]
+  );
+
+  useEffect(
+    function registerComponentsAndReturnCleanup() {
+      const cleanups = [
+        registerComponent(PANEL_COMPONENT, ChartPanel, hydrate),
+      ];
+      return () => {
+        cleanups.forEach(cleanup => cleanup());
+      };
+    },
+    [hydrate, registerComponent]
+  );
+
+  useListener(layout.eventHub, PanelEvent.OPEN, handlePanelOpen);
+
+  return <></>;
+};
+
+export default PlotlyChartPlugin;

--- a/packages/dashboard-core-plugins/src/index.test.tsx
+++ b/packages/dashboard-core-plugins/src/index.test.tsx
@@ -11,6 +11,7 @@ import {
   LinkerPlugin,
   MarkdownPlugin,
   PandasPlugin,
+  PlotlyChartPlugin,
 } from '.';
 
 it('handles mounting and unmount core plugins properly', () => {
@@ -21,6 +22,7 @@ it('handles mounting and unmount core plugins properly', () => {
         <FilterPlugin />
         <GridPlugin hydrate={() => undefined} />
         <ChartPlugin hydrate={() => undefined} />
+        <PlotlyChartPlugin hydrate={() => undefined} />
         <ConsolePlugin />
         <LinkerPlugin />
         <MarkdownPlugin />

--- a/packages/dashboard-core-plugins/src/index.ts
+++ b/packages/dashboard-core-plugins/src/index.ts
@@ -6,6 +6,7 @@ export { default as GridPlugin } from './GridPlugin';
 export { default as LinkerPlugin } from './LinkerPlugin';
 export { default as MarkdownPlugin } from './MarkdownPlugin';
 export { default as PandasPlugin } from './PandasPlugin';
+export { default as PlotlyChartPlugin } from './PlotlyChartPlugin';
 export { default as ControlType } from './controls/ControlType';
 export { default as LinkerUtils } from './linker/LinkerUtils';
 export type { Link } from './linker/LinkerUtils';


### PR DESCRIPTION
Set up DH as a Python module, install plotly, run test snippets.

`p = Node(json.loads(fig.to_json()))` is a temporary hack, eventually it should be something like `p = Plotly(fig)`

### Setup: import dataset
```
import deephaven.plugin.json.Node
import json
import plotly.express as px
gapminder_df = px.data.gapminder().query("year == 2007")
gapminder_df["world"] = "World"
```

### Treemap
```
fig = px.treemap(gapminder_df, 
                 path=['world','continent', 'country'], 
                 values='pop',
                 color='lifeExp', 
                 color_continuous_scale='RdBu')
p = Node(json.loads(fig.to_json()))
```

### Sunburst
```
figSunburst = px.sunburst(gapminder_df, 
    path=['continent', 'country'], 
    values='pop',
    color='lifeExp', 
    color_continuous_scale='RdBu')
pSunburst = Node(json.loads(figSunburst.to_json()))
```

### Histogram
```
figHist = px.histogram(tips_df, 
    x="total_bill", 
    color="sex", 
    marginal="rug", 
    hover_data=tips_df.columns)
pHist = Node(json.loads(figHist.to_json()))
```

### 3D Surface
```
import numpy as np
import plotly.graph_objects as go
x = np.outer(np.linspace(-2, 2, 30), np.ones(30))
y = x.copy().T
z = np.cos(x ** 2 + y ** 2)
  
figSurface = go.Figure(data=[go.Surface(x=x, y=y, z=z)])
pSurface = Node(json.loads(figSurface.to_json()))
```

### Plot data from a DH table
```
import plotly.graph_objects as go
from deephaven import empty_table, numpy
tDH = empty_table(200).update(formulas=["X = (double)i", "Y = Math.sin(X)"])
dataDH = numpy.to_numpy(tDH, ['X', 'Y'])
figDH = go.Figure(data=go.Scatter(x=dataDH[:,0], y=dataDH[:,1]))
pDH = Node(json.loads(figDH.to_json()))
```