### PR TITLE
Add all and visible maps for row/column size/position

### DIFF
--- a/packages/dashboard-core-plugins/src/panels/IrisGridPanel.tsx
+++ b/packages/dashboard-core-plugins/src/panels/IrisGridPanel.tsx
@@ -866,16 +866,16 @@ export class IrisGridPanel extends PureComponent<
     assertNotNull(metrics);
     const {
       columnHeaderHeight,
-      visibleColumnXs,
-      visibleColumnWidths,
+      allColumnXs,
+      allColumnWidths,
       right,
       columnHeaderMaxDepth,
     } = metrics;
     const columnIndex = model.getColumnIndexByName(columnName);
     assertNotNull(columnIndex);
     const visibleIndex = irisGrid.getVisibleColumn(columnIndex);
-    const columnX = visibleColumnXs.get(visibleIndex) ?? 0;
-    const columnWidth = visibleColumnWidths.get(visibleIndex) ?? 0;
+    const columnX = allColumnXs.get(visibleIndex) ?? 0;
+    const columnWidth = allColumnWidths.get(visibleIndex) ?? 0;
 
     const x = Math.max(
       rect.left,

--- a/packages/grid/src/Grid.tsx
+++ b/packages/grid/src/Grid.tsx
@@ -1874,7 +1874,7 @@ class Grid extends PureComponent<GridProps, GridState> {
 
         // get width of next column
         const columnWidth =
-          metrics.visibleColumnWidths.get(left) ??
+          metrics.allColumnWidths.get(left) ??
           metricCalculator.getVisibleColumnWidth(left, metricState);
 
         if (leftOffset >= columnWidth) {
@@ -1892,7 +1892,7 @@ class Grid extends PureComponent<GridProps, GridState> {
 
         // get width of next column
         const columnWidth =
-          metrics.visibleColumnWidths.get(left - 1) ??
+          metrics.allColumnWidths.get(left - 1) ??
           metricCalculator.getVisibleColumnWidth(left - 1, metricState);
 
         if (
@@ -1943,7 +1943,7 @@ class Grid extends PureComponent<GridProps, GridState> {
 
         // get height of next row
         const rowHeight =
-          metrics.visibleRowHeights.get(top) ??
+          metrics.allRowHeights.get(top) ??
           metricCalculator.getVisibleRowHeight(top, metricState);
 
         if (topOffset >= rowHeight) {
@@ -1961,7 +1961,7 @@ class Grid extends PureComponent<GridProps, GridState> {
 
         // get height of next row
         const rowHeight =
-          metrics.visibleRowHeights.get(top - 1) ??
+          metrics.allRowHeights.get(top - 1) ??
           metricCalculator.getVisibleRowHeight(top - 1, metricState);
 
         if (
@@ -2068,16 +2068,16 @@ class Grid extends PureComponent<GridProps, GridState> {
     const {
       gridX,
       gridY,
-      visibleColumnXs,
-      visibleRowYs,
-      visibleColumnWidths,
-      visibleRowHeights,
+      allColumnXs,
+      allRowYs,
+      allColumnWidths,
+      allRowHeights,
     } = metrics;
 
-    const x = visibleColumnXs.get(column);
-    const y = visibleRowYs.get(row);
-    const w = visibleColumnWidths.get(column);
-    const h = visibleRowHeights.get(row);
+    const x = allColumnXs.get(column);
+    const y = allRowYs.get(row);
+    const w = allColumnWidths.get(column);
+    const h = allRowHeights.get(row);
 
     // If the cell isn't visible, we still need to display an invisible cell for focus purposes
     const wrapperStyle: CSSProperties =

--- a/packages/grid/src/GridMetrics.ts
+++ b/packages/grid/src/GridMetrics.ts
@@ -121,6 +121,10 @@ export type GridMetrics = {
   visibleRows: VisibleIndex[];
   visibleColumns: VisibleIndex[];
 
+  // Map of the height/width of visible rows/columns
+  visibleRowHeights: SizeMap;
+  visibleColumnWidths: SizeMap;
+
   // Array of floating rows/columns, by grid index
   floatingRows: VisibleIndex[];
   floatingColumns: VisibleIndex[];
@@ -129,9 +133,9 @@ export type GridMetrics = {
   allRows: VisibleIndex[];
   allColumns: VisibleIndex[];
 
-  // Map of the height/width of visible rows/columns
-  visibleRowHeights: SizeMap;
-  visibleColumnWidths: SizeMap;
+  // Map of the height/width of all rows/columns, visible and floating
+  allRowHeights: SizeMap;
+  allColumnWidths: SizeMap;
 
   // Floating metrics
   floatingTopHeight: number;
@@ -139,9 +143,13 @@ export type GridMetrics = {
   floatingLeftWidth: number;
   floatingRightWidth: number;
 
-  // Map of the X/Y coordinates of the rows/columns, from the top left of the grid
+  // Map of the X/Y coordinates of the visible rows/columns, from the top left of the grid
   visibleRowYs: CoordinateMap;
   visibleColumnXs: CoordinateMap;
+
+  // Map of the X/Y coordinates of all rows/columns, visible and floating, from the top left of the grid
+  allRowYs: CoordinateMap;
+  allColumnXs: CoordinateMap;
 
   // The boxes user can click on for expanding/collapsing tree rows
   visibleRowTreeBoxes: Map<VisibleIndex, BoxCoordinates>;

--- a/packages/grid/src/GridRenderer.ts
+++ b/packages/grid/src/GridRenderer.ts
@@ -300,8 +300,8 @@ export class GridRenderer {
       floatingRows,
       rowCount,
       visibleColumns,
-      visibleRowYs,
-      visibleRowHeights,
+      allRowYs,
+      allRowHeights,
     } = metrics;
 
     if (floatingRows.length === 0) {
@@ -345,8 +345,8 @@ export class GridRenderer {
         top: 0,
         bottom: floatingTopRowCount - 1,
         maxY:
-          getOrThrow(visibleRowYs, floatingTopRowCount - 1) +
-          getOrThrow(visibleRowHeights, floatingTopRowCount - 1) -
+          getOrThrow(allRowYs, floatingTopRowCount - 1) +
+          getOrThrow(allRowHeights, floatingTopRowCount - 1) -
           0.5,
       });
     }
@@ -354,10 +354,10 @@ export class GridRenderer {
       this.drawSelectedRanges(context, state, {
         top: rowCount - floatingBottomRowCount - 1,
         bottom: rowCount - 1,
-        minY: getOrThrow(visibleRowYs, rowCount - floatingBottomRowCount) + 0.5,
+        minY: getOrThrow(allRowYs, rowCount - floatingBottomRowCount) + 0.5,
         maxY:
-          getOrThrow(visibleRowYs, rowCount - 1) +
-          getOrThrow(visibleRowHeights, rowCount - 1) -
+          getOrThrow(allRowYs, rowCount - 1) +
+          getOrThrow(allRowHeights, rowCount - 1) -
           0.5,
       });
     }
@@ -387,8 +387,8 @@ export class GridRenderer {
       maxX,
       columnCount,
       visibleRows,
-      visibleColumnXs,
-      visibleColumnWidths,
+      allColumnXs,
+      allColumnWidths,
       width,
       height,
     } = metrics;
@@ -451,8 +451,8 @@ export class GridRenderer {
       this.drawSelectedRanges(context, state, {
         left: 0,
         maxX:
-          getOrThrow(visibleColumnXs, floatingLeftColumnCount - 1) +
-          getOrThrow(visibleColumnWidths, floatingLeftColumnCount - 1),
+          getOrThrow(allColumnXs, floatingLeftColumnCount - 1) +
+          getOrThrow(allColumnWidths, floatingLeftColumnCount - 1),
       });
     }
     if (floatingRightColumnCount > 0) {
@@ -460,11 +460,10 @@ export class GridRenderer {
         left: columnCount - floatingRightColumnCount,
         right: columnCount - 1,
         minX:
-          getOrThrow(visibleColumnXs, columnCount - floatingRightColumnCount) +
-          0.5,
+          getOrThrow(allColumnXs, columnCount - floatingRightColumnCount) + 0.5,
         maxX:
-          getOrThrow(visibleColumnXs, columnCount - 1) +
-          getOrThrow(visibleColumnWidths, columnCount - 1),
+          getOrThrow(allColumnXs, columnCount - 1) +
+          getOrThrow(allColumnWidths, columnCount - 1),
       });
     }
 
@@ -490,10 +489,10 @@ export class GridRenderer {
       floatingRightColumnCount,
       rowCount,
       columnCount,
-      visibleRowYs,
-      visibleColumnXs,
-      visibleRowHeights,
-      visibleColumnWidths,
+      allRowYs,
+      allColumnXs,
+      allRowHeights,
+      allColumnWidths,
       maxX,
       maxY,
     } = metrics;
@@ -505,24 +504,23 @@ export class GridRenderer {
 
     if (floatingTopRowCount > 0) {
       const y =
-        getOrThrow(visibleRowYs, floatingTopRowCount - 1) +
-        getOrThrow(visibleRowHeights, floatingTopRowCount - 1) +
+        getOrThrow(allRowYs, floatingTopRowCount - 1) +
+        getOrThrow(allRowHeights, floatingTopRowCount - 1) +
         0.5;
       context.moveTo(0, y);
       context.lineTo(maxX, y);
     }
 
     if (floatingBottomRowCount > 0) {
-      const y =
-        getOrThrow(visibleRowYs, rowCount - floatingBottomRowCount) - 0.5;
+      const y = getOrThrow(allRowYs, rowCount - floatingBottomRowCount) - 0.5;
       context.moveTo(0, y);
       context.lineTo(maxX, y);
     }
 
     if (floatingLeftColumnCount > 0) {
       const x =
-        getOrThrow(visibleColumnXs, floatingLeftColumnCount - 1) +
-        getOrThrow(visibleColumnWidths, floatingLeftColumnCount - 1) +
+        getOrThrow(allColumnXs, floatingLeftColumnCount - 1) +
+        getOrThrow(allColumnWidths, floatingLeftColumnCount - 1) +
         0.5;
       context.moveTo(x, 0);
       context.lineTo(x, maxY);
@@ -530,8 +528,7 @@ export class GridRenderer {
 
     if (floatingRightColumnCount > 0) {
       const x =
-        getOrThrow(visibleColumnXs, columnCount - floatingRightColumnCount) -
-        0.5;
+        getOrThrow(allColumnXs, columnCount - floatingRightColumnCount) - 0.5;
       context.moveTo(x, 0);
       context.lineTo(x, maxY);
     }
@@ -544,24 +541,23 @@ export class GridRenderer {
 
     if (floatingTopRowCount > 0) {
       const y =
-        getOrThrow(visibleRowYs, floatingTopRowCount - 1) +
-        getOrThrow(visibleRowHeights, floatingTopRowCount - 1) +
+        getOrThrow(allRowYs, floatingTopRowCount - 1) +
+        getOrThrow(allRowHeights, floatingTopRowCount - 1) +
         0.5;
       context.moveTo(0, y);
       context.lineTo(maxX, y);
     }
 
     if (floatingBottomRowCount > 0) {
-      const y =
-        getOrThrow(visibleRowYs, rowCount - floatingBottomRowCount) - 0.5;
+      const y = getOrThrow(allRowYs, rowCount - floatingBottomRowCount) - 0.5;
       context.moveTo(0, y);
       context.lineTo(maxX, y);
     }
 
     if (floatingLeftColumnCount > 0) {
       const x =
-        getOrThrow(visibleColumnXs, floatingLeftColumnCount - 1) +
-        getOrThrow(visibleColumnWidths, floatingLeftColumnCount - 1) +
+        getOrThrow(allColumnXs, floatingLeftColumnCount - 1) +
+        getOrThrow(allColumnWidths, floatingLeftColumnCount - 1) +
         0.5;
       context.moveTo(x, 0);
       context.lineTo(x, maxY);
@@ -569,8 +565,7 @@ export class GridRenderer {
 
     if (floatingRightColumnCount > 0) {
       const x =
-        getOrThrow(visibleColumnXs, columnCount - floatingRightColumnCount) -
-        0.5;
+        getOrThrow(allColumnXs, columnCount - floatingRightColumnCount) - 0.5;
       context.moveTo(x, 0);
       context.lineTo(x, maxY);
     }
@@ -605,10 +600,10 @@ export class GridRenderer {
       floatingTopRowCount,
       columnCount,
       rowCount,
-      visibleRowHeights,
-      visibleRowYs,
-      visibleColumnXs,
-      visibleColumnWidths,
+      allRowHeights,
+      allRowYs,
+      allColumnXs,
+      allColumnWidths,
       width,
       height,
     } = metrics;
@@ -617,34 +612,31 @@ export class GridRenderer {
       right: Math.min(right, columnCount - floatingRightColumnCount - 1),
       minX:
         floatingLeftColumnCount > 0 &&
-        visibleColumnXs.has(floatingLeftColumnCount + 1)
-          ? getOrThrow(visibleColumnXs, floatingLeftColumnCount + 1)
+        allColumnXs.has(floatingLeftColumnCount + 1)
+          ? getOrThrow(allColumnXs, floatingLeftColumnCount + 1)
           : -10,
       minY:
-        floatingTopRowCount > 0 && visibleRowYs.has(floatingTopRowCount + 1)
-          ? getOrThrow(visibleRowYs, floatingTopRowCount + 1)
+        floatingTopRowCount > 0 && allRowYs.has(floatingTopRowCount + 1)
+          ? getOrThrow(allRowYs, floatingTopRowCount + 1)
           : -10,
       maxX:
         floatingRightColumnCount > 0 &&
-        visibleColumnXs.has(columnCount - floatingRightColumnCount - 1)
+        allColumnXs.has(columnCount - floatingRightColumnCount - 1)
           ? getOrThrow(
-              visibleColumnXs,
+              allColumnXs,
               columnCount - floatingRightColumnCount - 1
             ) +
             getOrThrow(
-              visibleColumnWidths,
+              allColumnWidths,
               columnCount - floatingRightColumnCount - 1
             ) -
             0.5
           : width + 10,
       maxY:
         floatingBottomRowCount > 0 &&
-        visibleRowYs.has(rowCount - floatingBottomRowCount - 1)
-          ? getOrThrow(visibleRowYs, rowCount - floatingBottomRowCount - 1) +
-            getOrThrow(
-              visibleRowHeights,
-              rowCount - floatingBottomRowCount - 1
-            ) -
+        allRowYs.has(rowCount - floatingBottomRowCount - 1)
+          ? getOrThrow(allRowYs, rowCount - floatingBottomRowCount - 1) +
+            getOrThrow(allRowHeights, rowCount - floatingBottomRowCount - 1) -
             0.5
           : height + 10,
     });
@@ -683,7 +675,7 @@ export class GridRenderer {
       rowBackgroundColors,
       maxDepth
     );
-    const { visibleRowYs, visibleRowHeights } = metrics;
+    const { allRowYs, allRowHeights } = metrics;
 
     // Optimize by grouping together all rows that end up with the same color
     const colorRowMap = new Map();
@@ -726,8 +718,8 @@ export class GridRenderer {
 
       for (let i = 0; i < colorRows.length; i += 1) {
         const row = colorRows[i];
-        const y = getOrThrow(visibleRowYs, row);
-        const rowHeight = getOrThrow(visibleRowHeights, row);
+        const y = getOrThrow(allRowYs, row);
+        const rowHeight = getOrThrow(allRowHeights, row);
         context.rect(minX, y, maxX, rowHeight);
       }
 
@@ -746,7 +738,7 @@ export class GridRenderer {
 
       for (let i = 0; i < topShadowRows.length; i += 1) {
         const row = topShadowRows[i];
-        const y = getOrThrow(visibleRowYs, row);
+        const y = getOrThrow(allRowYs, row);
         // Use a translate so we can reuse the gradient
         context.translate(0, y);
         context.fillRect(minX, 0, maxX, shadowBlur);
@@ -768,8 +760,8 @@ export class GridRenderer {
 
       for (let i = 0; i < bottomShadowRows.length; i += 1) {
         const row = bottomShadowRows[i];
-        const y = getOrThrow(visibleRowYs, row);
-        const rowHeight = getOrThrow(visibleRowHeights, row);
+        const y = getOrThrow(allRowYs, row);
+        const rowHeight = getOrThrow(allRowHeights, row);
         const gradientY = y + rowHeight - shadowBlur;
         // Use a translate so we can reuse the gradient
         context.translate(0, gradientY);
@@ -793,13 +785,13 @@ export class GridRenderer {
       return;
     }
 
-    const { visibleColumnWidths, visibleColumnXs, maxY } = metrics;
+    const { allColumnWidths, allColumnXs, maxY } = metrics;
     if (mouseY > maxY) {
       return;
     }
 
-    const x = getOrThrow(visibleColumnXs, mouseColumn);
-    const columnWidth = getOrThrow(visibleColumnWidths, mouseColumn);
+    const x = getOrThrow(allColumnXs, mouseColumn);
+    const columnWidth = getOrThrow(allColumnWidths, mouseColumn);
 
     context.fillStyle = theme.columnHoverBackgroundColor;
     context.fillRect(x, 0, columnWidth, maxY);
@@ -862,10 +854,10 @@ export class GridRenderer {
     row: VisibleIndex
   ): void {
     const { metrics, selectedRanges, theme } = state;
-    const { visibleRowHeights, visibleRowYs, maxX } = metrics;
+    const { allRowHeights, allRowYs, maxX } = metrics;
 
-    const y = getOrThrow(visibleRowYs, row);
-    const rowHeight = getOrThrow(visibleRowHeights, row);
+    const y = getOrThrow(allRowYs, row);
+    const rowHeight = getOrThrow(allRowHeights, row);
 
     if (theme.rowHoverBackgroundColor != null) {
       context.fillStyle = theme.rowHoverBackgroundColor;
@@ -937,10 +929,10 @@ export class GridRenderer {
     columns: VisibleIndex[]
   ): void {
     const { metrics } = state;
-    const { visibleColumnXs, maxY } = metrics;
+    const { allColumnXs, maxY } = metrics;
     for (let i = 0; i < columns.length; i += 1) {
       const column = columns[i];
-      const x = getOrThrow(visibleColumnXs, column) + 0.5;
+      const x = getOrThrow(allColumnXs, column) + 0.5;
       context.moveTo(x, 0);
       context.lineTo(x, maxY);
     }
@@ -952,13 +944,13 @@ export class GridRenderer {
     rows: VisibleIndex[]
   ): void {
     const { metrics } = state;
-    const { visibleRowYs, maxX: metricsMaxX } = metrics;
+    const { allRowYs, maxX: metricsMaxX } = metrics;
     const maxX = metricsMaxX;
 
     // Draw row lines
     for (let i = 0; i < rows.length; i += 1) {
       const row = rows[i];
-      const y = getOrThrow(visibleRowYs, row) + 0.5;
+      const y = getOrThrow(allRowYs, row) + 0.5;
       context.moveTo(0.5, y);
       context.lineTo(maxX - 0.5, y);
     }
@@ -1011,10 +1003,10 @@ export class GridRenderer {
       firstColumn,
       modelColumns,
       modelRows,
-      visibleColumnXs,
-      visibleColumnWidths,
-      visibleRowYs,
-      visibleRowHeights,
+      allColumnXs,
+      allColumnWidths,
+      allRowYs,
+      allRowHeights,
     } = metrics;
     const modelRow = getOrThrow(modelRows, row);
     const modelColumn = getOrThrow(modelColumns, column);
@@ -1028,10 +1020,10 @@ export class GridRenderer {
       isExpandableGridModel(model) && model.hasExpandableRows;
 
     if (backgroundColor != null) {
-      const x = getOrThrow(visibleColumnXs, column) + 1;
-      const y = getOrThrow(visibleRowYs, row) + 1;
-      const columnWidth = getOrThrow(visibleColumnWidths, column) - 1;
-      const rowHeight = getOrThrow(visibleRowHeights, row) - 1;
+      const x = getOrThrow(allColumnXs, column) + 1;
+      const y = getOrThrow(allRowYs, row) + 1;
+      const columnWidth = getOrThrow(allColumnWidths, column) - 1;
+      const rowHeight = getOrThrow(allRowHeights, row) - 1;
       context.fillStyle = backgroundColor;
       context.fillRect(x, y, columnWidth, rowHeight);
     }
@@ -1060,14 +1052,9 @@ export class GridRenderer {
     column: VisibleIndex
   ): void {
     const { metrics } = state;
-    const {
-      visibleColumnXs,
-      visibleColumnWidths,
-      visibleRows,
-      height,
-    } = metrics;
-    const x = getOrThrow(visibleColumnXs, column);
-    const columnWidth = getOrThrow(visibleColumnWidths, column);
+    const { allColumnXs, allColumnWidths, visibleRows, height } = metrics;
+    const x = getOrThrow(allColumnXs, column);
+    const columnWidth = getOrThrow(allColumnWidths, column);
 
     context.save();
 
@@ -1107,10 +1094,10 @@ export class GridRenderer {
     const { metrics, model, theme } = state;
     const {
       firstColumn,
-      visibleColumnXs,
-      visibleColumnWidths,
-      visibleRowYs,
-      visibleRowHeights,
+      allColumnXs,
+      allColumnWidths,
+      allRowYs,
+      allRowHeights,
     } = metrics;
     const {
       cellHorizontalPadding,
@@ -1118,10 +1105,10 @@ export class GridRenderer {
       treeHorizontalPadding,
     } = theme;
 
-    const x = getOrThrow(visibleColumnXs, column);
-    const y = getOrThrow(visibleRowYs, row);
-    const columnWidth = getOrThrow(visibleColumnWidths, column);
-    const rowHeight = getOrThrow(visibleRowHeights, row);
+    const x = getOrThrow(allColumnXs, column);
+    const y = getOrThrow(allRowYs, row);
+    const columnWidth = getOrThrow(allColumnWidths, column);
+    const rowHeight = getOrThrow(allRowHeights, row);
     const isFirstColumn = column === firstColumn;
     let treeIndent = 0;
     if (
@@ -1162,10 +1149,10 @@ export class GridRenderer {
       fontWidths,
       modelColumns,
       modelRows,
-      visibleRowHeights,
+      allRowHeights,
     } = metrics;
     const { textColor } = theme;
-    const rowHeight = getOrThrow(visibleRowHeights, row);
+    const rowHeight = getOrThrow(allRowHeights, row);
     const modelRow = getOrThrow(modelRows, row);
     const modelColumn = getOrThrow(modelColumns, column);
     const text = textOverride ?? model.textForCell(modelColumn, modelRow);
@@ -1219,17 +1206,17 @@ export class GridRenderer {
       firstColumn,
       gridX,
       gridY,
-      visibleColumnXs,
-      visibleColumnWidths,
-      visibleRowYs,
-      visibleRowHeights,
+      allColumnXs,
+      allColumnWidths,
+      allRowYs,
+      allRowHeights,
       visibleRowTreeBoxes,
     } = metrics;
     const { treeMarkerColor, treeMarkerHoverColor } = theme;
-    const columnX = getOrThrow(visibleColumnXs, firstColumn);
-    const columnWidth = getOrThrow(visibleColumnWidths, firstColumn);
-    const rowY = getOrThrow(visibleRowYs, row);
-    const rowHeight = getOrThrow(visibleRowHeights, row);
+    const columnX = getOrThrow(allColumnXs, firstColumn);
+    const columnWidth = getOrThrow(allColumnWidths, firstColumn);
+    const rowY = getOrThrow(allRowYs, row);
+    const rowHeight = getOrThrow(allRowHeights, row);
     if (!isExpandableGridModel(model) || !model.isRowExpandable(row)) {
       return;
     }
@@ -1287,16 +1274,11 @@ export class GridRenderer {
     const depth = model.depthForRow(row);
     if (depth === 0) return;
 
-    const {
-      firstColumn,
-      visibleColumnXs,
-      visibleRowYs,
-      visibleRowHeights,
-    } = metrics;
+    const { firstColumn, allColumnXs, allRowYs, allRowHeights } = metrics;
     const { treeDepthIndent, treeHorizontalPadding, treeLineColor } = theme;
-    const columnX = getOrThrow(visibleColumnXs, firstColumn);
-    const rowY = getOrThrow(visibleRowYs, row);
-    const rowHeight = getOrThrow(visibleRowHeights, row);
+    const columnX = getOrThrow(allColumnXs, firstColumn);
+    const rowY = getOrThrow(allRowYs, row);
+    const rowHeight = getOrThrow(allRowHeights, row);
     const depthRowAfter =
       rowAfter !== undefined ? model.depthForRow(rowAfter) : 0;
     const depthDiff = depth > depthRowAfter ? depth - depthRowAfter : 0;
@@ -1421,8 +1403,8 @@ export class GridRenderer {
       gridX,
       width,
       visibleColumns,
-      visibleColumnWidths,
-      visibleColumnXs,
+      allColumnWidths,
+      allColumnXs,
       floatingLeftColumnCount,
       floatingLeftWidth,
       floatingRightWidth,
@@ -1473,7 +1455,7 @@ export class GridRenderer {
     if (headerSeparatorColor) {
       context.strokeStyle = headerSeparatorColor;
 
-      const hiddenColumns = [...visibleColumnWidths.entries()]
+      const hiddenColumns = [...allColumnWidths.entries()]
         .filter(([_, w]) => w === 0)
         .map(([index]) => index);
 
@@ -1482,8 +1464,8 @@ export class GridRenderer {
       context.fillStyle = headerSeparatorColor;
       for (let i = 0; i < hiddenColumns.length; i += 1) {
         const column = hiddenColumns[i];
-        const columnX = getOrThrow(visibleColumnXs, column);
-        const columnWidth = getOrThrow(visibleColumnWidths, column);
+        const columnX = getOrThrow(allColumnXs, column);
+        const columnWidth = getOrThrow(allColumnWidths, column);
         const minX =
           gridX + columnX + columnWidth + 0.5 - headerHiddenSeparatorSize * 0.5;
         context.rect(
@@ -1535,11 +1517,8 @@ export class GridRenderer {
       ) {
         context.strokeStyle = headerSeparatorHoverColor;
 
-        const columnX = getOrThrow(visibleColumnXs, highlightedSeparator);
-        const columnWidth = getOrThrow(
-          visibleColumnWidths,
-          highlightedSeparator
-        );
+        const columnX = getOrThrow(allColumnXs, highlightedSeparator);
+        const columnWidth = getOrThrow(allColumnWidths, highlightedSeparator);
         const x = gridX + columnX + columnWidth + 0.5;
         const visibleColumnIndex = visibleColumns.indexOf(highlightedSeparator);
         const nextColumn =
@@ -1547,7 +1526,7 @@ export class GridRenderer {
             ? visibleColumns[visibleColumnIndex + 1]
             : null;
         const nextColumnWidth =
-          nextColumn != null ? visibleColumnWidths.get(nextColumn) : null;
+          nextColumn != null ? allColumnWidths.get(nextColumn) : null;
         const isColumnHidden = columnWidth === 0;
         const isNextColumnHidden =
           nextColumnWidth != null && nextColumnWidth === 0;
@@ -1615,11 +1594,11 @@ export class GridRenderer {
     const { metrics, model, theme } = state;
     const {
       modelColumns,
-      visibleColumnXs,
+      allColumnXs,
       gridX,
       calculatedColumnWidths,
       userColumnWidths,
-      visibleColumnWidths,
+      allColumnWidths,
       movedColumns,
     } = metrics;
     const { columnHeaderHeight, columnWidth } = theme;
@@ -1659,9 +1638,9 @@ export class GridRenderer {
         const modelColumn = getOrThrow(modelColumns, columnIndex);
         const columnGroupName = model.textForColumnHeader(modelColumn, depth);
         const columnGroupColor = model.colorForColumnHeader(modelColumn, depth);
-        let columnGroupLeft = getOrThrow(visibleColumnXs, columnIndex) + gridX;
+        let columnGroupLeft = getOrThrow(allColumnXs, columnIndex) + gridX;
         let columnGroupRight =
-          columnGroupLeft + getOrThrow(visibleColumnWidths, columnIndex);
+          columnGroupLeft + getOrThrow(allColumnWidths, columnIndex);
 
         if (columnGroupName != null) {
           // Need to determine if the column group is at least the width of the bounds
@@ -1768,14 +1747,9 @@ export class GridRenderer {
     bounds: { minX: number; maxX: number }
   ): void {
     const { metrics, model } = state;
-    const {
-      modelColumns,
-      visibleColumnWidths,
-      visibleColumnXs,
-      gridX,
-    } = metrics;
-    const width = getOrThrow(visibleColumnWidths, index);
-    const x = getOrThrow(visibleColumnXs, index) + gridX;
+    const { modelColumns, allColumnWidths, allColumnXs, gridX } = metrics;
+    const width = getOrThrow(allColumnWidths, index);
+    const x = getOrThrow(allColumnXs, index) + gridX;
     const modelColumn = getOrThrow(modelColumns, index);
     const text = model.textForColumnHeader(modelColumn);
 
@@ -1940,8 +1914,8 @@ export class GridRenderer {
       rowHeaderWidth,
       height,
       visibleRows,
-      visibleRowHeights,
-      visibleRowYs,
+      allRowHeights,
+      allRowYs,
     } = metrics;
     if (rowHeaderWidth <= 0) {
       return;
@@ -1977,8 +1951,8 @@ export class GridRenderer {
       let isPreviousRowHidden = false;
       for (let i = 0; i < visibleRows.length; i += 1) {
         const row = visibleRows[i];
-        const rowY = getOrThrow(visibleRowYs, row);
-        const rowHeight = getOrThrow(visibleRowHeights, row);
+        const rowY = getOrThrow(allRowYs, row);
+        const rowHeight = getOrThrow(allRowHeights, row);
         if (rowHeight > 0) {
           const y = gridY + rowY + rowHeight + 0.5;
 
@@ -2003,8 +1977,8 @@ export class GridRenderer {
       context.fillStyle = headerSeparatorColor;
       for (let i = 0; i < hiddenRows.length; i += 1) {
         const row = hiddenRows[i];
-        const rowY = getOrThrow(visibleRowYs, row);
-        const rowHeight = getOrThrow(visibleRowHeights, row);
+        const rowY = getOrThrow(allRowYs, row);
+        const rowHeight = getOrThrow(allRowHeights, row);
         const minY =
           gridY + rowY + rowHeight + 0.5 - headerHiddenSeparatorSize * 0.5;
         context.rect(
@@ -2032,8 +2006,8 @@ export class GridRenderer {
       if (highlightedSeparator != null) {
         context.strokeStyle = headerSeparatorHoverColor;
 
-        const rowY = getOrThrow(visibleRowYs, highlightedSeparator);
-        const rowHeight = getOrThrow(visibleRowHeights, highlightedSeparator);
+        const rowY = getOrThrow(allRowYs, highlightedSeparator);
+        const rowHeight = getOrThrow(allRowHeights, highlightedSeparator);
         const y = gridY + rowY + rowHeight + 0.5;
 
         const visibleRowIndex = visibleRows.indexOf(highlightedSeparator);
@@ -2042,7 +2016,7 @@ export class GridRenderer {
             ? visibleRows[visibleRowIndex + 1]
             : null;
         const nextRowHeight =
-          nextRow != null ? visibleRowHeights.get(nextRow) : null;
+          nextRow != null ? allRowHeights.get(nextRow) : null;
         const isRowHidden = rowHeight === 0;
         const isNextRowHidden = nextRowHeight != null && nextRowHeight === 0;
         if (isRowHidden) {
@@ -2081,8 +2055,8 @@ export class GridRenderer {
 
     for (let i = 0; i < visibleRows.length; i += 1) {
       const row = visibleRows[i];
-      const rowHeight = getOrThrow(visibleRowHeights, row);
-      const y = getOrThrow(visibleRowYs, row) + gridY;
+      const rowHeight = getOrThrow(allRowHeights, row);
+      const y = getOrThrow(allRowYs, row) + gridY;
       this.drawRowHeader(context, state, row, y, rowHeight);
     }
 
@@ -2128,8 +2102,8 @@ export class GridRenderer {
       height,
       verticalBarWidth,
       visibleRows,
-      visibleRowHeights,
-      visibleRowYs,
+      allRowHeights,
+      allRowYs,
       width,
     } = metrics;
     if (rowFooterWidth <= 0) {
@@ -2168,8 +2142,8 @@ export class GridRenderer {
       let isPreviousRowHidden = false;
       for (let i = 0; i < visibleRows.length; i += 1) {
         const row = visibleRows[i];
-        const rowY = getOrThrow(visibleRowYs, row);
-        const rowHeight = getOrThrow(visibleRowHeights, row);
+        const rowY = getOrThrow(allRowYs, row);
+        const rowHeight = getOrThrow(allRowHeights, row);
         if (rowHeight > 0) {
           const y = gridY + rowY + rowHeight + 0.5;
 
@@ -2194,8 +2168,8 @@ export class GridRenderer {
       context.fillStyle = headerSeparatorColor;
       for (let i = 0; i < hiddenRows.length; i += 1) {
         const row = hiddenRows[i];
-        const rowY = getOrThrow(visibleRowYs, row);
-        const rowHeight = getOrThrow(visibleRowHeights, row);
+        const rowY = getOrThrow(allRowYs, row);
+        const rowHeight = getOrThrow(allRowHeights, row);
         const minY =
           gridY + rowY + rowHeight + 0.5 - headerHiddenSeparatorSize * 0.5;
         context.rect(
@@ -2223,8 +2197,8 @@ export class GridRenderer {
       if (highlightedSeparator != null) {
         context.strokeStyle = headerSeparatorHoverColor;
 
-        const rowY = getOrThrow(visibleRowYs, highlightedSeparator);
-        const rowHeight = getOrThrow(visibleRowHeights, highlightedSeparator);
+        const rowY = getOrThrow(allRowYs, highlightedSeparator);
+        const rowHeight = getOrThrow(allRowHeights, highlightedSeparator);
         const y = gridY + rowY + rowHeight + 0.5;
 
         const visibleRowIndex = visibleRows.indexOf(highlightedSeparator);
@@ -2233,7 +2207,7 @@ export class GridRenderer {
             ? visibleRows[visibleRowIndex + 1]
             : null;
         const nextRowHeight =
-          nextRow != null ? visibleRowHeights.get(nextRow) : null;
+          nextRow != null ? allRowHeights.get(nextRow) : null;
         const isRowHidden = rowHeight === 0;
         const isNextRowHidden = nextRowHeight != null && nextRowHeight === 0;
         if (isRowHidden) {
@@ -2273,9 +2247,9 @@ export class GridRenderer {
     const textX = x + cellHorizontalPadding;
     for (let i = 0; i < visibleRows.length; i += 1) {
       const row = visibleRows[i];
-      const rowHeight = getOrThrow(visibleRowHeights, row);
+      const rowHeight = getOrThrow(allRowHeights, row);
       if (rowHeight > 0) {
-        const rowY = getOrThrow(visibleRowYs, row) + gridY;
+        const rowY = getOrThrow(allRowYs, row) + gridY;
         const modelRow = getOrThrow(modelRows, row);
         const textY = rowY + rowHeight * 0.5;
         context.fillText(model.textForRowFooter(modelRow), textX, textY);
@@ -2311,10 +2285,10 @@ export class GridRenderer {
       theme,
     } = state;
     const {
-      visibleColumnWidths,
-      visibleColumnXs,
-      visibleRowHeights,
-      visibleRowYs,
+      allColumnWidths,
+      allColumnXs,
+      allRowHeights,
+      allRowYs,
       width,
       height,
     } = metrics;
@@ -2340,14 +2314,14 @@ export class GridRenderer {
       draggingColumn == null &&
       column != null &&
       row != null &&
-      visibleColumnXs.has(column) &&
-      visibleRowYs.has(row);
+      allColumnXs.has(column) &&
+      allRowYs.has(row);
     if (isCursorVisible) {
       // Punch a hole out where the active cell is, it gets styled differently.
-      const x = getOrThrow(visibleColumnXs, column);
-      const y = getOrThrow(visibleRowYs, row);
-      const w = getOrThrow(visibleColumnWidths, column);
-      const h = getOrThrow(visibleRowHeights, row);
+      const x = getOrThrow(allColumnXs, column);
+      const y = getOrThrow(allRowYs, row);
+      const w = getOrThrow(allColumnWidths, column);
+      const h = getOrThrow(allRowHeights, row);
 
       context.save();
 
@@ -2379,29 +2353,25 @@ export class GridRenderer {
       ) {
         // Need to offset the x/y coordinates so that the line draws nice and crisp
         const x =
-          startColumn >= left && visibleColumnXs.has(startColumn)
-            ? Math.round(getOrThrow(visibleColumnXs, startColumn)) + 0.5
+          startColumn >= left && allColumnXs.has(startColumn)
+            ? Math.round(getOrThrow(allColumnXs, startColumn)) + 0.5
             : minX;
         const y =
-          startRow >= top && visibleRowYs.has(startRow)
-            ? Math.max(
-                Math.round(getOrThrow(visibleRowYs, startRow)) + 0.5,
-                0.5
-              )
+          startRow >= top && allRowYs.has(startRow)
+            ? Math.max(Math.round(getOrThrow(allRowYs, startRow)) + 0.5, 0.5)
             : minY;
 
         const endX =
-          endColumn <= right && visibleColumnXs.has(endColumn)
+          endColumn <= right && allColumnXs.has(endColumn)
             ? Math.round(
-                getOrThrow(visibleColumnXs, endColumn) +
-                  getOrThrow(visibleColumnWidths, endColumn)
+                getOrThrow(allColumnXs, endColumn) +
+                  getOrThrow(allColumnWidths, endColumn)
               ) - 0.5
             : maxX;
         const endY =
-          endRow <= bottom && visibleRowYs.has(endRow)
+          endRow <= bottom && allRowYs.has(endRow)
             ? Math.round(
-                getOrThrow(visibleRowYs, endRow) +
-                  getOrThrow(visibleRowHeights, endRow)
+                getOrThrow(allRowYs, endRow) + getOrThrow(allRowHeights, endRow)
               ) - 0.5
             : maxY;
 
@@ -2447,16 +2417,11 @@ export class GridRenderer {
     borderWidth = GridRenderer.ACTIVE_CELL_BORDER_WIDTH
   ): void {
     const { metrics, theme } = state;
-    const {
-      visibleColumnWidths,
-      visibleColumnXs,
-      visibleRowHeights,
-      visibleRowYs,
-    } = metrics;
-    const cellX = getOrThrow(visibleColumnXs, column);
-    const cellY = getOrThrow(visibleRowYs, row);
-    const cellW = getOrThrow(visibleColumnWidths, column);
-    const cellH = getOrThrow(visibleRowHeights, row);
+    const { allColumnWidths, allColumnXs, allRowHeights, allRowYs } = metrics;
+    const cellX = getOrThrow(allColumnXs, column);
+    const cellY = getOrThrow(allRowYs, row);
+    const cellW = getOrThrow(allColumnWidths, column);
+    const cellH = getOrThrow(allRowHeights, row);
 
     // Now get the outline for the active cell
     let x = cellX - borderWidth * 0.5;
@@ -2531,8 +2496,8 @@ export class GridRenderer {
     const {
       gridX,
       gridY,
-      visibleColumnXs,
-      visibleColumnWidths,
+      allColumnXs,
+      allColumnWidths,
       height,
       width,
       columnHeaderMaxDepth,
@@ -2557,10 +2522,9 @@ export class GridRenderer {
 
     const [startIndex, endIndex] = draggingColumnVisibleRange;
 
-    const originalLeft = getOrThrow(visibleColumnXs, startIndex);
+    const originalLeft = getOrThrow(allColumnXs, startIndex);
     const originalRight =
-      getOrThrow(visibleColumnXs, endIndex) +
-      getOrThrow(visibleColumnWidths, endIndex);
+      getOrThrow(allColumnXs, endIndex) + getOrThrow(allColumnWidths, endIndex);
     const originalWidth = originalRight - originalLeft;
 
     const draggingLeft = draggingColumn.left;
@@ -2669,9 +2633,9 @@ export class GridRenderer {
       return;
     }
 
-    const { gridX, gridY, visibleRowYs, visibleRowHeights, width } = metrics;
-    const y = getOrThrow(visibleRowYs, draggingRow);
-    const rowHeight = getOrThrow(visibleRowHeights, draggingRow) + 1;
+    const { gridX, gridY, allRowYs, allRowHeights, width } = metrics;
+    const y = getOrThrow(allRowYs, draggingRow);
+    const rowHeight = getOrThrow(allRowHeights, draggingRow) + 1;
     const {
       backgroundColor,
       font,

--- a/packages/grid/src/GridUtils.ts
+++ b/packages/grid/src/GridUtils.ts
@@ -75,21 +75,20 @@ export class GridUtils {
     const { row, column } = GridUtils.getGridPointFromXY(x, y, metrics);
 
     const {
-      visibleColumnWidths,
-      visibleRowHeights,
-      visibleColumnXs,
-      visibleRowYs,
+      allColumnWidths,
+      allRowHeights,
+      allColumnXs,
+      allRowYs,
       modelColumns,
       modelRows,
     } = metrics;
 
     const modelRow = row !== null ? modelRows.get(row) : null;
     const modelColumn = column !== null ? modelColumns.get(column) : null;
-    const left = column !== null ? visibleColumnXs.get(column) : null;
-    const top = row !== null ? visibleRowYs.get(row) : null;
-    const columnWidth =
-      column !== null ? visibleColumnWidths.get(column) : null;
-    const rowHeight = row !== null ? visibleRowHeights.get(row) : null;
+    const left = column !== null ? allColumnXs.get(column) : null;
+    const top = row !== null ? allRowYs.get(row) : null;
+    const columnWidth = column !== null ? allColumnWidths.get(column) : null;
+    const rowHeight = row !== null ? allRowHeights.get(row) : null;
 
     return {
       row,
@@ -312,8 +311,8 @@ export class GridUtils {
       floatingLeftColumnCount,
       floatingRightColumnCount,
       visibleColumns,
-      visibleColumnXs,
-      visibleColumnWidths,
+      allColumnXs,
+      allColumnWidths,
       gridX,
     } = metrics;
 
@@ -327,8 +326,8 @@ export class GridUtils {
       floatingLeftColumnCount,
       floatingRightColumnCount,
       visibleColumns,
-      visibleColumnXs,
-      visibleColumnWidths,
+      allColumnXs,
+      allColumnWidths,
       ignoreFloating
     );
   }
@@ -345,8 +344,8 @@ export class GridUtils {
       floatingBottomRowCount,
       rowCount,
       visibleRows,
-      visibleRowYs,
-      visibleRowHeights,
+      allRowYs,
+      allRowHeights,
       gridY,
     } = metrics;
 
@@ -360,8 +359,8 @@ export class GridUtils {
       floatingTopRowCount,
       floatingBottomRowCount,
       visibleRows,
-      visibleRowYs,
-      visibleRowHeights
+      allRowYs,
+      allRowHeights
     );
   }
 
@@ -453,8 +452,8 @@ export class GridUtils {
       floatingColumns,
       floatingLeftWidth,
       visibleColumns,
-      visibleColumnXs,
-      visibleColumnWidths,
+      allColumnXs,
+      allColumnWidths,
       columnHeaderMaxDepth,
     } = metrics;
     const { allowColumnResize, headerSeparatorHandleSize } = theme;
@@ -474,8 +473,8 @@ export class GridUtils {
     let isPreviousColumnHidden = false;
     for (let i = floatingColumns.length - 1; i >= 0; i -= 1) {
       const column = floatingColumns[i];
-      const columnX = visibleColumnXs.get(column) ?? 0;
-      const columnWidth = visibleColumnWidths.get(column) ?? 0;
+      const columnX = allColumnXs.get(column) ?? 0;
+      const columnWidth = allColumnWidths.get(column) ?? 0;
       const isColumnHidden = columnWidth === 0;
       if (!isPreviousColumnHidden || !isColumnHidden) {
         let midX = columnX + columnWidth;
@@ -499,8 +498,8 @@ export class GridUtils {
     isPreviousColumnHidden = false;
     for (let i = visibleColumns.length - 1; i >= 0; i -= 1) {
       const column = visibleColumns[i];
-      const columnX = visibleColumnXs.get(column) ?? 0;
-      const columnWidth = visibleColumnWidths.get(column) ?? 0;
+      const columnX = allColumnXs.get(column) ?? 0;
+      const columnWidth = allColumnWidths.get(column) ?? 0;
       const isColumnHidden = columnWidth === 0;
 
       // If this column is under the floating columns "layer". Terminate early.
@@ -549,8 +548,8 @@ export class GridUtils {
     columnIndex: VisibleIndex,
     metrics: GridMetrics
   ): boolean {
-    const { visibleColumnWidths } = metrics;
-    return GridUtils.isItemHidden(columnIndex, visibleColumnWidths);
+    const { allColumnWidths } = metrics;
+    return GridUtils.isItemHidden(columnIndex, allColumnWidths);
   }
 
   /**
@@ -635,10 +634,10 @@ export class GridUtils {
     columnIndex: VisibleIndex,
     metrics: GridMetrics
   ): VisibleIndex[] {
-    const { visibleColumns, visibleColumnWidths } = metrics;
+    const { visibleColumns, allColumnWidths } = metrics;
     return GridUtils.getHiddenItems(
       columnIndex,
-      visibleColumnWidths,
+      allColumnWidths,
       visibleColumns
     );
   }
@@ -661,8 +660,8 @@ export class GridUtils {
       rowHeaderWidth,
       columnHeaderHeight,
       visibleRows,
-      visibleRowYs,
-      visibleRowHeights,
+      allRowYs,
+      allRowHeights,
     } = metrics;
     const { allowRowResize, headerSeparatorHandleSize } = theme;
 
@@ -681,8 +680,8 @@ export class GridUtils {
     let isPreviousRowHidden = false;
     for (let i = visibleRows.length - 1; i >= 0; i -= 1) {
       const row = visibleRows[i];
-      const rowY = visibleRowYs.get(row) ?? 0;
-      const rowHeight = visibleRowHeights.get(row) ?? 0;
+      const rowY = allRowYs.get(row) ?? 0;
+      const rowHeight = allRowHeights.get(row) ?? 0;
       const isRowHidden = rowHeight === 0;
       if (!isPreviousRowHidden || !isRowHidden) {
         let midY = rowY + rowHeight;
@@ -713,8 +712,8 @@ export class GridUtils {
    * @returns True if the row is hidden, false otherwise
    */
   static isRowHidden(rowIndex: VisibleIndex, metrics: GridMetrics): boolean {
-    const { visibleRowHeights } = metrics;
-    return GridUtils.isItemHidden(rowIndex, visibleRowHeights);
+    const { allRowHeights } = metrics;
+    return GridUtils.isItemHidden(rowIndex, allRowHeights);
   }
 
   /**
@@ -727,8 +726,8 @@ export class GridUtils {
     rowIndex: VisibleIndex,
     metrics: GridMetrics
   ): VisibleIndex[] {
-    const { visibleRows, visibleRowHeights } = metrics;
-    return GridUtils.getHiddenItems(rowIndex, visibleRowHeights, visibleRows);
+    const { visibleRows, allRowHeights } = metrics;
+    return GridUtils.getHiddenItems(rowIndex, allRowHeights, visibleRows);
   }
 
   /**

--- a/packages/grid/src/mouse-handlers/GridColumnMoveMouseHandler.ts
+++ b/packages/grid/src/mouse-handlers/GridColumnMoveMouseHandler.ts
@@ -55,9 +55,9 @@ function getColumnInfo(
   const {
     modelColumns,
     movedColumns,
-    visibleColumnXs,
+    allColumnXs,
     columnCount,
-    visibleColumnWidths,
+    allColumnWidths,
     userColumnWidths,
     calculatedColumnWidths,
     floatingLeftWidth,
@@ -89,13 +89,13 @@ function getColumnInfo(
       movedColumns
     );
 
-    left = visibleColumnXs.get(startVisibleIndex) ?? floatingLeftWidth;
+    left = allColumnXs.get(startVisibleIndex) ?? floatingLeftWidth;
     right =
-      (visibleColumnXs.get(endVisibleIndex) ?? maxX) +
-      (visibleColumnWidths.get(endVisibleIndex) ?? 0);
+      (allColumnXs.get(endVisibleIndex) ?? maxX) +
+      (allColumnWidths.get(endVisibleIndex) ?? 0);
     range = [startVisibleIndex, endVisibleIndex];
   } else {
-    const possibleLeft = visibleColumnXs.get(visibleIndex);
+    const possibleLeft = allColumnXs.get(visibleIndex);
     if (possibleLeft == null) {
       return null;
     }
@@ -103,7 +103,7 @@ function getColumnInfo(
     left = possibleLeft;
     right =
       left +
-      (visibleColumnWidths.get(visibleIndex) ??
+      (allColumnWidths.get(visibleIndex) ??
         userColumnWidths.get(modelIndex) ??
         calculatedColumnWidths.get(modelIndex) ??
         0);
@@ -159,7 +159,7 @@ class GridColumnMoveMouseHandler extends GridMouseHandler {
         userColumnWidths,
         calculatedColumnWidths,
         movedColumns,
-        visibleColumnWidths,
+        allColumnWidths,
       } = metrics;
 
       let nextLeft = left;
@@ -184,7 +184,7 @@ class GridColumnMoveMouseHandler extends GridMouseHandler {
         }
       } else {
         nextOffset += SCROLL_DELTA;
-        let leftColumnWidth = visibleColumnWidths.get(left);
+        let leftColumnWidth = allColumnWidths.get(left);
         while (leftColumnWidth !== undefined && nextOffset > leftColumnWidth) {
           nextLeft += 1;
           nextOffset -= leftColumnWidth;
@@ -418,7 +418,7 @@ class GridColumnMoveMouseHandler extends GridMouseHandler {
       floatingLeftWidth,
       width,
       columnHeaderMaxDepth,
-      visibleColumnXs,
+      allColumnXs,
     } = metrics;
 
     const isDraggingLeft = deltaX < 0;
@@ -483,7 +483,7 @@ class GridColumnMoveMouseHandler extends GridMouseHandler {
         );
 
         this.draggingOffset =
-          mouseX - (visibleColumnXs.get(parentVisibleRange[0]) ?? 0);
+          mouseX - (allColumnXs.get(parentVisibleRange[0]) ?? 0);
         this.draggingColumn = {
           ...this.draggingColumn,
           left: mouseX - this.draggingOffset,

--- a/packages/grid/src/mouse-handlers/GridHorizontalScrollBarMouseHandler.ts
+++ b/packages/grid/src/mouse-handlers/GridHorizontalScrollBarMouseHandler.ts
@@ -23,7 +23,7 @@ class GridHorizontalScrollBarMouseHandler extends GridMouseHandler {
     }
     const left = Math.floor(rawLeft);
     const leftOffsetPercent = rawLeft - left;
-    let columnWidth = metrics.visibleColumnWidths.get(left);
+    let columnWidth = metrics.allColumnWidths.get(left);
     if (columnWidth == null) {
       const metricState = grid.getMetricState();
       columnWidth = metricCalculator.getVisibleColumnWidth(left, metricState);

--- a/packages/grid/src/mouse-handlers/GridRowMoveMouseHandler.ts
+++ b/packages/grid/src/mouse-handlers/GridRowMoveMouseHandler.ts
@@ -15,10 +15,10 @@ class GridRowMoveMouseHandler extends GridMouseHandler {
     const { metrics } = grid;
     if (!metrics) throw new Error('metrics not set');
 
-    const { columnHeaderHeight, rowHeaderWidth, visibleRowYs } = metrics;
+    const { columnHeaderHeight, rowHeaderWidth, allRowYs } = metrics;
 
     if (x <= rowHeaderWidth && row !== null && model.isRowMovable(row)) {
-      const rowY = getOrThrow(visibleRowYs, row);
+      const rowY = getOrThrow(allRowYs, row);
       this.draggingOffset = y - rowY - columnHeaderHeight;
       grid.setState({ draggingRowOffset: this.draggingOffset });
     }
@@ -62,16 +62,16 @@ class GridRowMoveMouseHandler extends GridMouseHandler {
       bottomVisible,
       rowCount,
       columnHeaderHeight,
-      visibleRowHeights,
-      visibleRowYs,
+      allRowHeights,
+      allRowYs,
       height,
     } = metrics;
     let minY = columnHeaderHeight;
     if (top < draggingRow) {
       const topRow = draggingRow - 1;
       minY =
-        getOrThrow(visibleRowYs, topRow) +
-        getOrThrow(visibleRowHeights, topRow) * 0.5 +
+        getOrThrow(allRowYs, topRow) +
+        getOrThrow(allRowHeights, topRow) * 0.5 +
         columnHeaderHeight;
     }
 
@@ -79,8 +79,8 @@ class GridRowMoveMouseHandler extends GridMouseHandler {
     if (draggingRow < bottom) {
       const bottomRow = draggingRow + 1;
       maxY =
-        getOrThrow(visibleRowYs, bottomRow) +
-        getOrThrow(visibleRowHeights, bottomRow) * 0.5 +
+        getOrThrow(allRowYs, bottomRow) +
+        getOrThrow(allRowHeights, bottomRow) * 0.5 +
         columnHeaderHeight;
     }
 
@@ -102,12 +102,11 @@ class GridRowMoveMouseHandler extends GridMouseHandler {
     }
     grid.setState({ movedRows, draggingRow });
 
-    const minMoveY =
-      columnHeaderHeight + getOrThrow(visibleRowHeights, top) * 0.5;
+    const minMoveY = columnHeaderHeight + getOrThrow(allRowHeights, top) * 0.5;
     const maxMoveY =
       columnHeaderHeight +
-      getOrThrow(visibleRowYs, bottomVisible) +
-      getOrThrow(visibleRowHeights, bottomVisible) * 0.5;
+      getOrThrow(allRowYs, bottomVisible) +
+      getOrThrow(allRowHeights, bottomVisible) * 0.5;
     if (mouseY < minMoveY && top > 0) {
       grid.setState({ top: top - 1 });
     } else if (mouseY > maxMoveY && top < lastTop) {

--- a/packages/grid/src/mouse-handlers/GridRowTreeMouseHandler.ts
+++ b/packages/grid/src/mouse-handlers/GridRowTreeMouseHandler.ts
@@ -18,10 +18,10 @@ class GridRowTreeMouseHandler extends GridMouseHandler {
       gridX,
       gridY,
       firstColumn,
-      visibleColumnXs,
-      visibleColumnWidths,
-      visibleRowHeights,
-      visibleRowYs,
+      allColumnXs,
+      allColumnWidths,
+      allRowHeights,
+      allRowYs,
       visibleRowTreeBoxes,
     } = metrics;
 
@@ -32,10 +32,10 @@ class GridRowTreeMouseHandler extends GridMouseHandler {
       x > gridX &&
       y > gridY
     ) {
-      const columnX = getOrThrow(visibleColumnXs, column);
-      const width = getOrThrow(visibleColumnWidths, column);
-      const rowY = getOrThrow(visibleRowYs, row);
-      const height = getOrThrow(visibleRowHeights, row);
+      const columnX = getOrThrow(allColumnXs, column);
+      const width = getOrThrow(allColumnWidths, column);
+      const rowY = getOrThrow(allRowYs, row);
+      const height = getOrThrow(allRowHeights, row);
       if (
         x >= gridX + columnX &&
         x <= gridX + columnX + width &&

--- a/packages/grid/src/mouse-handlers/GridVerticalScrollBarMouseHandler.ts
+++ b/packages/grid/src/mouse-handlers/GridVerticalScrollBarMouseHandler.ts
@@ -23,7 +23,7 @@ class GridVerticalScrollBarMouseHandler extends GridMouseHandler {
     }
     const top = Math.floor(rawTop);
     const topOffsetPercent = rawTop - top;
-    let rowHeight = metrics.visibleRowHeights.get(top);
+    let rowHeight = metrics.allRowHeights.get(top);
     if (rowHeight == null) {
       const metricState = grid.getMetricState();
       rowHeight = metricCalculator.getVisibleRowHeight(top, metricState);

--- a/packages/iris-grid/src/IrisGrid.tsx
+++ b/packages/iris-grid/src/IrisGrid.tsx
@@ -3277,13 +3277,13 @@ export class IrisGrid extends Component<IrisGridProps, IrisGridState> {
     assertNotNull(gridRect);
     const {
       columnHeaderHeight,
-      visibleColumnXs,
-      visibleColumnWidths,
+      allColumnXs,
+      allColumnWidths,
       width,
       columnHeaderMaxDepth,
     } = metrics;
-    const columnX = visibleColumnXs.get(shownColumnTooltip);
-    const columnWidth = visibleColumnWidths.get(shownColumnTooltip);
+    const columnX = allColumnXs.get(shownColumnTooltip);
+    const columnWidth = allColumnWidths.get(shownColumnTooltip);
 
     assertNotNull(columnX);
     assertNotNull(columnWidth);
@@ -3390,12 +3390,12 @@ export class IrisGrid extends Component<IrisGridProps, IrisGridState> {
     const {
       columnHeaderHeight,
       columnHeaderMaxDepth,
-      visibleColumnXs,
-      visibleColumnWidths,
+      allColumnXs,
+      allColumnWidths,
       width,
     } = metrics;
-    const columnX = visibleColumnXs.get(visibleIndex);
-    const columnWidth = visibleColumnWidths.get(visibleIndex);
+    const columnX = allColumnXs.get(visibleIndex);
+    const columnWidth = allColumnWidths.get(visibleIndex);
 
     if (columnX == null || columnWidth == null) {
       return null;
@@ -3616,15 +3616,9 @@ export class IrisGrid extends Component<IrisGridProps, IrisGridState> {
       : IrisGrid.maxDebounce;
 
     if (isFilterBarShown && focusedFilterBarColumn != null && metrics != null) {
-      const {
-        gridX,
-        gridY,
-        visibleColumnXs,
-        visibleColumnWidths,
-        width,
-      } = metrics;
-      const columnX = visibleColumnXs.get(focusedFilterBarColumn);
-      const columnWidth = visibleColumnWidths.get(focusedFilterBarColumn);
+      const { gridX, gridY, allColumnXs, allColumnWidths, width } = metrics;
+      const columnX = allColumnXs.get(focusedFilterBarColumn);
+      const columnWidth = allColumnWidths.get(focusedFilterBarColumn);
       if (columnX != null && columnWidth != null) {
         const x = gridX + columnX;
         const y = gridY - (theme.filterBarHeight ?? 0);
@@ -3717,16 +3711,16 @@ export class IrisGrid extends Component<IrisGridProps, IrisGridState> {
         gridX,
         gridY,
         visibleColumns,
-        visibleColumnXs,
-        visibleColumnWidths,
+        allColumnXs,
+        allColumnWidths,
       } = metrics;
       const { filterBarHeight } = theme;
 
       for (let i = 0; i < visibleColumns.length; i += 1) {
         const columnIndex = visibleColumns[i];
 
-        const columnX = visibleColumnXs.get(columnIndex);
-        const columnWidth = visibleColumnWidths.get(columnIndex);
+        const columnX = allColumnXs.get(columnIndex);
+        const columnWidth = allColumnWidths.get(columnIndex);
         const modelColumn = this.getModelColumn(columnIndex);
         if (modelColumn != null) {
           const isFilterable = model.isFilterable(modelColumn);
@@ -3803,14 +3797,14 @@ export class IrisGrid extends Component<IrisGridProps, IrisGridState> {
       const {
         gridX,
         visibleColumns,
-        visibleColumnXs,
-        visibleColumnWidths,
+        allColumnXs,
+        allColumnWidths,
         columnHeaderHeight,
       } = metrics;
       for (let i = 0; i < visibleColumns.length; i += 1) {
         const columnIndex = visibleColumns[i];
-        const columnX = visibleColumnXs.get(columnIndex);
-        const columnWidth = visibleColumnWidths.get(columnIndex);
+        const columnX = allColumnXs.get(columnIndex);
+        const columnWidth = allColumnWidths.get(columnIndex);
         if (columnX != null && columnWidth != null && columnWidth > 0) {
           const xColumnHeader = gridX + columnX;
           const xFilterBar = gridX + columnX + columnWidth - 20;

--- a/packages/iris-grid/src/IrisGridRenderer.ts
+++ b/packages/iris-grid/src/IrisGridRenderer.ts
@@ -178,7 +178,7 @@ class IrisGridRenderer extends GridRenderer {
   ): void {
     const { metrics, model, theme } = state;
     const { groupedColumns, columns } = model;
-    const { maxY, visibleColumnWidths, visibleColumnXs } = metrics;
+    const { maxY, allColumnWidths, allColumnXs } = metrics;
     if (
       groupedColumns.length === 0 ||
       theme.groupedColumnDividerColor == null
@@ -190,8 +190,8 @@ class IrisGridRenderer extends GridRenderer {
     const modelIndex = columns.findIndex(
       c => c.name === lastGroupedColumn.name
     );
-    const columnX = visibleColumnXs.get(modelIndex);
-    const columnWidth = visibleColumnWidths.get(modelIndex);
+    const columnX = allColumnXs.get(modelIndex);
+    const columnWidth = allColumnWidths.get(modelIndex);
     if (columnX == null || columnWidth == null) {
       return;
     }
@@ -211,7 +211,7 @@ class IrisGridRenderer extends GridRenderer {
     state: IrisGridRenderState
   ): void {
     const { metrics, model, theme } = state;
-    const { visibleRowYs, maxX } = metrics;
+    const { allRowYs, maxX } = metrics;
     const { pendingRowCount } = model;
     if (pendingRowCount <= 0) {
       return;
@@ -219,7 +219,7 @@ class IrisGridRenderer extends GridRenderer {
 
     const firstPendingRow =
       model.rowCount - model.pendingRowCount - model.floatingBottomRowCount;
-    let y = visibleRowYs.get(firstPendingRow);
+    let y = allRowYs.get(firstPendingRow);
     if (y == null) {
       return;
     }
@@ -249,10 +249,10 @@ class IrisGridRenderer extends GridRenderer {
       return;
     }
 
-    const { visibleColumnWidths, visibleColumnXs, maxY } = metrics;
+    const { allColumnWidths, allColumnXs, maxY } = metrics;
 
-    const x = visibleColumnXs.get(hoverSelectColumn);
-    const columnWidth = visibleColumnWidths.get(hoverSelectColumn);
+    const x = allColumnXs.get(hoverSelectColumn);
+    const columnWidth = allColumnWidths.get(hoverSelectColumn);
     assertNotNull(x);
     assertNotNull(columnWidth);
 
@@ -433,16 +433,16 @@ class IrisGridRenderer extends GridRenderer {
     const { metrics, model, theme } = state;
     const {
       modelColumns,
-      visibleColumnWidths,
-      visibleColumnXs,
+      allColumnWidths,
+      allColumnXs,
       gridX,
       columnHeaderHeight,
       fontWidths,
     } = metrics;
 
     const { headerHorizontalPadding } = theme;
-    const columnWidth = getOrThrow(visibleColumnWidths, index, 0);
-    const columnX = getOrThrow(visibleColumnXs, index) + gridX;
+    const columnWidth = getOrThrow(allColumnWidths, index, 0);
+    const columnX = getOrThrow(allColumnXs, index) + gridX;
     const modelColumn = modelColumns.get(index);
 
     if (modelColumn == null) {
@@ -526,8 +526,8 @@ class IrisGridRenderer extends GridRenderer {
       maxX,
       modelColumns,
       visibleColumns,
-      visibleColumnWidths,
-      visibleColumnXs,
+      allColumnWidths,
+      allColumnXs,
     } = metrics;
 
     const columnHeaderHeight = gridY - filterBarHeight;
@@ -564,8 +564,8 @@ class IrisGridRenderer extends GridRenderer {
     for (let i = 0; i < visibleColumns.length; i += 1) {
       const column = visibleColumns[i];
       const modelColumn = getOrThrow(modelColumns, column);
-      const columnX = getOrThrow(visibleColumnXs, column);
-      const columnWidth = getOrThrow(visibleColumnWidths, column);
+      const columnX = getOrThrow(allColumnXs, column);
+      const columnWidth = getOrThrow(allColumnWidths, column);
       if (model.isFilterable(modelColumn) && columnWidth > 0) {
         const x1 = gridX + (columnX ?? 0);
         context.rect(x1 + 0.5, y1 + 0.5, columnWidth, filterBarHeight - 2); // 1 for the border, 1 for the casing
@@ -575,8 +575,8 @@ class IrisGridRenderer extends GridRenderer {
 
     for (let i = 0; i < visibleColumns.length; i += 1) {
       const column = visibleColumns[i];
-      const columnWidth = getOrThrow(visibleColumnWidths, column);
-      const columnX = getOrThrow(visibleColumnXs, column);
+      const columnWidth = getOrThrow(allColumnWidths, column);
+      const columnX = getOrThrow(allColumnXs, column);
       const x = columnX + gridX;
       this.drawExpandedFilterHeader(context, state, column, x, columnWidth);
     }
@@ -696,8 +696,8 @@ class IrisGridRenderer extends GridRenderer {
       gridY,
       maxX,
       visibleColumns,
-      visibleColumnWidths,
-      visibleColumnXs,
+      allColumnWidths,
+      allColumnXs,
     } = metrics;
     const columnHeaderHeight = gridY - filterBarCollapsedHeight;
 
@@ -709,8 +709,8 @@ class IrisGridRenderer extends GridRenderer {
 
     for (let i = 0; i < visibleColumns.length; i += 1) {
       const column = visibleColumns[i];
-      const columnWidth = visibleColumnWidths.get(column);
-      const columnX = visibleColumnXs.get(column);
+      const columnWidth = allColumnWidths.get(column);
+      const columnX = allColumnXs.get(column);
       if (columnX != null && columnWidth != null) {
         const x = columnX + gridX;
         // draw the collapsed cells
@@ -816,8 +816,8 @@ class IrisGridRenderer extends GridRenderer {
       height,
       horizontalBarHeight,
       verticalBarWidth,
-      visibleRowHeights,
-      visibleRowYs,
+      allRowHeights,
+      allRowYs,
       width,
     } = metrics;
     // Only draw the footers on the floating rows
@@ -864,8 +864,8 @@ class IrisGridRenderer extends GridRenderer {
       floatingRows.includes(mouseRow)
     ) {
       context.fillStyle = rowHoverBackgroundColor;
-      const y = visibleRowYs.get(mouseRow);
-      const rowHeight = visibleRowHeights.get(mouseRow);
+      const y = allRowYs.get(mouseRow);
+      const rowHeight = allRowHeights.get(mouseRow);
       assertNotNull(y);
       assertNotNull(rowHeight);
       context.fillRect(x, y, rowFooterWidth, rowHeight);
@@ -892,8 +892,8 @@ class IrisGridRenderer extends GridRenderer {
     const textX = x + cellHorizontalPadding;
     for (let i = 0; i < floatingRows.length; i += 1) {
       const row = floatingRows[i];
-      const rowHeight = visibleRowHeights.get(row);
-      const rowY = visibleRowYs.get(row);
+      const rowHeight = allRowHeights.get(row);
+      const rowY = allRowYs.get(row);
       const modelRow = modelRows.get(row);
       if (rowY != null && rowHeight != null && modelRow != null) {
         const textY = rowY + rowHeight * 0.5;


### PR DESCRIPTION
Fixes #316 

This also should make the fix for #936 less hacky

I refactored all uses of `visible` to the `all` versions since the metrics were really exporting `all`. Then added back the `visible` versions of the metrics. The only actual uses of the `visible` metrics should be in `getMetrics` between where the `visible` is created and the `all` version is created. Previously the `visible` version was modified where `all` is created, so any uses of `visible` below it are really uses of `all`.