### PR TITLE
Re-enable strictLibCheck

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,8 +5,7 @@
     "paths": {
       "@deephaven/*": ["./packages/*/src"]
     },
-    "skipLibCheck": true,
-    "types": ["vite/client", "jest", "node"]
+    "types": ["jest", "node"]
   },
   "files": [],
   "watchOptions": {


### PR DESCRIPTION
This should not have been changed in the strict-boolean-expressions change. It adds <5% time to type generation and we weren't running into any issues with it before.

The reason I think it got enabled was because vite types were added globally, which is also incorrect. The vite types are added in `code-studio` and the embed packages only. With vite types globally, other packages could use `import.meta..env.VITE_ENV_VARIABLE` and TS would be fine with it.