### PR TITLE
Upgrade to bootstrap 4.6.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7390,12 +7390,19 @@
       "license": "ISC"
     },
     "node_modules/bootstrap": {
-      "version": "4.6.1",
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/bootstrap"
-      },
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.6.2.tgz",
+      "integrity": "sha512-51Bbp/Uxr9aTuy6ca/8FbFloBUJZLHwnhTcnjIeRn2suQWsWzcuJhGjKDB5eppVte/8oCdOL3VuwxvZDUggwGQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/twbs"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/bootstrap"
+        }
+      ],
       "peerDependencies": {
         "jquery": "1.9.1 - 3",
         "popper.js": "^1.16.1"
@@ -26544,7 +26551,7 @@
         "@deephaven/utils": "file:../utils",
         "@fortawesome/fontawesome-svg-core": "^6.1.1",
         "@fortawesome/react-fontawesome": "^0.1.18",
-        "bootstrap": "4.6.1",
+        "bootstrap": "4.6.2",
         "classnames": "^2.3.1",
         "event-target-shim": "^6.0.2",
         "lodash.clamp": "^4.0.3",
@@ -28269,7 +28276,7 @@
         "@deephaven/utils": "file:../utils",
         "@fortawesome/fontawesome-svg-core": "^6.1.1",
         "@fortawesome/react-fontawesome": "^0.1.18",
-        "bootstrap": "4.6.1",
+        "bootstrap": "4.6.2",
         "classnames": "^2.3.1",
         "event-target-shim": "^6.0.2",
         "lodash.clamp": "^4.0.3",
@@ -32743,7 +32750,9 @@
       "dev": true
     },
     "bootstrap": {
-      "version": "4.6.1",
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.6.2.tgz",
+      "integrity": "sha512-51Bbp/Uxr9aTuy6ca/8FbFloBUJZLHwnhTcnjIeRn2suQWsWzcuJhGjKDB5eppVte/8oCdOL3VuwxvZDUggwGQ==",
       "requires": {}
     },
     "brace-expansion": {

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -37,7 +37,7 @@
     "@deephaven/utils": "file:../utils",
     "@fortawesome/fontawesome-svg-core": "^6.1.1",
     "@fortawesome/react-fontawesome": "^0.1.18",
-    "bootstrap": "4.6.1",
+    "bootstrap": "4.6.2",
     "classnames": "^2.3.1",
     "event-target-shim": "^6.0.2",
     "lodash.clamp": "^4.0.3",


### PR DESCRIPTION
Resolves issue with color adjust warning. Smoke tested style guide, and UI.

https://github.com/twbs/bootstrap/releases/tag/v4.6.2

> We've replaced the deprecated color-adjust with print-color-adjust in our Sass files as part of the Autoprefixer v10.4.6 issues. This should quiet the issues folks have seen from that dependency change. If you're using our distribution CSS files, like bootstrap.min.css, you may still see the warning.