### PR TITLE
Add Download CSV options for hidden columns, headers and formatting

### DIFF
--- a/packages/iris-grid/src/IrisGrid.tsx
+++ b/packages/iris-grid/src/IrisGrid.tsx
@@ -1280,7 +1280,7 @@ export class IrisGrid extends Component<IrisGridProps, IrisGridState> {
     if (rawValue && modelColumn != null && modelRow != null) {
       const value = model.valueForCell(modelColumn, modelRow);
       if (TableUtils.isDateType(model.columns[modelColumn].type)) {
-        // The returned value is just a long value, we should return the value fromatted as a full date string
+        // The returned value is just a long value, we should return the value formatted as a full date string
         const { formatter } = model;
         return dh.i18n.DateTimeFormat.format(
           UNFORMATTED_DATE_PATTERN,
@@ -3074,7 +3074,9 @@ export class IrisGrid extends Component<IrisGridProps, IrisGridState> {
     frozenTable: Table,
     tableSubscription: TableViewportSubscription,
     snapshotRanges: GridRange[],
-    modelRanges: GridRange[]
+    modelRanges: GridRange[],
+    includeColumnHeaders: boolean,
+    useUnformattedValues: boolean
   ): void {
     const { canDownloadCsv } = this.props;
     if (canDownloadCsv) {
@@ -3084,7 +3086,9 @@ export class IrisGrid extends Component<IrisGridProps, IrisGridState> {
         frozenTable,
         tableSubscription,
         snapshotRanges,
-        modelRanges
+        modelRanges,
+        includeColumnHeaders,
+        useUnformattedValues
       );
       this.setState(() => {
         if (this.tableSaver) {
@@ -3093,7 +3097,9 @@ export class IrisGrid extends Component<IrisGridProps, IrisGridState> {
             frozenTable,
             tableSubscription,
             snapshotRanges,
-            modelRanges
+            modelRanges,
+            includeColumnHeaders,
+            useUnformattedValues
           );
         }
         return {

--- a/packages/iris-grid/src/sidebar/TableCsvExporter.scss
+++ b/packages/iris-grid/src/sidebar/TableCsvExporter.scss
@@ -20,6 +20,10 @@
     }
   }
 
+  .checkbox-options {
+    margin-bottom: $spacer-2;
+  }
+
   .section-footer {
     .error-message {
       color: $danger;

--- a/packages/iris-grid/src/sidebar/TableSaver.tsx
+++ b/packages/iris-grid/src/sidebar/TableSaver.tsx
@@ -2,6 +2,7 @@ import { PureComponent } from 'react';
 import { WritableStream as ponyfillWritableStream } from 'web-streams-polyfill/ponyfill';
 import dh, {
   Column,
+  DateWrapper,
   Table,
   TableData,
   TableViewportSubscription,
@@ -10,7 +11,7 @@ import dh, {
 import Log from '@deephaven/log';
 import { GridRange, GridRangeIndex, memoizeClear } from '@deephaven/grid';
 
-import { Formatter, FormatterUtils } from '@deephaven/jsapi-utils';
+import { Formatter, FormatterUtils, TableUtils } from '@deephaven/jsapi-utils';
 import {
   CancelablePromise,
   PromiseUtils,
@@ -19,6 +20,8 @@ import {
 import IrisGridUtils from '../IrisGridUtils';
 
 const log = Log.module('TableSaver');
+
+const UNFORMATTED_DATE_PATTERN = `yyyy-MM-dd'T'HH:mm:ss.SSSSSSSSS z`;
 
 interface TableSaverProps {
   getDownloadWorker: () => Promise<ServiceWorker>;
@@ -83,6 +86,9 @@ export default class TableSaver extends PureComponent<
     this.rangedSnapshotsTotal = [];
     this.rangedSnapshotCounter = 0;
 
+    this.includeColumnHeaders = true;
+    this.useUnformattedValues = false;
+
     this.snapshotsTotal = 0;
     this.snapshotCounter = 0;
     this.snapshotsBuffer = new Map();
@@ -142,6 +148,10 @@ export default class TableSaver extends PureComponent<
   columns?: Column[];
 
   fileName?: string;
+
+  includeColumnHeaders: boolean;
+
+  useUnformattedValues: boolean;
 
   chunkRows?: number;
 
@@ -255,7 +265,9 @@ export default class TableSaver extends PureComponent<
     frozenTable: Table,
     tableSubscription: TableViewportSubscription,
     snapshotRanges: GridRange[],
-    modelRanges: GridRange[]
+    modelRanges: GridRange[],
+    includeColumnHeaders: boolean,
+    useUnformattedValues: boolean
   ): void {
     // don't trigger another download when a download is ongoing
     const { isDownloading } = this.props;
@@ -273,6 +285,8 @@ export default class TableSaver extends PureComponent<
     );
     this.tableSubscription = tableSubscription;
     this.gridRanges = snapshotRanges;
+    this.includeColumnHeaders = includeColumnHeaders;
+    this.useUnformattedValues = useUnformattedValues;
 
     // Make filename RFC5987 compatible
     const encodedFileName = encodeURIComponent(fileName.replace(/\//g, ':'))
@@ -286,7 +300,7 @@ export default class TableSaver extends PureComponent<
 
     // if the browser doesn't support stream or there's no active service worker, use blobs for table download
     if (this.useBlobFallback) {
-      this.writeCsvTable();
+      this.writeCsvTable(includeColumnHeaders);
       return;
     }
 
@@ -354,6 +368,9 @@ export default class TableSaver extends PureComponent<
     this.rangedSnapshotsTotal = [];
     this.rangedSnapshotCounter = 0;
 
+    this.includeColumnHeaders = true;
+    this.useUnformattedValues = false;
+
     this.snapshotsTotal = 0;
     this.snapshotCounter = 0;
     this.snapshotsBuffer = new Map();
@@ -414,8 +431,10 @@ export default class TableSaver extends PureComponent<
     }
   }
 
-  writeCsvTable(): void {
-    this.writeTableHeader();
+  writeCsvTable(includeColumnHeaders: boolean): void {
+    if (includeColumnHeaders) {
+      this.writeTableHeader();
+    }
     this.startWriteTableBody();
   }
 
@@ -512,34 +531,49 @@ export default class TableSaver extends PureComponent<
 
     assertNotNull(this.columns);
 
+    const { useUnformattedValues } = this;
     for (let i = 0; i < rows.length; i += 1) {
       const rowIdx = rows[i];
       for (let j = 0; j < this.columns.length; j += 1) {
         const { type, name } = this.columns[j];
-        const hasCustomColumnFormat = this.getCachedCustomColumnFormatFlag(
-          formatter,
-          name,
-          type
-        );
-        let formatOverride = null;
-        if (!hasCustomColumnFormat) {
-          const cellFormat = snapshot.getFormat(rowIdx, this.columns[j]);
-          formatOverride = cellFormat?.formatString != null ? cellFormat : null;
-        }
         let cellData = null;
-        if (formatOverride) {
-          cellData = formatter.getFormattedString(
-            snapshot.getData(rowIdx, this.columns[j]),
-            type,
-            name,
-            formatOverride
-          );
+        if (useUnformattedValues) {
+          let value = snapshot.getData(rowIdx, this.columns[j]) ?? '';
+          if (value !== '' && TableUtils.isDateType(type)) {
+            // value is just a long value, we should return the value formatted as a full date string
+            value = dh.i18n.DateTimeFormat.format(
+              UNFORMATTED_DATE_PATTERN,
+              value as number | Date | DateWrapper,
+              dh.i18n.TimeZone.getTimeZone(formatter.timeZone)
+            );
+          }
+          cellData = value.toString();
         } else {
-          cellData = formatter.getFormattedString(
-            snapshot.getData(rowIdx, this.columns[j]),
-            type,
-            name
+          const hasCustomColumnFormat = this.getCachedCustomColumnFormatFlag(
+            formatter,
+            name,
+            type
           );
+          let formatOverride = null;
+          if (!hasCustomColumnFormat) {
+            const cellFormat = snapshot.getFormat(rowIdx, this.columns[j]);
+            formatOverride =
+              cellFormat?.formatString != null ? cellFormat : null;
+          }
+          if (formatOverride) {
+            cellData = formatter.getFormattedString(
+              snapshot.getData(rowIdx, this.columns[j]),
+              type,
+              name,
+              formatOverride
+            );
+          } else {
+            cellData = formatter.getFormattedString(
+              snapshot.getData(rowIdx, this.columns[j]),
+              type,
+              name
+            );
+          }
         }
         csvString += TableSaver.csvEscapeString(cellData);
         csvString += j === this.columns?.length - 1 ? '\n' : ',';
@@ -627,8 +661,9 @@ export default class TableSaver extends PureComponent<
       return;
     }
     if (download != null) {
+      const { includeColumnHeaders } = this;
       this.makeIframe(`${download}`);
-      this.writeCsvTable();
+      this.writeCsvTable(includeColumnHeaders);
     }
     if (readableStreamPulling != null) {
       if (!this.useBlobFallback) {


### PR DESCRIPTION
Fixes #938 
- Added checkboxes for the 3 options and their respective state in TableCsvExporter
- Added simple conditionals to TableSaver for hidden columns and header exporting
- Used `toString()` on raw cell value for unformatted option with separate `Date` type formatting