### PR TITLE
Allow up to 1% drop in code coverage per commit

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,10 @@
 flag_management:
   default_rules:
     carryforward: true
+coverage:
+  status:
+    project:
+      default:
+        # Allow up to a 1% drop in threshold for codecov
+        # A lot of bug fixes don't change test coverage, and then codecov fails
+        threshold: 1%

--- a/codecov.yml
+++ b/codecov.yml
@@ -5,6 +5,6 @@ coverage:
   status:
     project:
       default:
-        # Allow up to a 1% drop in threshold for codecov
+        # Allow up to a 0.05% drop in project threshold for codecov
         # A lot of bug fixes don't change test coverage, and then codecov fails
         threshold: 0.05%

--- a/codecov.yml
+++ b/codecov.yml
@@ -7,4 +7,4 @@ coverage:
       default:
         # Allow up to a 1% drop in threshold for codecov
         # A lot of bug fixes don't change test coverage, and then codecov fails
-        threshold: 1%
+        threshold: 0.05%


### PR DESCRIPTION
- Previously required each change to increase test code coverage, which is unrealistic for a lot of bug fixes
- Change the treshold to 1% so bug fixes can go in without needed to increase the threshold, but bigger features should still trigger it
