### PR TITLE
Added support for canCopy and canDownloadCsv server properties

### DIFF
--- a/packages/code-studio/src/main/AppInit.tsx
+++ b/packages/code-studio/src/main/AppInit.tsx
@@ -173,22 +173,6 @@ const AppInit = (props: AppInitProps) => {
       );
 
       const name = 'user';
-      const user: User = {
-        name,
-        operateAs: name,
-        groups: [],
-        permissions: {
-          isSuperUser: false,
-          isQueryViewOnly: false,
-          isNonInteractive: false,
-          canUsePanels: true,
-          canCreateDashboard: true,
-          canCreateCodeStudio: true,
-          canCreateQueryMonitor: true,
-          canCopy: true,
-          canDownloadCsv: true,
-        },
-      };
 
       const coreClient = createCoreClient();
 
@@ -248,8 +232,29 @@ const AppInit = (props: AppInitProps) => {
       };
 
       const configs = await coreClient.getServerConfigValues();
-
       const serverConfig = new Map(configs);
+
+      const user: User = {
+        name,
+        operateAs: name,
+        groups: [],
+        permissions: {
+          isSuperUser: false,
+          isQueryViewOnly: false,
+          isNonInteractive: false,
+          canUsePanels: true,
+          canCreateDashboard: true,
+          canCreateCodeStudio: true,
+          canCreateQueryMonitor: true,
+          canCopy: !(
+            serverConfig.get('internal.webClient.appInit.canCopy') === 'false'
+          ),
+          canDownloadCsv: !(
+            serverConfig.get('internal.webClient.appInit.canDownloadCsv') ===
+            'false'
+          ),
+        },
+      };
 
       setActiveTool(ToolType.DEFAULT);
       setServerConfigValues(serverConfig);


### PR DESCRIPTION
- Allows the server to pass values for canCopy and canDownloadCsv
- Defaults to true if no server values are passed in
- Fixes #703 

Manually tested for three scenarios:
1. server values of canCopy and canDownloadCsv being false
2. server values of canCopy and canDownloadCsv being true
3. server does not provide values for canCopy and canDownloadCsv

Usage:
docker-compose.yml:
```
version: "3.4"

services:
  deephaven:
    image: ghcr.io/deephaven/server:latest
    ports:
      - "${DEEPHAVEN_PORT:-10000}:10000"
    volumes:
      - ./data:/data
      - ./deephaven.prop:/opt/deephaven/config/deephaven.prop:ro
    environment:
      - START_OPTS=-Xmx4g
```
deephaven.prop:
```
includefiles=dh-defaults.prop

internal.webClient.appInit.canCopy=false
internal.webClient.appInit.canDownloadCsv=false

client.configuration.list=java.version,deephaven.version,barrage.version,internal.webClient.appInit.canCopy,internal.webClient.appInit.canDownloadCsv,
```