### PR TITLE
Version Bump v0.20.0

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -3,5 +3,5 @@
     "packages/*"
   ],
   "useWorkspaces": true,
-  "version": "0.19.1"
+  "version": "0.20.0"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -26231,7 +26231,7 @@
     },
     "packages/babel-preset": {
       "name": "@deephaven/babel-preset",
-      "version": "0.19.0",
+      "version": "0.20.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/core": "^7.16.0",
@@ -26245,7 +26245,7 @@
     },
     "packages/chart": {
       "name": "@deephaven/chart",
-      "version": "0.19.0",
+      "version": "0.20.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@deephaven/icons": "file:../icons",
@@ -26276,7 +26276,7 @@
     },
     "packages/code-studio": {
       "name": "@deephaven/code-studio",
-      "version": "0.19.1",
+      "version": "0.20.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@deephaven/chart": "file:../chart",
@@ -26427,7 +26427,7 @@
     },
     "packages/components": {
       "name": "@deephaven/components",
-      "version": "0.19.0",
+      "version": "0.20.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@deephaven/icons": "file:../icons",
@@ -26465,7 +26465,7 @@
     },
     "packages/console": {
       "name": "@deephaven/console",
-      "version": "0.19.0",
+      "version": "0.20.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@deephaven/chart": "file:../chart",
@@ -26501,7 +26501,7 @@
     },
     "packages/dashboard": {
       "name": "@deephaven/dashboard",
-      "version": "0.19.0",
+      "version": "0.20.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@deephaven/components": "file:../components",
@@ -26532,7 +26532,7 @@
     },
     "packages/dashboard-core-plugins": {
       "name": "@deephaven/dashboard-core-plugins",
-      "version": "0.19.1",
+      "version": "0.20.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@deephaven/chart": "file:../chart",
@@ -26592,7 +26592,7 @@
     },
     "packages/embed-chart": {
       "name": "@deephaven/embed-chart",
-      "version": "0.19.0",
+      "version": "0.20.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@deephaven/chart": "file:../chart",
@@ -26676,7 +26676,7 @@
     },
     "packages/embed-grid": {
       "name": "@deephaven/embed-grid",
-      "version": "0.19.0",
+      "version": "0.20.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@deephaven/components": "file:../components",
@@ -26760,7 +26760,7 @@
     },
     "packages/eslint-config": {
       "name": "@deephaven/eslint-config",
-      "version": "0.19.0",
+      "version": "0.20.0",
       "license": "Apache-2.0",
       "dependencies": {
         "eslint-config-airbnb": "18.2.1",
@@ -26778,7 +26778,7 @@
     },
     "packages/file-explorer": {
       "name": "@deephaven/file-explorer",
-      "version": "0.19.0",
+      "version": "0.20.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@deephaven/components": "file:../components",
@@ -26804,7 +26804,7 @@
     },
     "packages/filters": {
       "name": "@deephaven/filters",
-      "version": "0.19.0",
+      "version": "0.20.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@deephaven/tsconfig": "file:../tsconfig"
@@ -26815,7 +26815,7 @@
     },
     "packages/golden-layout": {
       "name": "@deephaven/golden-layout",
-      "version": "0.19.0",
+      "version": "0.20.0",
       "license": "Apache-2.0",
       "dependencies": {
         "jquery": "^3.6.0"
@@ -26833,7 +26833,7 @@
     },
     "packages/grid": {
       "name": "@deephaven/grid",
-      "version": "0.19.0",
+      "version": "0.20.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@deephaven/utils": "file:../utils",
@@ -26857,7 +26857,7 @@
     },
     "packages/icons": {
       "name": "@deephaven/icons",
-      "version": "0.19.0",
+      "version": "0.20.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@fortawesome/fontawesome-common-types": "^6.1.1"
@@ -26874,7 +26874,7 @@
     },
     "packages/iris-grid": {
       "name": "@deephaven/iris-grid",
-      "version": "0.19.0",
+      "version": "0.20.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@deephaven/components": "file:../components",
@@ -26916,7 +26916,7 @@
     },
     "packages/jsapi-components": {
       "name": "@deephaven/jsapi-components",
-      "version": "0.19.0",
+      "version": "0.20.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@deephaven/components": "file:../components",
@@ -26941,7 +26941,7 @@
     },
     "packages/jsapi-shim": {
       "name": "@deephaven/jsapi-shim",
-      "version": "0.19.0",
+      "version": "0.20.0",
       "license": "Apache-2.0",
       "dependencies": {
         "prop-types": "^15.7.2"
@@ -26955,7 +26955,7 @@
     },
     "packages/jsapi-utils": {
       "name": "@deephaven/jsapi-utils",
-      "version": "0.19.0",
+      "version": "0.20.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@deephaven/filters": "file:../filters",
@@ -26972,7 +26972,7 @@
     },
     "packages/log": {
       "name": "@deephaven/log",
-      "version": "0.19.0",
+      "version": "0.20.0",
       "license": "Apache-2.0",
       "dependencies": {
         "event-target-shim": "^6.0.2"
@@ -26986,7 +26986,7 @@
     },
     "packages/mocks": {
       "name": "@deephaven/mocks",
-      "version": "0.19.0",
+      "version": "0.20.0",
       "license": "Apache-2.0",
       "peerDependencies": {
         "jest": "26.x"
@@ -26994,7 +26994,7 @@
     },
     "packages/prettier-config": {
       "name": "@deephaven/prettier-config",
-      "version": "0.19.0",
+      "version": "0.20.0",
       "license": "Apache-2.0",
       "peerDependencies": {
         "prettier": "^2.2.1"
@@ -27002,7 +27002,7 @@
     },
     "packages/react-hooks": {
       "name": "@deephaven/react-hooks",
-      "version": "0.19.0",
+      "version": "0.20.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@deephaven/tsconfig": "file:../tsconfig"
@@ -27016,7 +27016,7 @@
     },
     "packages/redux": {
       "name": "@deephaven/redux",
-      "version": "0.19.0",
+      "version": "0.20.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@deephaven/jsapi-utils": "file:../jsapi-utils",
@@ -27036,7 +27036,7 @@
     },
     "packages/storage": {
       "name": "@deephaven/storage",
-      "version": "0.19.0",
+      "version": "0.20.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@deephaven/filters": "file:../filters",
@@ -27055,7 +27055,7 @@
     },
     "packages/stylelint-config": {
       "name": "@deephaven/stylelint-config",
-      "version": "0.19.0",
+      "version": "0.20.0",
       "license": "Apache-2.0",
       "dependencies": {
         "stylelint-config-prettier-scss": "^0.0.1",
@@ -27067,13 +27067,13 @@
     },
     "packages/tsconfig": {
       "name": "@deephaven/tsconfig",
-      "version": "0.19.0",
+      "version": "0.20.0",
       "license": "Apache-2.0"
     },
     "packages/util": {},
     "packages/utils": {
       "name": "@deephaven/utils",
-      "version": "0.19.0",
+      "version": "0.20.0",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=16"

--- a/packages/babel-preset/package.json
+++ b/packages/babel-preset/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/babel-preset",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "Deephaven Babel preset",
   "repository": {
     "type": "git",

--- a/packages/chart/package.json
+++ b/packages/chart/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/chart",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "Deephaven Chart",
   "author": "Deephaven Data Labs LLC",
   "license": "Apache-2.0",

--- a/packages/code-studio/package.json
+++ b/packages/code-studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/code-studio",
-  "version": "0.19.1",
+  "version": "0.20.0",
   "description": "Deephaven Code Studio",
   "author": "Deephaven Data Labs LLC",
   "license": "Apache-2.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/components",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "Deephaven React component library",
   "author": "Deephaven Data Labs LLC",
   "license": "Apache-2.0",

--- a/packages/console/package.json
+++ b/packages/console/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/console",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "Deephaven Console",
   "author": "Deephaven Data Labs LLC",
   "license": "Apache-2.0",

--- a/packages/dashboard-core-plugins/package.json
+++ b/packages/dashboard-core-plugins/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/dashboard-core-plugins",
-  "version": "0.19.1",
+  "version": "0.20.0",
   "description": "Deephaven Dashboard Core Plugins",
   "author": "Deephaven Data Labs LLC",
   "license": "Apache-2.0",

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/dashboard",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "Deephaven Dashboard",
   "author": "Deephaven Data Labs LLC",
   "license": "Apache-2.0",

--- a/packages/embed-chart/package.json
+++ b/packages/embed-chart/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/embed-chart",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "Deephaven Embedded Chart",
   "author": "Deephaven Data Labs LLC",
   "license": "Apache-2.0",

--- a/packages/embed-grid/package.json
+++ b/packages/embed-grid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/embed-grid",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "Deephaven Embedded Grid",
   "author": "Deephaven Data Labs LLC",
   "license": "Apache-2.0",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/eslint-config",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "Deephaven ESLint configuration",
   "repository": {
     "type": "git",

--- a/packages/file-explorer/package.json
+++ b/packages/file-explorer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/file-explorer",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "Deephaven File Explorer React component",
   "author": "Deephaven Data Labs LLC",
   "license": "Apache-2.0",

--- a/packages/filters/package.json
+++ b/packages/filters/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/filters",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "Deephaven Filters",
   "author": "Deephaven Data Labs LLC",
   "license": "Apache-2.0",

--- a/packages/golden-layout/package.json
+++ b/packages/golden-layout/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/golden-layout",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "author": "Deephaven Data Labs LLC",
   "license": "Apache-2.0",
   "description": "A multi-screen javascript Layout manager",

--- a/packages/grid/package.json
+++ b/packages/grid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/grid",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "Deephaven React grid component",
   "author": "Deephaven Data Labs LLC",
   "license": "Apache-2.0",

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/icons",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "Icons used in Deephaven client apps. Extends vscode-codicons to be font-awesome svg-core compatible and adds additional icons in a similar style.",
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/packages/iris-grid/package.json
+++ b/packages/iris-grid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/iris-grid",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "Deephaven Iris Grid",
   "author": "Deephaven Data Labs LLC",
   "license": "Apache-2.0",

--- a/packages/jsapi-components/package.json
+++ b/packages/jsapi-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/jsapi-components",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "Deephaven JSAPI Components",
   "author": "Deephaven Data Labs LLC",
   "license": "Apache-2.0",

--- a/packages/jsapi-shim/package.json
+++ b/packages/jsapi-shim/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/jsapi-shim",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "Deephaven JSAPI Shim",
   "author": "Deephaven Data Labs LLC",
   "license": "Apache-2.0",

--- a/packages/jsapi-utils/package.json
+++ b/packages/jsapi-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/jsapi-utils",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "Deephaven JSAPI Utils",
   "author": "Deephaven Data Labs LLC",
   "license": "Apache-2.0",

--- a/packages/log/package.json
+++ b/packages/log/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/log",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "Deephaven Logger",
   "author": "Deephaven Data Labs LLC",
   "license": "Apache-2.0",

--- a/packages/mocks/package.json
+++ b/packages/mocks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/mocks",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "Deephaven Mocks for common libraries",
   "repository": {
     "type": "git",

--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/prettier-config",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "Deephaven Prettier configuration",
   "repository": {
     "type": "git",

--- a/packages/react-hooks/package.json
+++ b/packages/react-hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/react-hooks",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "Deephaven React hooks library",
   "author": "Deephaven Data Labs LLC",
   "license": "Apache-2.0",

--- a/packages/redux/package.json
+++ b/packages/redux/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/redux",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "Deephaven Redux",
   "author": "Deephaven Data Labs LLC",
   "license": "Apache-2.0",

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/storage",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "Deephaven Storage abstract classes for storing app data",
   "author": "Deephaven Data Labs LLC",
   "license": "Apache-2.0",

--- a/packages/stylelint-config/package.json
+++ b/packages/stylelint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/stylelint-config",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "Deephaven Stylelint configuration",
   "repository": {
     "type": "git",

--- a/packages/tsconfig/package.json
+++ b/packages/tsconfig/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/tsconfig",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "Deephaven TypeScript configuration",
   "repository": {
     "type": "git",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/utils",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "Deephaven Utils",
   "author": "Deephaven Data Labs LLC",
   "license": "Apache-2.0",


### PR DESCRIPTION
## v0.20.0 (2022-10-21)

#### :boom: Breaking Change
* `code-studio`, `dashboard-core-plugins`, `dashboard`, `golden-layout`, `mocks`
  * [#796](https://github.com/deephaven/web-client-ui/pull/796) Convert golden-layout to TypeScript ([@mattrunyon](https://github.com/mattrunyon))
    1. Some golden-layout component configs need to assert their type param if it is a separate variable. The type on config was narrowed from `string` to a union of the available types.
      * Before: `const config = { type: 'stack', ... };`
      * After: `const config = { type: 'stack' as const, ... };`
    2. Some types will need to be modified as the `GoldenLayout` namespace type no longer exists. The types from the old namespace can be imported as named imports such as `import type { ContentItem } from '@deehpaven/golden-layout';`
      * Before: `item: GoldenLayout.ContentItem`
      * After: `item: ContentItem`
    3. `ConfigMinifier` is no longer a class with only static methods. Any uses should be switched to import the `minifyConfig` and `unminifyConfig` functions directly instead

* `chart`, `code-studio`, `dashboard-core-plugins`, `file-explorer`
  * [#810](https://github.com/deephaven/web-client-ui/pull/810) 790 file explorer render fail ([@jason-wang24](https://github.com/jason-wang24))
    * The `setExpanded()` and `collapseAll()` methods in the `FileStorageTable` interface in `FileStorage.ts` have changed (they now return `void` instead of `Promise<void>`). 

#### :rocket: Enhancement
* `code-studio`, `dashboard-core-plugins`, `dashboard`, `golden-layout`, `mocks`
  * [#796](https://github.com/deephaven/web-client-ui/pull/796) Convert golden-layout to TypeScript ([@mattrunyon](https://github.com/mattrunyon))
* `chart`, `code-studio`, `components`, `console`, `dashboard-core-plugins`, `dashboard`, `embed-chart`, `embed-grid`, `eslint-config`, `file-explorer`, `grid`, `iris-grid`, `jsapi-utils`, `log`, `redux`, `utils`
  * [#761](https://github.com/deephaven/web-client-ui/pull/761) Enabling Strict boolean expressions check ([@Zhou-Ziheng](https://github.com/Zhou-Ziheng))
* `components`
  * [#793](https://github.com/deephaven/web-client-ui/pull/793) Change Boostrap px-2 to separate custom-px-2 class for icon only buttons ([@jason-wang24](https://github.com/jason-wang24))
  * [#799](https://github.com/deephaven/web-client-ui/pull/799) Set aria-label for icon only buttons ([@dsmmcken](https://github.com/dsmmcken))

#### :bug: Bug Fix
* `grid`
  * [#835](https://github.com/deephaven/web-client-ui/pull/835) Fix context menu not showing on Grid ([@jason-wang24](https://github.com/jason-wang24))
* `components`
  * [#831](https://github.com/deephaven/web-client-ui/pull/831) Fix keyboard shortcuts not working in Grid ([@jason-wang24](https://github.com/jason-wang24))
* `chart`, `code-studio`, `dashboard-core-plugins`, `file-explorer`
  * [#810](https://github.com/deephaven/web-client-ui/pull/810) 790 file explorer render fail ([@jason-wang24](https://github.com/jason-wang24))
* `iris-grid`
  * [#794](https://github.com/deephaven/web-client-ui/pull/794) Catch and display errors in downloading in the `TableCsvExporter` component ([@jason-wang24](https://github.com/jason-wang24))
* `dashboard-core-plugins`
  * [#806](https://github.com/deephaven/web-client-ui/pull/806) Fix context menu in table plugins ([@mofojed](https://github.com/mofojed))

#### :house: Internal
* `components`, `console`, `dashboard-core-plugins`
  * [#823](https://github.com/deephaven/web-client-ui/pull/823) Refactor HTML buttons to Deephaven Buttons in `components`, `console`, and `dashboard-core-plugins` packages ([@jason-wang24](https://github.com/jason-wang24))
* Other
  * [#828](https://github.com/deephaven/web-client-ui/pull/828) Delete the component template ([@mofojed](https://github.com/mofojed))
  * [#814](https://github.com/deephaven/web-client-ui/pull/814) Re-enable strictLibCheck ([@mattrunyon](https://github.com/mattrunyon))
  * [#808](https://github.com/deephaven/web-client-ui/pull/808) Update to use new $GITHUB_OUTPUT instead of set-output ([@mofojed](https://github.com/mofojed))
* `code-studio`, `components`
  * [#822](https://github.com/deephaven/web-client-ui/pull/822) Refactor HTML buttons in `code-studio` to Deephaven Buttons ([@jason-wang24](https://github.com/jason-wang24))
* `file-explorer`
  * [#811](https://github.com/deephaven/web-client-ui/pull/811) Refactor <button> to <Button> in NewItemModal ([@jason-wang24](https://github.com/jason-wang24))
* `jsapi-components`
  * [#816](https://github.com/deephaven/web-client-ui/pull/816) Fix eslint errors in TableInput ([@vbabich](https://github.com/vbabich))
* `code-studio`
  * [#809](https://github.com/deephaven/web-client-ui/pull/809) Print app information to the log ([@mofojed](https://github.com/mofojed))

#### Committers: 6
- Don ([@dsmmcken](https://github.com/dsmmcken))
- Jason ([@jason-wang24](https://github.com/jason-wang24))
- Matthew Runyon ([@mattrunyon](https://github.com/mattrunyon))
- Mike Bender ([@mofojed](https://github.com/mofojed))
- Tony Zhou ([@Zhou-Ziheng](https://github.com/Zhou-Ziheng))
- Vlad Babich ([@vbabich](https://github.com/vbabich))