### PR TITLE
DH-13988 Fix issue with old buttons not getting disabled in console history

### DIFF
--- a/packages/console/src/Console.tsx
+++ b/packages/console/src/Console.tsx
@@ -345,7 +345,7 @@ export class Console extends PureComponent<ConsoleProps, ConsoleState> {
       const itemIndex = consoleHistory.lastIndexOf(historyItem);
       if (itemIndex < 0) {
         log.error(`historyItem not found in consoleHistory`);
-        return { consoleHistory };
+        return null;
       }
       const newHistory = consoleHistory.concat();
       newHistory[itemIndex] = newHistoryItem;

--- a/tests/console.spec.ts
+++ b/tests/console.spec.ts
@@ -1,27 +1,60 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, Page } from '@playwright/test';
 import shortid from 'shortid';
-import { typeInMonaco } from './utils';
+import { generateVarName, makeTableCommand, typeInMonaco } from './utils';
 
-test('print commands get logged', async ({ page }) => {
+let page: Page;
+
+test.beforeAll(async ({ browser }) => {
+  page = await browser.newPage();
   await page.goto('');
+});
 
-  // create a locator
-  const consoleInput = page.locator('.console-input');
+test.afterAll(async () => {
+  await page.close();
+});
 
-  // Monaco editor doesn't have a native input, so need to just click into it and type on the page
-  // https://github.com/microsoft/playwright/issues/14126
-  await consoleInput.click();
+test.describe('console input tests', () => {
+  test.beforeEach(async () => {
+    // Find the console input
+    const consoleInput = page.locator('.console-input');
 
-  const message = `Hello ${shortid()}!`;
-  const command = `print("${message}")`;
+    // Monaco editor doesn't have a native input, so need to just click into it and type on the page
+    // https://github.com/microsoft/playwright/issues/14126
+    await consoleInput.click();
+  });
 
-  await typeInMonaco(page, command);
-  await page.keyboard.press('Enter');
+  test('print commands get logged', async () => {
+    const message = `Hello ${shortid()}!`;
+    const command = `print("${message}")`;
 
-  // Expect the output to show up in the log
-  await expect(
-    await page
-      .locator('.console-history .log-message')
-      .filter({ hasText: message })
-  ).not.toBeNull();
+    await typeInMonaco(page, command);
+    await page.keyboard.press('Enter');
+
+    // Expect the output to show up in the log
+    await expect(
+      page.locator('.console-history .log-message').filter({ hasText: message })
+    ).toHaveCount(1);
+  });
+
+  test('object button is created when creating a table', async () => {
+    const tableName = generateVarName('t');
+    const command = makeTableCommand(tableName);
+
+    await typeInMonaco(page, command);
+    await page.keyboard.press('Enter');
+
+    // Expect a button to show up in the console history
+    const btnLocator = await page
+      .locator('.console-history .btn-console-object')
+      .filter({ hasText: tableName });
+    await expect(btnLocator).toHaveCount(1);
+    expect(await btnLocator.nth(0).isDisabled()).toBe(false);
+
+    // Enter the same command again; the old button should be disabled
+    await typeInMonaco(page, command);
+    await page.keyboard.press('Enter');
+    await expect(btnLocator).toHaveCount(2);
+    await expect(btnLocator.nth(0)).toBeDisabled();
+    await expect(btnLocator.nth(1)).not.toBeDisabled();
+  });
 });

--- a/tests/table.spec.ts
+++ b/tests/table.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect, Page } from '@playwright/test';
-import { generateVarName, typeInMonaco } from './utils';
+import { generateVarName, makeTableCommand, typeInMonaco } from './utils';
 
 // Run tests serially since they all use the same table
 test.describe.configure({ mode: 'serial' });
@@ -19,10 +19,7 @@ test('can open a simple table', async () => {
   const consoleInput = page.locator('.console-input');
   await consoleInput.click();
 
-  // Enter a command that creates a table with three columns, showing x/y/z
-  const tableName = generateVarName();
-  const command = `from deephaven import empty_table
-${tableName} = empty_table(100).update(["x=i", "y=Math.sin(i)", "z=Math.cos(i)"])`;
+  const command = makeTableCommand();
 
   await typeInMonaco(page, command);
   await page.keyboard.press('Enter');

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -16,7 +16,18 @@ export function generateVarName(prefix = 'v'): string {
 }
 
 /**
- * Types into monaco input and avoids autocomplete suggestions
+ * Create a command that creates a table with three columns, x/y/z
+ * @param tableName Name of the variable to assign the table to
+ * @returns String of the command to create a table
+ */
+export function makeTableCommand(tableName = generateVarName('t')): string {
+  return `from deephaven import empty_table
+${tableName} = empty_table(100).update(["x=i", "y=Math.sin(i)", "z=Math.cos(i)"])`;
+}
+
+/**
+ * Types into monaco input and avoids autocomplete suggestions.
+ * Assumes correct monaco input already has focus.
  * @param page The Page instance for each test
  * @param text Text to be typed, with carriage returns
  */


### PR DESCRIPTION
- We were mutating objects within the state, violating the immutability principle.
- Clone any object that we were mutating.
- Cleaned up some of the code.
- All tests pass
- Tested by running the steps in the description of #928, also tested importing a CSV and giving it the same name as a prior object. Old objects were updated correctly.
- Updated e2e tests:
  - Refactored creating a table command into it's own function
  - Fixed up old print commands tests - wasn't verifying the result correctly
  - Added test to check that an object button was created when creating a table, and that the old button was disabled when re-running the same command twice
- Fixes #928 
- Fixes [DH-13988](https://deephaven.atlassian.net/browse/DH-13988)