### PR TITLE
Make MonacoCompletionProvider supply the version for textDocument (#909)

### DIFF
--- a/packages/console/src/monaco/MonacoCompletionProvider.test.tsx
+++ b/packages/console/src/monaco/MonacoCompletionProvider.test.tsx
@@ -10,7 +10,7 @@ function makeCompletionProvider(
   language = DEFAULT_LANGUAGE,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   session = new (dh as any).IdeSession(language),
-  model = { uri: {} }
+  model = { uri: {}, getVersionId: () => 1 }
 ) {
   const wrapper = render(
     <MonacoCompletionProvider
@@ -71,7 +71,7 @@ it('provides completion items properly', () => {
   const session = new (dh as any).IdeSession(language);
   session.getCompletionItems = jest.fn(() => promiseItems);
 
-  const model = { uri: { path: 'test' } };
+  const model = { uri: { path: 'test' }, getVersionId: jest.fn(() => 1) };
   makeCompletionProvider(language, session, model);
   const position = { lineNumber: 1, column: 1 };
   expect(myRegister).toHaveBeenCalledTimes(1);

--- a/packages/console/src/monaco/MonacoCompletionProvider.tsx
+++ b/packages/console/src/monaco/MonacoCompletionProvider.tsx
@@ -57,6 +57,7 @@ class MonacoCompletionProvider extends PureComponent<
     const params = {
       textDocument: {
         uri: `${model.uri}`,
+        version: model.getVersionId(),
       },
       // Yes, the Monaco API Position is different than the Position received by the LSP
       // Why? I do not know.


### PR DESCRIPTION
Fixes #909 