### PR TITLE
Clean up non-semantic uses of defined colours

### DIFF
--- a/packages/chart/src/Chart.scss
+++ b/packages/chart/src/Chart.scss
@@ -1,6 +1,6 @@
 @import '@deephaven/components/scss/custom.scss';
 
-$chart-bg: $interfacegray;
+$chart-bg: $content-bg;
 $plotly-notifier-margin-right: 15px;
 $plotly-notifier-note-bg: $gray-600;
 $plotly-notifier-note-border-radius: 2px;

--- a/packages/chart/src/ChartTheme.module.scss
+++ b/packages/chart/src/ChartTheme.module.scss
@@ -2,7 +2,7 @@
 @import '@deephaven/components/scss/custom.scss';
 
 :export {
-  paper-bgcolor: $interfacegray;
+  paper-bgcolor: $content-bg;
   plot-bgcolor: $gray-850;
   title-color: $white;
   colorway: $blue $green $yellow $purple $orange $red $white;

--- a/packages/code-studio/src/settings/SettingsMenu.scss
+++ b/packages/code-studio/src/settings/SettingsMenu.scss
@@ -64,7 +64,7 @@ $settings-menu-z-index: $zindex-modal;
   color: $settings-menu-header-color;
 
   .btn-close-settings-menu {
-    color: $interfacewhite;
+    color: $foreground;
     font-size: 18px;
     // we want the close button to occupy at least
     // as much space as the triggering button below

--- a/packages/components/scss/BaseStyleSheet.scss
+++ b/packages/components/scss/BaseStyleSheet.scss
@@ -480,13 +480,13 @@ input[type='number']::-webkit-inner-spin-button {
   color: $gray-400;
   border: 1px solid $gray-400;
   &:hover {
-    color: $white;
+    color: $foreground;
   }
   &:focus {
     border-color: $input-focus-border-color;
   }
   &:disabled {
-    border-color: $black;
+    border-color: $background;
     cursor: not-allowed;
   }
 }
@@ -731,7 +731,7 @@ input[type='number']::-webkit-inner-spin-button {
   //for crossbrowser consistency this gradient is stacked bellow the svg used to get a caret (indicator) looking the same
   .custom-select {
     background-color: inherit !important;
-    color: $white;
+    color: $foreground;
     background-image: escape-svg($custom-select-indicator),
       linear-gradient(0deg, $input-bg, $input-bg);
     background-size: $custom-select-bg-size, cover;
@@ -740,7 +740,7 @@ input[type='number']::-webkit-inner-spin-button {
     //make the dotted duplicate focus line on firefox go away
     &:-moz-focusring {
       color: rgba(0, 0, 0, 0%);
-      text-shadow: 0 0 0 $white !important;
+      text-shadow: 0 0 0 $foreground !important;
     }
   }
 
@@ -749,7 +749,7 @@ input[type='number']::-webkit-inner-spin-button {
       linear-gradient(0deg, $gray-700, $gray-700);
     &:-moz-focusring {
       color: rgba(0, 0, 0, 0%);
-      text-shadow: 0 0 0 $white !important;
+      text-shadow: 0 0 0 $foreground !important;
     }
   }
 
@@ -758,7 +758,7 @@ input[type='number']::-webkit-inner-spin-button {
       linear-gradient(0deg, $gray-200, $gray-200);
     &:-moz-focusring {
       color: rgba(0, 0, 0, 0%);
-      text-shadow: 0 0 0 $black !important;
+      text-shadow: 0 0 0 $background !important;
     }
   }
 

--- a/packages/components/scss/BaseStyleSheet.scss
+++ b/packages/components/scss/BaseStyleSheet.scss
@@ -575,16 +575,16 @@ input[type='number']::-webkit-inner-spin-button {
 
 .modal-dialog.theme-bg-dark {
   .modal-title {
-    color: $interfacewhite;
+    color: $foreground;
   }
   .modal-header {
     .close {
-      color: $interfacewhite;
-      text-shadow: 0 1px 0 $interfaceblack;
+      color: $foreground;
+      text-shadow: 0 1px 0 $background;
     }
   }
   .modal-content {
-    background: $interfacegray;
+    background: $content-bg;
   }
 }
 
@@ -731,7 +731,7 @@ input[type='number']::-webkit-inner-spin-button {
   //for crossbrowser consistency this gradient is stacked bellow the svg used to get a caret (indicator) looking the same
   .custom-select {
     background-color: inherit !important;
-    color: $interfacewhite;
+    color: $white;
     background-image: escape-svg($custom-select-indicator),
       linear-gradient(0deg, $input-bg, $input-bg);
     background-size: $custom-select-bg-size, cover;

--- a/packages/components/scss/bootstrap_overrides.scss
+++ b/packages/components/scss/bootstrap_overrides.scss
@@ -133,7 +133,7 @@ $btn-border-width: 2px;
 //Override Inputs
 $input-bg: $gray-600;
 $input-disabled-bg: $gray-800;
-$input-color: $interfacewhite;
+$input-color: $foreground;
 $input-border-color: $gray-400;
 $input-placeholder-color: $gray-400;
 $input-focus-border-color: rgba($primary, 85%);
@@ -175,13 +175,13 @@ $toast-error-color: $foreground;
 
 //tooltips
 $tooltip-bg: $gray-700;
-$tooltip-color: $interfacewhite;
+$tooltip-color: $foreground;
 $tooltip-box-shadow: 0 0.1rem 1.5rem 0.1rem rgba($black, 80%);
 
 //drowdowns
 $dropdown-bg: $gray-600;
-$dropdown-link-color: $interfacewhite;
-$dropdown-link-hover-color: $interfacewhite;
+$dropdown-link-color: $foreground;
+$dropdown-link-hover-color: $foreground;
 $dropdown-link-hover-bg: $primary;
 $dropdown-divider-bg: $gray-700;
 
@@ -195,7 +195,7 @@ $contextmenu-selected-color: $foreground;
 
 //links
 $link-color: $gray-400;
-$link-hover-color: $interfacewhite;
+$link-hover-color: $foreground;
 
 //progress-bar
 $progress-bg: $gray-600;

--- a/packages/components/src/ThemeExport.module.scss
+++ b/packages/components/src/ThemeExport.module.scss
@@ -32,9 +32,6 @@
   mid: $mid;
   dark: $dark;
   text-muted: $text-muted;
-  interfacewhite: $interfacewhite;
-  interfaceblack: $interfaceblack;
-  interfacegray: $interfacegray;
   content-bg: $content-bg;
   background: $background;
   foreground: $foreground;

--- a/packages/console/src/command-history/CommandHistoryItem.scss
+++ b/packages/console/src/command-history/CommandHistoryItem.scss
@@ -3,12 +3,12 @@
 $shade: $primary;
 
 $command-history-bg: $gray-700;
-$selection-color: $interfacewhite;
+$selection-color: $foreground;
 $selection-bg: mix($shade, $command-history-bg, 35%);
 $selection-hover-bg: $shade;
 $selection-nofocus-bg: mix($shade, $command-history-bg, 12%);
 $selection-border-color: mix($shade, $command-history-bg, 55%);
-$selection-hover-color: $interfacewhite;
+$selection-hover-color: $foreground;
 
 .command-history {
   .command-history-item {

--- a/packages/console/src/log/LogLevelMenuItem.scss
+++ b/packages/console/src/log/LogLevelMenuItem.scss
@@ -22,7 +22,7 @@
 }
 
 .log-level-menu-item.STDOUT {
-  color: $interfacewhite;
+  color: $foreground;
 }
 
 .log-level-menu-item.WARN {

--- a/packages/console/src/monaco/MonacoTheme.module.scss
+++ b/packages/console/src/monaco/MonacoTheme.module.scss
@@ -44,7 +44,7 @@
   log-date: $gray-400;
   log-error: $danger;
   log-info: $blue;
-  log-stdout: $interfacewhite;
+  log-stdout: $foreground;
   log-warn: $yellow;
   log-debug: $purple;
   log-trace: $green;

--- a/packages/dashboard-core-plugins/src/controls/dropdown-filter/DropdownFilter.scss
+++ b/packages/dashboard-core-plugins/src/controls/dropdown-filter/DropdownFilter.scss
@@ -89,7 +89,7 @@ $dropdown-filter-icon-size: 31px;
 
     input {
       font-size: x-large;
-      color: $interfacewhite;
+      color: $foreground;
       text-align: center;
       background: transparent;
       border: none;

--- a/packages/dashboard-core-plugins/src/controls/input-filter/InputFilter.scss
+++ b/packages/dashboard-core-plugins/src/controls/input-filter/InputFilter.scss
@@ -76,7 +76,7 @@ $input-filter-icon-size: 31px;
 
     input {
       font-size: x-large;
-      color: $interfacewhite;
+      color: $foreground;
       text-align: center;
       background: transparent;
       border: none;

--- a/packages/dashboard-core-plugins/src/linker/LinkerOverlayContent.scss
+++ b/packages/dashboard-core-plugins/src/linker/LinkerOverlayContent.scss
@@ -23,7 +23,7 @@
     bottom: $toast-outer-padding;
     background: $modal-content-bg;
     max-width: 400px;
-    color: $interfaceblack;
+    color: $background;
     pointer-events: auto;
     box-shadow: $tooltip-box-shadow;
     z-index: $zindex-popover;

--- a/packages/dashboard-core-plugins/src/panels/FilterSetManager.scss
+++ b/packages/dashboard-core-plugins/src/panels/FilterSetManager.scss
@@ -97,7 +97,7 @@ $filter-set-manager-icon-size: 31px;
 
     input {
       font-size: x-large;
-      color: $interfacewhite;
+      color: $foreground;
       text-align: center;
       background: transparent;
       border: none;

--- a/packages/dashboard-core-plugins/src/panels/MarkdownNotebook.scss
+++ b/packages/dashboard-core-plugins/src/panels/MarkdownNotebook.scss
@@ -116,7 +116,7 @@ $btn-play-color: $success;
 
 @keyframes flash {
   0% {
-    text-shadow: 0 0 5px $interfacegray, 0 0 20px $interfacegray;
+    text-shadow: 0 0 5px $content-bg, 0 0 20px $content-bg;
   }
 
   50% {
@@ -124,6 +124,6 @@ $btn-play-color: $success;
   }
 
   100% {
-    text-shadow: 0 0 5px $interfacegray, 0 0 20px $interfacegray;
+    text-shadow: 0 0 5px $content-bg, 0 0 20px $content-bg;
   }
 }

--- a/packages/dashboard-core-plugins/src/panels/NotebookPanel.scss
+++ b/packages/dashboard-core-plugins/src/panels/NotebookPanel.scss
@@ -3,7 +3,7 @@
 $toolbar-font-size: 18px;
 $toolbar-width: 36px;
 $toolbar-height: 36px;
-$toolbar-bg: $interfacegray;
+$toolbar-bg: $content-bg;
 
 .notebook-title {
   &.is-preview {
@@ -26,7 +26,7 @@ $toolbar-bg: $interfacegray;
     flex-direction: row;
     flex-grow: 0;
     background: $toolbar-bg;
-    border-bottom: 2px solid $interfaceblack;
+    border-bottom: 2px solid $background;
     padding: $spacer-1;
 
     .btn {

--- a/packages/file-explorer/src/FileListItemEditor.scss
+++ b/packages/file-explorer/src/FileListItemEditor.scss
@@ -23,7 +23,7 @@ $item-list-item-height: 26px;
     }
   }
   .invalid-feedback {
-    color: $interfacewhite;
+    color: $foreground;
     background-color: $danger;
     font-size: 0.9rem;
     margin-top: 0;

--- a/packages/iris-grid/src/AdvancedFilterCreatorSelectValue.scss
+++ b/packages/iris-grid/src/AdvancedFilterCreatorSelectValue.scss
@@ -24,7 +24,7 @@
   }
 
   .btn-link {
-    color: $interfacewhite;
+    color: $foreground;
     text-decoration: underline;
   }
 

--- a/packages/iris-grid/src/IrisGrid.scss
+++ b/packages/iris-grid/src/IrisGrid.scss
@@ -1,7 +1,7 @@
 @import '@deephaven/components/scss/custom.scss';
 @import './IrisGridTheme.module.scss';
 
-$iris-grid-bg: $interfacegray;
+$iris-grid-bg: $content-bg;
 $iris-grid-font: 12px fira sans, sans-serif;
 $table-sidebar-max-width: 320px;
 $table-sidebar-bg: $gray-700;

--- a/packages/iris-grid/src/IrisGridTheme.module.scss
+++ b/packages/iris-grid/src/IrisGridTheme.module.scss
@@ -14,8 +14,8 @@ $header-height: 30px;
 :export {
   grid-bg: $gray-900;
   font: $font-size Fira Sans, sans-serif; // must be preloaded
-  white: $interfacewhite;
-  black: $interfaceblack;
+  white: $white;
+  black: $black;
   header-bg: $header-bg;
   header-color: $gray-200;
   header-height: $header-height;

--- a/packages/iris-grid/src/PendingDataBottomBar.scss
+++ b/packages/iris-grid/src/PendingDataBottomBar.scss
@@ -1,7 +1,7 @@
 @import '@deephaven/components/scss/custom.scss';
 
 .pending-data-bottom-bar {
-  background-color: $interfacegray;
+  background-color: $content-bg;
   .buttons-container {
     .btn-outline-primary {
       color: $gray-100;


### PR DESCRIPTION
Colors defined with `interface` prefix was intended for use within bootstrap overrides only.

Everywhere else should use either `$foreground`, `$background` or `$content-bg`. If the usage is not semantically relevant, then an explicit `$white` or `$black` is also acceptable.


This might be considered a breaking change as I also removed them from ThemeExport.