### PR TITLE
Fix up groupedColumns in TreeTables

### DIFF
--- a/packages/iris-grid/src/IrisGridTreeTableModel.ts
+++ b/packages/iris-grid/src/IrisGridTreeTableModel.ts
@@ -100,8 +100,8 @@ class IrisGridTreeTableModel extends IrisGridTableModelTemplate<
     return result;
   }
 
-  get groupedColumns(): [] {
-    return [];
+  get groupedColumns(): Column[] {
+    return this.table.groupedColumns;
   }
 
   get hasExpandableRows(): boolean {

--- a/packages/jsapi-shim/src/dh.types.ts
+++ b/packages/jsapi-shim/src/dh.types.ts
@@ -850,6 +850,7 @@ export interface TableTemplate<T = Table> extends Evented {
 
 export interface TreeTable extends TableTemplate<TreeTable>, TreeTableStatic {
   readonly isIncludeConstituents: boolean;
+  readonly groupedColumns: Column[];
 
   expand(row: number): void;
   expand(row: TreeRow): void;


### PR DESCRIPTION
- We didn't wire it up for some reason. It is now implemented on the core side.
- Used Colin's branch to test: `1763-js-hierarchical-tables`
- Tested with the following snippet in Groovy. Was able to filter the grouped column `J`, but not the column `I`.
```
t = emptyTable(100).update("I=i", "J = `` + (int)(i/10)")
h = t.rollup([io.deephaven.api.agg.Aggregation.of(io.deephaven.api.agg.spec.AggSpec.sum(), "I")], "J")
```