### PR TITLE
Stringify the error details before outputting to console

### DIFF
--- a/packages/code-studio/src/main/AppInit.tsx
+++ b/packages/code-studio/src/main/AppInit.tsx
@@ -167,7 +167,7 @@ const AppInit = (props: AppInitProps) => {
         dh.IdeConnection.HACK_CONNECTION_FAILURE,
         event => {
           const { detail } = event;
-          log.error('Connection failure', `${detail}`);
+          log.error('Connection failure', `${JSON.stringify(detail)}`);
           setError(`Unable to connect:  ${detail.details ?? 'Unknown Error'}`);
         }
       );

--- a/packages/code-studio/src/main/AppInit.tsx
+++ b/packages/code-studio/src/main/AppInit.tsx
@@ -167,7 +167,7 @@ const AppInit = (props: AppInitProps) => {
         dh.IdeConnection.HACK_CONNECTION_FAILURE,
         event => {
           const { detail } = event;
-          log.error('Connection failure', detail);
+          log.error('Connection failure', `${detail}`);
           setError(`Unable to connect:  ${detail.details ?? 'Unknown Error'}`);
         }
       );


### PR DESCRIPTION
- While looking through logs reported from a user, the error printed out was just `[AppInit] Connection failure Object`. Stringify it so we may have at least a bit more detail.
