### PR TITLE
Convert `serverConfigValues` from a `Map` to a JSON Object

### DIFF
--- a/packages/code-studio/src/main/AppInit.tsx
+++ b/packages/code-studio/src/main/AppInit.tsx
@@ -255,9 +255,14 @@ function AppInit(props: AppInitProps) {
           ),
         },
       };
+      const serverConfigValues = {
+        barrageVersion: serverConfig.get('barrage.version'),
+        javaVersion: serverConfig.get('java.version'),
+        deephavenVersion: serverConfig.get('deephaven.version'),
+      };
 
       setActiveTool(ToolType.DEFAULT);
-      setServerConfigValues(serverConfig);
+      setServerConfigValues(serverConfigValues);
       setCommandHistoryStorage(commandHistoryStorage);
       setDashboardData(DEFAULT_DASHBOARD_ID, dashboardData);
       setFileStorage(fileStorage);

--- a/packages/code-studio/src/settings/SettingsMenu.tsx
+++ b/packages/code-studio/src/settings/SettingsMenu.tsx
@@ -94,7 +94,7 @@ export class SettingsMenu extends Component<
 
   handleExportSupportLogs(): void {
     const { serverConfigValues } = this.props;
-    exportLogs(undefined, Object.fromEntries(serverConfigValues));
+    exportLogs(undefined, serverConfigValues);
   }
 
   render(): ReactElement {
@@ -103,9 +103,11 @@ export class SettingsMenu extends Component<
     const docsLink = import.meta.env.VITE_DOCS_LINK;
 
     const { serverConfigValues } = this.props;
-    const barrageVersion = serverConfigValues.get('barrage.version');
-    const javaVersion = serverConfigValues.get('java.version');
-    const deephavenVersion = serverConfigValues.get('deephaven.version');
+    const {
+      barrageVersion,
+      javaVersion,
+      deephavenVersion,
+    } = serverConfigValues;
 
     const getRow = (text: string, ver?: string) => (
       <>

--- a/packages/redux/src/store.ts
+++ b/packages/redux/src/store.ts
@@ -32,7 +32,11 @@ export interface User {
   groups: string[];
 }
 
-export type ServerConfigValues = Map<string, string>;
+export type ServerConfigValues = {
+  barrageVersion?: string;
+  javaVersion?: string;
+  deephavenVersion?: string;
+};
 
 export interface Storage {
   commandHistoryStorage: unknown;


### PR DESCRIPTION
On Enterprise, `serverConfigValues` are read from the server and saved as a JSON object in redux. However, in community, `serverConfigValues` are stored as a map. This creates incompatibility between redux states and all redux related functions between enterprise and community. 

Converted community serverConfigValues to a JSON object to fix the incompatibility.