### PR TITLE
Subtract the pending row count when displaying row count

### DIFF
--- a/packages/dashboard-core-plugins/src/panels/IrisGridPanelTooltip.tsx
+++ b/packages/dashboard-core-plugins/src/panels/IrisGridPanelTooltip.tsx
@@ -17,7 +17,8 @@ const IrisGridPanelTooltip = (
 ): ReactElement => {
   const { model, widgetName, glContainer, description } = props;
 
-  const formattedRowCount = model?.displayString(model?.rowCount ?? 0, 'long');
+  const rowCount = (model?.rowCount ?? 0) - (model?.pendingRowCount ?? 0);
+  const formattedRowCount = model?.displayString(rowCount, 'long');
 
   return (
     <WidgetPanelTooltip

--- a/packages/iris-grid/src/ColumnStatistics.tsx
+++ b/packages/iris-grid/src/ColumnStatistics.tsx
@@ -103,7 +103,7 @@ class ColumnStatistics extends Component<
   maybeGenerateStatistics(): void {
     const { model } = this.props;
 
-    const numRows = model.rowCount;
+    const numRows = model.rowCount - model.pendingRowCount;
     this.setState({ numRows });
     if (!model.isColumnStatisticsAvailable) {
       this.setState({ loading: false });
@@ -150,7 +150,7 @@ class ColumnStatistics extends Component<
     this.setState({
       loading: false,
       statistics,
-      numRows: model.rowCount,
+      numRows: model.rowCount - model.pendingRowCount,
     });
 
     onStatistics();


### PR DESCRIPTION
- We fudge the `rowCount` when using InputTables to make the infinite scrolling input table effect. Displaying this `rowCount` was confusing to the user, as that's not the actual size of the table.
- Don't include the pending row count in tooltips when displaying row count. 
- Fixes #889
