### PR TITLE
Fixes Grid isStuckToBottom prop doesn't work correctly on mount if rowCount doesn't increase

### DIFF
--- a/packages/grid/src/Grid.tsx
+++ b/packages/grid/src/Grid.tsx
@@ -437,6 +437,16 @@ class Grid extends PureComponent<GridProps, GridState> {
 
     this.updateCanvasScale();
     this.updateCanvas();
+
+    // apply on mount, so that it works with a static model
+    // https://github.com/deephaven/web-client-ui/issues/581
+    const { isStuckToBottom, isStuckToRight } = this.props;
+    if (isStuckToBottom) {
+      this.scrollToBottom();
+    }
+    if (isStuckToRight) {
+      this.scrollToRight();
+    }
   }
 
   componentDidUpdate(prevProps: GridProps, prevState: GridState): void {
@@ -450,6 +460,7 @@ class Grid extends PureComponent<GridProps, GridState> {
       onMovedRowsChanged,
       onMoveRowComplete,
     } = this.props;
+
     const {
       isStickyBottom: prevIsStickyBottom,
       isStickyRight: prevIsStickyRight,
@@ -507,47 +518,25 @@ class Grid extends PureComponent<GridProps, GridState> {
       return;
     }
 
-    const {
-      bottomVisible,
-      rightVisible,
-      rowCount,
-      columnCount,
-      top,
-      left,
-      height,
-      width,
-    } = this.metrics;
+    const { rowCount, columnCount, height, width } = this.metrics;
     const {
       rowCount: prevRowCount,
       columnCount: prevColumnCount,
       height: prevHeight,
       width: prevWidth,
     } = this.prevMetrics;
-    const metricState = this.getMetricState();
 
     if (prevRowCount !== rowCount || height !== prevHeight) {
-      const lastTop = this.metricCalculator.getLastTop(metricState);
-      const { isStuckToBottom } = this.state;
-      if (
-        (isStuckToBottom &&
-          bottomVisible < rowCount - 1 &&
-          bottomVisible > 0) ||
-        top > lastTop
-      ) {
-        this.setState({ top: lastTop });
+      const { isStuckToBottom: stuckToBottom } = this.state;
+      if (stuckToBottom) {
+        this.scrollToBottom();
       }
     }
 
     if (prevColumnCount !== columnCount || width !== prevWidth) {
-      const lastLeft = this.metricCalculator.getLastLeft(metricState);
       const { isStuckToRight } = this.state;
-      if (
-        (isStuckToRight &&
-          rightVisible < columnCount - 1 &&
-          rightVisible > 0) ||
-        left > lastLeft
-      ) {
-        this.setState({ left: lastLeft });
+      if (isStuckToRight) {
+        this.scrollToRight();
       }
     }
 
@@ -700,6 +689,35 @@ class Grid extends PureComponent<GridProps, GridState> {
     this.commitSelection();
 
     this.setState({ isStuckToBottom: false });
+  }
+
+  /**
+   * Scrolls to bottom, if not already at bottom
+   */
+  scrollToBottom(): void {
+    if (!this.metrics) return;
+    const { bottomVisible, rowCount, top } = this.metrics;
+    const metricState = this.getMetricState();
+    const lastTop = this.metricCalculator.getLastTop(metricState);
+    if ((bottomVisible < rowCount - 1 && bottomVisible > 0) || top > lastTop) {
+      this.setState({ top: lastTop });
+    }
+  }
+
+  /**
+   * Scrolls to right, if not already at right
+   */
+  scrollToRight(): void {
+    if (!this.metrics) return;
+    const { rightVisible, columnCount, left } = this.metrics;
+    const metricState = this.getMetricState();
+    const lastLeft = this.metricCalculator.getLastLeft(metricState);
+    if (
+      (rightVisible < columnCount - 1 && rightVisible > 0) ||
+      left > lastLeft
+    ) {
+      this.setState({ left: lastLeft });
+    }
   }
 
   /**

--- a/packages/grid/src/Grid.tsx
+++ b/packages/grid/src/Grid.tsx
@@ -527,8 +527,8 @@ class Grid extends PureComponent<GridProps, GridState> {
     } = this.prevMetrics;
 
     if (prevRowCount !== rowCount || height !== prevHeight) {
-      const { isStuckToBottom: stuckToBottom } = this.state;
-      if (stuckToBottom) {
+      const { isStuckToBottom } = this.state;
+      if (isStuckToBottom) {
         this.scrollToBottom();
       }
     }

--- a/packages/grid/src/Grid.tsx
+++ b/packages/grid/src/Grid.tsx
@@ -696,9 +696,7 @@ class Grid extends PureComponent<GridProps, GridState> {
    */
   scrollToBottom(): void {
     if (!this.metrics) return;
-    const { bottomVisible, rowCount, top } = this.metrics;
-    const metricState = this.getMetricState();
-    const lastTop = this.metricCalculator.getLastTop(metricState);
+    const { bottomVisible, rowCount, top, lastTop } = this.metrics;
     if ((bottomVisible < rowCount - 1 && bottomVisible > 0) || top > lastTop) {
       this.setState({ top: lastTop });
     }
@@ -709,9 +707,7 @@ class Grid extends PureComponent<GridProps, GridState> {
    */
   scrollToRight(): void {
     if (!this.metrics) return;
-    const { rightVisible, columnCount, left } = this.metrics;
-    const metricState = this.getMetricState();
-    const lastLeft = this.metricCalculator.getLastLeft(metricState);
+    const { rightVisible, columnCount, left, lastLeft } = this.metrics;
     if (
       (rightVisible < columnCount - 1 && rightVisible > 0) ||
       left > lastLeft

--- a/packages/grid/src/GridMetricCalculator.ts
+++ b/packages/grid/src/GridMetricCalculator.ts
@@ -796,9 +796,9 @@ export class GridMetricCalculator {
     visibleWidth: number = this.getVisibleWidth(state)
   ): VisibleIndex {
     const { model } = state;
-    const { columnCount } = model;
+    const { columnCount, floatingRightColumnCount } = model;
 
-    let lastLeft = columnCount - 1;
+    let lastLeft = Math.max(0, columnCount - floatingRightColumnCount - 1);
     if (right != null) {
       lastLeft = right;
     }
@@ -820,15 +820,10 @@ export class GridMetricCalculator {
   /**
    * The last row that can be the top row (e.g. scrolled to the bottom)
    * If no bottom row is provided, then the last row that is not floating is used
-   */
-
-  /**
-   * The last row that can be the top row (e.g. scrolled to the bottom)
-   * If no bottom row is provided, then the last row that is not floating is used
    * @param state The current grid state
    * @param bottom The bottom-most row to be visible, or null to default to last cell
    * @param visibleHeight The height of the "visible" area (excluding floating items)
-   * @returns The index of the last left visible column
+   * @returns The index of the last top visible row
    */
   getLastTop(
     state: GridMetricState,
@@ -836,12 +831,9 @@ export class GridMetricCalculator {
     visibleHeight: number = this.getVisibleHeight(state)
   ): VisibleIndex {
     const { model } = state;
-    const { rowCount, floatingTopRowCount, floatingBottomRowCount } = model;
+    const { rowCount, floatingBottomRowCount } = model;
 
-    let lastTop = Math.max(
-      0,
-      rowCount - floatingTopRowCount - floatingBottomRowCount - 1
-    );
+    let lastTop = Math.max(0, rowCount - floatingBottomRowCount - 1);
     if (bottom != null) {
       lastTop = bottom;
     }

--- a/packages/grid/src/GridMetricCalculator.ts
+++ b/packages/grid/src/GridMetricCalculator.ts
@@ -836,9 +836,12 @@ export class GridMetricCalculator {
     visibleHeight: number = this.getVisibleHeight(state)
   ): VisibleIndex {
     const { model } = state;
-    const { rowCount, floatingBottomRowCount } = model;
+    const { rowCount, floatingTopRowCount, floatingBottomRowCount } = model;
 
-    let lastTop = Math.max(0, rowCount - floatingBottomRowCount - 1);
+    let lastTop = Math.max(
+      0,
+      rowCount - floatingTopRowCount - floatingBottomRowCount - 1
+    );
     if (bottom != null) {
       lastTop = bottom;
     }

--- a/packages/grid/src/GridMetricCalculator.ts
+++ b/packages/grid/src/GridMetricCalculator.ts
@@ -792,8 +792,8 @@ export class GridMetricCalculator {
    */
   getLastLeft(
     state: GridMetricState,
-    right: VisibleIndex | null = null,
-    visibleWidth: number = this.getVisibleWidth(state)
+    right: VisibleIndex | null,
+    visibleWidth: number
   ): VisibleIndex {
     const { model } = state;
     const { columnCount, floatingRightColumnCount } = model;
@@ -827,8 +827,8 @@ export class GridMetricCalculator {
    */
   getLastTop(
     state: GridMetricState,
-    bottom: VisibleIndex | null = null,
-    visibleHeight: number = this.getVisibleHeight(state)
+    bottom: VisibleIndex | null,
+    visibleHeight: number
   ): VisibleIndex {
     const { model } = state;
     const { rowCount, floatingBottomRowCount } = model;

--- a/packages/iris-grid/src/IrisGrid.tsx
+++ b/packages/iris-grid/src/IrisGrid.tsx
@@ -2040,7 +2040,11 @@ export class IrisGrid extends Component<IrisGridProps, IrisGridState> {
     } else if (rightVisible < column) {
       const metricState = this.grid?.getMetricState();
       assertNotNull(metricState);
-      const newLeft = metricCalculator.getLastLeft(metricState, column);
+      const newLeft = metricCalculator.getLastLeft(
+        metricState,
+        column,
+        metricCalculator.getVisibleWidth(metricState)
+      );
       this.grid?.setViewState(
         { left: Math.min(newLeft, lastLeft), leftOffset: 0 },
         true


### PR DESCRIPTION
Fixes #581 

@mofojed why does lastTop take into account floating rows but lastLeft doesn't? Noticed, because lastTop was not taking into account floating top rows.