### PR TITLE
Fix silent error when saving notebook with duplicate name

### DIFF
--- a/packages/code-studio/src/storage/grpc/GrpcFileStorage.ts
+++ b/packages/code-studio/src/storage/grpc/GrpcFileStorage.ts
@@ -111,7 +111,7 @@ export class GrpcFileStorage implements FileStorage {
     const itemDetails = allItems[0];
     return {
       filename: this.removeRoot(itemDetails.filename),
-      basename: this.removeRoot(itemDetails.basename),
+      basename: itemDetails.basename,
       id: this.removeRoot(itemDetails.filename),
       type: itemDetails.type,
     };


### PR DESCRIPTION
Fixes #956 

When saving a notebook with a duplicate name, it will ask you if you want to overwrite.
