### PR TITLE
Fix weird UI when dragging a panel with linker overlay open

### DIFF
--- a/packages/dashboard-core-plugins/src/linker/Linker.tsx
+++ b/packages/dashboard-core-plugins/src/linker/Linker.tsx
@@ -116,7 +116,7 @@ export class Linker extends Component<LinkerProps, LinkerState> {
     this.state = {
       linkInProgress: undefined,
       selectedIds: new Set<string>(),
-      isDraggingPanel: true,
+      isDraggingPanel: false,
     };
   }
 
@@ -527,7 +527,7 @@ export class Linker extends Component<LinkerProps, LinkerState> {
       const link = links[i];
       const { start, end } = link;
       if (start.panelId === componentId || end?.panelId === componentId) {
-        this.setState({ isDraggingPanel: false });
+        this.setState({ isDraggingPanel: true });
         return;
       }
     }
@@ -539,7 +539,7 @@ export class Linker extends Component<LinkerProps, LinkerState> {
       const link = links[i];
       const { start, end } = link;
       if (start.panelId === componentId || end?.panelId === componentId) {
-        this.setState({ isDraggingPanel: true });
+        this.setState({ isDraggingPanel: false });
         return;
       }
     }
@@ -617,8 +617,7 @@ export class Linker extends Component<LinkerProps, LinkerState> {
 
   isOverlayShown(): boolean {
     const { activeTool } = this.props;
-    const { isDraggingPanel } = this.state;
-    return isDraggingPanel && activeTool === ToolType.LINKER;
+    return activeTool === ToolType.LINKER;
   }
 
   updateSelectionValidators(): void {
@@ -695,7 +694,7 @@ export class Linker extends Component<LinkerProps, LinkerState> {
 
   render(): JSX.Element | null {
     const { links, isolatedLinkerPanelId, panelManager } = this.props;
-    const { linkInProgress, selectedIds } = this.state;
+    const { linkInProgress, selectedIds, isDraggingPanel } = this.state;
 
     const isLinkOverlayShown = this.isOverlayShown();
     const disabled = linkInProgress != null && linkInProgress.start != null;
@@ -704,7 +703,7 @@ export class Linker extends Component<LinkerProps, LinkerState> {
         ? 'Click a column source, then click a column target to create a filter link. The filter comparison operator used by a selected link can be changed. Delete a filter link by clicking the delete button or with alt+click. Click done when finished.'
         : 'Create a link between the source column button and a table column by clicking on one, then the other. Delete a filter link by clicking the delete button or with alt+click. Click done when finished.';
 
-    return isLinkOverlayShown ? (
+    return !isDraggingPanel ? (
       <CSSTransition
         in={isLinkOverlayShown}
         timeout={ThemeExport.transitionMs}

--- a/packages/dashboard-core-plugins/src/linker/Linker.tsx
+++ b/packages/dashboard-core-plugins/src/linker/Linker.tsx
@@ -533,16 +533,8 @@ export class Linker extends Component<LinkerProps, LinkerState> {
     }
   }
 
-  handlePanelDropped(componentId: string): void {
-    const { links } = this.props;
-    for (let i = 0; i < links.length; i += 1) {
-      const link = links[i];
-      const { start, end } = link;
-      if (start.panelId === componentId || end?.panelId === componentId) {
-        this.setState({ isDraggingPanel: false });
-        return;
-      }
-    }
+  handlePanelDropped(): void {
+    this.setState({ isDraggingPanel: false });
   }
 
   handlePanelClosed(panelId: string): void {

--- a/packages/dashboard-core-plugins/src/linker/Linker.tsx
+++ b/packages/dashboard-core-plugins/src/linker/Linker.tsx
@@ -615,7 +615,8 @@ export class Linker extends Component<LinkerProps, LinkerState> {
 
   isOverlayShown(): boolean {
     const { activeTool } = this.props;
-    return activeTool === ToolType.LINKER;
+    const { showOverlay } = this.state;
+    return showOverlay && activeTool === ToolType.LINKER;
   }
 
   updateSelectionValidators(): void {
@@ -690,9 +691,9 @@ export class Linker extends Component<LinkerProps, LinkerState> {
     return type !== 'invalid';
   }
 
-  render(): JSX.Element {
+  render(): JSX.Element | null {
     const { links, isolatedLinkerPanelId, panelManager } = this.props;
-    const { linkInProgress, selectedIds, showOverlay } = this.state;
+    const { linkInProgress, selectedIds } = this.state;
 
     const isLinkOverlayShown = this.isOverlayShown();
     const disabled = linkInProgress != null && linkInProgress.start != null;
@@ -701,7 +702,7 @@ export class Linker extends Component<LinkerProps, LinkerState> {
         ? 'Click a column source, then click a column target to create a filter link. Remove a filter link by clicking again to erase. Click done when finished.'
         : 'Create a link between the source column button and a table column by clicking on one, then the other. Remove the link by clicking it directly. Click done when finished.';
 
-    return (
+    return isLinkOverlayShown ? (
       <CSSTransition
         in={isLinkOverlayShown}
         timeout={ThemeExport.transitionMs}
@@ -710,27 +711,25 @@ export class Linker extends Component<LinkerProps, LinkerState> {
         unmountOnExit
         onExited={this.handleExited}
       >
-        {showOverlay && (
-          <LinkerOverlayContent
-            disabled={disabled}
-            panelManager={panelManager}
-            links={this.getCachedLinks(
-              links,
-              linkInProgress,
-              isolatedLinkerPanelId
-            )}
-            selectedIds={selectedIds}
-            messageText={linkerOverlayMessage}
-            onLinkSelected={this.handleLinkSelected}
-            onLinkDeleted={this.handleLinkDeleted}
-            onAllLinksDeleted={this.handleAllLinksDeleted}
-            onLinksUpdated={this.handleLinksUpdated}
-            onDone={this.handleDone}
-            onCancel={this.handleCancel}
-          />
-        )}
+        <LinkerOverlayContent
+          disabled={disabled}
+          panelManager={panelManager}
+          links={this.getCachedLinks(
+            links,
+            linkInProgress,
+            isolatedLinkerPanelId
+          )}
+          selectedIds={selectedIds}
+          messageText={linkerOverlayMessage}
+          onLinkSelected={this.handleLinkSelected}
+          onLinkDeleted={this.handleLinkDeleted}
+          onAllLinksDeleted={this.handleAllLinksDeleted}
+          onLinksUpdated={this.handleLinksUpdated}
+          onDone={this.handleDone}
+          onCancel={this.handleCancel}
+        />
       </CSSTransition>
-    );
+    ) : null;
   }
 }
 

--- a/packages/dashboard-core-plugins/src/linker/Linker.tsx
+++ b/packages/dashboard-core-plugins/src/linker/Linker.tsx
@@ -86,7 +86,7 @@ export type LinkerProps = OwnProps &
 export type LinkerState = {
   linkInProgress?: Link;
   selectedIds: Set<string>;
-  showOverlay: boolean;
+  isDraggingPanel: boolean;
 };
 
 export class Linker extends Component<LinkerProps, LinkerState> {
@@ -116,7 +116,7 @@ export class Linker extends Component<LinkerProps, LinkerState> {
     this.state = {
       linkInProgress: undefined,
       selectedIds: new Set<string>(),
-      showOverlay: true,
+      isDraggingPanel: true,
     };
   }
 
@@ -525,7 +525,7 @@ export class Linker extends Component<LinkerProps, LinkerState> {
       const link = links[i];
       const { start, end } = link;
       if (start.panelId === componentId || end?.panelId === componentId) {
-        this.setState({ showOverlay: false });
+        this.setState({ isDraggingPanel: false });
         return;
       }
     }
@@ -537,7 +537,7 @@ export class Linker extends Component<LinkerProps, LinkerState> {
       const link = links[i];
       const { start, end } = link;
       if (start.panelId === componentId || end?.panelId === componentId) {
-        this.setState({ showOverlay: true });
+        this.setState({ isDraggingPanel: true });
         return;
       }
     }
@@ -615,8 +615,8 @@ export class Linker extends Component<LinkerProps, LinkerState> {
 
   isOverlayShown(): boolean {
     const { activeTool } = this.props;
-    const { showOverlay } = this.state;
-    return showOverlay && activeTool === ToolType.LINKER;
+    const { isDraggingPanel } = this.state;
+    return isDraggingPanel && activeTool === ToolType.LINKER;
   }
 
   updateSelectionValidators(): void {

--- a/packages/dashboard-core-plugins/src/linker/Linker.tsx
+++ b/packages/dashboard-core-plugins/src/linker/Linker.tsx
@@ -108,6 +108,7 @@ export class Linker extends Component<LinkerProps, LinkerState> {
     this.handleStateChange = this.handleStateChange.bind(this);
     this.handleExited = this.handleExited.bind(this);
     this.handleLinkSelected = this.handleLinkSelected.bind(this);
+    this.handlePanelDragging = this.handlePanelDragging.bind(this);
     this.isColumnSelectionValid = this.isColumnSelectionValid.bind(this);
 
     this.state = { linkInProgress: undefined, selectedIds: new Set<string>() };
@@ -154,6 +155,7 @@ export class Linker extends Component<LinkerProps, LinkerState> {
     );
     eventHub.on(InputFilterEvent.COLUMNS_CHANGED, this.handleColumnsChanged);
     eventHub.on(PanelEvent.CLOSED, this.handlePanelClosed);
+    eventHub.on(PanelEvent.DRAGGING, this.handlePanelDragging);
   }
 
   stopListening(layout: GoldenLayout): void {
@@ -171,6 +173,7 @@ export class Linker extends Component<LinkerProps, LinkerState> {
     );
     eventHub.off(InputFilterEvent.COLUMNS_CHANGED, this.handleColumnsChanged);
     eventHub.off(PanelEvent.CLOSED, this.handlePanelClosed);
+    eventHub.off(PanelEvent.DRAGGING, this.handlePanelDragging);
   }
 
   handleCancel(): void {
@@ -505,6 +508,18 @@ export class Linker extends Component<LinkerProps, LinkerState> {
         cloneId
       );
       this.addLinks(linksToAdd);
+    }
+  }
+
+  handlePanelDragging(componentId: string): void {
+    const { links } = this.props;
+    for (let i = 0; i < links.length; i += 1) {
+      const link = links[i];
+      const { start, end } = link;
+      if (start.panelId === componentId || end?.panelId === componentId) {
+        this.handleDone();
+        return;
+      }
     }
   }
 

--- a/packages/dashboard-core-plugins/src/linker/LinkerOverlayContent.tsx
+++ b/packages/dashboard-core-plugins/src/linker/LinkerOverlayContent.tsx
@@ -292,7 +292,7 @@ export class LinkerOverlayContent extends Component<
             startColumnType,
           };
         } catch (error) {
-          log.error('Unable to get point for link', link, error);
+          log.warn('Unable to get point for link', link, error);
           return null;
         }
       })

--- a/packages/dashboard/src/DashboardLayout.tsx
+++ b/packages/dashboard/src/DashboardLayout.tsx
@@ -226,9 +226,14 @@ export function DashboardLayout({
     [layout.eventHub]
   );
 
-  const handleLayoutItemDropped = useCallback(() => {
-    setIsItemDragging(false);
-  }, []);
+  const handleLayoutItemDropped = useCallback(
+    (component: Container) => {
+      const componentId = LayoutUtils.getIdFromContainer(component);
+      layout.eventHub.emit(PanelEvent.DROPPED, componentId);
+      setIsItemDragging(false);
+    },
+    [layout.eventHub]
+  );
 
   const handleComponentCreated = useCallback(item => {
     log.debug2('handleComponentCreated', item);

--- a/packages/dashboard/src/DashboardLayout.tsx
+++ b/packages/dashboard/src/DashboardLayout.tsx
@@ -217,9 +217,14 @@ export function DashboardLayout({
     onLayoutInitialized,
   ]);
 
-  const handleLayoutItemPickedUp = useCallback(() => {
-    setIsItemDragging(true);
-  }, []);
+  const handleLayoutItemPickedUp = useCallback(
+    (component: Container) => {
+      const componentId = LayoutUtils.getIdFromContainer(component);
+      layout.eventHub.emit(PanelEvent.DRAGGING, componentId);
+      setIsItemDragging(true);
+    },
+    [layout.eventHub]
+  );
 
   const handleLayoutItemDropped = useCallback(() => {
     setIsItemDragging(false);

--- a/packages/dashboard/src/PanelEvent.ts
+++ b/packages/dashboard/src/PanelEvent.ts
@@ -33,4 +33,7 @@ export default Object.freeze({
 
   // Event to close a panel that's currently open
   CLOSE: 'PanelEvent.CLOSE',
+
+  // Event to close a panel that's currently open
+  DRAGGING: 'PanelEvent.DRAGGING',
 });

--- a/packages/dashboard/src/PanelEvent.ts
+++ b/packages/dashboard/src/PanelEvent.ts
@@ -34,6 +34,9 @@ export default Object.freeze({
   // Event to close a panel that's currently open
   CLOSE: 'PanelEvent.CLOSE',
 
-  // Event to close a panel that's currently open
+  // Panel is being dragged
   DRAGGING: 'PanelEvent.DRAGGING',
+
+  // Panel is dropped
+  DROPPED: 'PanelEvent.DROPPED',
 });


### PR DESCRIPTION
Fixes #964 
- Added `PanelEvent.DRAGGING` and `PanelEvent.DROPPED` events and `isDraggingPanel` state to `Linker.tsx`. isDraggingPanel is set to false if the panel being dragged has a link starting or ending in that panel and set back to true when the panel is dropped.
- Perhaps we can also reopen the linker overlay when the panel is dropped (this would require adding a new event but is otherwise trivial)