### PR TITLE
[Fix] Toast Wrapping with Overridden Plotly Styles

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,8 @@ To get started quickly:
 1. Navigate to [https://github.com/deephaven/web-client-ui](https://github.com/deephaven/web-client-ui).
 2. Click `Fork` in the top right corner.
 3. `git clone git@github.com:<username>/web-client-ui.git`
-4. Commit changes to your own branches in your forked repository.
+4. In order to view the UI, you must also be running the [deephaven-core](https://github.com/deephaven/deephaven-core). deephaven-core provides REST APIs that the web-client-ui depends upon. An easy way to get started is to follow the steps for [Launch Python](https://github.com/deephaven/deephaven-core#launch-python).
+5. Commit changes to your own branches in your forked repository.
 
 For details on working with git on GitHub, see:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ To get started quickly:
 1. Navigate to [https://github.com/deephaven/web-client-ui](https://github.com/deephaven/web-client-ui).
 2. Click `Fork` in the top right corner.
 3. `git clone git@github.com:<username>/web-client-ui.git`
-4. In order to view the UI, you must also be running the [deephaven-core](https://github.com/deephaven/deephaven-core). deephaven-core provides REST APIs that the web-client-ui depends upon. An easy way to get started is to follow the steps for [Launch Python](https://github.com/deephaven/deephaven-core#launch-python).
+4. In order to use the UI, you must also be running a [deephaven-core](https://github.com/deephaven/deephaven-core) server on port 10000. The server provides APIs that the web-client-ui depends upon. An easy way to get started is to follow the steps for [Launch Python](https://github.com/deephaven/deephaven-core#launch-python).
 5. Commit changes to your own branches in your forked repository.
 
 For details on working with git on GitHub, see:

--- a/packages/chart/src/Chart.scss
+++ b/packages/chart/src/Chart.scss
@@ -8,6 +8,10 @@ $plotly-color-btn-active: rgba(255, 255, 255, 70%);
 
 .plotly-notifier {
   margin-right: $plotly-notifier-margin-right;
+
+  // Needed to specify in order to override the plotly styles
+  max-width: 325px;
+  width: 325px;
 }
 
 .plotly-notifier .notifier-note {
@@ -17,6 +21,12 @@ $plotly-color-btn-active: rgba(255, 255, 255, 70%);
   border: 0 !important;
   border-radius: $plotly-notifier-note-border-radius !important;
   background: $plotly-notifier-note-bg !important;
+  min-width: fit-content !important;
+  max-width: inherit !important;
+  
+  // This prevents line wrapping
+  overflow: hidden !important;
+  white-space: nowrap !important;
 }
 
 .chart-wrapper {

--- a/packages/chart/src/Chart.scss
+++ b/packages/chart/src/Chart.scss
@@ -8,10 +8,6 @@ $plotly-color-btn-active: rgba(255, 255, 255, 70%);
 
 .plotly-notifier {
   margin-right: $plotly-notifier-margin-right;
-
-  // Needed to specify in order to override the plotly styles
-  // max-width: 325px;
-  // width: 325px;
 }
 
 .plotly-notifier .notifier-note {

--- a/packages/chart/src/Chart.scss
+++ b/packages/chart/src/Chart.scss
@@ -10,23 +10,30 @@ $plotly-color-btn-active: rgba(255, 255, 255, 70%);
   margin-right: $plotly-notifier-margin-right;
 
   // Needed to specify in order to override the plotly styles
-  max-width: 325px;
-  width: 325px;
+  // max-width: 325px;
+  // width: 325px;
 }
 
 .plotly-notifier .notifier-note {
   // Mark these properties as !important because plotly css can be loaded in a different order in production
   // See comments on IDS-4808
   // https://illumon.aha.io/comments/6737799632463662636
+  color: $foreground !important;
   border: 0 !important;
   border-radius: $plotly-notifier-note-border-radius !important;
   background: $plotly-notifier-note-bg !important;
-  min-width: fit-content !important;
-  max-width: inherit !important;
-  
-  // This prevents line wrapping
-  overflow: hidden !important;
-  white-space: nowrap !important;
+  overflow-wrap: normal !important;
+  hyphens: unset !important;
+  margin-bottom: $spacer-2 !important;
+  box-shadow: $box-shadow !important;
+}
+
+.plotly-notifier .notifier-close {
+  color: $gray-400 !important;
+  transition: $transition-base !important;
+  &:hover {
+    color: $foreground !important;
+  }
 }
 
 .chart-wrapper {


### PR DESCRIPTION
Fixes https://github.com/deephaven/web-client-ui/issues/1009 

Hello! :wave: @mattrunyon & @dsmmcken 
I'm trying to get more into my open source contributions and came across this project.   I saw this issue and it is listed as `bug` and `good first issue` so I decided to give it a shot.

Just as I was prepping this PR did I notice that [Don opened up a PR that made some improvements with the toast stuff](https://github.com/deephaven/web-client-ui/pull/1010). Hopefully this fixes the issue that Matthew identified and we can use Don's changes in conjunction. 

# Summary
Fixed the toast issue wrapping issue in Chrome.  

# Screenshot
![Screenshot from 2023-01-12 00-11-07](https://user-images.githubusercontent.com/9396787/211993207-5a8b88b5-96be-48fa-b2db-c38de971b5f7.png)

# Testing
Manually tested clicking the "Download as Png" in Chrome.  Looks good.