### PR TITLE
Fix null in new notebook panels

### DIFF
--- a/packages/dashboard-core-plugins/src/panels/NotebookPanel.tsx
+++ b/packages/dashboard-core-plugins/src/panels/NotebookPanel.tsx
@@ -972,12 +972,11 @@ class NotebookPanel extends Component<NotebookPanelProps, NotebookPanelState> {
       },
     ];
 
-    const portal = tab.element.find('.lm_title_before').get(0);
-    assertNotNull(portal);
+    const portal = tab?.element.find('.lm_title_before').get(0);
 
     return (
       <>
-        {tab &&
+        {portal &&
           ReactDOM.createPortal(
             <span
               className={classNames('editor-unsaved-indicator', {


### PR DESCRIPTION
- tab can be null immediately after panel creation, so make it optional
- check that portal isn't null when rendering, instead of asserting that it's not null
