### PR TITLE
Fix console error that is logged about NaN when running tests

### DIFF
--- a/packages/console/src/Console.test.tsx
+++ b/packages/console/src/Console.test.tsx
@@ -13,6 +13,18 @@ function makeMockCommandHistoryStorage(): CommandHistoryStorage {
   };
 }
 
+/**
+ * Need to mock out the MonacoTheme as module.scss are not loaded in tests.
+ * scss files are mocked as defined by our `moduleNameMapper` setting in `jest.config.base.cjs
+ */
+
+jest.mock('./monaco', () => ({
+  ...jest.requireActual('./monaco'),
+  MonacoTheme: {
+    'line-height': '19px',
+  },
+}));
+
 jest.mock('./Console', () => ({
   ...(jest.requireActual('./Console') as Record<string, unknown>),
   commandHistory: jest.fn(),


### PR DESCRIPTION
- MonacoTheme['line-height'] is NaN when running tests, as scss is mocked out in tests
- Just mock out MonacoTheme to include a value for line-height.

Tested by running `npm test`, then press `p` to filter and enter `Console.test`
Previous this console.error was printed out. The test passed, but it had an error in the logs:
```
 PASS   @deephaven/console  packages/console/src/Console.test.tsx
  ● Console

    console.error
      Warning: `NaN` is an invalid value for the `height` css style property.
          at div
          at div
          at div
          at ConsoleInput (/home/bender/dev/deephaven/iris-oss/web-client-ui/main/packages/console/src/ConsoleInput.tsx:59:41)
          at div
          at div
          at Console (/home/bender/dev/deephaven/iris-oss/web-client-ui/main/packages/console/src/Console.tsx:148:36)
```

Now the test just passes.