### PR TITLE
Add missing exports and fix CSS for DHE

### DIFF
--- a/packages/components/.gitignore
+++ b/packages/components/.gitignore
@@ -9,6 +9,7 @@
 # production
 /build
 /dist
+/css
 
 # misc
 .vscode

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -21,7 +21,7 @@
     "build": "cross-env NODE_ENV=production run-p build:*",
     "build-dev": "cross-env NODE_ENV=development run-p build:*",
     "babel": "babel ./src --out-dir ./dist --extensions \".ts,.tsx,.js,.jsx\" --source-maps --root-mode upward",
-    "sass": "sass ./src:./dist",
+    "sass": "sass --load-path=../../node_modules ./src:./dist ./scss/BaseStyleSheet.scss:./css/BaseStyleSheet.css",
     "build:babel": "npm run babel",
     "build:sass": "npm run sass",
     "watch": "run-p watch:*",
@@ -62,7 +62,8 @@
   },
   "files": [
     "dist",
-    "scss"
+    "scss",
+    "css"
   ],
   "sideEffects": [
     "*.scss"

--- a/packages/components/scss/BaseStyleSheet.scss
+++ b/packages/components/scss/BaseStyleSheet.scss
@@ -1,6 +1,6 @@
 //Import our custom variables and bootstrap
 @import './custom.scss';
-@import '../../../node_modules/bootstrap/scss/bootstrap';
+@import 'bootstrap/scss/bootstrap';
 
 //Various non-variable css overides
 //Overide default size from 16px to 14px. We need density.

--- a/packages/components/scss/BaseStyleSheet.scss
+++ b/packages/components/scss/BaseStyleSheet.scss
@@ -1,4 +1,5 @@
-//Import our custom variables and bootstrap
+// Import our custom variables and bootstrap
+// Can be imported directly by Vite since it resolves bootstrap to node_modules/bootstrap
 @import './custom.scss';
 @import 'bootstrap/scss/bootstrap';
 

--- a/packages/components/scss/custom.scss
+++ b/packages/components/scss/custom.scss
@@ -1,14 +1,15 @@
-// Use this import within OSS for anything that isn't bundled by Webpack
+// Use this import for anything that can resolve 'bootstrap/scss' to '<root>/node_modules/bootstrap/scss'
+// Vite/rollup can resolve this properly. Webpack should use the custom_webpack.scss version
 
 //Make bootstrap functions available for use in overrides
-@import '../../../node_modules/bootstrap/scss/_functions.scss';
+@import 'bootstrap/scss/_functions.scss';
 @import './bootstrap_overrides.scss';
 
 //_variable imports come after bootstrap default overrides,
 // makes all other variables and mixins from bootstrap available
 /// with just importing customer.scss
-@import '../../../node_modules/bootstrap/scss/_variables.scss';
-@import '../../../node_modules/bootstrap/scss/_mixins.scss';
+@import 'bootstrap/scss/_variables.scss';
+@import 'bootstrap/scss/_mixins.scss';
 
 //New variables come after imports
 @import './new_variables.scss';

--- a/packages/components/scss/custom.scss
+++ b/packages/components/scss/custom.scss
@@ -1,15 +1,17 @@
-// Use this import for anything that can resolve 'bootstrap/scss' to '<root>/node_modules/bootstrap/scss'
-// Vite/rollup can resolve this properly. Webpack should use the custom_webpack.scss version
+// Use this for packages within the monorepo which extend our styles or need theme variables
+// This will not work well when consumed because of the relative paths
+// Sass load-path to make non-relative paths work is bugged and watches thousands of files
+// https://github.com/sass/dart-sass/issues/1377
 
 //Make bootstrap functions available for use in overrides
-@import 'bootstrap/scss/_functions.scss';
+@import '../../../node_modules/bootstrap/scss/_functions.scss';
 @import './bootstrap_overrides.scss';
 
 //_variable imports come after bootstrap default overrides,
 // makes all other variables and mixins from bootstrap available
 /// with just importing customer.scss
-@import 'bootstrap/scss/_variables.scss';
-@import 'bootstrap/scss/_mixins.scss';
+@import '../../../node_modules/bootstrap/scss/_variables.scss';
+@import '../../../node_modules/bootstrap/scss/_mixins.scss';
 
 //New variables come after imports
 @import './new_variables.scss';

--- a/packages/components/scss/custom_vite.scss
+++ b/packages/components/scss/custom_vite.scss
@@ -1,0 +1,15 @@
+// Use this import for anything that is bundled by Webpack
+// It should be able to resolve bootstrap/ to node_modules/bootstrap
+
+//Make bootstrap functions available for use in overrides
+@import 'bootstrap/scss/_functions.scss';
+@import './bootstrap_overrides.scss';
+
+//_variable imports come after bootstrap default overrides,
+// makes all other variables and mixins from bootstrap available
+/// with just importing customer.scss
+@import 'bootstrap/scss/_variables.scss';
+@import 'bootstrap/scss/_mixins.scss';
+
+//New variables come after imports
+@import './new_variables.scss';

--- a/packages/console/src/index.ts
+++ b/packages/console/src/index.ts
@@ -12,5 +12,6 @@ export * from './command-history';
 export * from './console-history';
 export { default as LogView } from './log/LogView';
 export { default as HeapUsage } from './HeapUsage';
+export { default as NewTableColumnTypes } from './csv/NewTableColumnTypes';
 
 export { default } from './Console';

--- a/packages/iris-grid/src/index.ts
+++ b/packages/iris-grid/src/index.ts
@@ -19,3 +19,5 @@ export { default as IrisGridUtils } from './IrisGridUtils';
 export * from './IrisGridUtils';
 export { default } from './IrisGrid';
 export * from './IrisGrid';
+export { default as TableViewportUpdater } from './TableViewportUpdater';
+export { default as TreeTableViewportUpdater } from './TreeTableViewportUpdater';

--- a/packages/iris-grid/src/sidebar/index.ts
+++ b/packages/iris-grid/src/sidebar/index.ts
@@ -31,3 +31,4 @@ export type { FormattingRule as SidebarFormattingRule };
 export * from './aggregations';
 export * from './RollupRows';
 export * from './ChartBuilder';
+export * from './icons';

--- a/packages/jsapi-shim/src/index.ts
+++ b/packages/jsapi-shim/src/index.ts
@@ -1,5 +1,6 @@
 export { default as dh } from './dh';
 export { default as PropTypes } from './PropTypes';
 export * from './dh.types';
+export type { default as dhType } from './dh.types';
 
 export { default } from './dh';


### PR DESCRIPTION
This will allow us to move DHE to the latest DHC and also switch to Vite.

The exported items were being imported from DHE as `import { item } from @deephaven/package/dist/item` which is bad.

The sass for BaseStyleSheet is not built any more, but DHE can import the sass file since it is published instead of the built css