### PR TITLE
Added function `close` to `interface IdeSession` in `dh.type`

### DIFF
--- a/packages/jsapi-shim/src/dh.types.ts
+++ b/packages/jsapi-shim/src/dh.types.ts
@@ -150,6 +150,7 @@ export interface IdeSession extends Evented {
   closeDocument(params: unknown): void;
   openDocument(params: unknown): void;
   changeDocument(params: unknown): void;
+  close(): void;
 }
 
 export interface Evented {


### PR DESCRIPTION
the function `close` was missing in type `IdeSession`.