### PR TITLE
Version Bump v0.16.0

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,5 +2,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "0.15.6"
+  "version": "0.16.0"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -39121,7 +39121,7 @@
     },
     "packages/babel-preset": {
       "name": "@deephaven/babel-preset",
-      "version": "0.15.0",
+      "version": "0.16.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/core": "^7.16.0",
@@ -39135,7 +39135,7 @@
     },
     "packages/chart": {
       "name": "@deephaven/chart",
-      "version": "0.15.6",
+      "version": "0.16.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@deephaven/icons": "file:../icons",
@@ -39166,7 +39166,7 @@
     },
     "packages/code-studio": {
       "name": "@deephaven/code-studio",
-      "version": "0.15.6",
+      "version": "0.16.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@deephaven/chart": "file:../chart",
@@ -39227,7 +39227,7 @@
     },
     "packages/components": {
       "name": "@deephaven/components",
-      "version": "0.15.6",
+      "version": "0.16.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@deephaven/icons": "file:../icons",
@@ -39266,7 +39266,7 @@
     },
     "packages/console": {
       "name": "@deephaven/console",
-      "version": "0.15.6",
+      "version": "0.16.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@deephaven/chart": "file:../chart",
@@ -39302,7 +39302,7 @@
     },
     "packages/dashboard": {
       "name": "@deephaven/dashboard",
-      "version": "0.15.6",
+      "version": "0.16.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@deephaven/components": "file:../components",
@@ -39334,7 +39334,7 @@
     },
     "packages/dashboard-core-plugins": {
       "name": "@deephaven/dashboard-core-plugins",
-      "version": "0.15.6",
+      "version": "0.16.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@deephaven/chart": "file:../chart",
@@ -39395,7 +39395,7 @@
     },
     "packages/embed-chart": {
       "name": "@deephaven/embed-chart",
-      "version": "0.15.4",
+      "version": "0.16.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@deephaven/chart": "file:../chart",
@@ -39452,7 +39452,7 @@
     },
     "packages/embed-grid": {
       "name": "@deephaven/embed-grid",
-      "version": "0.15.6",
+      "version": "0.16.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/core": "^7.16.0",
@@ -39523,7 +39523,7 @@
     },
     "packages/eslint-config": {
       "name": "@deephaven/eslint-config",
-      "version": "0.15.0",
+      "version": "0.16.0",
       "license": "Apache-2.0",
       "dependencies": {
         "eslint-config-airbnb": "18.2.1",
@@ -39541,7 +39541,7 @@
     },
     "packages/file-explorer": {
       "name": "@deephaven/file-explorer",
-      "version": "0.15.6",
+      "version": "0.16.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@deephaven/components": "file:../components",
@@ -39569,7 +39569,7 @@
     },
     "packages/filters": {
       "name": "@deephaven/filters",
-      "version": "0.15.2",
+      "version": "0.16.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@deephaven/tsconfig": "file:../tsconfig"
@@ -39580,7 +39580,7 @@
     },
     "packages/golden-layout": {
       "name": "@deephaven/golden-layout",
-      "version": "0.15.2",
+      "version": "0.16.0",
       "license": "Apache-2.0",
       "dependencies": {
         "jquery": "^3.6.0"
@@ -39588,7 +39588,7 @@
     },
     "packages/grid": {
       "name": "@deephaven/grid",
-      "version": "0.15.6",
+      "version": "0.16.0",
       "license": "Apache-2.0",
       "dependencies": {
         "classnames": "^2.3.1",
@@ -39611,7 +39611,7 @@
     },
     "packages/icons": {
       "name": "@deephaven/icons",
-      "version": "0.15.0",
+      "version": "0.16.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@fortawesome/fontawesome-common-types": "^6.1.1"
@@ -39623,7 +39623,7 @@
     },
     "packages/iris-grid": {
       "name": "@deephaven/iris-grid",
-      "version": "0.15.6",
+      "version": "0.16.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@deephaven/components": "file:../components",
@@ -39666,7 +39666,7 @@
     },
     "packages/jsapi-shim": {
       "name": "@deephaven/jsapi-shim",
-      "version": "0.15.6",
+      "version": "0.16.0",
       "license": "Apache-2.0",
       "dependencies": {
         "prop-types": "^15.7.2"
@@ -39680,7 +39680,7 @@
     },
     "packages/jsapi-utils": {
       "name": "@deephaven/jsapi-utils",
-      "version": "0.15.6",
+      "version": "0.16.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@deephaven/filters": "file:../filters",
@@ -39697,7 +39697,7 @@
     },
     "packages/log": {
       "name": "@deephaven/log",
-      "version": "0.15.5",
+      "version": "0.16.0",
       "license": "Apache-2.0",
       "dependencies": {
         "event-target-shim": "^6.0.2"
@@ -39711,7 +39711,7 @@
     },
     "packages/mocks": {
       "name": "@deephaven/mocks",
-      "version": "0.15.0",
+      "version": "0.16.0",
       "license": "Apache-2.0",
       "peerDependencies": {
         "jest": "26.x"
@@ -39719,7 +39719,7 @@
     },
     "packages/prettier-config": {
       "name": "@deephaven/prettier-config",
-      "version": "0.15.0",
+      "version": "0.16.0",
       "license": "Apache-2.0",
       "peerDependencies": {
         "prettier": "^2.2.1"
@@ -39727,7 +39727,7 @@
     },
     "packages/react-hooks": {
       "name": "@deephaven/react-hooks",
-      "version": "0.15.2",
+      "version": "0.16.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@deephaven/tsconfig": "file:../tsconfig"
@@ -39741,7 +39741,7 @@
     },
     "packages/redux": {
       "name": "@deephaven/redux",
-      "version": "0.15.6",
+      "version": "0.16.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@deephaven/jsapi-utils": "file:../jsapi-utils",
@@ -39761,7 +39761,7 @@
     },
     "packages/storage": {
       "name": "@deephaven/storage",
-      "version": "0.15.5",
+      "version": "0.16.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@deephaven/filters": "file:../filters",
@@ -39780,7 +39780,7 @@
     },
     "packages/stylelint-config": {
       "name": "@deephaven/stylelint-config",
-      "version": "0.15.0",
+      "version": "0.16.0",
       "license": "Apache-2.0",
       "dependencies": {
         "stylelint-config-prettier-scss": "^0.0.1",
@@ -39792,13 +39792,13 @@
     },
     "packages/tsconfig": {
       "name": "@deephaven/tsconfig",
-      "version": "0.15.2",
+      "version": "0.16.0",
       "license": "Apache-2.0"
     },
     "packages/util": {},
     "packages/utils": {
       "name": "@deephaven/utils",
-      "version": "0.15.6",
+      "version": "0.16.0",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=16"

--- a/packages/babel-preset/package.json
+++ b/packages/babel-preset/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/babel-preset",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "Deephaven Babel preset",
   "repository": {
     "type": "git",

--- a/packages/chart/package.json
+++ b/packages/chart/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/chart",
-  "version": "0.15.6",
+  "version": "0.16.0",
   "description": "Deephaven Chart",
   "author": "Deephaven Data Labs LLC",
   "license": "Apache-2.0",

--- a/packages/code-studio/package.json
+++ b/packages/code-studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/code-studio",
-  "version": "0.15.6",
+  "version": "0.16.0",
   "description": "Deephaven Code Studio",
   "author": "Deephaven Data Labs LLC",
   "license": "Apache-2.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/components",
-  "version": "0.15.6",
+  "version": "0.16.0",
   "description": "Deephaven React component library",
   "author": "Deephaven Data Labs LLC",
   "license": "Apache-2.0",

--- a/packages/console/package.json
+++ b/packages/console/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/console",
-  "version": "0.15.6",
+  "version": "0.16.0",
   "description": "Deephaven Console",
   "author": "Deephaven Data Labs LLC",
   "license": "Apache-2.0",

--- a/packages/dashboard-core-plugins/package.json
+++ b/packages/dashboard-core-plugins/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/dashboard-core-plugins",
-  "version": "0.15.6",
+  "version": "0.16.0",
   "description": "Deephaven Dashboard Core Plugins",
   "author": "Deephaven Data Labs LLC",
   "license": "Apache-2.0",

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/dashboard",
-  "version": "0.15.6",
+  "version": "0.16.0",
   "description": "Deephaven Dashboard",
   "author": "Deephaven Data Labs LLC",
   "license": "Apache-2.0",

--- a/packages/embed-chart/package.json
+++ b/packages/embed-chart/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/embed-chart",
-  "version": "0.15.4",
+  "version": "0.16.0",
   "description": "Deephaven Embedded Chart",
   "author": "Deephaven Data Labs LLC",
   "license": "Apache-2.0",

--- a/packages/embed-grid/package.json
+++ b/packages/embed-grid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/embed-grid",
-  "version": "0.15.6",
+  "version": "0.16.0",
   "description": "Deephaven Embedded Grid",
   "author": "Deephaven Data Labs LLC",
   "license": "Apache-2.0",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/eslint-config",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "Deephaven ESLint configuration",
   "repository": {
     "type": "git",

--- a/packages/file-explorer/package.json
+++ b/packages/file-explorer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/file-explorer",
-  "version": "0.15.6",
+  "version": "0.16.0",
   "description": "Deephaven File Explorer React component",
   "author": "Deephaven Data Labs LLC",
   "license": "Apache-2.0",

--- a/packages/filters/package.json
+++ b/packages/filters/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/filters",
-  "version": "0.15.2",
+  "version": "0.16.0",
   "description": "Deephaven Filters",
   "author": "Deephaven Data Labs LLC",
   "license": "Apache-2.0",

--- a/packages/golden-layout/package.json
+++ b/packages/golden-layout/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/golden-layout",
-  "version": "0.15.2",
+  "version": "0.16.0",
   "author": "Deephaven Data Labs LLC",
   "license": "Apache-2.0",
   "description": "A multi-screen javascript Layout manager",

--- a/packages/grid/package.json
+++ b/packages/grid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/grid",
-  "version": "0.15.6",
+  "version": "0.16.0",
   "description": "Deephaven React grid component",
   "author": "Deephaven Data Labs LLC",
   "license": "Apache-2.0",

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/icons",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "Icons used in Deephaven client apps. Extends vscode-codicons to be font-awesome svg-core compatible and adds additional icons in a similar style.",
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/packages/iris-grid/package.json
+++ b/packages/iris-grid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/iris-grid",
-  "version": "0.15.6",
+  "version": "0.16.0",
   "description": "Deephaven Iris Grid",
   "author": "Deephaven Data Labs LLC",
   "license": "Apache-2.0",

--- a/packages/jsapi-shim/package.json
+++ b/packages/jsapi-shim/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/jsapi-shim",
-  "version": "0.15.6",
+  "version": "0.16.0",
   "description": "Deephaven JSAPI Shim",
   "author": "Deephaven Data Labs LLC",
   "license": "Apache-2.0",

--- a/packages/jsapi-utils/package.json
+++ b/packages/jsapi-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/jsapi-utils",
-  "version": "0.15.6",
+  "version": "0.16.0",
   "description": "Deephaven JSAPI Utils",
   "author": "Deephaven Data Labs LLC",
   "license": "Apache-2.0",

--- a/packages/log/package.json
+++ b/packages/log/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/log",
-  "version": "0.15.5",
+  "version": "0.16.0",
   "description": "Deephaven Logger",
   "author": "Deephaven Data Labs LLC",
   "license": "Apache-2.0",

--- a/packages/mocks/package.json
+++ b/packages/mocks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/mocks",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "Deephaven Mocks for common libraries",
   "repository": {
     "type": "git",

--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/prettier-config",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "Deephaven Prettier configuration",
   "repository": {
     "type": "git",

--- a/packages/react-hooks/package.json
+++ b/packages/react-hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/react-hooks",
-  "version": "0.15.2",
+  "version": "0.16.0",
   "description": "Deephaven React hooks library",
   "author": "Deephaven Data Labs LLC",
   "license": "Apache-2.0",

--- a/packages/redux/package.json
+++ b/packages/redux/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/redux",
-  "version": "0.15.6",
+  "version": "0.16.0",
   "description": "Deephaven Redux",
   "author": "Deephaven Data Labs LLC",
   "license": "Apache-2.0",

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/storage",
-  "version": "0.15.5",
+  "version": "0.16.0",
   "description": "Deephaven Storage abstract classes for storing app data",
   "author": "Deephaven Data Labs LLC",
   "license": "Apache-2.0",

--- a/packages/stylelint-config/package.json
+++ b/packages/stylelint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/stylelint-config",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "Deephaven Stylelint configuration",
   "repository": {
     "type": "git",

--- a/packages/tsconfig/package.json
+++ b/packages/tsconfig/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/tsconfig",
-  "version": "0.15.2",
+  "version": "0.16.0",
   "description": "Deephaven TypeScript configuration",
   "repository": {
     "type": "git",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/utils",
-  "version": "0.15.6",
+  "version": "0.16.0",
   "description": "Deephaven Utils",
   "author": "Deephaven Data Labs LLC",
   "license": "Apache-2.0",


### PR DESCRIPTION
## v0.16.0 (2022-09-02)

#### :rocket: Enhancement
* `code-studio`, `components`
  * [#737](https://github.com/deephaven/web-client-ui/pull/737) Add ValidateLabelInput component ([@mofojed](https://github.com/mofojed))
* `embed-chart`, `embed-grid`
  * [#707](https://github.com/deephaven/web-client-ui/pull/707) Create @deephaven/embed-chart ([@mofojed](https://github.com/mofojed))

#### :bug: Bug Fix
* `chart`
  * [#741](https://github.com/deephaven/web-client-ui/pull/741) DH-9164 Fix title overlap on twin Y charts in Enterprise (cherry-pick #687) ([@vbabich](https://github.com/vbabich))
* `iris-grid`, `jsapi-utils`
  * [#736](https://github.com/deephaven/web-client-ui/pull/736) DH-13043 Filter validation fixes and nulls in Advanced Filters ([@mofojed](https://github.com/mofojed))
* `components`
  * [#738](https://github.com/deephaven/web-client-ui/pull/738) DH-12503 Fix TimeSlider selection issue when swapping start/end times ([@vbabich](https://github.com/vbabich))

#### :house: Internal
* `components`
  * [#740](https://github.com/deephaven/web-client-ui/pull/740) Component updates for Parameterized Query UI (cherry-pick #666) ([@vbabich](https://github.com/vbabich))
* `chart`, `iris-grid`, `jsapi-utils`, `redux`
  * [#739](https://github.com/deephaven/web-client-ui/pull/739) Clean up references to @deephaven/redux ([@mofojed](https://github.com/mofojed))

#### Committers: 2
- Mike Bender ([@mofojed](https://github.com/mofojed))
- Vlad Babich ([@vbabich](https://github.com/vbabich))