### PR TITLE
Version bump 0.13.10

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,5 +2,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "0.13.9"
+  "version": "0.13.10"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -39118,7 +39118,7 @@
     },
     "packages/chart": {
       "name": "@deephaven/chart",
-      "version": "0.13.9",
+      "version": "0.13.10",
       "license": "Apache-2.0",
       "dependencies": {
         "@deephaven/icons": "file:../icons",
@@ -39146,7 +39146,7 @@
     },
     "packages/code-studio": {
       "name": "@deephaven/code-studio",
-      "version": "0.13.9",
+      "version": "0.13.10",
       "license": "Apache-2.0",
       "dependencies": {
         "@deephaven/chart": "file:../chart",
@@ -39281,7 +39281,7 @@
     },
     "packages/dashboard": {
       "name": "@deephaven/dashboard",
-      "version": "0.13.9",
+      "version": "0.13.10",
       "license": "Apache-2.0",
       "dependencies": {
         "@deephaven/components": "file:../components",
@@ -39311,7 +39311,7 @@
     },
     "packages/dashboard-core-plugins": {
       "name": "@deephaven/dashboard-core-plugins",
-      "version": "0.13.9",
+      "version": "0.13.10",
       "license": "Apache-2.0",
       "dependencies": {
         "@deephaven/chart": "file:../chart",
@@ -39356,7 +39356,7 @@
     },
     "packages/embed-grid": {
       "name": "@deephaven/embed-grid",
-      "version": "0.13.9",
+      "version": "0.13.10",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/core": "^7.16.0",
@@ -39473,7 +39473,7 @@
     },
     "packages/grid": {
       "name": "@deephaven/grid",
-      "version": "0.13.2",
+      "version": "0.13.10",
       "license": "Apache-2.0",
       "dependencies": {
         "classnames": "^2.3.1",
@@ -39508,7 +39508,7 @@
     },
     "packages/iris-grid": {
       "name": "@deephaven/iris-grid",
-      "version": "0.13.9",
+      "version": "0.13.10",
       "license": "Apache-2.0",
       "dependencies": {
         "@deephaven/components": "file:../components",
@@ -39551,7 +39551,7 @@
     },
     "packages/jsapi-components": {
       "name": "@deephaven/jsapi-components",
-      "version": "0.13.9",
+      "version": "0.13.10",
       "license": "Apache-2.0",
       "dependencies": {
         "@deephaven/components": "file:../components",
@@ -39590,7 +39590,7 @@
     },
     "packages/jsapi-utils": {
       "name": "@deephaven/jsapi-utils",
-      "version": "0.13.9",
+      "version": "0.13.10",
       "license": "Apache-2.0",
       "dependencies": {
         "@deephaven/components": "file:../components",
@@ -39652,7 +39652,7 @@
     },
     "packages/redux": {
       "name": "@deephaven/redux",
-      "version": "0.13.9",
+      "version": "0.13.10",
       "license": "Apache-2.0",
       "dependencies": {
         "@deephaven/jsapi-utils": "file:../jsapi-utils",

--- a/packages/chart/package.json
+++ b/packages/chart/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/chart",
-  "version": "0.13.9",
+  "version": "0.13.10",
   "description": "Deephaven Chart",
   "author": "Deephaven Data Labs LLC",
   "license": "Apache-2.0",

--- a/packages/code-studio/package.json
+++ b/packages/code-studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/code-studio",
-  "version": "0.13.9",
+  "version": "0.13.10",
   "description": "Deephaven Code Studio",
   "author": "Deephaven Data Labs LLC",
   "license": "Apache-2.0",

--- a/packages/dashboard-core-plugins/package.json
+++ b/packages/dashboard-core-plugins/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/dashboard-core-plugins",
-  "version": "0.13.9",
+  "version": "0.13.10",
   "description": "Deephaven Dashboard Core Plugins",
   "author": "Deephaven Data Labs LLC",
   "license": "Apache-2.0",

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/dashboard",
-  "version": "0.13.9",
+  "version": "0.13.10",
   "description": "Deephaven Dashboard",
   "author": "Deephaven Data Labs LLC",
   "license": "Apache-2.0",

--- a/packages/embed-grid/package.json
+++ b/packages/embed-grid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/embed-grid",
-  "version": "0.13.9",
+  "version": "0.13.10",
   "description": "Deephaven Embedded Grid",
   "author": "Deephaven Data Labs LLC",
   "license": "Apache-2.0",

--- a/packages/grid/package.json
+++ b/packages/grid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/grid",
-  "version": "0.13.2",
+  "version": "0.13.10",
   "description": "Deephaven React grid component",
   "author": "Deephaven Data Labs LLC",
   "license": "Apache-2.0",

--- a/packages/iris-grid/package.json
+++ b/packages/iris-grid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/iris-grid",
-  "version": "0.13.9",
+  "version": "0.13.10",
   "description": "Deephaven Iris Grid",
   "author": "Deephaven Data Labs LLC",
   "license": "Apache-2.0",

--- a/packages/jsapi-components/package.json
+++ b/packages/jsapi-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/jsapi-components",
-  "version": "0.13.9",
+  "version": "0.13.10",
   "description": "Deephaven JSAPI Components",
   "author": "Deephaven Data Labs LLC",
   "license": "Apache-2.0",

--- a/packages/jsapi-utils/package.json
+++ b/packages/jsapi-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/jsapi-utils",
-  "version": "0.13.9",
+  "version": "0.13.10",
   "description": "Deephaven JSAPI Utils",
   "author": "Deephaven Data Labs LLC",
   "license": "Apache-2.0",

--- a/packages/redux/package.json
+++ b/packages/redux/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deephaven/redux",
-  "version": "0.13.9",
+  "version": "0.13.10",
   "description": "Deephaven Redux",
   "author": "Deephaven Data Labs LLC",
   "license": "Apache-2.0",


### PR DESCRIPTION
## v0.13.10 (2022-12-02)

#### :bug: Bug Fix
* `grid`
  * [#917](https://github.com/deephaven/web-client-ui/pull/917) Fix Linker Esc shortcut (#907) ([@vbabich](https://github.com/vbabich))
* `code-studio`, `grid`
  * [#905](https://github.com/deephaven/web-client-ui/pull/905) Fix broken ctrl+e to clear filters shortcut (#664) ([@vbabich](https://github.com/vbabich))
* `dashboard-core-plugins`, `iris-grid`, `jsapi-utils`
  * [#900](https://github.com/deephaven/web-client-ui/pull/900) Fix null in links on grouped columns (#892) ([@vbabich](https://github.com/vbabich))

#### Committers: 1
- Vlad Babich ([@vbabich](https://github.com/vbabich))