### PR TITLE
Fix cannot scroll left after marking columns as hidden

### DIFF
--- a/packages/grid/src/Grid.tsx
+++ b/packages/grid/src/Grid.tsx
@@ -810,25 +810,25 @@ class Grid extends PureComponent<GridProps, GridState> {
     canvasContext.scale(scale, scale);
   }
 
+  updateScrollBounds(): void {
+    if (!this.metrics) throw new Error('metrics not set');
+    const { left, top } = this.state;
+    const { lastLeft, lastTop } = this.metrics;
+    if (left > lastLeft) {
+      this.setState({ left: lastLeft, leftOffset: 0 });
+    }
+    if (top > lastTop) {
+      this.setState({ top: lastTop, topOffset: 0 });
+    }
+  }
+
   updateMetrics(state = this.state): GridMetrics {
     this.prevMetrics = this.metrics;
 
     const { metricCalculator } = this;
     const metricState = this.getMetricState(state);
     this.metrics = metricCalculator.getMetrics(metricState);
-
-    // Fix for https://github.com/deephaven/web-client-ui/issues/936
-    // If metrics update from something like visibility panel, the lastLeft
-    // Can change due to hidden columns. Left should always be <= lastLeft
-    // Same for top
-    const { left, top } = state;
-    const { lastLeft, lastTop } = this.metrics;
-    if (left > lastLeft) {
-      this.setState({ left: lastLeft });
-    }
-    if (top > lastTop) {
-      this.setState({ top: lastTop });
-    }
+    this.updateScrollBounds();
 
     return this.metrics;
   }
@@ -1803,14 +1803,7 @@ class Grid extends PureComponent<GridProps, GridState> {
 
     if (!this.metrics) throw new Error('metrics not set');
 
-    const { left, top } = this.state;
-    const { lastLeft, lastTop } = this.metrics;
-    if (left > lastLeft) {
-      this.setState({ left: lastLeft, leftOffset: 0 });
-    }
-    if (top > lastTop) {
-      this.setState({ top: lastTop, topOffset: 0 });
-    }
+    this.updateScrollBounds();
     this.forceUpdate();
   }
 

--- a/packages/grid/src/Grid.tsx
+++ b/packages/grid/src/Grid.tsx
@@ -1582,6 +1582,18 @@ class Grid extends PureComponent<GridProps, GridState> {
     const theme = this.getTheme();
     const width = this.canvas.clientWidth;
     const height = this.canvas.clientHeight;
+    const { lastLeft, lastTop } = metrics;
+
+    // Fix for https://github.com/deephaven/web-client-ui/issues/936
+    // The metrics rely on left to calculate visibleColumnWidths which is needed to calculate lastLeft
+    // But lastLeft is needed to determine the actual value of left
+    // visibleColumnWidths is part of what determines what to draw
+    // So without reworking metrics algorithms, we can't fix this in metrics due to the cyclic dependency
+    this.setState({
+      left: Math.min(left, lastLeft),
+      top: Math.min(top, lastTop),
+    });
+
     const renderState = {
       left,
       top,

--- a/packages/grid/src/Grid.tsx
+++ b/packages/grid/src/Grid.tsx
@@ -1803,7 +1803,6 @@ class Grid extends PureComponent<GridProps, GridState> {
 
     if (!this.metrics) throw new Error('metrics not set');
 
-    this.updateScrollBounds();
     this.forceUpdate();
   }
 

--- a/packages/grid/src/GridRenderer.ts
+++ b/packages/grid/src/GridRenderer.ts
@@ -46,10 +46,6 @@ export type EditingCell = {
 };
 
 export type GridRenderState = {
-  // The top/left cell of the scrolled viewport
-  left: VisibleIndex;
-  top: VisibleIndex;
-
   // Width and height of the total canvas area
   width: number;
   height: number;


### PR DESCRIPTION
Fixes #936 

Also removed `left` and `top` from the render state passed to the render function. They aren't used and should be retrieved from metrics instead.

I have a version of this which instead updates `left` and `top` in the metric calculator instead of updating the grid state after metrics if that is preferred (relies on #997). In that case we would probably still want to update the state in Grid since a few handlers in Grid use that state.