### PR TITLE
Fixes command history not scrolled to bottom on load

### DIFF
--- a/packages/components/src/ItemList.scss
+++ b/packages/components/src/ItemList.scss
@@ -1,8 +1,8 @@
 @import '../scss/custom.scss';
 .item-list-scroll-pane {
+  // no point in padding, it will be ignored by list scrollToItem(last)
   border: 1px solid $input-border-color;
   border-radius: $input-border-radius;
-  padding: $input-padding-y 0 $input-padding-y;
   &:focus {
     outline: none;
   }

--- a/packages/components/src/ItemList.tsx
+++ b/packages/components/src/ItemList.tsx
@@ -181,18 +181,11 @@ export class ItemList<T> extends PureComponent<
     };
   }
 
-  componentDidMount(): void {
-    const { isStickyBottom } = this.props;
-    if (isStickyBottom && !this.isListAtBottom()) {
-      this.scrollToBottom();
-    }
-  }
-
   componentDidUpdate(
     prevProps: ItemListProps<T>,
     prevState: ItemListState
   ): void {
-    const { selectedRanges: propSelectedRanges } = this.props;
+    const { selectedRanges: propSelectedRanges, itemCount } = this.props;
     const {
       focusIndex,
       isStuckToBottom,
@@ -200,7 +193,7 @@ export class ItemList<T> extends PureComponent<
       height,
       selectedRanges,
     } = this.state;
-    if (isStuckToBottom && !this.isListAtBottom()) {
+    if (isStuckToBottom && !this.isListAtBottom() && itemCount > 0) {
       this.scrollToBottom();
     }
 
@@ -322,6 +315,10 @@ export class ItemList<T> extends PureComponent<
 
   focus(): void {
     this.listContainer.current?.focus();
+  }
+
+  update(): void {
+    this.list.current?.forceUpdate();
   }
 
   getElement(itemIndex: number): Element | null {
@@ -755,7 +752,7 @@ export class ItemList<T> extends PureComponent<
       rowHeight,
       'data-testid': dataTestId,
     } = this.props;
-    const { selectedRanges } = this.state;
+    const { selectedRanges, isStuckToBottom } = this.state;
     return (
       <AutoSizer className="item-list-auto-sizer" onResize={this.handleResize}>
         {({ width, height }) => (
@@ -763,6 +760,7 @@ export class ItemList<T> extends PureComponent<
             className="item-list-scroll-pane"
             height={height}
             width={width}
+            initialScrollOffset={isStuckToBottom ? itemCount * rowHeight : 0}
             itemCount={itemCount}
             itemSize={rowHeight}
             // This prop isn't actually used by us, it is passed to the render function by react-window

--- a/packages/components/src/ItemList.tsx
+++ b/packages/components/src/ItemList.tsx
@@ -317,7 +317,7 @@ export class ItemList<T> extends PureComponent<
     this.listContainer.current?.focus();
   }
 
-  update(): void {
+  restoreScrollPosition(): void {
     const { scrollOffset } = this.state;
     if (scrollOffset != null) {
       // manually restore the scroll containers offset

--- a/packages/components/src/ItemList.tsx
+++ b/packages/components/src/ItemList.tsx
@@ -318,7 +318,12 @@ export class ItemList<T> extends PureComponent<
   }
 
   update(): void {
-    this.list.current?.forceUpdate();
+    const { scrollOffset } = this.state;
+    if (scrollOffset != null) {
+      // manually restore the scroll containers offset
+      // virtual list doesn't restore scrolloffset in a re-render if it's the same
+      this.listContainer.current?.scrollTo(0, scrollOffset);
+    }
   }
 
   getElement(itemIndex: number): Element | null {

--- a/packages/console/src/command-history/CommandHistory.tsx
+++ b/packages/console/src/command-history/CommandHistory.tsx
@@ -176,6 +176,7 @@ class CommandHistory extends Component<
 
     this.pending = new Pending();
     this.searchInputRef = React.createRef();
+    this.itemListRef = React.createRef();
 
     const { table } = props;
 
@@ -203,6 +204,8 @@ class CommandHistory extends Component<
   pending: Pending;
 
   searchInputRef: RefObject<SearchInput>;
+
+  itemListRef: React.RefObject<ItemList<CommandHistoryStorageItem>>;
 
   /**
    * Retrieves the selected commands as an array.
@@ -351,6 +354,10 @@ class CommandHistory extends Component<
     }
   }
 
+  update(): void {
+    this.itemListRef.current?.update();
+  }
+
   render(): ReactElement {
     const { language, table } = this.props;
     const {
@@ -382,6 +389,7 @@ class CommandHistory extends Component<
         </div>
         <div className="command-history-list">
           <ItemList
+            ref={this.itemListRef}
             itemCount={itemCount}
             items={items}
             offset={offset}

--- a/packages/console/src/command-history/CommandHistory.tsx
+++ b/packages/console/src/command-history/CommandHistory.tsx
@@ -354,8 +354,8 @@ class CommandHistory extends Component<
     }
   }
 
-  update(): void {
-    this.itemListRef.current?.update();
+  restoreScrollPosition(): void {
+    this.itemListRef.current?.restoreScrollPosition();
   }
 
   render(): ReactElement {

--- a/packages/dashboard-core-plugins/src/panels/CommandHistoryPanel.tsx
+++ b/packages/dashboard-core-plugins/src/panels/CommandHistoryPanel.tsx
@@ -57,6 +57,7 @@ class CommandHistoryPanel extends Component<
     this.handleFocusHistory = this.handleFocusHistory.bind(this);
     this.handleSessionOpened = this.handleSessionOpened.bind(this);
     this.handleSessionClosed = this.handleSessionClosed.bind(this);
+    this.handleShow = this.handleShow.bind(this);
     this.handleSendToConsole = this.handleSendToConsole.bind(this);
     this.handleSendToNotebook = this.handleSendToNotebook.bind(this);
 
@@ -103,6 +104,11 @@ class CommandHistoryPanel extends Component<
     if (this.container.current) {
       this.container.current.focus();
     }
+  }
+
+  handleShow(): void {
+    // virtual list requires a force re-render when picked up and dropped in same place
+    this.container.current?.update();
   }
 
   handleSessionOpened(
@@ -184,6 +190,7 @@ class CommandHistoryPanel extends Component<
         glEventHub={glEventHub}
         onSessionOpen={this.handleSessionOpened}
         onSessionClose={this.handleSessionClosed}
+        onShow={this.handleShow}
       >
         {!table && (
           <div className="command-history-disconnected-message">

--- a/packages/dashboard-core-plugins/src/panels/CommandHistoryPanel.tsx
+++ b/packages/dashboard-core-plugins/src/panels/CommandHistoryPanel.tsx
@@ -107,8 +107,8 @@ class CommandHistoryPanel extends Component<
   }
 
   handleShow(): void {
-    // virtual list requires a force re-render when picked up and dropped in same place
-    this.container.current?.update();
+    // virtual list requires a forced reset to scroll position when picked up and dropped in same place
+    this.container.current?.restoreScrollPosition();
   }
 
   handleSessionOpened(


### PR DESCRIPTION
Resolves #859

- Use initialScrollOffset prop to set initial position instead of scrolling to bottom in did mount (which doesn't work when in a backgrounded tab)
- forceUpdate the virtualized list when it is picked up and dropped in the same place