### PR TITLE
Fix closing linker using shortcut not resetting state

### DIFF
--- a/packages/dashboard-core-plugins/src/linker/Linker.tsx
+++ b/packages/dashboard-core-plugins/src/linker/Linker.tsx
@@ -109,7 +109,6 @@ export class Linker extends Component<LinkerProps, LinkerState> {
     this.handleExited = this.handleExited.bind(this);
     this.handleLinkSelected = this.handleLinkSelected.bind(this);
     this.isColumnSelectionValid = this.isColumnSelectionValid.bind(this);
-    this.reset = this.reset.bind(this);
 
     this.state = { linkInProgress: undefined, selectedIds: new Set<string>() };
   }

--- a/packages/dashboard-core-plugins/src/linker/Linker.tsx
+++ b/packages/dashboard-core-plugins/src/linker/Linker.tsx
@@ -109,6 +109,7 @@ export class Linker extends Component<LinkerProps, LinkerState> {
     this.handleExited = this.handleExited.bind(this);
     this.handleLinkSelected = this.handleLinkSelected.bind(this);
     this.isColumnSelectionValid = this.isColumnSelectionValid.bind(this);
+    this.reset = this.reset.bind(this);
 
     this.state = { linkInProgress: undefined, selectedIds: new Set<string>() };
   }
@@ -128,10 +129,7 @@ export class Linker extends Component<LinkerProps, LinkerState> {
     if (activeTool !== prevProps.activeTool) {
       this.updateSelectionValidators();
       if (activeTool === ToolType.DEFAULT) {
-        this.setState({
-          linkInProgress: undefined,
-          selectedIds: new Set<string>(),
-        });
+        this.reset();
       }
     }
   }
@@ -179,6 +177,13 @@ export class Linker extends Component<LinkerProps, LinkerState> {
     eventHub.off(InputFilterEvent.COLUMNS_CHANGED, this.handleColumnsChanged);
     eventHub.off(PanelEvent.CLOSE, this.handlePanelClosed);
     eventHub.off(PanelEvent.CLOSED, this.handlePanelClosed);
+  }
+
+  reset(): void {
+    this.setState({
+      linkInProgress: undefined,
+      selectedIds: new Set<string>(),
+    });
   }
 
   handleCancel(): void {
@@ -429,7 +434,7 @@ export class Linker extends Component<LinkerProps, LinkerState> {
       );
       this.deleteLinks(isolatedLinks);
     }
-    this.setState({ linkInProgress: undefined });
+    this.reset();
   }
 
   handleLinkDeleted(linkId: string): void {

--- a/packages/dashboard-core-plugins/src/linker/Linker.tsx
+++ b/packages/dashboard-core-plugins/src/linker/Linker.tsx
@@ -186,7 +186,6 @@ export class Linker extends Component<LinkerProps, LinkerState> {
     if (linkInProgress == null) {
       const { setActiveTool } = this.props;
       setActiveTool(ToolType.DEFAULT);
-      this.setState({ selectedIds: new Set<string>() });
     }
     this.setState({ linkInProgress: undefined });
   }
@@ -194,10 +193,6 @@ export class Linker extends Component<LinkerProps, LinkerState> {
   handleDone(): void {
     const { setActiveTool } = this.props;
     setActiveTool(ToolType.DEFAULT);
-    this.setState({
-      linkInProgress: undefined,
-      selectedIds: new Set<string>(),
-    });
   }
 
   handleChartColumnSelect(panel: PanelComponent, column: LinkColumn): void {

--- a/packages/dashboard-core-plugins/src/linker/Linker.tsx
+++ b/packages/dashboard-core-plugins/src/linker/Linker.tsx
@@ -127,6 +127,12 @@ export class Linker extends Component<LinkerProps, LinkerState> {
     }
     if (activeTool !== prevProps.activeTool) {
       this.updateSelectionValidators();
+      if (activeTool === ToolType.DEFAULT) {
+        this.setState({
+          linkInProgress: undefined,
+          selectedIds: new Set<string>(),
+        });
+      }
     }
   }
 
@@ -180,6 +186,7 @@ export class Linker extends Component<LinkerProps, LinkerState> {
     if (linkInProgress == null) {
       const { setActiveTool } = this.props;
       setActiveTool(ToolType.DEFAULT);
+      this.setState({ selectedIds: new Set<string>() });
     }
     this.setState({ linkInProgress: undefined });
   }


### PR DESCRIPTION
Fixes #971 
- Set `linkInProgress` to undefined and `selectedIDs` to an empty set when `activeTool` is set to default 
- Remove unnecessary setStates based on above change