### PR TITLE
Set aria-label for icon only buttons

### DIFF
--- a/packages/components/src/Button.tsx
+++ b/packages/components/src/Button.tsx
@@ -38,7 +38,7 @@ type ButtonWithChildren = BaseButtonProps & {
   children: React.ReactNode;
 };
 
-type IconOnlyButtoStringTooltip = BaseButtonProps & {
+type IconOnlyButtonStringTooltip = BaseButtonProps & {
   tooltip: string;
   icon: IconDefinition | JSX.Element;
   children?: undefined;
@@ -51,7 +51,7 @@ type IconOnlyButtonJsxTooltip = BaseButtonProps & {
   children?: undefined;
 };
 
-type IconOnlyButton = IconOnlyButtoStringTooltip | IconOnlyButtonJsxTooltip;
+type IconOnlyButton = IconOnlyButtonStringTooltip | IconOnlyButtonJsxTooltip;
 
 type ButtonProps = IconOnlyButton | ButtonWithChildren;
 

--- a/packages/components/src/Button.tsx
+++ b/packages/components/src/Button.tsx
@@ -38,11 +38,20 @@ type ButtonWithChildren = BaseButtonProps & {
   children: React.ReactNode;
 };
 
-type IconOnlyButton = BaseButtonProps & {
-  tooltip: string | JSX.Element;
+type IconOnlyButtoStringTooltip = BaseButtonProps & {
+  tooltip: string;
   icon: IconDefinition | JSX.Element;
   children?: undefined;
 };
+
+type IconOnlyButtonJsxTooltip = BaseButtonProps & {
+  tooltip: JSX.Element;
+  'aria-label': string;
+  icon: IconDefinition | JSX.Element;
+  children?: undefined;
+};
+
+type IconOnlyButton = IconOnlyButtoStringTooltip | IconOnlyButtonJsxTooltip;
 
 type ButtonProps = IconOnlyButton | ButtonWithChildren;
 
@@ -116,6 +125,13 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
         typeof tooltip === 'string' ? <Tooltip>{tooltip}</Tooltip> : tooltip;
     }
 
+    // use tooltip as arial-label for iconOnly buttons only
+    // if tooltip is also a string and aria-label is not set
+    let ariaLabelString = ariaLabel;
+    if (!ariaLabel && iconOnly && tooltip && typeof tooltip === 'string') {
+      ariaLabelString = tooltip;
+    }
+
     const button = (
       <button
         data-testid={dataTestId}
@@ -132,7 +148,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
         onClick={onClick}
         style={style}
         disabled={disabled}
-        aria-label={ariaLabel}
+        aria-label={ariaLabelString}
       >
         {icon && iconElem}
         {children}


### PR DESCRIPTION
Resolves #798

Re-uses tooltip as aria-label for iconOnly buttons that don't have a defined aria-label. If tooltip is a jsx element require a aria-label to be set with typescript.