### PR TITLE
Change publish tokens to deephaven-bot

### DIFF
--- a/.github/workflows/publish-alpha.yml
+++ b/.github/workflows/publish-alpha.yml
@@ -31,4 +31,4 @@ jobs:
       # https://github.com/lerna/lerna/issues/2788
       - run: ./node_modules/.bin/lerna publish --no-verify-access --canary --force-publish=\* --preid ${{ github.event.inputs.preid }} --yes
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN_MIKEBENDER }}
+          NODE_AUTH_TOKEN: ${{ secrets.DEEPHAVENBOT_NPM_TOKEN }}

--- a/.github/workflows/publish-nightly.yml
+++ b/.github/workflows/publish-nightly.yml
@@ -42,4 +42,4 @@ jobs:
       # https://github.com/lerna/lerna/issues/2788
       - run: ./node_modules/.bin/lerna publish --no-verify-access --canary --force-publish=\* --preid beta --dist-tag nightly --yes
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN_MIKEBENDER }}
+          NODE_AUTH_TOKEN: ${{ secrets.DEEPHAVENBOT_NPM_TOKEN }}

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -23,4 +23,4 @@ jobs:
       # https://github.com/lerna/lerna/issues/2788
       - run: ./node_modules/.bin/lerna publish --no-verify-access from-package --yes
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN_MIKEBENDER }}
+          NODE_AUTH_TOKEN: ${{ secrets.DEEPHAVENBOT_NPM_TOKEN }}


### PR DESCRIPTION
- Now packages will be published as `deephaven-bot` instead of `mikebender`
- `DEEPHAVENBOT_NPM_TOKEN` is an organization secret
- I will kick off an alpha build to test