### PR TITLE
Cancelled promises reject immediately

### DIFF
--- a/packages/dashboard-core-plugins/src/panels/ChartPanel.test.tsx
+++ b/packages/dashboard-core-plugins/src/panels/ChartPanel.test.tsx
@@ -208,7 +208,7 @@ it('shows an error properly if model loading fails', async () => {
   await expect(modelPromise).rejects.toThrow(error);
 
   expect(
-    screen.getByText('Unable to open chart. Error: TEST ERROR MESSAGE')
+    await screen.findByText('Unable to open chart. Error: TEST ERROR MESSAGE')
   ).toBeTruthy();
   const warning = screen.getByRole('img', { hidden: true });
   expect(warning).toBeTruthy();

--- a/packages/utils/src/PromiseUtils.ts
+++ b/packages/utils/src/PromiseUtils.ts
@@ -17,6 +17,7 @@ export class PromiseUtils {
     cleanup?: (val: T) => void | null
   ): CancelablePromise<T> {
     let resolved: T | undefined;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let rejectFn: (val?: any) => void;
 
     const wrappedPromise = new Promise((resolve, reject) => {

--- a/packages/utils/src/PromiseUtils.ts
+++ b/packages/utils/src/PromiseUtils.ts
@@ -18,8 +18,7 @@ export class PromiseUtils {
   ): CancelablePromise<T> {
     let hasCanceled = false;
     let resolved: T | undefined;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    let rejectFn: (val?: any) => void;
+    let rejectFn: (val?: unknown) => void;
 
     const wrappedPromise = new Promise((resolve, reject) => {
       rejectFn = reject;
@@ -29,15 +28,12 @@ export class PromiseUtils {
             if (cleanup) {
               cleanup(val);
             }
-            reject(new CanceledPromiseError());
           } else {
             resolved = val;
             resolve(val);
           }
         })
-        .catch(error =>
-          hasCanceled ? reject(new CanceledPromiseError()) : reject(error)
-        );
+        .catch(error => reject(error));
     });
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
Fixes #949 

When the cancel function is called on a cancellablePromise, the wrapper promise immediately rejects.