### PR TITLE
Allow embed-grid to open pandas dataframes

### DIFF
--- a/packages/embed-grid/src/App.tsx
+++ b/packages/embed-grid/src/App.tsx
@@ -6,13 +6,8 @@ import {
   IrisGridModel,
   IrisGridModelFactory,
 } from '@deephaven/iris-grid'; // iris-grid is used to display Deephaven tables
-import dh, {
-  IdeConnection,
-  Sort,
-  Table,
-  VariableTypeUnion,
-} from '@deephaven/jsapi-shim'; // Import the shim to use the JS API
-import { TableUtils } from '@deephaven/jsapi-utils';
+import dh, { IdeConnection, Sort, Table } from '@deephaven/jsapi-shim'; // Import the shim to use the JS API
+import { fetchVariableDefinition, TableUtils } from '@deephaven/jsapi-utils';
 import Log from '@deephaven/log';
 import './App.scss'; // Styles for in this app
 
@@ -42,12 +37,11 @@ export type SortCommandType = {
  */
 async function loadTable(
   connection: IdeConnection,
-  name: string,
-  type: VariableTypeUnion = dh.VariableType.TABLE
+  name: string
 ): Promise<Table> {
   log.info(`Fetching table ${name}...`);
 
-  const definition = { name, type };
+  const definition = await fetchVariableDefinition(connection, name);
   return (await connection.getObject(definition)) as Table;
 }
 
@@ -71,8 +65,6 @@ function App(): JSX.Element {
   );
   const canCopy = searchParams.get('canCopy') != null;
   const canDownloadCsv = searchParams.get('canDownloadCsv') != null;
-  const type = (searchParams.get('type') ??
-    dh.VariableType.TABLE) as VariableTypeUnion;
 
   useEffect(
     function initializeApp() {
@@ -99,7 +91,7 @@ function App(): JSX.Element {
           log.debug('Loading table', name, '...');
 
           // Load the table up.
-          const table = await loadTable(connection, name, type);
+          const table = await loadTable(connection, name);
 
           // Create the `IrisGridModel` for use with the `IrisGrid` component
           log.debug(`Creating model...`);
@@ -117,7 +109,7 @@ function App(): JSX.Element {
       }
       initApp();
     },
-    [searchParams, type]
+    [searchParams]
   );
 
   useEffect(

--- a/packages/embed-grid/src/App.tsx
+++ b/packages/embed-grid/src/App.tsx
@@ -15,6 +15,12 @@ Log.setLogLevel(parseInt(import.meta.env.VITE_LOG_LEVEL ?? '', 10));
 
 const log = Log.module('EmbedGrid.App');
 
+export const SUPPORTED_TYPES: string[] = [
+  dh.VariableType.TABLE,
+  dh.VariableType.TREETABLE,
+  dh.VariableType.PANDAS,
+];
+
 export type Command = 'filter' | 'sort';
 
 /** Input value for filter commands */
@@ -42,7 +48,13 @@ async function loadTable(
   log.info(`Fetching table ${name}...`);
 
   const definition = await fetchVariableDefinition(connection, name);
-  return (await connection.getObject(definition)) as Table;
+  if (!SUPPORTED_TYPES.includes(definition.type)) {
+    throw new Error(
+      `Unsupported type '${definition.type}' for variable named '${name}'`
+    );
+  }
+  const object = await connection.getObject(definition);
+  return object as Table;
 }
 
 /**

--- a/packages/jsapi-utils/src/ConnectionUtils.test.ts
+++ b/packages/jsapi-utils/src/ConnectionUtils.test.ts
@@ -1,0 +1,114 @@
+import dh, { VariableDefinition } from '@deephaven/jsapi-shim';
+import { TimeoutError } from '@deephaven/utils';
+import { fetchVariableDefinition } from './ConnectionUtils';
+
+const mockRemoveListener = jest.fn();
+const mockSubscribeToFieldUpdates = jest.fn(
+  changeListener => mockRemoveListener
+);
+
+const connection = new dh.IdeConnection('http://mockserver');
+connection.subscribeToFieldUpdates = mockSubscribeToFieldUpdates;
+
+const testDefinition1: VariableDefinition = {
+  title: 'TEST_DEF',
+  type: dh.VariableType.TABLE,
+};
+
+const testDefinition2: VariableDefinition = {
+  title: 'ANOTHER_DEF',
+  type: dh.VariableType.FIGURE,
+};
+
+beforeAll(() => {
+  jest.useFakeTimers();
+});
+
+afterAll(() => {
+  jest.useRealTimers();
+});
+
+beforeEach(() => {
+  mockRemoveListener.mockClear();
+  mockSubscribeToFieldUpdates.mockClear();
+});
+
+it('finds the right definition if variable exists', async () => {
+  const fetchPromise = fetchVariableDefinition(
+    connection,
+    testDefinition1.title ?? ''
+  );
+
+  expect(mockSubscribeToFieldUpdates).toHaveBeenCalled();
+  expect(mockRemoveListener).not.toHaveBeenCalled();
+
+  const listener = mockSubscribeToFieldUpdates.mock.calls[0][0];
+
+  listener({
+    created: [testDefinition1, testDefinition2],
+    updated: [],
+    removed: [],
+  });
+
+  const result = await fetchPromise;
+
+  expect(result).toBe(testDefinition1);
+  expect(mockRemoveListener).toHaveBeenCalled();
+});
+
+it('finds the definition in the second update if not after the first update', async () => {
+  const fetchPromise = fetchVariableDefinition(
+    connection,
+    testDefinition2.title ?? ''
+  );
+
+  expect(mockSubscribeToFieldUpdates).toHaveBeenCalled();
+  expect(mockRemoveListener).not.toHaveBeenCalled();
+
+  const listener = mockSubscribeToFieldUpdates.mock.calls[0][0];
+
+  listener({
+    created: [testDefinition1],
+    updated: [],
+    removed: [],
+  });
+
+  expect(mockRemoveListener).not.toHaveBeenCalled();
+
+  listener({
+    created: [testDefinition2],
+    updated: [],
+    removed: [],
+  });
+
+  const result = await fetchPromise;
+
+  expect(result).toBe(testDefinition2);
+  expect(mockRemoveListener).toHaveBeenCalled();
+});
+
+it('throws a TimeoutError if variable not found', async () => {
+  const fetchPromise = fetchVariableDefinition(
+    connection,
+    testDefinition2.title ?? ''
+  );
+
+  expect(mockSubscribeToFieldUpdates).toHaveBeenCalled();
+  expect(mockRemoveListener).not.toHaveBeenCalled();
+
+  const listener = mockSubscribeToFieldUpdates.mock.calls[0][0];
+
+  listener({
+    created: [testDefinition1],
+    updated: [],
+    removed: [],
+  });
+
+  expect(mockRemoveListener).not.toHaveBeenCalled();
+
+  jest.runOnlyPendingTimers();
+
+  expect(mockRemoveListener).toHaveBeenCalled();
+
+  await expect(fetchPromise).rejects.toThrow(TimeoutError);
+});

--- a/packages/jsapi-utils/src/ConnectionUtils.test.ts
+++ b/packages/jsapi-utils/src/ConnectionUtils.test.ts
@@ -1,4 +1,4 @@
-import dh, { VariableDefinition } from '@deephaven/jsapi-shim';
+import dh from '@deephaven/jsapi-shim';
 import { TimeoutError } from '@deephaven/utils';
 import { fetchVariableDefinition } from './ConnectionUtils';
 
@@ -10,12 +10,12 @@ const mockSubscribeToFieldUpdates = jest.fn(
 const connection = new dh.IdeConnection('http://mockserver');
 connection.subscribeToFieldUpdates = mockSubscribeToFieldUpdates;
 
-const testDefinition1: VariableDefinition = {
+const testDefinition1 = {
   title: 'TEST_DEF',
   type: dh.VariableType.TABLE,
 };
 
-const testDefinition2: VariableDefinition = {
+const testDefinition2 = {
   title: 'ANOTHER_DEF',
   type: dh.VariableType.FIGURE,
 };
@@ -36,7 +36,7 @@ beforeEach(() => {
 it('finds the right definition if variable exists', async () => {
   const fetchPromise = fetchVariableDefinition(
     connection,
-    testDefinition1.title ?? ''
+    testDefinition1.title
   );
 
   expect(mockSubscribeToFieldUpdates).toHaveBeenCalled();
@@ -59,7 +59,7 @@ it('finds the right definition if variable exists', async () => {
 it('finds the definition in the second update if not after the first update', async () => {
   const fetchPromise = fetchVariableDefinition(
     connection,
-    testDefinition2.title ?? ''
+    testDefinition2.title
   );
 
   expect(mockSubscribeToFieldUpdates).toHaveBeenCalled();
@@ -90,7 +90,7 @@ it('finds the definition in the second update if not after the first update', as
 it('throws a TimeoutError if variable not found', async () => {
   const fetchPromise = fetchVariableDefinition(
     connection,
-    testDefinition2.title ?? ''
+    testDefinition2.title
   );
 
   expect(mockSubscribeToFieldUpdates).toHaveBeenCalled();

--- a/packages/jsapi-utils/src/ConnectionUtils.ts
+++ b/packages/jsapi-utils/src/ConnectionUtils.ts
@@ -1,0 +1,46 @@
+import {
+  IdeConnection,
+  VariableChanges,
+  VariableDefinition,
+} from '@deephaven/jsapi-shim';
+import { TimeoutError } from '@deephaven/utils';
+
+/** Default timeout for fetching a variable definition */
+export const FETCH_TIMEOUT = 10_000;
+
+/**
+ * Fetch the definition for a variable given a connection. Subscribes to field updates and triggers when the variable is found.
+ * @param connection Connection to get the variable from
+ * @param name Name of the definition to fetch
+ * @param timeout Timeout for the fetch
+ * @returns Promise the resolves to the variable definition if found, or rejects if there's an error or the timeout has exceeded
+ */
+export function fetchVariableDefinition(
+  connection: IdeConnection,
+  name: string,
+  timeout = FETCH_TIMEOUT
+): Promise<VariableDefinition> {
+  return new Promise<VariableDefinition>((resolve, reject) => {
+    let removeListener: () => void;
+
+    const timeoutId = setTimeout(() => {
+      removeListener?.();
+      reject(new TimeoutError(`Variable ${name} not found`));
+    }, timeout);
+
+    /**
+     * Checks if the variable we're looking for is in the changes, and resolves the promise if it does
+     * @param changes Variables changes that have occurred
+     */
+    function handleFieldUpdates(changes: VariableChanges): void {
+      const definition = changes.created.find(def => def.title === name);
+      if (definition != null) {
+        clearTimeout(timeoutId);
+        removeListener?.();
+        resolve(definition);
+      }
+    }
+
+    removeListener = connection.subscribeToFieldUpdates(handleFieldUpdates);
+  });
+}

--- a/packages/jsapi-utils/src/index.ts
+++ b/packages/jsapi-utils/src/index.ts
@@ -1,3 +1,4 @@
+export * from './ConnectionUtils';
 export * from './formatters';
 export * from './DateUtils';
 export * from './Formatter';


### PR DESCRIPTION
- Pass in an optional `type` parameter that specifies the variable type
- No need for reload button in this case/marking it like a pandas dataframe like we do in panels, just use the browser refresh
- Preparation for https://github.com/deephaven/deephaven-ipywidgets/issues/4 (which I'll get Joseph to do)

Tested by executing the following code:
```
import pandas as pd

data_frame = pd.DataFrame(
    {'A': [1, 2, 3],
     'B': ['X', 'Y', 'Z']}
)

from deephaven import empty_table
t = empty_table(100).update("x=i")
```

Then navigated to the following two addresses, made sure they both appeared correctly:
http://localhost:4010/?name=data_frame
http://localhost:4010/?name=t