### PR TITLE
Adjust margin in column header grouping list

### DIFF
--- a/packages/iris-grid/src/sidebar/visibility-ordering-builder/sortable-tree/TreeItem.scss
+++ b/packages/iris-grid/src/sidebar/visibility-ordering-builder/sortable-tree/TreeItem.scss
@@ -70,7 +70,7 @@ $depth-margin: calc(
   .item-wrapper {
     list-style: none;
     box-sizing: border-box;
-    margin-bottom: -1px;
+    margin-bottom: 1px;
     width: 100%;
     display: flex;
     flex-direction: row;
@@ -135,7 +135,7 @@ $depth-margin: calc(
     .depth-line {
       margin-left: $depth-margin;
       margin-right: $spacer-1; // Gives breathing room to the item boxes
-      padding-bottom: 2px;
+      margin-top: -1px; // removes gaps between depth lines caused by item's margin-bottom
       border-left: 1px solid $depth-line-color;
     }
   }


### PR DESCRIPTION
The negative margin was looking weird with the transparency overlapping creating a darker border, give the items a 1px bottom margin to create a small gap between items, then remove that gap on the depth lines with negative margin so they are still continuous.