### PR TITLE
Switch column header group text to dark if background is light

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26054,6 +26054,7 @@
       "version": "0.16.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "@deephaven/utils": "file:../utils",
         "classnames": "^2.3.1",
         "color-convert": "^2.0.1",
         "event-target-shim": "^6.0.2",
@@ -27628,6 +27629,7 @@
       "version": "file:packages/grid",
       "requires": {
         "@deephaven/tsconfig": "file:../tsconfig",
+        "@deephaven/utils": "file:../utils",
         "classnames": "^2.3.1",
         "color-convert": "^2.0.1",
         "event-target-shim": "^6.0.2",

--- a/packages/grid/package.json
+++ b/packages/grid/package.json
@@ -39,6 +39,7 @@
     "dist"
   ],
   "dependencies": {
+    "@deephaven/utils": "file:../utils",
     "classnames": "^2.3.1",
     "color-convert": "^2.0.1",
     "event-target-shim": "^6.0.2",

--- a/packages/grid/src/GridRenderer.ts
+++ b/packages/grid/src/GridRenderer.ts
@@ -1820,6 +1820,8 @@ export class GridRenderer {
       headerBackgroundColor,
       headerColor,
       headerSeparatorColor,
+      black,
+      white,
     } = theme;
     const { fontWidths, width } = metrics;
     const fontWidth =
@@ -1835,12 +1837,17 @@ export class GridRenderer {
 
     let { textColor = headerColor } = style ?? {};
 
-    const isDarkBackground = ColorUtils.isDark(backgroundColor);
-    const isDarkText = ColorUtils.isDark(textColor);
-    if (isDarkBackground && isDarkText) {
-      textColor = '#f0f0ee'; // Deephaven $interfacewhite
-    } else if (!isDarkBackground && !isDarkText) {
-      textColor = '#1a171a'; // Deephaven $interfaceblack
+    try {
+      const isDarkBackground = ColorUtils.isDark(backgroundColor);
+      const isDarkText = ColorUtils.isDark(textColor);
+      if (isDarkBackground && isDarkText) {
+        textColor = white;
+      } else if (!isDarkBackground && !isDarkText) {
+        textColor = black;
+      }
+    } catch {
+      // Invalid color provided
+      // no-op since we don't use logging in base grid
     }
 
     let { minX = 0, maxX = width } = bounds ?? {};

--- a/packages/grid/src/GridRenderer.ts
+++ b/packages/grid/src/GridRenderer.ts
@@ -1616,13 +1616,7 @@ export class GridRenderer {
       visibleColumnWidths,
       movedColumns,
     } = metrics;
-    const {
-      headerBackgroundColor,
-      headerColor,
-      headerSeparatorColor,
-      columnHeaderHeight,
-      columnWidth,
-    } = theme;
+    const { columnHeaderHeight, columnWidth } = theme;
     const { columnHeaderMaxDepth } = model;
     const { minX, maxX } = bounds;
     const visibleWidth = maxX - minX;
@@ -1767,7 +1761,7 @@ export class GridRenderer {
     index: VisibleIndex,
     bounds: { minX: number; maxX: number }
   ): void {
-    const { metrics, model, theme } = state;
+    const { metrics, model } = state;
     const {
       modelColumns,
       visibleColumnWidths,

--- a/packages/grid/src/GridTheme.ts
+++ b/packages/grid/src/GridTheme.ts
@@ -29,6 +29,10 @@ export type GridTheme = {
   // Color to draw text
   textColor: GridColor;
 
+  // Black and white to use if needed
+  black: GridColor;
+  white: GridColor;
+
   // Amount of padding within a cell and header
   cellHorizontalPadding: number;
   headerHorizontalPadding: number;
@@ -132,7 +136,7 @@ export type GridTheme = {
 /**
  * Default theme for a Grid.
  */
-export default Object.freeze({
+const defaultTheme: GridTheme = Object.freeze({
   allowColumnResize: true,
   allowRowResize: true,
   autoSelectRow: false, // Select the full row upon selection
@@ -140,6 +144,8 @@ export default Object.freeze({
   autoSizeColumns: true, // Automatically size the columns to fit content
   autoSizeRows: true,
   backgroundColor: '#000000',
+  black: '#000000',
+  white: '#ffffff',
   cellHorizontalPadding: 5,
   headerHorizontalPadding: 5,
   font: '12px Arial, sans serif',
@@ -213,4 +219,6 @@ export default Object.freeze({
   // Divider colors between the floating parts and the grid
   floatingDividerOuterColor: '#000000',
   floatingDividerInnerColor: '#cccccc',
-}) as GridTheme;
+});
+
+export default defaultTheme;

--- a/packages/grid/tsconfig.json
+++ b/packages/grid/tsconfig.json
@@ -4,6 +4,20 @@
     "rootDir": "src/",
     "outDir": "dist/"
   },
-  "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.js", "src/**/*.jsx"],
-  "exclude": ["node_modules", "src/**/*.test.*", "src/**/__mocks__/*"]
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.tsx",
+    "src/**/*.js",
+    "src/**/*.jsx"
+  ],
+  "exclude": [
+    "node_modules",
+    "src/**/*.test.*",
+    "src/**/__mocks__/*"
+  ],
+  "references": [
+    {
+      "path": "../utils"
+    }
+  ]
 }

--- a/packages/iris-grid/src/IrisGrid.tsx
+++ b/packages/iris-grid/src/IrisGrid.tsx
@@ -456,7 +456,7 @@ export class IrisGrid extends Component<IrisGridProps, IrisGridState> {
     canCopy: true,
     canDownloadCsv: true,
     frozenColumns: null,
-    theme: {},
+    theme: IrisGridTheme,
     canToggleSearch: true,
   };
 

--- a/packages/iris-grid/src/IrisGridTheme.module.scss
+++ b/packages/iris-grid/src/IrisGridTheme.module.scss
@@ -14,6 +14,8 @@ $header-height: 30px;
 :export {
   grid-bg: $gray-900;
   font: $font-size Fira Sans, sans-serif; // must be preloaded
+  white: $interfacewhite;
+  black: $interfaceblack;
   header-bg: $header-bg;
   header-color: $gray-200;
   header-height: $header-height;

--- a/packages/iris-grid/src/IrisGridTheme.ts
+++ b/packages/iris-grid/src/IrisGridTheme.ts
@@ -41,6 +41,8 @@ export type IrisGridThemeType = GridThemeType & {
 
 const theme: Partial<IrisGridThemeType> = Object.freeze({
   backgroundColor: IrisGridTheme['grid-bg'],
+  white: IrisGridTheme.white,
+  black: IrisGridTheme.black,
   font: IrisGridTheme.font,
   headerBackgroundColor: IrisGridTheme['header-bg'],
   headerColor: IrisGridTheme['header-color'],


### PR DESCRIPTION
Fixes an issue where if a light colored background was used in a column header group, the text was white and not easily readable.

Grid doesn't rely on any deephaven packages (except utils now), so it has no concept of deephaven theme. Could switch to have a `white` and `black` values in the grid theme if that's preferred

Example Python snippet
```python
from deephaven import new_table
from deephaven.column import string_col, char_col, int_col

groups = [
    {'name': 'MyShorts', 'children': ['Short', 'Short2', 'Short3'], 'color': 'yellow'},
    {'name': 'MyInts', 'children': ['Int2', 'Int3'], 'color': 'blue'}
]

table = new_table([
    string_col("Short", ["A" , "B", "C", "D"]),
    char_col("Char", "ABCD"),
    int_col("Int", [123456789, 234567890, 42, 8675309]),
    string_col("Short2", ["A" , "B", "C", "D"]),
    char_col("Char2", "ABCD"),
    int_col("Int2", [123456789, 234567890, 42, 8675309]),
    string_col("Short3", ["A" , "B", "C", "D"]),
    char_col("Char3", "ABCD"),
    int_col("Int3", [123456789, 234567890, 42, 8675309]),
]).layout_hints(column_groups=groups)
```