### PR TITLE
Fix context menu not showing on Grid

### DIFF
--- a/packages/grid/src/Grid.tsx
+++ b/packages/grid/src/Grid.tsx
@@ -1642,7 +1642,7 @@ class Grid extends PureComponent<GridProps, GridState> {
     const mouseHandlers = this.getMouseHandlers();
     for (let i = 0; i < mouseHandlers.length; i += 1) {
       const mouseHandler = mouseHandlers[i];
-      if (mouseHandler.onContextMenu(gridPoint, this, event) != null) {
+      if (mouseHandler.onContextMenu(gridPoint, this, event) !== false) {
         event.stopPropagation();
         event.preventDefault();
         break;


### PR DESCRIPTION
**Bug**
The context menu was not showing when right clicking the table or column headers. 

**Fix**
The bug was in `Grid`s `handleContextMenu` method, where the if statement checked whether the `EventHandlerResult` (due to a mouse event) was not `null`. Rather, the result should've been compared to `false` because `EventHandlerResult` can return a boolean or undefined.