### PR TITLE
Fix null in links on grouped columns

### DIFF
--- a/packages/dashboard-core-plugins/src/linker/Linker.tsx
+++ b/packages/dashboard-core-plugins/src/linker/Linker.tsx
@@ -447,7 +447,7 @@ export class Linker extends Component<LinkerProps, LinkerState> {
         let text = `${value}`;
         if (value === null && isExpandable && isGrouped) {
           // Clear filter on empty rollup grouping columns
-          (value as string | undefined) = undefined;
+          value = undefined;
         }
         if (columnType != null && TableUtils.isDateType(columnType)) {
           const dateFilterFormatter = new DateTimeColumnFormatter({
@@ -457,7 +457,7 @@ export class Linker extends Component<LinkerProps, LinkerState> {
             defaultDateTimeFormatString: DateUtils.FULL_DATE_FORMAT,
           });
           // The values are Dates for dateType values, not string like everything else
-          text = dateFilterFormatter.format((value as unknown) as Date);
+          text = dateFilterFormatter.format(value as Date);
         }
         filterMap.set(columnName, {
           columnType,

--- a/packages/dashboard-core-plugins/src/linker/Linker.tsx
+++ b/packages/dashboard-core-plugins/src/linker/Linker.tsx
@@ -442,8 +442,13 @@ export class Linker extends Component<LinkerProps, LinkerState> {
         const filterMap = panelFilterMap.has(endPanelId)
           ? panelFilterMap.get(endPanelId)
           : new Map();
-        const { value } = dataMap[start.columnName];
+        const { isExpandable, isGrouped } = dataMap[start.columnName];
+        let { value } = dataMap[start.columnName];
         let text = `${value}`;
+        if (value === null && isExpandable && isGrouped) {
+          // Clear filter on empty rollup grouping columns
+          (value as string | undefined) = undefined;
+        }
         if (columnType != null && TableUtils.isDateType(columnType)) {
           const dateFilterFormatter = new DateTimeColumnFormatter({
             timeZone,

--- a/packages/dashboard-core-plugins/src/linker/Linker.tsx
+++ b/packages/dashboard-core-plugins/src/linker/Linker.tsx
@@ -14,6 +14,7 @@ import type GoldenLayout from '@deephaven/golden-layout';
 import {
   DateTimeColumnFormatter,
   DateUtils,
+  RowDataMap,
   TableUtils,
 } from '@deephaven/jsapi-utils';
 import Log from '@deephaven/log';
@@ -39,7 +40,6 @@ import LinkerUtils, {
   isLinkablePanel,
   Link,
   LinkColumn,
-  LinkDataMap,
   LinkFilterMap,
   LinkType,
 } from './LinkerUtils';
@@ -427,7 +427,7 @@ export class Linker extends Component<LinkerProps, LinkerState> {
     }
   }
 
-  handleUpdateValues(panel: PanelComponent, dataMap: LinkDataMap): void {
+  handleUpdateValues(panel: PanelComponent, dataMap: RowDataMap): void {
     const panelId = LayoutUtils.getIdFromPanel(panel);
     const { links, timeZone } = this.props;
     // Map of panel ID to filterMap

--- a/packages/dashboard-core-plugins/src/linker/LinkerUtils.tsx
+++ b/packages/dashboard-core-plugins/src/linker/LinkerUtils.tsx
@@ -38,6 +38,8 @@ export type LinkDataMapValue = {
   type: string;
   text: string;
   value: string;
+  isExpandable: boolean;
+  isGrouped: boolean;
 };
 
 export type LinkDataMap = Record<string, LinkDataMapValue>;

--- a/packages/dashboard-core-plugins/src/linker/LinkerUtils.tsx
+++ b/packages/dashboard-core-plugins/src/linker/LinkerUtils.tsx
@@ -37,7 +37,7 @@ export type LinkFilterMap<T = unknown> = Map<string, LinkFilterMapValue<T>>;
 export type LinkDataMapValue = {
   type: string;
   text: string;
-  value: string;
+  value: unknown;
   isExpandable: boolean;
   isGrouped: boolean;
 };

--- a/packages/dashboard-core-plugins/src/linker/LinkerUtils.tsx
+++ b/packages/dashboard-core-plugins/src/linker/LinkerUtils.tsx
@@ -34,16 +34,6 @@ export type LinkFilterMapValue<T = unknown> = {
 
 export type LinkFilterMap<T = unknown> = Map<string, LinkFilterMapValue<T>>;
 
-export type LinkDataMapValue = {
-  type: string;
-  text: string;
-  value: unknown;
-  isExpandable: boolean;
-  isGrouped: boolean;
-};
-
-export type LinkDataMap = Record<string, LinkDataMapValue>;
-
 // [x,y] screen coordinates used by the Linker
 export type LinkerCoordinate = [number, number];
 

--- a/packages/iris-grid/src/IrisGrid.test.tsx
+++ b/packages/iris-grid/src/IrisGrid.test.tsx
@@ -116,3 +116,47 @@ it('handles copy key handler', () => {
 
   expect(component.copyRanges).toHaveBeenCalled();
 });
+
+it('handles value: undefined in setFilterMap, clears column filter', () => {
+  const component = makeComponent();
+  component.removeQuickFilter = jest.fn();
+  component.setQuickFilter = jest.fn();
+  component.setFilterMap(
+    new Map([
+      [
+        '2',
+        {
+          columnType: IrisGridTestUtils.DEFAULT_TYPE,
+          text: 'any',
+          value: undefined,
+        },
+      ],
+    ])
+  );
+  expect(component.setQuickFilter).not.toHaveBeenCalled();
+  expect(component.removeQuickFilter).toHaveBeenCalledWith(2);
+});
+
+it('handles value: null in setFilterMap', () => {
+  const component = makeComponent();
+  component.removeQuickFilter = jest.fn();
+  component.setQuickFilter = jest.fn();
+  component.setFilterMap(
+    new Map([
+      [
+        '2',
+        {
+          columnType: IrisGridTestUtils.DEFAULT_TYPE,
+          text: 'any',
+          value: null,
+        },
+      ],
+    ])
+  );
+  expect(component.setQuickFilter).toHaveBeenCalledWith(
+    2,
+    expect.anything(),
+    '=null'
+  );
+  expect(component.removeQuickFilter).not.toHaveBeenCalled();
+});

--- a/packages/iris-grid/src/IrisGrid.tsx
+++ b/packages/iris-grid/src/IrisGrid.tsx
@@ -76,6 +76,7 @@ import {
   TableUtils,
   FormattingRule,
   ReverseType,
+  RowDataMap,
   SortDirection,
   DateTimeColumnFormatterOptions,
   TableColumnFormat,
@@ -2444,16 +2445,7 @@ export class IrisGrid extends Component<IrisGridProps, IrisGridState> {
   selectData(columnIndex: ModelIndex, rowIndex: ModelIndex): void {
     const { model } = this.props;
     const { columns, groupedColumns } = model;
-    const dataMap: Record<
-      string,
-      {
-        value: unknown;
-        text: string | null;
-        type: string;
-        isExpandable: boolean;
-        isGrouped: boolean;
-      }
-    > = {};
+    const dataMap: RowDataMap = {};
     for (let i = 0; i < columns.length; i += 1) {
       const column = columns[i];
       const { name, type } = column;

--- a/packages/jsapi-utils/src/TableUtils.ts
+++ b/packages/jsapi-utils/src/TableUtils.ts
@@ -46,6 +46,16 @@ export type AdvancedFilterOptions = {
   selectedValues: unknown[];
 };
 
+export type RowDataMapValue = {
+  type: string;
+  text: string;
+  value: unknown;
+  isExpandable: boolean;
+  isGrouped: boolean;
+};
+
+export type RowDataMap = Record<string, RowDataMapValue>;
+
 /** Utility class to provide some functions for working with tables */
 export class TableUtils {
   static dataType = {


### PR DESCRIPTION
- Pass `isGrouped` and `isExpandable` flags in selected data in addition to column type, text, and value
- Clear quick filters when applying links on columns with `undefined` value
- Fixes #875