### PR TITLE
DH-13043 Filter validation fixes and nulls in Advanced Filters

### DIFF
--- a/packages/iris-grid/src/AdvancedFilterCreator.tsx
+++ b/packages/iris-grid/src/AdvancedFilterCreator.tsx
@@ -484,6 +484,7 @@ class AdvancedFilterCreator extends PureComponent<
             onDelete={this.getFilterDeleteHandler(i)}
             selectedType={selectedType}
             value={value}
+            formatter={formatter}
           />
         );
         filterItemElements.push(element);

--- a/packages/iris-grid/src/AdvancedFilterCreatorFilterItem.scss
+++ b/packages/iris-grid/src/AdvancedFilterCreatorFilterItem.scss
@@ -1,0 +1,10 @@
+@import '../../components/scss/custom.scss';
+
+.advanced-filter-creator-filter-item {
+  input.error {
+    color: $danger;
+    &:focus {
+      box-shadow: inset 0 0 0 2px $danger, $input-focus-box-shadow;
+    }
+  }
+}

--- a/packages/iris-grid/src/AdvancedFilterCreatorFilterItem.tsx
+++ b/packages/iris-grid/src/AdvancedFilterCreatorFilterItem.tsx
@@ -10,18 +10,27 @@ import {
   TypeValue as FilterTypeValue,
 } from '@deephaven/filters';
 import { vsTrash } from '@deephaven/icons';
-import { AdvancedFilterItemType, TableUtils } from '@deephaven/jsapi-utils';
+import { Column } from '@deephaven/jsapi-shim';
+import {
+  AdvancedFilterItemType,
+  Formatter,
+  TableUtils,
+} from '@deephaven/jsapi-utils';
 import Log from '@deephaven/log';
+import classNames from 'classnames';
+import memoizeOne from 'memoize-one';
+import './AdvancedFilterCreatorFilterItem.scss';
 
 const log = Log.module('AdvancedFilterCreatorFilterItem');
 
 export interface AdvancedFilterCreatorFilterItemProps {
-  column: { type: string };
+  column: Column;
   filterTypes: FilterTypeValue[];
   onChange(type: FilterTypeValue, value: string): void;
   onDelete(): void;
   selectedType?: FilterTypeValue;
   value?: string;
+  formatter: Formatter;
 }
 
 export type AdvancedFilterCreatorFilterItemState = AdvancedFilterItemType;
@@ -122,11 +131,41 @@ export class AdvancedFilterCreatorFilterItem extends PureComponent<
     onDelete();
   }
 
+  getCachedIsValid = memoizeOne(
+    (
+      column: Column,
+      operation: FilterTypeValue,
+      value: string,
+      timeZone: string
+    ): boolean => {
+      try {
+        // We don't want to show an error for an empty value
+        return (
+          !value ||
+          TableUtils.makeAdvancedValueFilter(
+            column,
+            operation,
+            value,
+            timeZone
+          ) != null
+        );
+      } catch (e) {
+        return false;
+      }
+    }
+  );
+
   render(): JSX.Element {
-    const { column, filterTypes } = this.props;
+    const { column, filterTypes, formatter } = this.props;
     const { selectedType, value } = this.state;
     const showValueInput = !TableUtils.isBooleanType(column.type);
     const typeOptionElements = [];
+    const isValid = this.getCachedIsValid(
+      column,
+      selectedType,
+      value,
+      formatter.timeZone
+    );
     for (let i = 0; i < filterTypes.length; i += 1) {
       const type = filterTypes[i];
       const label = AdvancedFilterCreatorFilterItem.getLabelForFilter(
@@ -161,7 +200,7 @@ export class AdvancedFilterCreatorFilterItem extends PureComponent<
               <div className="input-group">
                 <input
                   type="text"
-                  className="form-control"
+                  className={classNames('form-control', { error: !isValid })}
                   placeholder="Enter value"
                   value={value}
                   onChange={this.handleValueChange}

--- a/packages/iris-grid/src/IrisGrid.tsx
+++ b/packages/iris-grid/src/IrisGrid.tsx
@@ -1392,17 +1392,10 @@ export class IrisGrid extends Component<IrisGridProps, IrisGridState> {
           return false;
         }
       }
-      const filter = IrisGrid.makeQuickFilter(
-        column,
-        value,
-        formatter.timeZone
-      );
-      if (filter) {
-        quickFilters.set(modelIndex, {
-          text: value,
-          filter,
-        });
-      }
+      quickFilters.set(modelIndex, {
+        text: value,
+        filter: IrisGrid.makeQuickFilter(column, value, formatter.timeZone),
+      });
       return true;
     }
     return quickFilters.delete(modelIndex);

--- a/packages/jsapi-utils/src/TableUtils.test.ts
+++ b/packages/jsapi-utils/src/TableUtils.test.ts
@@ -7,6 +7,7 @@ import dh, {
 import {
   Operator as FilterOperator,
   Type as FilterType,
+  TypeValue as FilterTypeValue,
 } from '@deephaven/filters';
 import TableUtils from './TableUtils';
 import DateUtils from './DateUtils';
@@ -1298,7 +1299,7 @@ describe('quick filter tests', () => {
     }
 
     it('handles default operation', () => {
-      testCharFilter('c', FilterType.eq, 'c');
+      testCharFilter('c', FilterType.eq, '"c"');
     });
 
     it('handles empty cases', () => {
@@ -1324,8 +1325,24 @@ describe('quick filter tests', () => {
       testCharFilter('F', FilterType.eq, 'F');
     });
 
-    it('handles = operation', () => {
+    it('handles shorthand operations', () => {
       testCharFilter('=c', FilterType.eq, 'c');
+      testCharFilter('!=c', FilterType.notEq, 'c');
+      testCharFilter('!c', FilterType.notEq, 'c');
+    });
+
+    it('handles range operations', () => {
+      testCharFilter('>c', FilterType.greaterThan, '"c"');
+      testCharFilter('>=c', FilterType.greaterThanOrEqualTo, '"c"');
+      testCharFilter('=>c', FilterType.greaterThanOrEqualTo, '"c"');
+      testCharFilter('<c', FilterType.lessThan, '"c"');
+      testCharFilter('<=c', FilterType.lessThanOrEqualTo, '"c"');
+      testCharFilter('=<c', FilterType.lessThanOrEqualTo, '"c"');
+    });
+
+    it('handles values that are already quoted', () => {
+      testCharFilter('"c"', FilterType.eq, '"c"');
+      testCharFilter("'c'", FilterType.eq, "'c'");
     });
 
     it('handles null', () => {
@@ -1390,5 +1407,81 @@ describe('makeCancelableTableEventPromise', () => {
     jest.runOnlyPendingTimers();
     cancelablePromise.cancel();
     expect(DEFAULT_TABLE.removeEventListener).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('converts filter type to appropriate string value for quick filters', () => {
+  function testFilterType(filterType: FilterTypeValue, expectedResult: string) {
+    expect(TableUtils.getFilterOperatorString(filterType)).toBe(expectedResult);
+  }
+  function testFilterTypeThrows(filterType: FilterTypeValue) {
+    expect(() => TableUtils.getFilterOperatorString(filterType)).toThrow();
+  }
+  it('handles valid options correctly', () => {
+    testFilterType(FilterType.eq, '=');
+    testFilterType(FilterType.notEq, '!=');
+    testFilterType(FilterType.greaterThan, '>');
+    testFilterType(FilterType.greaterThanOrEqualTo, '>=');
+    testFilterType(FilterType.lessThan, '<');
+    testFilterType(FilterType.lessThanOrEqualTo, '<=');
+    testFilterType(FilterType.contains, '~');
+    testFilterType(FilterType.notContains, '!~');
+  });
+  it('throws for types without a shorthand string', () => {
+    testFilterTypeThrows(FilterType.eqIgnoreCase);
+    testFilterTypeThrows(FilterType.notEqIgnoreCase);
+    testFilterTypeThrows(FilterType.startsWith);
+    testFilterTypeThrows(FilterType.endsWith);
+    testFilterTypeThrows(FilterType.in);
+    testFilterTypeThrows(FilterType.inIgnoreCase);
+    testFilterTypeThrows(FilterType.notIn);
+    testFilterTypeThrows(FilterType.notInIgnoreCase);
+    testFilterTypeThrows(FilterType.isTrue);
+    testFilterTypeThrows(FilterType.isFalse);
+    testFilterTypeThrows(FilterType.isNull);
+    testFilterTypeThrows(FilterType.invoke);
+    testFilterTypeThrows(FilterType.containsAny);
+  });
+});
+
+describe('quote values', () => {
+  function testQuoteValue(value: string, expectedValue: string) {
+    expect(TableUtils.quoteValue(value)).toBe(expectedValue);
+  }
+  it('quotes unquoted values properly', () => {
+    testQuoteValue('', '""');
+    testQuoteValue('c', '"c"');
+    testQuoteValue('hello', '"hello"');
+  });
+  it('does not add quotes if already quoted', () => {
+    testQuoteValue('"c"', '"c"');
+    testQuoteValue("'c'", "'c'");
+    testQuoteValue("''", "''");
+    testQuoteValue('""', '""');
+    testQuoteValue('"hello"', '"hello"');
+  });
+});
+
+describe('range operations', () => {
+  function testIsRangeOperation(operation: string, expectedResult = true) {
+    expect(TableUtils.isRangeOperation(operation)).toBe(expectedResult);
+  }
+
+  it('returns true for range operations', () => {
+    testIsRangeOperation('<');
+    testIsRangeOperation('<=');
+    testIsRangeOperation('=<');
+    testIsRangeOperation('>');
+    testIsRangeOperation('>=');
+    testIsRangeOperation('=>');
+  });
+
+  it('returns false for other operations', () => {
+    testIsRangeOperation('!', false);
+    testIsRangeOperation('!=', false);
+    testIsRangeOperation('=', false);
+    testIsRangeOperation('', false);
+    testIsRangeOperation('!~', false);
+    testIsRangeOperation('~', false);
   });
 });

--- a/packages/jsapi-utils/src/TableUtils.test.ts
+++ b/packages/jsapi-utils/src/TableUtils.test.ts
@@ -1299,7 +1299,7 @@ describe('quick filter tests', () => {
     }
 
     it('handles default operation', () => {
-      testCharFilter('c', FilterType.eq, '"c"');
+      testCharFilter('c', FilterType.eq, 'c');
     });
 
     it('handles empty cases', () => {

--- a/packages/jsapi-utils/src/TableUtils.ts
+++ b/packages/jsapi-utils/src/TableUtils.ts
@@ -922,7 +922,7 @@ export class TableUtils {
   static quoteValue(value: string): string {
     if (
       value.length >= 2 &&
-      ((value.charAt(0) === '"' && value.charAt(value.length - 1)) ||
+      ((value.charAt(0) === '"' && value.charAt(value.length - 1) === '"') ||
         (value.charAt(0) === "'" && value.charAt(value.length - 1) === "'"))
     ) {
       return value;


### PR DESCRIPTION
- Show validation error when error making quick filter (was broken)
- Allow `null` in Advanced Filters, ranged char filters
- Add validation error for advanced filter values

Tested with the null and random values table, testing both quick and advanced filters, valid and invalid values, and range filters on char columns from both quick and advanced filters:
```
from deephaven import empty_table, time_table

simple_ticking = time_table("00:00:01").update([
        "MyString=new String(`a`+i)",
        "MyInt=new Integer(i)",
        "MyLong=new Long(i)",
        "MyDouble=new Double(i+i/10)",
        "MyFloat=new Float(i+i/10)",
        "MyBoolean=new Boolean(i%2==0)",
        "MyChar= new Character((char) ((i%26)+97))",
        "MyShort=new Short(Integer.toString(i%32767))",
        "MyByte= new java.lang.Byte(Integer.toString(i%127))"])

complex_ticking = simple_ticking.update([
        "MyBigDecimal= new java.math.BigDecimal(i+i/10)",
        "MyBigInteger= new java.math.BigInteger(Integer.toString(i))"
])

size = 100
scale = 1000

random_values_with_null_NaN = empty_table(size).update([
    "MyString=(i%11==0? null : `a`+(int)(scale*(Math.random()*2-1)))",
    "MyInt=(i%12==0 ? null : (int)(scale*(Math.random()*2-1)))",
    "MyLong=(i%13==0 ? null : (long)(scale*(Math.random()*2-1)))",
    "MyFloat=(float)(i%14==0 ? null : i%10==0 ? 1.0F/0.0F: i%5==0 ? -1.0F/0.0F : (float) scale*(Math.random()*2-1))",
    "MyDouble=(double)(i%16==0 ? null : i%10==0 ? 1.0D/0.0D: i%5==0 ? -1.0D/0.0D : (double) scale*(Math.random()*2-1))",
    "MyBoolean = (i%17==0 ? null : (int)(10*Math.random())%2==0)",
    "MyChar = (i%18==0 ? null : new Character((char) (((26*Math.random())%26)+97)) )",
    "MyShort=(short)(i%19==0 ? null : (int)(scale*(Math.random()*2-1)))",
    "MyByte=(Byte)(i%19==0 ? null : new Byte( Integer.toString((int)(Byte.MAX_VALUE*(Math.random()*2-1)))))",
    "MyBigDecimal=(i%21==0 ? null : new java.math.BigDecimal(scale*(Math.random()*2-1)))",
    "MyBigInteger=(i%22==0 ? null : new java.math.BigInteger(Integer.toString((int)(scale*(Math.random()*2-1)))))"
])

random_values_source = empty_table(10).update([
    "MyString=(i%11==0? null : `a`+(int)(scale*(Math.random()*2-1)))",
    "MyInt=(i==0 ? null : (int)(scale*(Math.random()*2-1)))",
    "MyLong=(i==0 ? null : (long)(scale*(Math.random()*2-1)))",
    "MyFloat=(float)(i==0 ? null : i%10==0 ? 1.0F/0.0F: i%5==0 ? -1.0F/0.0F : (float) scale*(Math.random()*2-1))",
    "MyDouble=(double)(i==0 ? null : i%10==0 ? 1.0D/0.0D: i%5==0 ? -1.0D/0.0D : (double) scale*(Math.random()*2-1))"
])
```
