### PR TITLE
Validate custom column names

### DIFF
--- a/packages/iris-grid/src/IrisGrid.tsx
+++ b/packages/iris-grid/src/IrisGrid.tsx
@@ -2979,7 +2979,11 @@ export class IrisGrid extends Component<IrisGridProps, IrisGridState> {
     }
 
     this.setState({ customColumns });
-    this.startLoading('Applying custom columns...');
+    if (customColumns.length > 0) {
+      // If there are no custom columns, the change handler never fires
+      // This causes the loader to stay until canceled by the user
+      this.startLoading('Applying custom columns...');
+    }
   }
 
   handleCustomColumnsChanged(): void {

--- a/packages/iris-grid/src/sidebar/CustomColumnBuilder.test.tsx
+++ b/packages/iris-grid/src/sidebar/CustomColumnBuilder.test.tsx
@@ -1,0 +1,178 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { EventShimCustomEvent } from '@deephaven/utils';
+import CustomColumnBuilder, {
+  CustomColumnBuilderProps,
+} from './CustomColumnBuilder';
+import IrisGridTestUtils from '../IrisGridTestUtils';
+import IrisGridModel from '../IrisGridModel';
+
+function Builder({
+  model = IrisGridTestUtils.makeModel(),
+  customColumns = [],
+  onSave = jest.fn(),
+  onCancel = jest.fn(),
+}: Partial<CustomColumnBuilderProps>) {
+  return (
+    <CustomColumnBuilder
+      model={model}
+      customColumns={customColumns}
+      onSave={onSave}
+      onCancel={onCancel}
+    />
+  );
+}
+
+test('Renders the default state', async () => {
+  render(<Builder />);
+  expect(screen.getByPlaceholderText('Column Name')).toBeInTheDocument();
+  expect(screen.getByText('Column Formula')).toBeInTheDocument();
+});
+
+test('Calls on save', async () => {
+  const user = userEvent.setup();
+  const customColumns = ['abc=def', 'foo=bar'];
+  const mockSave = jest.fn();
+  render(<Builder onSave={mockSave} customColumns={customColumns} />);
+
+  await user.type(screen.getByDisplayValue('abc'), 'cba');
+  await user.click(screen.getByText(/Save/));
+  expect(mockSave).toHaveBeenLastCalledWith(['abccba=def', 'foo=bar']);
+});
+
+test('Switches to loader button while saving', async () => {
+  jest.useFakeTimers();
+  const user = userEvent.setup({ delay: null });
+  const model = IrisGridTestUtils.makeModel();
+  const mockSave = jest.fn(() =>
+    setTimeout(() => {
+      model.dispatchEvent(
+        new EventShimCustomEvent(IrisGridModel.EVENT.COLUMNS_CHANGED)
+      );
+    }, 50)
+  );
+
+  render(
+    <Builder model={model} onSave={mockSave} customColumns={['foo=bar']} />
+  );
+
+  await user.click(screen.getByText(/Save/));
+  expect(screen.getByText('Applying')).toBeInTheDocument();
+  jest.advanceTimersByTime(50);
+  expect(screen.getByText('Success')).toBeInTheDocument();
+  jest.advanceTimersByTime(CustomColumnBuilder.SUCCESS_SHOW_DURATION);
+  expect(screen.getByText(/Save/)).toBeInTheDocument();
+
+  // Component should ignore this event and not change the save button
+  model.dispatchEvent(
+    new EventShimCustomEvent(IrisGridModel.EVENT.COLUMNS_CHANGED)
+  );
+  expect(screen.getByText(/Save/)).toBeInTheDocument();
+  jest.useRealTimers();
+});
+
+test('Adds a column', async () => {
+  const user = userEvent.setup();
+  render(<Builder />);
+
+  await user.click(screen.getByText('Add Another Column'));
+  expect(screen.getAllByPlaceholderText('Column Name').length).toBe(2);
+  expect(screen.getAllByText('Column Formula').length).toBe(2);
+});
+
+test('Ignores empty names or formulas on save', async () => {
+  const user = userEvent.setup();
+  const customColumns = ['foo=bar'];
+  const mockSave = jest.fn();
+  render(<Builder customColumns={customColumns} onSave={mockSave} />);
+
+  await user.click(screen.getByText('Add Another Column'));
+  await user.type(screen.getAllByPlaceholderText('Column Name')[1], 'test');
+  await user.click(screen.getByText(/Save/));
+  expect(mockSave).toBeCalledWith(customColumns);
+});
+
+test('Deletes columns', async () => {
+  const user = userEvent.setup();
+  const customColumns = ['abc=def', 'foo=bar'];
+  render(<Builder customColumns={customColumns} />);
+
+  await user.click(screen.getAllByLabelText(/Delete/)[0]);
+  expect(screen.queryByDisplayValue('abc')).toBeNull();
+  expect(screen.queryByDisplayValue('def')).toBeNull();
+  expect(screen.getByDisplayValue('foo')).toBeInTheDocument();
+  expect(screen.getByDisplayValue('bar')).toBeInTheDocument();
+
+  await user.click(screen.getByLabelText(/Delete/));
+  expect(screen.queryByDisplayValue('foo')).toBeNull();
+  expect(screen.queryByDisplayValue('bar')).toBeNull();
+  expect(screen.getByPlaceholderText('Column Name')).toBeInTheDocument();
+  expect(screen.getByText('Column Formula')).toBeInTheDocument();
+});
+
+test('Displays request failure message', async () => {
+  const user = userEvent.setup();
+  const model = IrisGridTestUtils.makeModel();
+  render(<Builder model={model} customColumns={['foo=bar']} />);
+
+  // Should ignore this since not in saving state
+  model.dispatchEvent(
+    new EventShimCustomEvent(IrisGridModel.EVENT.REQUEST_FAILED, {
+      detail: { errorMessage: 'Error message' },
+    })
+  );
+  expect(screen.queryByText(/Error message/)).toBeNull();
+
+  await user.click(screen.getByText(/Save/));
+  model.dispatchEvent(
+    new EventShimCustomEvent(IrisGridModel.EVENT.REQUEST_FAILED, {
+      detail: { errorMessage: 'Error message' },
+    })
+  );
+
+  expect(screen.getByText(/Error message/)).toBeInTheDocument();
+
+  const input = screen.getByDisplayValue('foo');
+  await user.click(input);
+  expect(input).not.toHaveClass('is-invalid');
+});
+
+test('Handles focus changes via keyboard', async () => {
+  const user = userEvent.setup();
+  const { container } = render(
+    <Builder customColumns={['abc=bar', 'foo=bar']} />
+  );
+
+  const nameInputs = screen.getAllByPlaceholderText('Column Name');
+  const formulaInputs = container.querySelectorAll(
+    '.input-editor-wrapper textarea'
+  );
+  const deleteButtons = screen.getAllByLabelText(/Delete/);
+  const dragHandles = screen.getAllByLabelText(/Drag/);
+  await user.click(nameInputs[0]);
+
+  await user.keyboard('{Tab}');
+  expect(deleteButtons[0]).toHaveFocus();
+  await user.keyboard('{Tab}');
+  expect(dragHandles[0]).toHaveFocus();
+  await user.keyboard('{Tab}');
+  expect(formulaInputs[0]).toHaveFocus();
+
+  await user.keyboard('{Tab}');
+  expect(nameInputs[1]).toHaveFocus();
+  await user.keyboard('{Tab}');
+  expect(deleteButtons[1]).toHaveFocus();
+  await user.keyboard('{Tab}');
+  expect(dragHandles[1]).toHaveFocus();
+  await user.keyboard('{Tab}');
+  expect(formulaInputs[1]).toHaveFocus();
+
+  await user.keyboard('{Tab}');
+  expect(screen.getByText('Add Another Column')).toHaveFocus();
+
+  await user.keyboard('{Shift>}{Tab}{/Shift}');
+  expect(formulaInputs[1]).toHaveFocus();
+  await user.keyboard('{Shift>}{Tab}{/Shift}');
+  expect(dragHandles[1]).toHaveFocus();
+});

--- a/packages/iris-grid/src/sidebar/CustomColumnBuilder.tsx
+++ b/packages/iris-grid/src/sidebar/CustomColumnBuilder.tsx
@@ -9,6 +9,7 @@ import { dhNewCircleLargeFilled, vsWarning, vsPass } from '@deephaven/icons';
 import CustomColumnInput from './CustomColumnInput';
 import './CustomColumnBuilder.scss';
 import IrisGridModel from '../IrisGridModel';
+import { DbNameValidator } from '@deephaven/utils';
 
 export type CustomColumnKey = 'eventKey' | 'name' | 'formula';
 
@@ -334,6 +335,9 @@ class CustomColumnBuilder extends Component<
   renderSaveButton(): ReactElement {
     const { inputs, isCustomColumnApplying, isSuccessShowing } = this.state;
     const saveText = inputs.length > 1 ? 'Save Columns' : 'Save Column';
+    const areNamesValid = inputs.every(({ name }) =>
+      DbNameValidator.isValidColumnName(name)
+    );
 
     return (
       <Button
@@ -341,7 +345,7 @@ class CustomColumnBuilder extends Component<
         className={classNames('btn-apply', {
           'btn-spinner': isCustomColumnApplying,
         })}
-        disabled={isSuccessShowing || isCustomColumnApplying}
+        disabled={isSuccessShowing || isCustomColumnApplying || !areNamesValid}
         onClick={this.handleSaveClick}
       >
         {isCustomColumnApplying && (

--- a/packages/iris-grid/src/sidebar/CustomColumnBuilder.tsx
+++ b/packages/iris-grid/src/sidebar/CustomColumnBuilder.tsx
@@ -279,7 +279,7 @@ class CustomColumnBuilder extends Component<
   }
 
   handleSaveClick(): void {
-    const { onSave } = this.props;
+    const { onSave, customColumns: originalCustomColumns } = this.props;
     const { inputs, isCustomColumnApplying } = this.state;
     if (isCustomColumnApplying) {
       return;
@@ -292,7 +292,11 @@ class CustomColumnBuilder extends Component<
       }
     });
     this.resetErrorMessage();
-    this.setState({ isCustomColumnApplying: true });
+    this.setState({
+      // If both are 0, then moving from no custom to no custom. The parent won't re-render to cancel the loading state
+      isCustomColumnApplying:
+        customColumns.length > 0 || originalCustomColumns.length > 0,
+    });
     onSave(customColumns);
   }
 
@@ -336,11 +340,13 @@ class CustomColumnBuilder extends Component<
   renderSaveButton(): ReactElement {
     const { inputs, isCustomColumnApplying, isSuccessShowing } = this.state;
     const saveText = inputs.length > 1 ? 'Save Columns' : 'Save Column';
-    const areNamesValid = inputs.every(({ name }) =>
-      DbNameValidator.isValidColumnName(name)
+    const areNamesValid = inputs.every(
+      ({ name }) => name === '' || DbNameValidator.isValidColumnName(name)
     );
-    const areNamesUnique =
-      new Set(inputs.map(({ name }) => name)).size === inputs.length;
+    const filteredNames = inputs
+      .filter(({ name }) => name !== '')
+      .map(({ name }) => name);
+    const areNamesUnique = new Set(filteredNames).size === filteredNames.length;
 
     return (
       <Button

--- a/packages/iris-grid/src/sidebar/CustomColumnBuilder.tsx
+++ b/packages/iris-grid/src/sidebar/CustomColumnBuilder.tsx
@@ -18,7 +18,7 @@ type Input = {
   name: string;
   formula: string;
 };
-interface CustomColumnBuilderProps {
+export interface CustomColumnBuilderProps {
   model: IrisGridModel;
   customColumns: string[];
   onSave: (columns: string[]) => void;
@@ -37,12 +37,6 @@ class CustomColumnBuilder extends Component<
   CustomColumnBuilderState
 > {
   static SUCCESS_SHOW_DURATION = 750;
-
-  static defaultProps = {
-    customColumns: [],
-    onSave: (): void => undefined,
-    onCancel: (): void => undefined,
-  };
 
   static makeCustomColumnInputEventKey(): string {
     return shortid.generate();
@@ -266,15 +260,15 @@ class CustomColumnBuilder extends Component<
     const { inputs } = this.state;
     // focus on drag handle
     if (shiftKey) {
-      (this.container?.querySelectorAll(`.btn-drag-handle`)[
+      (this.container?.querySelectorAll('.btn-drag-handle')[
         focusEditorIndex
       ] as HTMLButtonElement).focus();
       return;
     }
     if (focusEditorIndex === inputs.length - 1) {
-      (this.container?.querySelectorAll(`.btn-add-column`)[
-        focusEditorIndex
-      ] as HTMLButtonElement).focus();
+      (this.container?.querySelector(
+        '.btn-add-column'
+      ) as HTMLButtonElement)?.focus();
     } else {
       // focus on next column name input
       const nextFocusIndex = focusEditorIndex + 1;
@@ -364,7 +358,6 @@ class CustomColumnBuilder extends Component<
           <span>
             <LoadingSpinner />
             <span className="btn-normal-content">Applying</span>
-            <span className="btn-hover-content">Applying</span>
           </span>
         )}
         {!isSuccessShowing && !isCustomColumnApplying && saveText}
@@ -377,7 +370,7 @@ class CustomColumnBuilder extends Component<
     );
   }
 
-  render(): ReactElement {
+  render(): JSX.Element {
     const { onCancel } = this.props;
     const { errorMessage } = this.state;
     return (

--- a/packages/iris-grid/src/sidebar/CustomColumnBuilder.tsx
+++ b/packages/iris-grid/src/sidebar/CustomColumnBuilder.tsx
@@ -308,12 +308,14 @@ class CustomColumnBuilder extends Component<
   renderInputs(): ReactElement[] {
     const { inputs, hasRequestFailed } = this.state;
 
-    const nameSet = new Set();
+    const nameCount = new Map();
+    inputs.forEach(({ name }) =>
+      nameCount.set(name, (nameCount.get(name) ?? 0) + 1)
+    );
 
     return inputs.map((input, index) => {
       const { eventKey, name, formula } = input;
-      const isDuplicate = nameSet.has(name);
-      nameSet.add(name);
+      const isDuplicate = (nameCount.get(name) ?? 0) > 1;
       return (
         <CustomColumnInput
           key={eventKey}

--- a/packages/iris-grid/src/sidebar/CustomColumnInput.test.tsx
+++ b/packages/iris-grid/src/sidebar/CustomColumnInput.test.tsx
@@ -1,0 +1,72 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { DragDropContext, Droppable } from 'react-beautiful-dnd';
+import CustomColumnInput, { CustomColumnInputProps } from './CustomColumnInput';
+
+const TEST_ID = 'TEST_ID';
+
+function Input({
+  eventKey = TEST_ID,
+  inputIndex = 0,
+  name = '',
+  formula = '',
+  onChange = jest.fn(),
+  onDeleteColumn = jest.fn(),
+  onTabInEditor = jest.fn(),
+  invalid = false,
+  isDuplicate = false,
+}: Partial<CustomColumnInputProps>) {
+  return (
+    <div>
+      <DragDropContext onDragEnd={jest.fn()}>
+        <Droppable droppableId="test-droppable">
+          {() => (
+            <CustomColumnInput
+              eventKey={eventKey}
+              inputIndex={inputIndex}
+              name={name}
+              formula={formula}
+              onChange={onChange}
+              onDeleteColumn={onDeleteColumn}
+              onTabInEditor={onTabInEditor}
+              invalid={invalid}
+              isDuplicate={isDuplicate}
+            />
+          )}
+        </Droppable>
+      </DragDropContext>
+    </div>
+  );
+}
+
+test('Fires change events', async () => {
+  const user = userEvent.setup();
+  const mockOnChange = jest.fn();
+  render(<Input onChange={mockOnChange} />);
+  await user.type(screen.getByPlaceholderText('Column Name'), 'a');
+  expect(mockOnChange).toBeCalledWith(TEST_ID, 'name', 'a');
+
+  mockOnChange.mockClear();
+  await user.click(screen.getByText('Column Formula'));
+  await user.keyboard('b');
+  expect(mockOnChange).toBeCalledWith(TEST_ID, 'formula', 'b');
+  await user.keyboard('[Backspace]');
+  expect(mockOnChange).toBeCalledWith(TEST_ID, 'formula', 'b');
+});
+
+test('Fires delete event', async () => {
+  const user = userEvent.setup();
+  const mockDelete = jest.fn();
+  render(<Input onDeleteColumn={mockDelete} />);
+  await user.click(screen.getByLabelText('Delete custom column'));
+  expect(mockDelete).toBeCalledWith(TEST_ID);
+});
+
+test('Displays validation errors', async () => {
+  const { rerender } = render(<Input isDuplicate />);
+  expect(screen.getByText('Duplicate name')).toBeInTheDocument();
+
+  rerender(<Input name=":abc" />);
+  expect(screen.getByText('Invalid name')).toBeInTheDocument();
+});

--- a/packages/iris-grid/src/sidebar/CustomColumnInput.tsx
+++ b/packages/iris-grid/src/sidebar/CustomColumnInput.tsx
@@ -46,7 +46,7 @@ function CustomColumnInput({
   const isValidName = name === '' || DbNameValidator.isValidColumnName(name);
   const handleFormulaEditorContentChanged = useCallback(
     (formulaValue?: string) => {
-      if (formulaValue !== undefined && formulaValue !== '') {
+      if (formulaValue !== undefined) {
         formulaValue.replace(/(\r\n|\n|\r)/gm, ''); // remove line break
         onChange(eventKey, INPUT_TYPE.FORMULA, formulaValue);
       }

--- a/packages/iris-grid/src/sidebar/CustomColumnInput.tsx
+++ b/packages/iris-grid/src/sidebar/CustomColumnInput.tsx
@@ -6,6 +6,7 @@ import { Button, Tooltip } from '@deephaven/components';
 import { vsTrash, vsGripper } from '@deephaven/icons';
 import InputEditor from './InputEditor';
 import { CustomColumnKey } from './CustomColumnBuilder';
+import { DbNameValidator } from '@deephaven/utils';
 
 interface CustomColumnInputProps {
   eventKey: string;
@@ -70,6 +71,9 @@ class CustomColumnInput extends PureComponent<
       onTabInEditor,
       invalid,
     } = this.props;
+
+    const isValidName = DbNameValidator.isValidColumnName(name);
+
     return (
       <Draggable
         draggableId={eventKey}
@@ -86,40 +90,47 @@ class CustomColumnInput extends PureComponent<
             {...provided.draggableProps}
           >
             <div className="custom-column-input-container">
-              <div className="d-flex flex-row pb-3 custom-column-name">
-                <input
-                  className={classNames('form-control custom-column-input', {
-                    'is-invalid': invalid,
-                  })}
-                  placeholder="Column Name"
-                  value={name}
-                  onChange={event => {
-                    onChange(
-                      eventKey,
-                      CustomColumnInput.INPUT_TYPE.NAME as CustomColumnKey,
-                      event.target.value
-                    );
-                  }}
-                />
-                <Button
-                  kind="ghost"
-                  className="ml-1 px-2"
-                  onClick={() => {
-                    onDeleteColumn(eventKey);
-                  }}
-                  icon={vsTrash}
-                  tooltip="Delete custom column"
-                />
+              <div className="pb-3">
+                <div className="d-flex flex-row custom-column-name">
+                  <input
+                    className={classNames('form-control custom-column-input', {
+                      'is-invalid': invalid || !isValidName,
+                    })}
+                    placeholder="Column Name"
+                    value={name}
+                    onChange={event => {
+                      onChange(
+                        eventKey,
+                        CustomColumnInput.INPUT_TYPE.NAME as CustomColumnKey,
+                        event.target.value
+                      );
+                    }}
+                  />
+                  <Button
+                    kind="ghost"
+                    className="ml-1 px-2"
+                    onClick={() => {
+                      onDeleteColumn(eventKey);
+                    }}
+                    icon={vsTrash}
+                    tooltip="Delete custom column"
+                  />
 
-                <button
-                  type="button"
-                  className="btn btn-link btn-link-icon px-2 btn-drag-handle"
-                  // eslint-disable-next-line react/jsx-props-no-spreading
-                  {...provided.dragHandleProps}
-                >
-                  <Tooltip>Drag column to re-order</Tooltip>
-                  <FontAwesomeIcon icon={vsGripper} />
-                </button>
+                  <button
+                    type="button"
+                    className="btn btn-link btn-link-icon px-2 btn-drag-handle"
+                    // eslint-disable-next-line react/jsx-props-no-spreading
+                    {...provided.dragHandleProps}
+                  >
+                    <Tooltip>Drag column to re-order</Tooltip>
+                    <FontAwesomeIcon icon={vsGripper} />
+                  </button>
+                </div>
+                {!isValidName && (
+                  <p className="validate-label-error text-danger mb-0 mt-2 pl-1">
+                    Invalid column name
+                  </p>
+                )}
               </div>
               <InputEditor
                 editorSettings={{ language: 'deephavenDb' }}

--- a/packages/iris-grid/src/sidebar/CustomColumnInput.tsx
+++ b/packages/iris-grid/src/sidebar/CustomColumnInput.tsx
@@ -1,14 +1,13 @@
 import React, { useCallback } from 'react';
 import classNames from 'classnames';
 import { Draggable } from 'react-beautiful-dnd';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { Button, Tooltip } from '@deephaven/components';
+import { Button } from '@deephaven/components';
 import { vsTrash, vsGripper } from '@deephaven/icons';
 import { DbNameValidator } from '@deephaven/utils';
 import InputEditor from './InputEditor';
 import { CustomColumnKey } from './CustomColumnBuilder';
 
-interface CustomColumnInputProps {
+export interface CustomColumnInputProps {
   eventKey: string;
   inputIndex: number;
   name: string;
@@ -28,6 +27,10 @@ const INPUT_TYPE = Object.freeze({
   NAME: 'name',
   FORMULA: 'formula',
 });
+
+const EMPTY_FN = () => {
+  // no-op
+};
 
 function CustomColumnInput({
   eventKey,
@@ -89,19 +92,19 @@ function CustomColumnInput({
                   tooltip="Delete custom column"
                 />
 
-                <button
-                  type="button"
-                  className="btn btn-link btn-link-icon px-2 btn-drag-handle"
+                <Button
+                  kind="ghost"
+                  className="btn-drag-handle"
+                  onClick={EMPTY_FN}
                   // eslint-disable-next-line react/jsx-props-no-spreading
                   {...provided.dragHandleProps}
-                >
-                  <Tooltip>Drag column to re-order</Tooltip>
-                  <FontAwesomeIcon icon={vsGripper} />
-                </button>
+                  icon={vsGripper}
+                  tooltip="Drag column to re-order"
+                />
               </div>
               {(!isValidName || isDuplicate) && (
                 <p className="validate-label-error text-danger mb-0 mt-2 pl-1">
-                  {!isValidName ? 'Invalid column name' : 'Duplicate name'}
+                  {!isValidName ? 'Invalid name' : 'Duplicate name'}
                 </p>
               )}
             </div>

--- a/packages/iris-grid/src/sidebar/InputEditor.tsx
+++ b/packages/iris-grid/src/sidebar/InputEditor.tsx
@@ -119,7 +119,7 @@ export default class InputEditor extends Component<
   handleContentChanged(): void {
     const { onContentChanged } = this.props;
     const value = this.editor?.getModel()?.getValue();
-    if (value !== '' && value !== undefined) {
+    if (value !== undefined) {
       this.setState({ isEditorEmpty: value.length === 0 });
     }
     onContentChanged(value);

--- a/packages/iris-grid/src/sidebar/InputEditor.tsx
+++ b/packages/iris-grid/src/sidebar/InputEditor.tsx
@@ -103,6 +103,9 @@ export default class InputEditor extends Component<
     // disable tab to spaces in this editor to improve tab navigation
     this.editor.getModel()?.updateOptions({ tabSize: 0 });
 
+    // monaco does not propagate tab or enter events
+    this.editor.onKeyDown(this.handleKeyDown);
+
     this.editor.onDidChangeModelContent(this.handleContentChanged);
     this.editor.onDidFocusEditorText(this.handleEditorFocus);
     this.editor.onDidBlurEditorText(this.handleEditorBlur);
@@ -127,10 +130,7 @@ export default class InputEditor extends Component<
   }
 
   handleEditorBlur(): void {
-    const value = this.editor?.getModel()?.getValue();
-    if (value === undefined || value === '') {
-      throw new Error('value is undefined');
-    }
+    const value = this.editor?.getModel()?.getValue() ?? '';
     this.setState({
       isEditorEmpty: value.length === 0,
       isEditorFocused: false,
@@ -146,9 +146,11 @@ export default class InputEditor extends Component<
     this.editor?.focus();
   }
 
-  handleKeyDown(event: React.KeyboardEvent<HTMLDivElement>): void {
+  handleKeyDown(event: monaco.IKeyboardEvent): void {
     const { onTab, editorIndex } = this.props;
-    if (event.key === 'Tab') {
+    if (event.code === 'Tab') {
+      event.stopPropagation();
+      event.preventDefault();
       onTab(editorIndex, event.shiftKey);
     }
   }
@@ -162,7 +164,6 @@ export default class InputEditor extends Component<
           focused: isEditorFocused,
           invalid,
         })}
-        onKeyDown={this.handleKeyDown}
         role="presentation"
         onClick={this.handleContainerClick}
       >


### PR DESCRIPTION
Fixes #939 

Does not validate that the names aren't duplicates of existing column names, only of existing custom columns. The API seems to allow custom columns that overwrite an existing column name. For example, table with coiumns `A, B, C`. Create a custom column `A=C` and `B=A`. All of the columns will display column `C`. If you swap the order of the custom columns, then `B` will show the original `A` and `A` will show `C`.

The API does not allow invalid custom column names (table column validation) or duplicate custom column names.