### PR TITLE
Update browserslist to latest defaults

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,0 +1,3 @@
+# Just use the defaults value for browsers we support
+
+defaults

--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,3 +1,3 @@
-# Just use the defaults value for browsers we support
+# Use the default value for browsers we support https://browsersl.ist/#q=defaults
 
 defaults

--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,3 +1,4 @@
 # Use the default value for browsers we support https://browsersl.ist/#q=defaults
+# Used by post-css only, JS browser targeting is controlled by Vite https://vitejs.dev/config/build-options.html#build-target
 
 defaults

--- a/packages/code-studio/package.json
+++ b/packages/code-studio/package.json
@@ -82,12 +82,6 @@
     "autoprefixer": "^10.4.8",
     "vite": "^3.1.0"
   },
-  "browserslist": [
-    ">0.2%",
-    "not dead",
-    "not ie >= 0",
-    "not op_mini all"
-  ],
   "publishConfig": {
     "access": "public"
   }

--- a/packages/embed-chart/package.json
+++ b/packages/embed-chart/package.json
@@ -40,12 +40,6 @@
     "@vitejs/plugin-react": "^2.0.0",
     "vite": "^3.1.0"
   },
-  "browserslist": [
-    ">0.2%",
-    "not dead",
-    "not ie >= 0",
-    "not op_mini all"
-  ],
   "publishConfig": {
     "access": "public"
   }

--- a/packages/embed-grid/package.json
+++ b/packages/embed-grid/package.json
@@ -40,12 +40,6 @@
     "@vitejs/plugin-react": "^2.0.0",
     "vite": "^3.1.0"
   },
-  "browserslist": [
-    ">0.2%",
-    "not dead",
-    "not ie >= 0",
-    "not op_mini all"
-  ],
   "publishConfig": {
     "access": "public"
   }


### PR DESCRIPTION
- Just use the latest defaults specified with browserslist instead of our own list
- Use a root `.browserlistrc` file instead of specifying it in package.json
- Fixes #658
