### PR TITLE
Fix EditableItemList selection, change to multiselect

### DIFF
--- a/packages/components/src/EditableItemList.test.tsx
+++ b/packages/components/src/EditableItemList.test.tsx
@@ -16,12 +16,7 @@ function makeWrapper({
   onAdd = jest.fn(),
   onDelete = jest.fn(),
   validate = undefined,
-}: {
-  items?: string[];
-  onAdd?: (item: string) => void;
-  onDelete?: (items: string[]) => void;
-  validate?: (item: string) => Error | null;
-} = {}) {
+}: Partial<EditableItemListProps> = {}) {
   return render(
     <EditableItemList
       items={items}

--- a/packages/components/src/EditableItemList.test.tsx
+++ b/packages/components/src/EditableItemList.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import EditableItemList from './EditableItemList';
+import EditableItemList, { EditableItemListProps } from './EditableItemList';
 
 const INVALID_INPUT_CLASS = 'is-invalid';
 

--- a/packages/components/src/EditableItemList.tsx
+++ b/packages/components/src/EditableItemList.tsx
@@ -11,7 +11,7 @@ import { vsAdd, vsTrash } from '@deephaven/icons';
 import { Range, RangeUtils } from '@deephaven/utils';
 import { Button, ItemList } from '.';
 
-interface EditableItemListProps {
+export interface EditableItemListProps {
   isInvalid?: boolean;
   items: string[];
   onDelete: (items: string[]) => void;

--- a/packages/components/src/EditableItemList.tsx
+++ b/packages/components/src/EditableItemList.tsx
@@ -8,13 +8,13 @@ import React, {
 import classNames from 'classnames';
 import clamp from 'lodash.clamp';
 import { vsAdd, vsTrash } from '@deephaven/icons';
-import { Range } from '@deephaven/utils';
+import { Range, RangeUtils } from '@deephaven/utils';
 import { Button, ItemList } from '.';
 
 interface EditableItemListProps {
   isInvalid?: boolean;
   items: string[];
-  onDelete: (item: string) => void;
+  onDelete: (items: string[]) => void;
   onAdd: (item: string) => void;
   validate?: (item: string) => Error | null;
 }
@@ -29,25 +29,27 @@ const EditableItemList = (props: EditableItemListProps): React.ReactElement => {
     validate = () => null,
   } = props;
   const [inputError, setInputError] = useState<Error | null>(null);
-  const [selectedIndex, setSelectedIndex] = useState<number | undefined>();
+  const [selectedRanges, setSelectedRanges] = useState<Range[]>([]);
   const [value, setValue] = useState('');
 
-  const handleSelect = useCallback(index => {
-    setSelectedIndex(index);
+  const handleSelectionChange = useCallback((ranges: Range[]) => {
+    setSelectedRanges(ranges);
   }, []);
 
   const handleDelete = useCallback(() => {
-    const newIndex =
-      selectedIndex === items.length - 1 ? items.length - 2 : selectedIndex;
-    if (
-      selectedIndex !== undefined &&
-      selectedIndex >= 0 &&
-      selectedIndex < items.length
-    ) {
-      onDelete(items[selectedIndex]);
-    }
-    setSelectedIndex(newIndex === -1 ? undefined : newIndex);
-  }, [items, selectedIndex, onDelete]);
+    const itemsToDelete: string[] = selectedRanges.reduce(
+      (acc: string[], range: Range) => {
+        const result = [...acc];
+        for (let i = range[0]; i <= range[1]; i += 1) {
+          result.push(items[i]);
+        }
+        return result;
+      },
+      []
+    );
+    onDelete(itemsToDelete);
+    setSelectedRanges([]);
+  }, [items, selectedRanges, onDelete]);
 
   const handleAdd = useCallback(() => {
     if (value === '') {
@@ -72,7 +74,7 @@ const EditableItemList = (props: EditableItemListProps): React.ReactElement => {
   );
 
   const handleInputFocus = useCallback(() => {
-    setSelectedIndex(undefined);
+    setSelectedRanges([]);
   }, []);
 
   const handleInputKeyDown = useCallback(
@@ -84,11 +86,6 @@ const EditableItemList = (props: EditableItemListProps): React.ReactElement => {
     [handleAdd]
   );
 
-  const selectedRanges = useMemo(
-    (): Range[] =>
-      selectedIndex === undefined ? [] : [[selectedIndex, selectedIndex]],
-    [selectedIndex]
-  );
   const containerHeight = useMemo(
     (): number => 14 + clamp(items.length, 1, 6) * ItemList.DEFAULT_ROW_HEIGHT,
     [items.length]
@@ -105,11 +102,12 @@ const EditableItemList = (props: EditableItemListProps): React.ReactElement => {
           itemCount={items.length}
           items={items.map((item, index) => ({
             value: item,
-            isSelected: index === selectedIndex,
+            isSelected: RangeUtils.isSelected(selectedRanges, index),
           }))}
           offset={0}
-          onSelect={handleSelect}
           selectedRanges={selectedRanges}
+          onSelectionChange={handleSelectionChange}
+          isMultiSelect
         />
       </div>
       <div className="d-flex flex-row pt-2">
@@ -138,7 +136,7 @@ const EditableItemList = (props: EditableItemListProps): React.ReactElement => {
           <Button
             kind="ghost"
             onClick={handleDelete}
-            disabled={selectedIndex === undefined}
+            disabled={selectedRanges.length === 0}
             icon={vsTrash}
             tooltip="Delete selected item"
             data-testid="delete-item-button"

--- a/packages/components/src/EditableItemList.tsx
+++ b/packages/components/src/EditableItemList.tsx
@@ -128,7 +128,7 @@ const EditableItemList = (props: EditableItemListProps): React.ReactElement => {
             onClick={handleDelete}
             disabled={selectedRanges.length === 0}
             icon={vsTrash}
-            tooltip="Delete selected item"
+            tooltip="Delete selected items"
             data-testid="delete-item-button"
           />
         </div>

--- a/packages/components/src/EditableItemList.tsx
+++ b/packages/components/src/EditableItemList.tsx
@@ -37,17 +37,7 @@ const EditableItemList = (props: EditableItemListProps): React.ReactElement => {
   }, []);
 
   const handleDelete = useCallback(() => {
-    const itemsToDelete: string[] = selectedRanges.reduce(
-      (acc: string[], range: Range) => {
-        const result = [...acc];
-        for (let i = range[0]; i <= range[1]; i += 1) {
-          result.push(items[i]);
-        }
-        return result;
-      },
-      []
-    );
-    onDelete(itemsToDelete);
+    onDelete(RangeUtils.getItemsInRanges(items, selectedRanges));
     setSelectedRanges([]);
   }, [items, selectedRanges, onDelete]);
 

--- a/packages/utils/src/RangeUtils.test.ts
+++ b/packages/utils/src/RangeUtils.test.ts
@@ -1,0 +1,25 @@
+import RangeUtils from './RangeUtils';
+
+describe('getItemsInRanges', () => {
+  it('handles edge cases', () => {
+    expect(RangeUtils.getItemsInRanges([], [])).toEqual([]);
+    expect(RangeUtils.getItemsInRanges([1, 2, 3], [])).toEqual([]);
+    expect(RangeUtils.getItemsInRanges([1, 2, 3], [[-1, 1]])).toEqual([
+      undefined,
+      1,
+      2,
+    ]);
+  });
+
+  it('returns correct items in provided valid ranges', () => {
+    expect(
+      RangeUtils.getItemsInRanges(
+        [1, 2, 3, 4],
+        [
+          [0, 0],
+          [2, 3],
+        ]
+      )
+    ).toEqual([1, 3, 4]);
+  });
+});

--- a/packages/utils/src/RangeUtils.ts
+++ b/packages/utils/src/RangeUtils.ts
@@ -97,6 +97,22 @@ class RangeUtils {
   static count(ranges: Range[]): number {
     return ranges.reduce((sum, range) => sum + (range[1] - range[0] + 1), 0);
   }
+
+  /**
+   * Get the items in the ranges provided
+   * @param items List of items
+   * @param ranges The ranges to include in the result
+   * @returns The items in the provided ranges
+   */
+  static getItemsInRanges<T>(items: T[], ranges: Range[]): T[] {
+    return ranges.reduce((acc: T[], range: Range) => {
+      const result = [...acc];
+      for (let i = range[0]; i <= range[1]; i += 1) {
+        result.push(items[i]);
+      }
+      return result;
+    }, []);
+  }
 }
 
 export default RangeUtils;


### PR DESCRIPTION
EditableItemList was using wrong event for tracking selection.
- Changed `onSelect` to `onSelectionChange`
- Also changed the list to multiselect, as suggested by QA

Breaking change: `onDelete` is now triggered with array of values instead of a single value