### PR TITLE
790 file explorer render fail

### DIFF
--- a/packages/chart/src/FigureChartModel.ts
+++ b/packages/chart/src/FigureChartModel.ts
@@ -46,8 +46,6 @@ class FigureChartModel extends ChartModel {
     this.handleDownsampleFail = this.handleDownsampleFail.bind(this);
     this.handleDownsampleNeeded = this.handleDownsampleNeeded.bind(this);
     this.handleRequestFailed = this.handleRequestFailed.bind(this);
-    // We need to debounce adding series so we subscribe to them all in the same tick
-    // This should no longer be necessary after IDS-5049 lands
 
     this.figure = figure;
     this.settings = settings;
@@ -185,6 +183,8 @@ class FigureChartModel extends ChartModel {
     this.updateLayoutFormats();
   }
 
+  // We need to debounce adding series so we subscribe to them all in the same tick
+  // This should no longer be necessary after IDS-5049 lands
   addPendingSeries = debounce(() => {
     const { pendingSeries } = this;
     for (let i = 0; i < pendingSeries.length; i += 1) {

--- a/packages/code-studio/src/storage/grpc/GrpcFileStorageTable.test.ts
+++ b/packages/code-studio/src/storage/grpc/GrpcFileStorageTable.test.ts
@@ -22,12 +22,18 @@ function makeStorageService(): StorageService {
 
 beforeEach(() => {
   storageService = makeStorageService();
+  jest.useFakeTimers();
+});
+
+afterEach(() => {
+  jest.useRealTimers();
 });
 
 it('Does not get contents until a viewport is set', () => {
   const table = makeTable();
   expect(storageService.listItems).not.toHaveBeenCalled();
   table.setViewport({ top: 0, bottom: 10 });
+  jest.runOnlyPendingTimers();
   expect(storageService.listItems).toHaveBeenCalled();
 });
 
@@ -91,6 +97,9 @@ describe('directory expansion tests', () => {
     const handleUpdate = jest.fn();
     table.onUpdate(handleUpdate);
     table.setViewport({ top: 0, bottom: 5 });
+
+    jest.runAllTimers();
+
     await table.getViewportData();
     expect(handleUpdate).toHaveBeenCalledWith({
       offset: 0,
@@ -104,7 +113,10 @@ describe('directory expansion tests', () => {
     });
     handleUpdate.mockReset();
 
-    await table.setExpanded('/dir1/', true);
+    table.setExpanded('/dir1/', true);
+
+    jest.runAllTimers();
+
     await table.getViewportData();
     expect(handleUpdate).toHaveBeenCalledWith({
       offset: 0,
@@ -118,7 +130,10 @@ describe('directory expansion tests', () => {
     });
     handleUpdate.mockReset();
 
-    await table.setExpanded('/dir1/dir1/', true);
+    table.setExpanded('/dir1/dir1/', true);
+
+    jest.runAllTimers();
+
     await table.getViewportData();
     expect(handleUpdate).toHaveBeenCalledWith({
       offset: 0,
@@ -133,7 +148,10 @@ describe('directory expansion tests', () => {
     handleUpdate.mockReset();
 
     // Now collapse it all
-    await table.setExpanded('/dir1/', false);
+    table.setExpanded('/dir1/', false);
+
+    jest.runAllTimers();
+
     await table.getViewportData();
     expect(handleUpdate).toHaveBeenCalledWith({
       offset: 0,

--- a/packages/code-studio/src/storage/grpc/GrpcFileStorageTable.ts
+++ b/packages/code-studio/src/storage/grpc/GrpcFileStorageTable.ts
@@ -9,13 +9,18 @@ import {
   IndexRange,
   StorageSnapshot,
 } from '@deephaven/storage';
-import { CancelablePromise, PromiseUtils } from '@deephaven/utils';
+import {
+  CancelablePromise,
+  CanceledPromiseError,
+  PromiseUtils,
+} from '@deephaven/utils';
 import {
   FileStorageItem,
   FileStorageTable,
   FileUtils,
 } from '@deephaven/file-explorer';
 import { StorageService } from '@deephaven/jsapi-shim';
+import debounce from 'lodash.debounce';
 
 const log = Log.module('GrpcFileStorageTable');
 
@@ -24,6 +29,8 @@ const log = Log.module('GrpcFileStorageTable');
  * Takes a path to specify what root this table should start at.
  */
 export class GrpcFileStorageTable implements FileStorageTable {
+  static REFRESH_DEBOUNCE = 50;
+
   private readonly storageService: StorageService;
 
   private readonly baseRoot: string;
@@ -57,6 +64,12 @@ export class GrpcFileStorageTable implements FileStorageTable {
     this.storageService = storageService;
     this.baseRoot = baseRoot;
     this.root = root;
+    if (root === baseRoot) {
+      this.doRefresh = debounce(
+        this.doRefresh.bind(this),
+        GrpcFileStorageTable.REFRESH_DEBOUNCE
+      );
+    }
   }
 
   private removeBaseRoot(filename: string): string {
@@ -82,7 +95,7 @@ export class GrpcFileStorageTable implements FileStorageTable {
     return this.currentSize;
   }
 
-  async setExpanded(path: string, expanded: boolean): Promise<void> {
+  setExpanded(path: string, expanded: boolean): void {
     const paths = path.split('/');
     let nextPath = paths.shift();
     if (!nextPath) {
@@ -114,14 +127,14 @@ export class GrpcFileStorageTable implements FileStorageTable {
       }
     }
     if (this.currentViewport) {
-      await this.refreshInternal();
+      this.refreshInternal();
     }
   }
 
-  async collapseAll(): Promise<void> {
+  collapseAll(): void {
     this.childTables.clear();
     if (this.currentViewport) {
-      await this.refreshInternal();
+      this.refreshInternal();
     }
   }
 
@@ -161,28 +174,59 @@ export class GrpcFileStorageTable implements FileStorageTable {
     };
   }
 
-  async refresh(): Promise<ViewportData<FileStorageItem>> {
-    log.debug2(this.root, 'refreshData');
+  doRefresh(callback: ViewportUpdateCallback<FileStorageItem>): void {
+    log.debug('doRefresh', this.root);
+
+    const viewportDataPromise = this.fetchData();
+
+    viewportDataPromise.then(callback).catch(e => {
+      if (!PromiseUtils.isCanceled(e)) {
+        log.error('Error fetching viewport data', e);
+      }
+    });
+  }
+
+  refresh(): void {
+    log.debug2('refresh', this.root);
 
     this.viewportUpdatePromise?.cancel();
 
-    this.viewportUpdatePromise = PromiseUtils.makeCancelable(this.fetchData());
+    const refreshPromise = new Promise<ViewportData<FileStorageItem>>(
+      resolve => {
+        this.doRefresh(resolve);
+      }
+    );
 
-    const viewportData = await this.viewportUpdatePromise;
+    const viewportUpdatePromise = PromiseUtils.makeCancelable(
+      refreshPromise.then(viewportData => {
+        if (this.viewportUpdatePromise !== viewportUpdatePromise) {
+          throw new CanceledPromiseError();
+        }
 
-    this.currentViewportData = viewportData;
+        this.currentViewportData = viewportData;
 
-    this.sendUpdate();
+        this.sendUpdate();
 
-    return viewportData;
+        return viewportData;
+      })
+    );
+
+    // Add a catch here as we're not catching the promises anywhere else
+    viewportUpdatePromise.catch(e => {
+      if (!PromiseUtils.isCanceled(e)) {
+        log.error('Error updating viewport', e);
+      }
+    });
+
+    this.viewportUpdatePromise = viewportUpdatePromise;
   }
 
   /**
    * Refreshes data, but catches any errors and logs them
    */
-  private async refreshInternal(): Promise<void> {
+  private refreshInternal(): void {
     try {
-      await this.refresh();
+      this.refresh();
     } catch (e) {
       if (!PromiseUtils.isCanceled(e)) {
         log.error('Unable to refresh data', e);

--- a/packages/code-studio/src/storage/grpc/GrpcFileStorageTable.ts
+++ b/packages/code-studio/src/storage/grpc/GrpcFileStorageTable.ts
@@ -174,16 +174,11 @@ export class GrpcFileStorageTable implements FileStorageTable {
     };
   }
 
-  doRefresh(callback: ViewportUpdateCallback<FileStorageItem>): void {
-    log.debug('doRefresh', this.root);
-
-    const viewportDataPromise = this.fetchData();
-
-    viewportDataPromise.then(callback).catch(e => {
-      if (!PromiseUtils.isCanceled(e)) {
-        log.error('Error fetching viewport data', e);
-      }
-    });
+  doRefresh(
+    callback: (fetchPromise: Promise<ViewportData<FileStorageItem>>) => void
+  ): void {
+    log.debug2('doRefresh', this.root);
+    callback(this.fetchData());
   }
 
   refresh(): void {

--- a/packages/dashboard-core-plugins/src/panels/FileExplorerPanel.test.tsx
+++ b/packages/dashboard-core-plugins/src/panels/FileExplorerPanel.test.tsx
@@ -140,7 +140,7 @@ describe('selects and expands directory for NewItemModal correctly', () => {
 
     const foundButtons = await findAllByRole(modal, 'button');
     const buttonContent = foundButtons.map(button => button.innerHTML);
-    const homeButton = await findAllByRole(modal, 'button', { name: 'home' });
+    const homeButton = await findAllByRole(modal, 'button', { name: 'Home' });
 
     expect(homeButton).toHaveLength(1);
     expect(buttonContent).toContain('testdir0');
@@ -161,7 +161,7 @@ describe('selects and expands directory for NewItemModal correctly', () => {
 
     const foundButtons = await findAllByRole(modal, 'button');
     const buttonContent = foundButtons.map(button => button.innerHTML);
-    const homeButton = await findAllByRole(modal, 'button', { name: 'home' });
+    const homeButton = await findAllByRole(modal, 'button', { name: 'Home' });
 
     expect(homeButton).toHaveLength(1);
     for (let i = 0; i < dirs.length; i += 1) {
@@ -178,7 +178,7 @@ describe('selects and expands directory for NewItemModal correctly', () => {
 
     const foundButtons = await findAllByRole(modal, 'button');
     const buttonContent = foundButtons.map(button => button.innerHTML);
-    const homeButton = await findAllByRole(modal, 'button', { name: 'home' });
+    const homeButton = await findAllByRole(modal, 'button', { name: 'Home' });
 
     expect(homeButton).toHaveLength(1);
     for (let i = 0; i < dirs.length; i += 1) {
@@ -201,7 +201,7 @@ describe('selects and expands directory for NewItemModal correctly', () => {
 
     const foundButtons = await findAllByRole(modal, 'button');
     const buttonContent = foundButtons.map(button => button.innerHTML);
-    const homeButton = await findAllByRole(modal, 'button', { name: 'home' });
+    const homeButton = await findAllByRole(modal, 'button', { name: 'Home' });
 
     expect(homeButton).toHaveLength(1);
     expect(buttonContent).toContain('testdir2');
@@ -226,7 +226,7 @@ describe('selects and expands directory for NewItemModal correctly', () => {
 
     const foundButtons = await findAllByRole(modal, 'button');
     const buttonContent = foundButtons.map(button => button.innerHTML);
-    const homeButton = await findAllByRole(modal, 'button', { name: 'home' });
+    const homeButton = await findAllByRole(modal, 'button', { name: 'Home' });
 
     expect(homeButton).toHaveLength(1);
     expect(buttonContent).toContain('testdir2');
@@ -271,7 +271,7 @@ describe('selects and expands directory for NewItemModal correctly', () => {
 
     const foundButtons = await findAllByRole(modal, 'button');
     const buttonContent = foundButtons.map(button => button.innerHTML);
-    const homeButton = await findAllByRole(modal, 'button', { name: 'home' });
+    const homeButton = await findAllByRole(modal, 'button', { name: 'Home' });
 
     expect(homeButton).toHaveLength(1);
     expect(buttonContent).toContain('testdir0');
@@ -280,7 +280,7 @@ describe('selects and expands directory for NewItemModal correctly', () => {
     userEvent.click(within(modal).getByRole('button', { name: 'testdir0' }));
     const newFoundButtons = await findAllByRole(modal, 'button');
     const newButtonContent = newFoundButtons.map(button => button.innerHTML);
-    const newFoundHome = await findAllByRole(modal, 'button', { name: 'home' });
+    const newFoundHome = await findAllByRole(modal, 'button', { name: 'Home' });
 
     expect(newFoundHome).toHaveLength(1);
     expect(newButtonContent).toContain('testdir0');
@@ -313,7 +313,7 @@ describe('selects and expands directory for NewItemModal correctly', () => {
     expect(dirs[1].isExpanded).toBe(false);
     expect(dirs[2].isExpanded).toBe(false);
 
-    userEvent.click(within(modal).getByRole('button', { name: 'home' }));
+    userEvent.click(within(modal).getByRole('button', { name: 'Home' }));
     for (let i = 0; i < dirs.length; i += 1) {
       expect(dirs[i].isExpanded).toBe(false);
     }

--- a/packages/file-explorer/src/FileStorage.ts
+++ b/packages/file-explorer/src/FileStorage.ts
@@ -42,12 +42,12 @@ export interface FileStorageTable extends StorageTable<FileStorageItem> {
    * @param path The path to expand
    * @param expanded What expanded state to set
    */
-  setExpanded(path: string, expanded: boolean): Promise<void>;
+  setExpanded(path: string, expanded: boolean): void;
 
   /**
    * Collapses all directories
    */
-  collapseAll(): Promise<void>;
+  collapseAll(): void;
 }
 
 /**

--- a/packages/file-explorer/src/NewItemModal.tsx
+++ b/packages/file-explorer/src/NewItemModal.tsx
@@ -8,7 +8,6 @@ import {
   ModalHeader,
   BasicModal,
   Button,
-  Tooltip,
 } from '@deephaven/components';
 import {
   CancelablePromise,
@@ -408,11 +407,11 @@ class NewItemModal extends PureComponent<NewItemModalProps, NewItemModalState> {
             kind="ghost"
             className="directory-breadcrumbs"
             onClick={() => this.handleBreadcrumbSelect(directoryPath)}
-            aria-label={index === 0 ? 'home' : undefined}
+            aria-label={index === 0 ? 'Home' : undefined}
             icon={index === 0 ? vsHome : undefined}
+            tooltip={index === 0 ? 'Home' : undefined}
           >
             {basename}
-            {index === 0 && <Tooltip>Home</Tooltip>}
           </Button>
           /
         </React.Fragment>

--- a/packages/file-explorer/src/NewItemModal.tsx
+++ b/packages/file-explorer/src/NewItemModal.tsx
@@ -8,6 +8,7 @@ import {
   ModalHeader,
   BasicModal,
   Button,
+  Tooltip,
 } from '@deephaven/components';
 import {
   CancelablePromise,
@@ -411,6 +412,7 @@ class NewItemModal extends PureComponent<NewItemModalProps, NewItemModalState> {
             icon={index === 0 ? vsHome : undefined}
           >
             {basename}
+            {index === 0 && <Tooltip>Home</Tooltip>}
           </Button>
           /
         </React.Fragment>


### PR DESCRIPTION
Fixes #790 
- added Tooltip to NewItemModal home button and renamed aria-label to uppercase "Home"
- refactored GrpcFileStorageTable and added timers to its test file

## Breaking Change
The `setExpanded()` and `collapseAll()` methods in the `FileStorageTable` interface in `FileStorage.ts` have changed (they now return `void` instead of `Promise<void>`). 