### PR TITLE
Fix context menu in table plugins

### DIFF
--- a/packages/dashboard-core-plugins/src/panels/IrisGridPanel.tsx
+++ b/packages/dashboard-core-plugins/src/panels/IrisGridPanel.tsx
@@ -598,7 +598,7 @@ export class IrisGridPanel extends PureComponent<
     modelRow: GridRangeIndex;
     modelColumn: GridRangeIndex;
   }): ContextAction {
-    return this.pluginRef.current?.getMenu?.({ data: obj }) ?? [];
+    return this.pluginRef.current?.getMenu?.(obj) ?? [];
   }
 
   isColumnSelectionValid(tableColumn: Column | null): boolean {


### PR DESCRIPTION
- Was broken when we converted to TypeScript
- Just pass the object in, instead of passing in as the `data` property
- Tested with table-example plugin: https://github.com/deephaven/deephaven-js-plugins/tree/main/table-example