### PR TITLE
Remove reference to TouchEvent

### DIFF
--- a/packages/golden-layout/src/controls/DragProxy.ts
+++ b/packages/golden-layout/src/controls/DragProxy.ts
@@ -134,13 +134,8 @@ export default class DragProxy extends EventEmitter {
    * @param event
    */
   _onDrag(offsetX: number, offsetY: number, event: JQuery.TriggeredEvent) {
-    const baseEvent =
-      event.originalEvent instanceof TouchEvent
-        ? event.originalEvent.touches[0]
-        : event;
-
-    const x = baseEvent.pageX ?? 0;
-    const y = baseEvent.pageY ?? 0;
+    const x = event.pageX ?? 0;
+    const y = event.pageY ?? 0;
     const isWithinContainer =
       x > this._minX && x < this._maxX && y > this._minY && y < this._maxY;
 

--- a/packages/golden-layout/src/utils/DragListener.ts
+++ b/packages/golden-layout/src/utils/DragListener.ts
@@ -132,13 +132,9 @@ class DragListener extends EventEmitter {
   }
 
   _getCoordinates(event: JQuery.TriggeredEvent) {
-    const baseEvent =
-      event.originalEvent instanceof TouchEvent
-        ? event.originalEvent.touches[0]
-        : event;
     return {
-      x: baseEvent.pageX,
-      y: baseEvent.pageY,
+      x: event.pageX ?? 0,
+      y: event.pageY ?? 0,
     };
   }
 }


### PR DESCRIPTION
- TouchEvent is not always available on desktop machines: https://developer.mozilla.org/en-US/docs/Web/API/Touch_events#example
--> It's not defined at all on FireFox desktop or Safari Desktop
- We could use PointerEvents to support both mouse and touch events better: https://developer.mozilla.org/en-US/docs/Web/API/Pointer_events
--> However, we don't really support touch anyway with Golden-layout, and we probably want to build in intentional support rather than this which has been left behind
