### PR TITLE
Clean up the release action a little bit

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -12,20 +12,21 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          fetch-depth: '0' # This action defaults to only getting the latest commit. Setting to 0 makes it retrieve the full git commit history
+          # This action defaults to only getting the latest commit. Setting to 0 makes it retrieve the full git commit history
+          fetch-depth: '0'
       - run: |
           git config --global user.email "ci@deephaven.io"
           git config --global user.name "GitHub CI"
       - uses: actions/setup-node@v3
         with:
           node-version: '16.x'
-        # Get the changelog and write it out to a file so it can be used by the create-release step later
       - name: Get changelog
+        # Get the changelog and write it out to a file so it can be used by the create-release step later
         env:
           GITHUB_AUTH: ${{ secrets.GITHUB_TOKEN }}
         run: npx lerna-changelog --next-version=${{ github.event.inputs.version }} > /tmp/changelog.md
-        # lerna version will bump the version, tag it and push the branch
-      - name: Bump version
+      - name: Version bump
+        # lerna version will bump the version, tag it, and push
         run: npx lerna version ${{ github.event.inputs.version }} --yes
       - name: Create Release
         id: create_release


### PR DESCRIPTION
- I verified that it was getting the changelog and bumping the version correctly by testing on my forked repo. You can take a look at the actions run: https://github.com/mofojed/web-client-ui/actions
- I think the action was already working, but was failing due to branch protection. New branch protection rules should allow pushing from GitHub actions and was recently fixed: https://github.com/integrations/terraform-provider-github/pull/1453/files
- Should probably move to conventional commits, and simply remove the use of `lerna-changelog`. That would be a team-wide change, but ultimately would be a cleaner process, as we could just run `lerna version` and it would automatically detect whether to do a major, minor, or patch version bump instead of having to manually enter the version