### PR TITLE
Only close documents that have been opened

### DIFF
--- a/packages/console/src/notebook/ScriptEditor.tsx
+++ b/packages/console/src/notebook/ScriptEditor.tsx
@@ -274,9 +274,9 @@ class ScriptEditor extends Component<ScriptEditorProps, ScriptEditorState> {
     if (this.completionCleanup) {
       this.completionCleanup.dispose();
       this.completionCleanup = undefined;
-    }
-    if (this.editor && session != null) {
-      MonacoUtils.closeDocument(this.editor, session);
+      if (this.editor && session != null) {
+        MonacoUtils.closeDocument(this.editor, session);
+      }
     }
   }
 


### PR DESCRIPTION
- Server doesn't like it when we close a document without opening it beforehand. Will want to handle that error more gracefully.
- Fixes #969
