### PR TITLE
Downgrading monaco-editor to v0.31.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18206,9 +18206,9 @@
       }
     },
     "node_modules/monaco-editor": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.34.0.tgz",
-      "integrity": "sha512-VF+S5zG8wxfinLKLrWcl4WUizMx+LeJrG4PM/M78OhcwocpV0jiyhX/pG6Q9jIOhrb/ckYi6nHnaR5OojlOZCQ=="
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.31.1.tgz",
+      "integrity": "sha512-FYPwxGZAeP6mRRyrr5XTGHD9gRXVjy7GUzF4IPChnyt3fS5WrNxIkS8DNujWf6EQy0Zlzpxw8oTVE+mWI2/D1Q=="
     },
     "node_modules/moo-color": {
       "version": "1.0.3",
@@ -26596,7 +26596,7 @@
         "lodash.throttle": "^4.1.1",
         "memoize-one": "^5.1.1",
         "memoizee": "^0.4.15",
-        "monaco-editor": "^0.34.0",
+        "monaco-editor": "^0.31.1",
         "papaparse": "^5.3.2",
         "popper.js": "^1.16.1",
         "prop-types": "^15.7.2",
@@ -27012,7 +27012,7 @@
         "lodash.throttle": "^4.1.1",
         "memoize-one": "^5.1.1",
         "memoizee": "^0.4.15",
-        "monaco-editor": "^0.34.0",
+        "monaco-editor": "^0.31.1",
         "prop-types": "^15.7.2",
         "react-beautiful-dnd": "^13.1.0",
         "react-transition-group": "^4.4.2",
@@ -28310,7 +28310,7 @@
         "lodash.throttle": "^4.1.1",
         "memoize-one": "^5.1.1",
         "memoizee": "^0.4.15",
-        "monaco-editor": "^0.34.0",
+        "monaco-editor": "^0.31.1",
         "papaparse": "^5.3.2",
         "popper.js": "^1.16.1",
         "prop-types": "^15.7.2",
@@ -28598,7 +28598,7 @@
         "lodash.throttle": "^4.1.1",
         "memoize-one": "^5.1.1",
         "memoizee": "^0.4.15",
-        "monaco-editor": "^0.34.0",
+        "monaco-editor": "^0.31.1",
         "prop-types": "^15.7.2",
         "react-beautiful-dnd": "^13.1.0",
         "react-transition-group": "^4.4.2",
@@ -40053,9 +40053,9 @@
       }
     },
     "monaco-editor": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.34.0.tgz",
-      "integrity": "sha512-VF+S5zG8wxfinLKLrWcl4WUizMx+LeJrG4PM/M78OhcwocpV0jiyhX/pG6Q9jIOhrb/ckYi6nHnaR5OojlOZCQ=="
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.31.1.tgz",
+      "integrity": "sha512-FYPwxGZAeP6mRRyrr5XTGHD9gRXVjy7GUzF4IPChnyt3fS5WrNxIkS8DNujWf6EQy0Zlzpxw8oTVE+mWI2/D1Q=="
     },
     "moo-color": {
       "version": "1.0.3",

--- a/packages/console/package.json
+++ b/packages/console/package.json
@@ -44,7 +44,7 @@
     "lodash.throttle": "^4.1.1",
     "memoize-one": "^5.1.1",
     "memoizee": "^0.4.15",
-    "monaco-editor": "^0.34.0",
+    "monaco-editor": "^0.31.1",
     "papaparse": "^5.3.2",
     "popper.js": "^1.16.1",
     "prop-types": "^15.7.2",

--- a/packages/console/src/monaco/MonacoUtils.ts
+++ b/packages/console/src/monaco/MonacoUtils.ts
@@ -6,6 +6,7 @@ import { Shortcut } from '@deephaven/components';
 import { IdeSession } from '@deephaven/jsapi-shim';
 import { assertNotNull } from '@deephaven/utils';
 import * as monaco from 'monaco-editor';
+import type { Environment } from 'monaco-editor';
 // @ts-ignore
 import { KeyCodeUtils } from 'monaco-editor/esm/vs/base/common/keyCodes.js';
 // @ts-ignore
@@ -20,6 +21,18 @@ import LogLang from './lang/log';
 import { Language } from './lang/Language';
 
 const log = Log.module('MonacoUtils');
+
+declare global {
+  interface Window {
+    MonacoEnvironment: Environment;
+  }
+}
+
+window.MonacoEnvironment = {
+  getWorker() {
+    return editorWorker();
+  },
+};
 
 class MonacoUtils {
   static init(): void {

--- a/packages/console/src/monaco/MonacoUtils.ts
+++ b/packages/console/src/monaco/MonacoUtils.ts
@@ -21,12 +21,6 @@ import { Language } from './lang/Language';
 
 const log = Log.module('MonacoUtils');
 
-window.MonacoEnvironment = {
-  getWorker(workerId, label) {
-    return editorWorker();
-  },
-};
-
 class MonacoUtils {
   static init(): void {
     log.debug('Initializing Monaco...');

--- a/packages/iris-grid/package.json
+++ b/packages/iris-grid/package.json
@@ -50,7 +50,7 @@
     "lodash.throttle": "^4.1.1",
     "memoize-one": "^5.1.1",
     "memoizee": "^0.4.15",
-    "monaco-editor": "^0.34.0",
+    "monaco-editor": "^0.31.1",
     "prop-types": "^15.7.2",
     "react-beautiful-dnd": "^13.1.0",
     "react-transition-group": "^4.4.2",


### PR DESCRIPTION
- Fixes #773  being unable to escape the suggestion widget
- I don't know what change introduced the issue, as it's not reproducible in v0.34.0 playground and it's just in our code for some reason

I went down a rabbit hole debugging this...
The issue is that container is null when initializing the suggest widget contextview: https://github.com/microsoft/vscode/blob/0c22a33a9d670a84309447b36abdbd8c04ee6219/src/vs/base/browser/ui/contextview/contextview.ts#L162
Because it is null, this listener never gets registered: https://github.com/microsoft/vscode/blob/main/src/vs/base/browser/ui/contextview/contextview.ts#L183
Subsequently, this.hide() never gets called: https://github.com/microsoft/vscode/blob/0c22a33a9d670a84309447b36abdbd8c04ee6219/src/vs/base/browser/ui/contextview/contextview.ts#L352
I don't know how it's supposed to work since the container is always null for that service: https://github.com/microsoft/vscode/blob/0c22a33a9d670a84309447b36abdbd8c04ee6219/src/vs/editor/standalone/browser/standaloneLayoutService.ts#L27
I don't understand why this works in the Playground. I'm missing something, but for now I'm just going to roll back to v0.31.1 which doesn't have this issue.