### PR TITLE
Fix linker spamming errors, change linker dialog text, add delete key to delete selected links

### DIFF
--- a/packages/dashboard-core-plugins/src/linker/Linker.tsx
+++ b/packages/dashboard-core-plugins/src/linker/Linker.tsx
@@ -153,6 +153,7 @@ export class Linker extends Component<LinkerProps, LinkerState> {
       this.handleFilterColumnSelect
     );
     eventHub.on(InputFilterEvent.COLUMNS_CHANGED, this.handleColumnsChanged);
+    eventHub.on(PanelEvent.CLOSE, this.handlePanelClosed);
     eventHub.on(PanelEvent.CLOSED, this.handlePanelClosed);
   }
 
@@ -170,6 +171,7 @@ export class Linker extends Component<LinkerProps, LinkerState> {
       this.handleFilterColumnSelect
     );
     eventHub.off(InputFilterEvent.COLUMNS_CHANGED, this.handleColumnsChanged);
+    eventHub.off(PanelEvent.CLOSE, this.handlePanelClosed);
     eventHub.off(PanelEvent.CLOSED, this.handlePanelClosed);
   }
 
@@ -509,7 +511,7 @@ export class Linker extends Component<LinkerProps, LinkerState> {
   }
 
   handlePanelClosed(panelId: string): void {
-    // Delete links on PanelEvent.CLOSED instead of UNMOUNT
+    // Delete links on PanelEvent.CLOSE and PanelEvent.CLOSED instead of UNMOUNT
     // because the panels can get unmounted on errors and we want to keep the links if that happens
     log.debug(`Panel ${panelId} closed, deleting links.`);
     this.deleteLinksForPanelId(panelId);
@@ -663,8 +665,8 @@ export class Linker extends Component<LinkerProps, LinkerState> {
     const disabled = linkInProgress != null && linkInProgress.start != null;
     const linkerOverlayMessage =
       isolatedLinkerPanelId === undefined
-        ? 'Click a column source, then click a column target to create a filter link. Remove a filter link by clicking again to erase. Click done when finished.'
-        : 'Create a link between the source column button and a table column by clicking on one, then the other. Remove the link by clicking it directly. Click done when finished.';
+        ? 'Click a column source, then click a column target to create a filter link. Change its comparison operator by clicking on the link and then the dropdown menu button. Delete a filter link by clicking the delete button or with alt+click. Click done when finished.'
+        : 'Create a link between the source column button and a table column by clicking on one, then the other. Change its comparison operator by clicking on the link and then the dropdown menu button. Delete a filter link by clicking the delete button or with alt+click. Click done when finished.';
 
     return (
       <CSSTransition

--- a/packages/dashboard-core-plugins/src/linker/Linker.tsx
+++ b/packages/dashboard-core-plugins/src/linker/Linker.tsx
@@ -665,8 +665,8 @@ export class Linker extends Component<LinkerProps, LinkerState> {
     const disabled = linkInProgress != null && linkInProgress.start != null;
     const linkerOverlayMessage =
       isolatedLinkerPanelId === undefined
-        ? 'Click a column source, then click a column target to create a filter link. Change its comparison operator by clicking on the link and then the dropdown menu button. Delete a filter link by clicking the delete button or with alt+click. Click done when finished.'
-        : 'Create a link between the source column button and a table column by clicking on one, then the other. Change its comparison operator by clicking on the link and then the dropdown menu button. Delete a filter link by clicking the delete button or with alt+click. Click done when finished.';
+        ? 'Click a column source, then click a column target to create a filter link. The filter comparison operator used by a selected link can be changed. Delete a filter link by clicking the delete button or with alt+click. Click done when finished.'
+        : 'Create a link between the source column button and a table column by clicking on one, then the other. Delete a filter link by clicking the delete button or with alt+click. Click done when finished.';
 
     return (
       <CSSTransition

--- a/packages/dashboard-core-plugins/src/linker/LinkerOverlayContent.tsx
+++ b/packages/dashboard-core-plugins/src/linker/LinkerOverlayContent.tsx
@@ -222,6 +222,10 @@ export class LinkerOverlayContent extends Component<
       this.setState({
         mode: 'delete',
       });
+    } else if (event.key === 'Delete') {
+      const { selectedIds, onLinkDeleted } = this.props;
+      event.preventDefault();
+      selectedIds.forEach(id => onLinkDeleted(id));
     }
   }
 

--- a/packages/dashboard-core-plugins/src/linker/LinkerOverlayContent.tsx
+++ b/packages/dashboard-core-plugins/src/linker/LinkerOverlayContent.tsx
@@ -222,7 +222,7 @@ export class LinkerOverlayContent extends Component<
       this.setState({
         mode: 'delete',
       });
-    } else if (event.key === 'Delete') {
+    } else if (event.key === 'Delete' || event.key === 'Backspace') {
       const { selectedIds, onLinkDeleted } = this.props;
       event.preventDefault();
       selectedIds.forEach(id => onLinkDeleted(id));


### PR DESCRIPTION
- Fix linker spamming errors
    - Add listener for `PanelEvent.CLOSE` because we originally only listened to `PanelEvent.CLOSED` and it does not emit every time we need it to
- Change linker dialog text to reflect the ability to change comparison operator and new ways to delete links. Feel free to make it better
- `Delete` key now deletes the selected link, if any. Currently, this is event.key or event.code `Delete` and not `Backspace`. I know on mac keyboards the key labelled delete is actually backspace, which currently shouldn't work. Open to discussion