### PR TITLE
Fix null in links on grouped columns

### DIFF
--- a/packages/dashboard-core-plugins/src/linker/Linker.tsx
+++ b/packages/dashboard-core-plugins/src/linker/Linker.tsx
@@ -439,8 +439,13 @@ export class Linker extends Component<LinkerProps, LinkerState> {
         const filterMap = panelFilterMap.has(endPanelId)
           ? panelFilterMap.get(endPanelId)
           : new Map();
-        const { value } = dataMap[start.columnName];
+        const { isExpandable, isGrouped } = dataMap[start.columnName];
+        let { value } = dataMap[start.columnName];
         let text = `${value}`;
+        if (value === null && isExpandable && isGrouped) {
+          // Clear filter on empty rollup grouping columns
+          (value as string | undefined) = undefined;
+        }
         if (TableUtils.isDateType(columnType)) {
           const dateFilterFormatter = new DateTimeColumnFormatter({
             timeZone,

--- a/packages/dashboard-core-plugins/src/linker/LinkerUtils.tsx
+++ b/packages/dashboard-core-plugins/src/linker/LinkerUtils.tsx
@@ -38,6 +38,8 @@ export type LinkDataMapValue = {
   type: string;
   text: string;
   value: string;
+  isExpandable: boolean;
+  isGrouped: boolean;
 };
 
 export type LinkDataMap = Record<string, LinkDataMapValue>;

--- a/packages/iris-grid/src/IrisGrid.jsx
+++ b/packages/iris-grid/src/IrisGrid.jsx
@@ -1002,7 +1002,9 @@ export class IrisGrid extends Component {
         return;
       }
       const columnIndex = model.getColumnIndexByName(column.name);
-      if (value === null) {
+      if (value === undefined) {
+        this.removeQuickFilter(columnIndex);
+      } else if (value === null) {
         this.setQuickFilter(columnIndex, column.filter().isNull(), '=null');
       } else {
         const filterValue = TableUtils.isTextType(columnType)
@@ -1030,6 +1032,17 @@ export class IrisGrid extends Component {
         quickFilters: newQuickFilters,
         advancedFilters: newAdvancedFilters,
       };
+    });
+  }
+
+  removeQuickFilter(modelColumn) {
+    this.startLoading('Clearing Filter...', true);
+
+    this.setState(({ quickFilters }) => {
+      const newQuickFilters = new Map(quickFilters);
+      newQuickFilters.delete(modelColumn);
+
+      return { quickFilters: newQuickFilters };
     });
   }
 
@@ -1887,16 +1900,17 @@ export class IrisGrid extends Component {
    */
   selectData(columnIndex, rowIndex) {
     const { model } = this.props;
-    const { columns } = model;
+    const { columns, groupedColumns } = model;
     const dataMap = {};
     for (let i = 0; i < columns.length; i += 1) {
       const column = columns[i];
       const { name, type } = column;
       const value = model.valueForCell(i, rowIndex);
       const text = model.textForCell(i, rowIndex);
-      dataMap[name] = { value, text, type };
+      const isExpandable = model.isRowExpandable(rowIndex);
+      const isGrouped = groupedColumns.find(c => c.name === name) != null;
+      dataMap[name] = { value, text, type, isGrouped, isExpandable };
     }
-
     const { onDataSelected } = this.props;
     onDataSelected(rowIndex, dataMap);
   }


### PR DESCRIPTION
Fixes #875
- Pass `isGrouped` and `isExpandable` flags in selected data in addition to column type, text, and value
- Clear quick filters when applying links on columns with `undefined` value