### PR TITLE
Add NotebookPanel hydration function

### DIFF
--- a/packages/dashboard-core-plugins/src/ConsolePlugin.tsx
+++ b/packages/dashboard-core-plugins/src/ConsolePlugin.tsx
@@ -1,10 +1,13 @@
 import { ScriptEditor } from '@deephaven/console';
 import {
   assertIsDashboardPluginProps,
+  DashboardPanelProps,
   DashboardPluginComponentProps,
+  DashboardUtils,
   LayoutUtils,
   PanelComponent,
   PanelHydrateFunction,
+  PanelProps,
   useListener,
 } from '@deephaven/dashboard';
 import { FileUtils } from '@deephaven/file-explorer';
@@ -452,6 +455,18 @@ export const ConsolePlugin = (
     [createNotebook, panelManager]
   );
 
+  const hydrateNotebook = useCallback(
+    (panelProps: PanelProps, panelDashboardId: string): DashboardPanelProps =>
+      DashboardUtils.hydrate(
+        {
+          ...panelProps,
+          notebooksUrl,
+        },
+        panelDashboardId
+      ),
+    [notebooksUrl]
+  );
+
   useEffect(
     function registerComponentsAndReturnCleanup() {
       const cleanups = [
@@ -459,14 +474,18 @@ export const ConsolePlugin = (
         registerComponent(CommandHistoryPanel.COMPONENT, CommandHistoryPanel),
         registerComponent(FileExplorerPanel.COMPONENT, FileExplorerPanel),
         registerComponent(LogPanel.COMPONENT, LogPanel),
-        registerComponent(NotebookPanel.COMPONENT, NotebookPanel),
+        registerComponent(
+          NotebookPanel.COMPONENT,
+          NotebookPanel,
+          hydrateNotebook
+        ),
       ];
 
       return () => {
         cleanups.forEach(cleanup => cleanup());
       };
     },
-    [registerComponent, hydrateConsole]
+    [registerComponent, hydrateConsole, hydrateNotebook]
   );
 
   useListener(layout.eventHub, ConsoleEvent.SEND_COMMAND, handleSendCommand);


### PR DESCRIPTION
- Properly add the notebooksUrl to hydrated NotebookPanels
- Fixes #800

Previously, NotebookPanel had a default prop being set for notebooksUrl. We removed that after changing build system to Vite (which was correct). However, we never added a hydrate function to properly add the `notebooksUrl` prop to `NotebookPanel`s when they were rehydrated. We passed it in correctly when `selectNotebook` or `createNotebook` was called, but not in `NotebookPanel` hydration (which just used the default hydration).

The only place `notebooksUrl` is used is in markdown notebooks that have links in them, so this problem did not manifest for regular notebooks. 