### PR TITLE
Version Bump v0.17.0

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,7 @@
 {
-  "packages": ["packages/*"],
+  "packages": [
+    "packages/*"
+  ],
   "useWorkspaces": true,
-  "version": "0.16.0"
+  "version": "0.17.0"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -25456,7 +25456,7 @@
     },
     "packages/babel-preset": {
       "name": "@deephaven/babel-preset",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/core": "^7.16.0",
@@ -25470,7 +25470,7 @@
     },
     "packages/chart": {
       "name": "@deephaven/chart",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@deephaven/icons": "file:../icons",
@@ -25501,7 +25501,7 @@
     },
     "packages/code-studio": {
       "name": "@deephaven/code-studio",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@deephaven/chart": "file:../chart",
@@ -25653,7 +25653,7 @@
     },
     "packages/components": {
       "name": "@deephaven/components",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@deephaven/icons": "file:../icons",
@@ -25692,7 +25692,7 @@
     },
     "packages/console": {
       "name": "@deephaven/console",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@deephaven/chart": "file:../chart",
@@ -25728,7 +25728,7 @@
     },
     "packages/dashboard": {
       "name": "@deephaven/dashboard",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@deephaven/components": "file:../components",
@@ -25760,7 +25760,7 @@
     },
     "packages/dashboard-core-plugins": {
       "name": "@deephaven/dashboard-core-plugins",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@deephaven/chart": "file:../chart",
@@ -25819,7 +25819,7 @@
     },
     "packages/embed-chart": {
       "name": "@deephaven/embed-chart",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@deephaven/chart": "file:../chart",
@@ -25903,7 +25903,7 @@
     },
     "packages/embed-grid": {
       "name": "@deephaven/embed-grid",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@deephaven/components": "file:../components",
@@ -25987,7 +25987,7 @@
     },
     "packages/eslint-config": {
       "name": "@deephaven/eslint-config",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "license": "Apache-2.0",
       "dependencies": {
         "eslint-config-airbnb": "18.2.1",
@@ -26005,7 +26005,7 @@
     },
     "packages/file-explorer": {
       "name": "@deephaven/file-explorer",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@deephaven/components": "file:../components",
@@ -26032,7 +26032,7 @@
     },
     "packages/filters": {
       "name": "@deephaven/filters",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@deephaven/tsconfig": "file:../tsconfig"
@@ -26043,7 +26043,7 @@
     },
     "packages/golden-layout": {
       "name": "@deephaven/golden-layout",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "license": "Apache-2.0",
       "dependencies": {
         "jquery": "^3.6.0"
@@ -26051,7 +26051,7 @@
     },
     "packages/grid": {
       "name": "@deephaven/grid",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "license": "Apache-2.0",
       "dependencies": {
         "classnames": "^2.3.1",
@@ -26074,7 +26074,7 @@
     },
     "packages/icons": {
       "name": "@deephaven/icons",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@fortawesome/fontawesome-common-types": "^6.1.1"
@@ -26091,7 +26091,7 @@
     },
     "packages/iris-grid": {
       "name": "@deephaven/iris-grid",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@deephaven/components": "file:../components",
@@ -26133,7 +26133,7 @@
     },
     "packages/jsapi-shim": {
       "name": "@deephaven/jsapi-shim",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "license": "Apache-2.0",
       "dependencies": {
         "prop-types": "^15.7.2"
@@ -26147,7 +26147,7 @@
     },
     "packages/jsapi-utils": {
       "name": "@deephaven/jsapi-utils",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@deephaven/filters": "file:../filters",
@@ -26164,7 +26164,7 @@
     },
     "packages/log": {
       "name": "@deephaven/log",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "license": "Apache-2.0",
       "dependencies": {
         "event-target-shim": "^6.0.2"
@@ -26178,7 +26178,7 @@
     },
     "packages/mocks": {
       "name": "@deephaven/mocks",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "license": "Apache-2.0",
       "peerDependencies": {
         "jest": "26.x"
@@ -26186,7 +26186,7 @@
     },
     "packages/prettier-config": {
       "name": "@deephaven/prettier-config",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "license": "Apache-2.0",
       "peerDependencies": {
         "prettier": "^2.2.1"
@@ -26194,7 +26194,7 @@
     },
     "packages/react-hooks": {
       "name": "@deephaven/react-hooks",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@deephaven/tsconfig": "file:../tsconfig"
@@ -26208,7 +26208,7 @@
     },
     "packages/redux": {
       "name": "@deephaven/redux",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@deephaven/jsapi-utils": "file:../jsapi-utils",
@@ -26228,7 +26228,7 @@
     },
     "packages/storage": {
       "name": "@deephaven/storage",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@deephaven/filters": "file:../filters",
@@ -26247,7 +26247,7 @@
     },
     "packages/stylelint-config": {
       "name": "@deephaven/stylelint-config",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "license": "Apache-2.0",
       "dependencies": {
         "stylelint-config-prettier-scss": "^0.0.1",
@@ -26259,13 +26259,13 @@
     },
     "packages/tsconfig": {
       "name": "@deephaven/tsconfig",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "license": "Apache-2.0"
     },
     "packages/util": {},
     "packages/utils": {
       "name": "@deephaven/utils",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=16"

--- a/packages/babel-preset/package.json
+++ b/packages/babel-preset/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/babel-preset",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "Deephaven Babel preset",
   "repository": {
     "type": "git",

--- a/packages/chart/package.json
+++ b/packages/chart/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/chart",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "Deephaven Chart",
   "author": "Deephaven Data Labs LLC",
   "license": "Apache-2.0",

--- a/packages/code-studio/package.json
+++ b/packages/code-studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/code-studio",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "Deephaven Code Studio",
   "author": "Deephaven Data Labs LLC",
   "license": "Apache-2.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/components",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "Deephaven React component library",
   "author": "Deephaven Data Labs LLC",
   "license": "Apache-2.0",

--- a/packages/console/package.json
+++ b/packages/console/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/console",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "Deephaven Console",
   "author": "Deephaven Data Labs LLC",
   "license": "Apache-2.0",

--- a/packages/dashboard-core-plugins/package.json
+++ b/packages/dashboard-core-plugins/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/dashboard-core-plugins",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "Deephaven Dashboard Core Plugins",
   "author": "Deephaven Data Labs LLC",
   "license": "Apache-2.0",

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/dashboard",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "Deephaven Dashboard",
   "author": "Deephaven Data Labs LLC",
   "license": "Apache-2.0",

--- a/packages/embed-chart/package.json
+++ b/packages/embed-chart/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/embed-chart",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "Deephaven Embedded Chart",
   "author": "Deephaven Data Labs LLC",
   "license": "Apache-2.0",

--- a/packages/embed-grid/package.json
+++ b/packages/embed-grid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/embed-grid",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "Deephaven Embedded Grid",
   "author": "Deephaven Data Labs LLC",
   "license": "Apache-2.0",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/eslint-config",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "Deephaven ESLint configuration",
   "repository": {
     "type": "git",

--- a/packages/file-explorer/package.json
+++ b/packages/file-explorer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/file-explorer",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "Deephaven File Explorer React component",
   "author": "Deephaven Data Labs LLC",
   "license": "Apache-2.0",

--- a/packages/filters/package.json
+++ b/packages/filters/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/filters",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "Deephaven Filters",
   "author": "Deephaven Data Labs LLC",
   "license": "Apache-2.0",

--- a/packages/golden-layout/package.json
+++ b/packages/golden-layout/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/golden-layout",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "author": "Deephaven Data Labs LLC",
   "license": "Apache-2.0",
   "description": "A multi-screen javascript Layout manager",

--- a/packages/grid/package.json
+++ b/packages/grid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/grid",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "Deephaven React grid component",
   "author": "Deephaven Data Labs LLC",
   "license": "Apache-2.0",

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/icons",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "Icons used in Deephaven client apps. Extends vscode-codicons to be font-awesome svg-core compatible and adds additional icons in a similar style.",
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/packages/iris-grid/package.json
+++ b/packages/iris-grid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/iris-grid",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "Deephaven Iris Grid",
   "author": "Deephaven Data Labs LLC",
   "license": "Apache-2.0",

--- a/packages/jsapi-shim/package.json
+++ b/packages/jsapi-shim/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/jsapi-shim",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "Deephaven JSAPI Shim",
   "author": "Deephaven Data Labs LLC",
   "license": "Apache-2.0",

--- a/packages/jsapi-utils/package.json
+++ b/packages/jsapi-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/jsapi-utils",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "Deephaven JSAPI Utils",
   "author": "Deephaven Data Labs LLC",
   "license": "Apache-2.0",

--- a/packages/log/package.json
+++ b/packages/log/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/log",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "Deephaven Logger",
   "author": "Deephaven Data Labs LLC",
   "license": "Apache-2.0",

--- a/packages/mocks/package.json
+++ b/packages/mocks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/mocks",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "Deephaven Mocks for common libraries",
   "repository": {
     "type": "git",

--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/prettier-config",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "Deephaven Prettier configuration",
   "repository": {
     "type": "git",

--- a/packages/react-hooks/package.json
+++ b/packages/react-hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/react-hooks",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "Deephaven React hooks library",
   "author": "Deephaven Data Labs LLC",
   "license": "Apache-2.0",

--- a/packages/redux/package.json
+++ b/packages/redux/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/redux",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "Deephaven Redux",
   "author": "Deephaven Data Labs LLC",
   "license": "Apache-2.0",

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/storage",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "Deephaven Storage abstract classes for storing app data",
   "author": "Deephaven Data Labs LLC",
   "license": "Apache-2.0",

--- a/packages/stylelint-config/package.json
+++ b/packages/stylelint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/stylelint-config",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "Deephaven Stylelint configuration",
   "repository": {
     "type": "git",

--- a/packages/tsconfig/package.json
+++ b/packages/tsconfig/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/tsconfig",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "Deephaven TypeScript configuration",
   "repository": {
     "type": "git",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/utils",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "Deephaven Utils",
   "author": "Deephaven Data Labs LLC",
   "license": "Apache-2.0",


### PR DESCRIPTION
## v0.17.0 (2022-09-16)

#### :rocket: Enhancement
* `code-studio`, `dashboard-core-plugins`, `embed-chart`, `embed-grid`, `jsapi-shim`, `redux`
  * [#743](https://github.com/deephaven/web-client-ui/pull/743) Support for no console in the web UI ([@mofojed](https://github.com/mofojed))
* `babel-preset`, `code-studio`, `components`, `console`, `dashboard-core-plugins`, `dashboard`, `embed-chart`, `embed-grid`, `file-explorer`, `icons`, `iris-grid`, `jsapi-shim`, `redux`, `utils`
  * [#711](https://github.com/deephaven/web-client-ui/pull/711) Change build system to Vite ([@mattrunyon](https://github.com/mattrunyon))
* `components`
  * [#753](https://github.com/deephaven/web-client-ui/pull/753) Cherry-pick #744 Editable Item List  ([@vbabich](https://github.com/vbabich))

#### :bug: Bug Fix
* `file-explorer`
  * [#755](https://github.com/deephaven/web-client-ui/pull/755) Changed cursor type in file explorer to pointer ([@SparkyFnay](https://github.com/SparkyFnay))
* `console`
  * [#746](https://github.com/deephaven/web-client-ui/pull/746) Blank commands not added to history ([@jason-wang24](https://github.com/jason-wang24))

#### :house: Internal
* `console`, `dashboard-core-plugins`, `embed-grid`, `iris-grid`, `mocks`
  * [#747](https://github.com/deephaven/web-client-ui/pull/747) Update monaco version ([@mofojed](https://github.com/mofojed))

#### Committers: 5
- Jason ([@jason-wang24](https://github.com/jason-wang24))
- Matthew Runyon ([@mattrunyon](https://github.com/mattrunyon))
- Mike Bender ([@mofojed](https://github.com/mofojed))
- Tony Zhou ([@SparkyFnay](https://github.com/SparkyFnay))
- Vlad Babich ([@vbabich](https://github.com/vbabich))