### PR TITLE
Persist iris grid advanced settings

### DIFF
--- a/packages/dashboard-core-plugins/src/panels/IrisGridPanel.tsx
+++ b/packages/dashboard-core-plugins/src/panels/IrisGridPanel.tsx
@@ -105,9 +105,10 @@ export interface PanelState {
   };
   irisGridState: DehydratedIrisGridState;
   irisGridPanelState: {
-    partitionColumn: ColumnName;
-    partition: string;
+    partitionColumn: ColumnName | undefined;
+    partition: string | undefined;
     isSelectingPartition: boolean;
+    advancedSettings: [AdvancedSettingsType, boolean][];
   };
   pluginState: unknown;
 }
@@ -407,11 +408,18 @@ export class IrisGridPanel extends PureComponent<
   );
 
   getDehydratedIrisGridPanelState = memoize(
-    (model, isSelectingPartition, partition, partitionColumn) =>
+    (
+      model: IrisGridModel,
+      isSelectingPartition: boolean,
+      partition: string | undefined,
+      partitionColumn: Column | undefined,
+      advancedSettings: Map<AdvancedSettingsType, boolean>
+    ) =>
       IrisGridUtils.dehydrateIrisGridPanelState(model, {
         isSelectingPartition,
         partition,
         partitionColumn,
+        advancedSettings,
       })
   );
 
@@ -984,6 +992,7 @@ export class IrisGridPanel extends PureComponent<
         isSelectingPartition,
         partition,
         partitionColumn,
+        advancedSettings,
       } = IrisGridUtils.hydrateIrisGridPanelState(model, irisGridPanelState);
       const {
         advancedFilters,
@@ -1021,6 +1030,7 @@ export class IrisGridPanel extends PureComponent<
       );
       this.setState({
         advancedFilters,
+        advancedSettings,
         conditionalFormats,
         customColumns,
         customColumnFormatMap,
@@ -1062,6 +1072,7 @@ export class IrisGridPanel extends PureComponent<
       isSelectingPartition,
       partition,
       partitionColumn,
+      advancedSettings,
     } = this.state;
     const {
       advancedFilters,
@@ -1083,6 +1094,7 @@ export class IrisGridPanel extends PureComponent<
       frozenColumns,
       conditionalFormats,
     } = irisGridState;
+    assertNotNull(model);
     assertNotNull(metrics);
     const { userColumnWidths, userRowHeights } = metrics;
     assertNotNull(gridState);
@@ -1098,7 +1110,8 @@ export class IrisGridPanel extends PureComponent<
         model,
         isSelectingPartition,
         partition,
-        partitionColumn
+        partitionColumn,
+        advancedSettings
       ),
       this.getDehydratedIrisGridState(
         model,

--- a/packages/iris-grid/src/IrisGridUtils.ts
+++ b/packages/iris-grid/src/IrisGridUtils.ts
@@ -46,6 +46,8 @@ import { UIRollupConfig } from './sidebar/RollupRows';
 import { AggregationSettings } from './sidebar/aggregations/Aggregations';
 import { FormattingRule as SidebarFormattingRule } from './sidebar/conditional-formatting/ConditionalFormattingUtils';
 import IrisGridModel from './IrisGridModel';
+import type AdvancedSettingsType from './sidebar/AdvancedSettingsType';
+import AdvancedSettings from './sidebar/AdvancedSettings';
 
 const log = Log.module('IrisGridUtils');
 
@@ -401,24 +403,28 @@ class IrisGridUtils {
     irisGridPanelState: {
       // This needs to be changed after IrisGridPanel is done
       isSelectingPartition: boolean;
-      partition: string;
-      partitionColumn: Column;
+      partition: string | undefined;
+      partitionColumn: Column | undefined;
+      advancedSettings: Map<AdvancedSettingsType, boolean>;
     }
   ): {
     isSelectingPartition: boolean;
-    partition: string;
+    partition: string | undefined;
     partitionColumn: ColumnName | null;
+    advancedSettings: [AdvancedSettingsType, boolean][];
   } {
     const {
       isSelectingPartition,
       partition,
       partitionColumn,
+      advancedSettings,
     } = irisGridPanelState;
 
     return {
       isSelectingPartition,
       partition,
       partitionColumn: partitionColumn != null ? partitionColumn.name : null,
+      advancedSettings: [...advancedSettings],
     };
   }
 
@@ -433,18 +439,21 @@ class IrisGridUtils {
     irisGridPanelState: {
       // This needs to be changed after IrisGridPanel is done
       isSelectingPartition: boolean;
-      partition: string;
-      partitionColumn: ColumnName;
+      partition: string | undefined;
+      partitionColumn: ColumnName | undefined;
+      advancedSettings: [AdvancedSettingsType, boolean][];
     }
   ): {
     isSelectingPartition: boolean;
-    partition: string;
+    partition?: string;
     partitionColumn?: Column;
+    advancedSettings: Map<AdvancedSettingsType, boolean>;
   } {
     const {
       isSelectingPartition,
       partition,
       partitionColumn,
+      advancedSettings,
     } = irisGridPanelState;
 
     const { columns } = model;
@@ -455,6 +464,10 @@ class IrisGridUtils {
         partitionColumn != null
           ? IrisGridUtils.getColumnByName(columns, partitionColumn)
           : undefined,
+      advancedSettings: new Map([
+        ...AdvancedSettings.DEFAULTS,
+        ...advancedSettings,
+      ]),
     };
   }
 
@@ -800,13 +813,13 @@ class IrisGridUtils {
     panelState: {
       irisGridState: { advancedFilters: AF; quickFilters: QF; sorts: S };
       irisGridPanelState: {
-        partitionColumn: ColumnName;
-        partition: unknown;
+        partitionColumn?: ColumnName;
+        partition?: unknown;
       };
     },
     inputFilters: InputFilter[] = []
   ): {
-    partitionColumn: ColumnName;
+    partitionColumn: ColumnName | undefined;
     partition: unknown;
     advancedFilters: AF;
     inputFilters: InputFilter[];


### PR DESCRIPTION
Fixes #897 

This will also merge the saved settings over the default settings if we were to add another advanced setting. It will not purge settings if they're removed, but we have 2 advanced settings and not sure we'll remove any anytime soon.

Enterprise has been updated in the silverheels Vite PR to get advancedSettings from the dehydrated panel state instead of iris grid state. Iris grid doesn't track the settings, the panel does.