### PR TITLE
Fix missing props in pandas panel by using correct import

### DIFF
--- a/packages/dashboard-core-plugins/src/panels/IrisGridPanel.tsx
+++ b/packages/dashboard-core-plugins/src/panels/IrisGridPanel.tsx
@@ -9,7 +9,11 @@ import React, {
 import memoize from 'memoize-one';
 import { connect } from 'react-redux';
 import debounce from 'lodash.debounce';
-import { LayoutUtils, PanelComponent } from '@deephaven/dashboard';
+import {
+  DEFAULT_DASHBOARD_ID,
+  LayoutUtils,
+  PanelComponent,
+} from '@deephaven/dashboard';
 import {
   AdvancedSettings,
   IrisGrid,
@@ -1313,21 +1317,18 @@ export class IrisGridPanel extends PureComponent<
 
 const mapStateToProps = (
   state: RootState,
-  ownProps: { localDashboardId: string }
-) => {
-  const { localDashboardId } = ownProps;
-  return {
-    inputFilters: getInputFiltersForDashboard(state, localDashboardId),
-    links: getLinksForDashboard(state, localDashboardId),
-    columnSelectionValidator: getColumnSelectionValidatorForDashboard(
-      state,
-      localDashboardId
-    ),
-    user: getUser(state),
-    workspace: getWorkspace(state),
-    settings: getSettings(state),
-  };
-};
+  { localDashboardId = DEFAULT_DASHBOARD_ID }: { localDashboardId?: string }
+) => ({
+  inputFilters: getInputFiltersForDashboard(state, localDashboardId),
+  links: getLinksForDashboard(state, localDashboardId),
+  columnSelectionValidator: getColumnSelectionValidatorForDashboard(
+    state,
+    localDashboardId
+  ),
+  user: getUser(state),
+  workspace: getWorkspace(state),
+  settings: getSettings(state),
+});
 
 export default connect(mapStateToProps, null, null, { forwardRef: true })(
   IrisGridPanel

--- a/packages/dashboard-core-plugins/src/panels/PandasPanel.tsx
+++ b/packages/dashboard-core-plugins/src/panels/PandasPanel.tsx
@@ -4,7 +4,11 @@ import React, { Component, ReactElement, RefObject } from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { dhRefresh } from '@deephaven/icons';
 import { Tooltip } from '@deephaven/components';
-import { IrisGridPanel, IrisGridPanelProps, PanelState } from './IrisGridPanel';
+import ConnectedIrisGridPanel, {
+  IrisGridPanel,
+  IrisGridPanelProps,
+  PanelState,
+} from './IrisGridPanel';
 import './PandasPanel.scss';
 
 export interface PandasPanelProps extends IrisGridPanelProps {
@@ -75,7 +79,7 @@ class PandasPanel extends Component<PandasPanelProps, PandasPanelState> {
     const { ...props } = this.props;
 
     return (
-      <IrisGridPanel
+      <ConnectedIrisGridPanel
         ref={this.irisGridRef}
         onStateChange={this.handleGridStateChange}
         onPanelStateUpdate={this.handlePanelStateUpdate}
@@ -101,7 +105,7 @@ class PandasPanel extends Component<PandasPanelProps, PandasPanelState> {
             automatically.
           </Tooltip>
         </button>
-      </IrisGridPanel>
+      </ConnectedIrisGridPanel>
     );
   }
 }


### PR DESCRIPTION
Fixes error with pandas panel not loading props from store

```
TypeError: Cannot read properties of undefined (reading 'permissions')
IrisGridPanel.render
src/panels/IrisGridPanel.tsx:1207
  1204 | const childrenContent =
  1205 |   children ??
  1206 |   this.getPluginContent(Plugin, model, user, workspace, pluginState);
> 1207 | const { permissions } = user;
       | ^  1208 | const { canCopy, canDownloadCsv } = permissions;
  1209 | const formattedRowCount = model?.displayString(
  1210 |   model?.rowCount ?? 0,
```