### PR TITLE
Fix broken contextmenu handler again.

### DIFF
--- a/packages/dashboard-core-plugins/src/panels/IrisGridPanel.tsx
+++ b/packages/dashboard-core-plugins/src/panels/IrisGridPanel.tsx
@@ -594,7 +594,7 @@ export class IrisGridPanel extends PureComponent<
     modelRow: GridRangeIndex;
     modelColumn: GridRangeIndex;
   }): ContextAction {
-    return this.pluginRef.current.getMenu?.({ data: obj }) ?? [];
+    return this.pluginRef.current?.getMenu?.({ data: obj }) ?? [];
   }
 
   isColumnSelectionValid(tableColumn: Column | null): boolean {

--- a/packages/iris-grid/src/format-context-menus/DateTimeFormatContextMenu.ts
+++ b/packages/iris-grid/src/format-context-menus/DateTimeFormatContextMenu.ts
@@ -23,7 +23,7 @@ class DateTimeFormatContextMenu {
    */
   static getOptions(
     formatter: Formatter,
-    selectedFormat: TableColumnFormat
+    selectedFormat: TableColumnFormat | null
   ): FormatContextMenuOption[] {
     const currentTime = new Date();
     const formatItems = [

--- a/packages/iris-grid/src/format-context-menus/FormatContextMenuUtils.tsx
+++ b/packages/iris-grid/src/format-context-menus/FormatContextMenuUtils.tsx
@@ -22,7 +22,7 @@ class FormatContextMenuUtils {
    * Returns true if default option should be active in the context menu
    * @param selectedFormat selected format object or null
    */
-  static isDefaultSelected(selectedFormat: TableColumnFormat): boolean {
+  static isDefaultSelected(selectedFormat: TableColumnFormat | null): boolean {
     return (
       !selectedFormat ||
       ![

--- a/packages/iris-grid/src/mousehandlers/IrisGridContextMenuHandler.tsx
+++ b/packages/iris-grid/src/mousehandlers/IrisGridContextMenuHandler.tsx
@@ -724,7 +724,7 @@ class IrisGridContextMenuHandler extends GridMouseHandler {
     const { model } = this.irisGrid.props;
     const { formatter } = model;
     const selectedFormat = formatter.getColumnFormat(column.type, column.name);
-    assertNotNull(selectedFormat);
+
     const formatOptions = DateTimeFormatContextMenu.getOptions(
       formatter,
       selectedFormat

--- a/packages/jsapi-utils/src/formatters/DateTimeColumnFormatter.ts
+++ b/packages/jsapi-utils/src/formatters/DateTimeColumnFormatter.ts
@@ -57,13 +57,13 @@ export class DateTimeColumnFormatter extends TableColumnFormatter<
    * @returns True if the formats match
    */
   static isSameFormat(
-    formatA?: TableColumnFormat,
-    formatB?: TableColumnFormat
+    formatA: TableColumnFormat | null,
+    formatB: TableColumnFormat | null
   ): boolean {
     return (
       formatA === formatB ||
-      (formatA != null &&
-        formatB != null &&
+      (formatA !== null &&
+        formatB !== null &&
         formatA.type === formatB.type &&
         formatA.formatString === formatB.formatString)
     );

--- a/packages/jsapi-utils/src/formatters/DecimalColumnFormatter.ts
+++ b/packages/jsapi-utils/src/formatters/DecimalColumnFormatter.ts
@@ -132,8 +132,8 @@ export class DecimalColumnFormatter extends TableColumnFormatter<number> {
    * @returns True if the formats match
    */
   static isSameFormat(
-    formatA?: DecimalColumnFormat,
-    formatB?: DecimalColumnFormat
+    formatA: DecimalColumnFormat | null,
+    formatB: DecimalColumnFormat | null
   ): boolean {
     return (
       formatA === formatB ||

--- a/packages/jsapi-utils/src/formatters/IntegerColumnFormatter.ts
+++ b/packages/jsapi-utils/src/formatters/IntegerColumnFormatter.ts
@@ -99,8 +99,8 @@ export class IntegerColumnFormatter extends TableColumnFormatter<number> {
    * @returns True if the formats match
    */
   static isSameFormat(
-    formatA?: IntegerColumnFormat,
-    formatB?: IntegerColumnFormat
+    formatA: IntegerColumnFormat | null,
+    formatB: IntegerColumnFormat | null
   ): boolean {
     return (
       formatA === formatB ||

--- a/packages/jsapi-utils/src/formatters/TableColumnFormatter.ts
+++ b/packages/jsapi-utils/src/formatters/TableColumnFormatter.ts
@@ -38,8 +38,8 @@ export class TableColumnFormatter<T = unknown> {
    * @returns True if the formats match
    */
   static isSameFormat(
-    formatA?: TableColumnFormat,
-    formatB?: TableColumnFormat
+    formatA: TableColumnFormat | null,
+    formatB: TableColumnFormat | null
   ): boolean {
     throw new Error('isSameFormat not implemented');
   }


### PR DESCRIPTION
Context menu Broken in PR #693. Handle context menu needs a ? before getMenu. 

Also fixes #647 remove assert not null, getColumnFormat can return null, accept null the jsdoc comments already say null is allowed.