### PR TITLE
Change tooltip default placement to bottom instead of auto

### DIFF
--- a/packages/components/scss/BaseStyleSheet.scss
+++ b/packages/components/scss/BaseStyleSheet.scss
@@ -109,6 +109,7 @@ button:focus {
 }
 
 span.btn-disabled-wrapper {
+  display: inline-block;
   .btn.disabled,
   .btn:disabled {
     pointer-events: none;

--- a/packages/components/src/popper/Popper.tsx
+++ b/packages/components/src/popper/Popper.tsx
@@ -150,6 +150,7 @@ class Popper extends Component<PopperProps, PopperState> {
     let { options } = this.props;
     options = {
       placement: 'auto',
+      modifiers: { preventOverflow: { boundariesElement: 'viewport' } },
       ...options,
     };
     document.body.appendChild(this.element);

--- a/packages/components/src/popper/Tooltip.tsx
+++ b/packages/components/src/popper/Tooltip.tsx
@@ -291,13 +291,19 @@ class Tooltip extends Component<TooltipProps, TooltipState> {
     const {
       interactive,
       children,
-      options,
       referenceObject,
       popperClassName,
       'data-testid': dataTestId,
       onEntered,
     } = this.props;
     const { isShown } = this.state;
+
+    let { options } = this.props;
+    options = {
+      placement: 'bottom',
+      ...options,
+    };
+
     return (
       <div
         ref={this.container}

--- a/packages/console/src/ConsoleMenu.tsx
+++ b/packages/console/src/ConsoleMenu.tsx
@@ -181,15 +181,19 @@ class ConsoleMenu extends PureComponent<ConsoleMenuProps, ConsoleMenuState> {
     );
     const popperOptions: PopperOptions = { placement: 'bottom-end' };
 
+    const disableTableActions = tableActions.length === 0;
+    const disableWidgetActions = widgetActions.length === 0;
+
     return (
       <div className="console-pane-menu">
         <Button
           kind="ghost"
           className="btn-link-icon"
-          disabled={tableActions.length === 0}
+          disabled={disableTableActions}
           onClick={() => {
             // no-op: click is handled in `DropdownMenu`
           }}
+          tooltip={disableTableActions ? 'No tables available' : 'Tables'}
         >
           <div className="fa-md fa-layers">
             <FontAwesomeIcon
@@ -199,7 +203,6 @@ class ConsoleMenu extends PureComponent<ConsoleMenuProps, ConsoleMenuState> {
             />
             <FontAwesomeIcon icon={vsTriangleDown} transform="right-8 down-6" />
           </div>
-          <Tooltip>Tables</Tooltip>
           <DropdownMenu
             key="table-actions "
             actions={tableActions}
@@ -216,6 +219,7 @@ class ConsoleMenu extends PureComponent<ConsoleMenuProps, ConsoleMenuState> {
           onClick={() => {
             // no-op: click is handled in `DropdownMenu'
           }}
+          tooltip={disableWidgetActions ? 'No widgets available' : 'Widgets'}
         >
           <div className="fa-md fa-layers">
             <FontAwesomeIcon
@@ -225,7 +229,6 @@ class ConsoleMenu extends PureComponent<ConsoleMenuProps, ConsoleMenuState> {
             />
             <FontAwesomeIcon icon={vsTriangleDown} transform="right-8 down-6" />
           </div>
-          <Tooltip>Widgets</Tooltip>
           <DropdownMenu
             key="table-actions"
             actions={widgetActions}

--- a/packages/console/src/ConsoleMenu.tsx
+++ b/packages/console/src/ConsoleMenu.tsx
@@ -11,7 +11,6 @@ import {
   DropdownMenu,
   PopperOptions,
   SearchInput,
-  Tooltip,
 } from '@deephaven/components';
 import {
   dhTable,

--- a/packages/dashboard-core-plugins/src/panels/RenameDialog.tsx
+++ b/packages/dashboard-core-plugins/src/panels/RenameDialog.tsx
@@ -163,7 +163,6 @@ export default class RenameDialog extends PureComponent<
         onExited={onCancel}
         options={{
           placement: 'bottom',
-          modifiers: { preventOverflow: { boundariesElement: 'viewport' } },
         }}
         interactive
         closeOnBlur

--- a/packages/file-explorer/src/FileList.tsx
+++ b/packages/file-explorer/src/FileList.tsx
@@ -148,7 +148,6 @@ export const renderFileListItem = (
         {children ?? item.basename}
         <Tooltip
           options={{
-            modifiers: { preventOverflow: { boundariesElement: 'window' } },
             placement: 'left',
           }}
         >


### PR DESCRIPTION
Fixes #966

- Sets tooltip placement to bottom by default. Tooltips belong below by convention and not just the side with the most space. 
- Sets boundaries element to viewport by default on popper, instead of scroll parent. We want to allow poppers to escape their panel/scroll parent in almost all cases.

Testing: tried all the tooltips I could find in community, some have new positioning, but it's all fine.
