### PR TITLE
Fix new notebooks not saving when first created

### DIFF
--- a/packages/code-studio/src/storage/grpc/GrpcFileStorage.ts
+++ b/packages/code-studio/src/storage/grpc/GrpcFileStorage.ts
@@ -118,7 +118,7 @@ export class GrpcFileStorage implements FileStorage {
   }
 
   private refreshTables = throttle(() => {
-    this.tables.every(table => table.refresh().catch(() => undefined));
+    this.tables.forEach(table => table.refresh());
   }, GrpcFileStorage.REFRESH_THROTTLE);
 }
 


### PR DESCRIPTION
**Bug**
Newly created notebooks don't save properly after clicking the save button.
1. Go to File Explorer and click the 'New Notebook' button
2. Type something into the notebook
3. Click the save button 
4. Rename the notebook 
5. Click save
**Expected**
The blue dot indicating unsaved modifications were made to the file disappears. The tooltip when hovering over the file tab now shows the new file name. Clicking the close button of the file tab does not make the 'Do you want to save changes' modal to open.
**Actual**
The blue dot remains. The tooltip still shows 'untitled-x.py' even though the file has been renamed. Closing the file tab makes the 'Do you want to save changes' modal appear.

**Fix**
The `GrpcFileStorage` was updated in #810 where the `refresh()` method no longer returns a promise (now returns void). The now redundant `.catch()` inside of the `refreshTables()` method has been removed. `every` has also been changed to `forEach`.