### PR TITLE
Fix default button focusing on BasicModal re-render

### DIFF
--- a/packages/components/src/BasicModal.test.tsx
+++ b/packages/components/src/BasicModal.test.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import userEvent from '@testing-library/user-event';
+import { render } from '@testing-library/react';
+import BasicModal from './BasicModal';
+
+const DEFAULT_BODY_TEXT = 'DEFAULT_TEXT';
+const DEFAULT_TEST_ID = 'DEFAULT_TEST_ID';
+
+function makeWrapper(
+  isOpen = true,
+  bodyText = DEFAULT_BODY_TEXT,
+  dataTestId = DEFAULT_TEST_ID,
+  onConfirm = jest.fn()
+) {
+  return render(
+    <BasicModal
+      data-testid={dataTestId}
+      isOpen={isOpen}
+      headerText=""
+      bodyText={bodyText}
+      onConfirm={onConfirm}
+    />
+  );
+}
+
+it('mounts and unmounts without failing', () => {
+  makeWrapper();
+});
+
+it('focuses default button on first render after opening', () => {
+  const { getByTestId } = makeWrapper();
+  expect(getByTestId(`${DEFAULT_TEST_ID}-btn-confirm`)).toHaveFocus();
+});
+
+it('does not re-focus default button on re-render', () => {
+  const { getByTestId, rerender } = makeWrapper();
+  userEvent.tab();
+  expect(getByTestId(`${DEFAULT_TEST_ID}-btn-confirm`)).not.toHaveFocus();
+  rerender(
+    <BasicModal
+      isOpen
+      headerText=""
+      bodyText={DEFAULT_BODY_TEXT}
+      data-testid={DEFAULT_TEST_ID}
+      onConfirm={jest.fn()}
+    />
+  );
+  expect(getByTestId(`${DEFAULT_TEST_ID}-btn-confirm`)).not.toHaveFocus();
+});

--- a/packages/components/src/BasicModal.tsx
+++ b/packages/components/src/BasicModal.tsx
@@ -4,7 +4,7 @@ import ButtonGroup from './ButtonGroup';
 import Button from './Button';
 import { Modal, ModalBody, ModalFooter, ModalHeader } from './modal';
 
-interface BasicModalProps {
+export interface BasicModalProps {
   isOpen: boolean;
   headerText: string;
   bodyText: string | (() => string);
@@ -63,19 +63,17 @@ function BasicModal(props: BasicModalProps) {
     onConfirm();
   }, [onConfirm, onModalDisable]);
 
+  const onOpened = useCallback(() => {
+    confirmButton.current?.focus();
+  }, []);
+
   let modalBody = '';
   if (isOpen) {
     modalBody = typeof bodyText === 'function' ? bodyText() : bodyText;
   }
 
   return (
-    <Modal
-      isOpen={isOpen}
-      className="theme-bg-light"
-      onOpened={() => {
-        confirmButton.current?.focus();
-      }}
-    >
+    <Modal isOpen={isOpen} className="theme-bg-light" onOpened={onOpened}>
       <ModalHeader closeButton={false}>{headerText}</ModalHeader>
       <ModalBody>{modalBody}</ModalBody>
       <ModalFooter>


### PR DESCRIPTION
- Replace inline function in the `Modal` `onOpened` prop with a `useCallback` to prevent re-focusing default button on each `BasicModal` render
- Unit tests
- Fixes #792 