### PR TITLE
Print app information to the log

### DIFF
--- a/packages/code-studio/src/main/AppInit.tsx
+++ b/packages/code-studio/src/main/AppInit.tsx
@@ -151,6 +151,11 @@ const AppInit = (props: AppInitProps) => {
 
   const initClient = useCallback(async () => {
     try {
+      log.info(
+        'Initializing Web UI',
+        import.meta.env.npm_package_version,
+        navigator.userAgent
+      );
       const newPlugins = await loadPlugins();
       const connection = createConnection();
       const sessionWrapper = await loadSessionWrapper(connection);


### PR DESCRIPTION
- Often we get a copy of the log or a screenshot of the log the rest of the Support Logs zip (which has this information in it)
- Sometimes the app crashes and the settings menu is inaccessible, so you cannot click the Export Support Logs button
- Log the version and user agent so we have more info for debugging
