### PR TITLE
Proxy the ws socket within vite to allow tunneling

### DIFF
--- a/packages/code-studio/.env.development
+++ b/packages/code-studio/.env.development
@@ -1,5 +1,4 @@
 VITE_ENABLE_LOG_PROXY=false
-VITE_CORE_API_URL=http://localhost:10000/jsapi
 VITE_FAVICON=/favicon-cc-app-dev.svg
 
 BASE_URL=/
@@ -8,3 +7,4 @@ PORT=4000
 VITE_LOG_LEVEL=4
 
 VITE_PROXY_URL=http://localhost:10000
+VITE_PROXY_WS=ws://localhost:10000

--- a/packages/code-studio/.env.development
+++ b/packages/code-studio/.env.development
@@ -7,4 +7,3 @@ PORT=4000
 VITE_LOG_LEVEL=4
 
 VITE_PROXY_URL=http://localhost:10000
-VITE_PROXY_WS=ws://localhost:10000

--- a/packages/code-studio/vite.config.ts
+++ b/packages/code-studio/vite.config.ts
@@ -40,13 +40,14 @@ export default defineConfig(({ mode }) => {
       target: `http://localhost:${port}/src/styleguide/index.html`,
       rewrite: () => '',
     },
+
     // proxy the websocket requests, allows tunneling to work with a single port
-    '^/arrow.*': {
+    '^/arrow\\.*': {
       target: env.VITE_PROXY_URL,
       changeOrigin: true,
       ws: true,
     },
-    '^/io.deephaven.*': {
+    '^/io\\.deephaven\\..*': {
       target: env.VITE_PROXY_URL,
       changeOrigin: true,
       ws: true,

--- a/packages/code-studio/vite.config.ts
+++ b/packages/code-studio/vite.config.ts
@@ -40,30 +40,15 @@ export default defineConfig(({ mode }) => {
       target: `http://localhost:${port}/src/styleguide/index.html`,
       rewrite: () => '',
     },
-    // proxy the websocket, allows tunneling to work with a single port
-    '/': {
-      protocol: 'ws',
-      target: env.VITE_PROXY_WS,
-      changeOrigin: true,
-      ws: true,
-    },
   };
 
-  // Some paths need to proxy to the engine server
-  // Vite does not have a "any unknown fallback to proxy" like CRA
-  // It is possible to add one with a custom middleware though if this list grows
+  // Proxy all paths, including websocket
   if (env.VITE_PROXY_URL) {
-    [
-      env.VITE_CORE_API_URL,
-      env.VITE_NOTEBOOKS_URL,
-      env.VITE_LAYOUTS_URL,
-      env.VITE_MODULE_PLUGINS_URL,
-    ].forEach(p => {
-      proxy[p] = {
-        target: env.VITE_PROXY_URL,
-        changeOrigin: true,
-      };
-    });
+    proxy['/'] = {
+      target: env.VITE_PROXY_URL,
+      changeOrigin: true,
+      ws: true,
+    };
   }
 
   return {

--- a/packages/code-studio/vite.config.ts
+++ b/packages/code-studio/vite.config.ts
@@ -40,6 +40,13 @@ export default defineConfig(({ mode }) => {
       target: `http://localhost:${port}/src/styleguide/index.html`,
       rewrite: () => '',
     },
+    // proxy the websocket, allows tunneling to work with a single port
+    '/': {
+      protocol: 'ws',
+      target: env.VITE_PROXY_WS,
+      changeOrigin: true,
+      ws: true,
+    },
   };
 
   // Some paths need to proxy to the engine server


### PR DESCRIPTION
Proxy the websocket (and jsapi files) with the vite server. This is cool because it lets you open an ngrok tunnel to just port 4000 and have everything work.