### PR TITLE
Fix broken ctrl+e to clear filters shortcut (#664)

### DIFF
--- a/packages/code-studio/src/main/AppMainContainer.jsx
+++ b/packages/code-studio/src/main/AppMainContainer.jsx
@@ -13,6 +13,7 @@ import {
   GLOBAL_SHORTCUTS,
   Popper,
 } from '@deephaven/components';
+import { SHORTCUTS as IRIS_GRID_SHORTCUTS } from '@deephaven/iris-grid';
 import {
   Dashboard,
   DashboardUtils,
@@ -130,24 +131,15 @@ export class AppMainContainer extends Component {
             // widget panels can subscribe to his event, and execute their own clearing logic
             this.sendClearFilter();
           },
-          order: 50,
-          shortcut: GLOBAL_SHORTCUTS.CLEAR_ALL_FILTERS,
+          shortcut: IRIS_GRID_SHORTCUTS.TABLE.CLEAR_ALL_FILTERS,
+          isGlobal: true,
         },
         {
           action: () => {
             log.debug('Consume unhandled save shortcut');
           },
           shortcut: GLOBAL_SHORTCUTS.SAVE,
-        },
-        {
-          action: () => {
-            this.sendRestartSession();
-          },
-        },
-        {
-          action: () => {
-            this.sendDisconnectSession();
-          },
+          isGlobal: true,
         },
       ],
       isPanelsMenuShown: false,

--- a/packages/grid/src/key-handlers/SelectionKeyHandler.ts
+++ b/packages/grid/src/key-handlers/SelectionKeyHandler.ts
@@ -22,23 +22,47 @@ class SelectionKeyHandler extends KeyHandler {
         return this.handleArrowMove(1, 0, event, grid);
       case 'ArrowLeft':
         return this.handleArrowMove(-1, 0, event, grid);
-      case 'k': // h/j/k/l keys are grouped together for quick navigation by power users
-      case 'PageUp':
+      /**
+       * h/j/k/l keys are grouped together for quick navigation by power users.
+       * Bender added these as shortcuts in the original commit of keyboard shortcuts.
+       * We have no idea why, or what might have inspired them (not excel, not swing, vim?).
+       * Maybe lack of page up keys on a laptop at the time?
+       */
+      case 'k':
+      case 'K':
+        if (GridUtils.isModifierKeyDown(event)) return false;
         return this.handlePageUp(event, grid);
       case 'j':
-      case 'PageDown':
+      case 'J':
+        if (GridUtils.isModifierKeyDown(event)) return false;
         return this.handlePageDown(event, grid);
       case 'h':
-        grid.clearSelectedRanges();
-        grid.moveCursorToPosition(0, grid.state.cursorRow);
+      case 'H':
+        if (GridUtils.isModifierKeyDown(event)) return false;
+        if (!event.shiftKey) {
+          grid.clearSelectedRanges();
+        }
+        grid.moveCursorToPosition(0, grid.state.cursorRow, event.shiftKey);
         return true;
-      case 'l': {
+      case 'l':
+      case 'L': {
+        if (GridUtils.isModifierKeyDown(event)) return false;
         const { model } = grid.props;
         const { columnCount } = model;
-        grid.clearSelectedRanges();
-        grid.moveCursorToPosition(columnCount - 1, grid.state.cursorRow);
+        if (!event.shiftKey) {
+          grid.clearSelectedRanges();
+        }
+        grid.moveCursorToPosition(
+          columnCount - 1,
+          grid.state.cursorRow,
+          event.shiftKey
+        );
         return true;
       }
+      case 'PageDown':
+        return this.handlePageDown(event, grid);
+      case 'PageUp':
+        return this.handlePageUp(event, grid);
       case 'Home':
         if (!event.shiftKey) {
           grid.clearSelectedRanges();


### PR DESCRIPTION
* Resolves #663 by copying enterprise fix DH-12258. Removes dead code.
* Fix shortcut broken by #203 Separating dashboard into own package
* Cleanup hjkl shortcuts to not conflict with ctrl+L for linker
* add shift key support