### PR TITLE
Version Bump v0.22.2

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -3,5 +3,5 @@
     "packages/*"
   ],
   "useWorkspaces": true,
-  "version": "0.22.1"
+  "version": "0.22.2"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -26329,7 +26329,7 @@
     },
     "packages/code-studio": {
       "name": "@deephaven/code-studio",
-      "version": "0.22.1",
+      "version": "0.22.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@deephaven/chart": "file:../chart",
@@ -26482,7 +26482,7 @@
     },
     "packages/components": {
       "name": "@deephaven/components",
-      "version": "0.22.0",
+      "version": "0.22.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@deephaven/icons": "file:../icons",
@@ -26520,7 +26520,7 @@
     },
     "packages/console": {
       "name": "@deephaven/console",
-      "version": "0.22.1",
+      "version": "0.22.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@deephaven/chart": "file:../chart",
@@ -26556,7 +26556,7 @@
     },
     "packages/dashboard": {
       "name": "@deephaven/dashboard",
-      "version": "0.22.1",
+      "version": "0.22.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@deephaven/components": "file:../components",
@@ -26587,7 +26587,7 @@
     },
     "packages/dashboard-core-plugins": {
       "name": "@deephaven/dashboard-core-plugins",
-      "version": "0.22.1",
+      "version": "0.22.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@deephaven/chart": "file:../chart",
@@ -26647,7 +26647,7 @@
     },
     "packages/embed-chart": {
       "name": "@deephaven/embed-chart",
-      "version": "0.22.1",
+      "version": "0.22.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@deephaven/chart": "file:../chart",
@@ -26731,7 +26731,7 @@
     },
     "packages/embed-grid": {
       "name": "@deephaven/embed-grid",
-      "version": "0.22.1",
+      "version": "0.22.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@deephaven/components": "file:../components",
@@ -26833,7 +26833,7 @@
     },
     "packages/file-explorer": {
       "name": "@deephaven/file-explorer",
-      "version": "0.22.0",
+      "version": "0.22.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@deephaven/components": "file:../components",
@@ -26888,7 +26888,7 @@
     },
     "packages/grid": {
       "name": "@deephaven/grid",
-      "version": "0.22.0",
+      "version": "0.22.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@deephaven/utils": "file:../utils",
@@ -26929,7 +26929,7 @@
     },
     "packages/iris-grid": {
       "name": "@deephaven/iris-grid",
-      "version": "0.22.1",
+      "version": "0.22.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@deephaven/components": "file:../components",
@@ -26971,7 +26971,7 @@
     },
     "packages/jsapi-components": {
       "name": "@deephaven/jsapi-components",
-      "version": "0.22.1",
+      "version": "0.22.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@deephaven/components": "file:../components",
@@ -27049,7 +27049,7 @@
     },
     "packages/pouch-storage": {
       "name": "@deephaven/pouch-storage",
-      "version": "0.22.1",
+      "version": "0.22.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@deephaven/console": "file:../console",

--- a/packages/code-studio/package.json
+++ b/packages/code-studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/code-studio",
-  "version": "0.22.1",
+  "version": "0.22.2",
   "description": "Deephaven Code Studio",
   "author": "Deephaven Data Labs LLC",
   "license": "Apache-2.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/components",
-  "version": "0.22.0",
+  "version": "0.22.2",
   "description": "Deephaven React component library",
   "author": "Deephaven Data Labs LLC",
   "license": "Apache-2.0",

--- a/packages/console/package.json
+++ b/packages/console/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/console",
-  "version": "0.22.1",
+  "version": "0.22.2",
   "description": "Deephaven Console",
   "author": "Deephaven Data Labs LLC",
   "license": "Apache-2.0",

--- a/packages/dashboard-core-plugins/package.json
+++ b/packages/dashboard-core-plugins/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/dashboard-core-plugins",
-  "version": "0.22.1",
+  "version": "0.22.2",
   "description": "Deephaven Dashboard Core Plugins",
   "author": "Deephaven Data Labs LLC",
   "license": "Apache-2.0",

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/dashboard",
-  "version": "0.22.1",
+  "version": "0.22.2",
   "description": "Deephaven Dashboard",
   "author": "Deephaven Data Labs LLC",
   "license": "Apache-2.0",

--- a/packages/embed-chart/package.json
+++ b/packages/embed-chart/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/embed-chart",
-  "version": "0.22.1",
+  "version": "0.22.2",
   "description": "Deephaven Embedded Chart",
   "author": "Deephaven Data Labs LLC",
   "license": "Apache-2.0",

--- a/packages/embed-grid/package.json
+++ b/packages/embed-grid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/embed-grid",
-  "version": "0.22.1",
+  "version": "0.22.2",
   "description": "Deephaven Embedded Grid",
   "author": "Deephaven Data Labs LLC",
   "license": "Apache-2.0",

--- a/packages/file-explorer/package.json
+++ b/packages/file-explorer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/file-explorer",
-  "version": "0.22.0",
+  "version": "0.22.2",
   "description": "Deephaven File Explorer React component",
   "author": "Deephaven Data Labs LLC",
   "license": "Apache-2.0",

--- a/packages/grid/package.json
+++ b/packages/grid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/grid",
-  "version": "0.22.0",
+  "version": "0.22.2",
   "description": "Deephaven React grid component",
   "author": "Deephaven Data Labs LLC",
   "license": "Apache-2.0",

--- a/packages/iris-grid/package.json
+++ b/packages/iris-grid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/iris-grid",
-  "version": "0.22.1",
+  "version": "0.22.2",
   "description": "Deephaven Iris Grid",
   "author": "Deephaven Data Labs LLC",
   "license": "Apache-2.0",

--- a/packages/jsapi-components/package.json
+++ b/packages/jsapi-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/jsapi-components",
-  "version": "0.22.1",
+  "version": "0.22.2",
   "description": "Deephaven JSAPI Components",
   "author": "Deephaven Data Labs LLC",
   "license": "Apache-2.0",

--- a/packages/pouch-storage/package.json
+++ b/packages/pouch-storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/pouch-storage",
-  "version": "0.22.1",
+  "version": "0.22.2",
   "description": "Deephaven Storage based on PouchDB",
   "author": "Deephaven Data Labs LLC",
   "license": "Apache-2.0",


### PR DESCRIPTION

## v0.22.2 (2022-12-01)

#### :rocket: Enhancement
* `code-studio`
  * [#904](https://github.com/deephaven/web-client-ui/pull/904) Added support for canCopy and canDownloadCsv server properties ([@Zhou-Ziheng](https://github.com/Zhou-Ziheng))

#### :bug: Bug Fix
* `dashboard-core-plugins`, `iris-grid`
  * [#916](https://github.com/deephaven/web-client-ui/pull/916) Subtract the pending row count when displaying row count ([@mofojed](https://github.com/mofojed))
* `console`
  * [#911](https://github.com/deephaven/web-client-ui/pull/911) Fix console error that is logged about NaN when running tests ([@mofojed](https://github.com/mofojed))
  * [#918](https://github.com/deephaven/web-client-ui/pull/918) Don't trigger autocomplete when running code from notebook ([@mofojed](https://github.com/mofojed))
* `grid`
  * [#907](https://github.com/deephaven/web-client-ui/pull/907) Fix Linker Esc shortcut ([@vbabich](https://github.com/vbabich))
* `components`, `console`, `dashboard-core-plugins`
  * [#902](https://github.com/deephaven/web-client-ui/pull/902) Dropdown menu not closing after toggle ([@Zhou-Ziheng](https://github.com/Zhou-Ziheng))

#### :house: Internal
* Other
  * [#915](https://github.com/deephaven/web-client-ui/pull/915) Update github action versions to remove node 12 warning ([@dsmmcken](https://github.com/dsmmcken))
* `console`
  * [#910](https://github.com/deephaven/web-client-ui/pull/910) Make MonacoCompletionProvider supply the version for textDocument (#909) ([@JamesXNelson](https://github.com/JamesXNelson))

#### Committers: 5
- Don ([@dsmmcken](https://github.com/dsmmcken))
- James Nelson ([@JamesXNelson](https://github.com/JamesXNelson))
- Mike Bender ([@mofojed](https://github.com/mofojed))
- Tony Zhou ([@Zhou-Ziheng](https://github.com/Zhou-Ziheng))
- Vlad Babich ([@vbabich](https://github.com/vbabich))
