### PR TITLE
Fix cell overflow viewer with browser zoom

### DIFF
--- a/packages/iris-grid/src/IrisGridCellOverflowModal.tsx
+++ b/packages/iris-grid/src/IrisGridCellOverflowModal.tsx
@@ -130,6 +130,7 @@ export default function IrisGridCellOverflowModal({
         setHeight(0);
       }}
       className="theme-bg-dark cell-overflow-modal"
+      size="xl"
     >
       <ModalHeader toggle={onClose}>
         <h5 className="overflow-modal-title">Cell Contents</h5>

--- a/packages/iris-grid/src/IrisGridCellOverflowModal.tsx
+++ b/packages/iris-grid/src/IrisGridCellOverflowModal.tsx
@@ -107,6 +107,7 @@ export default function IrisGridCellOverflowModal({
 
   function onEditorInitialized(editor: monaco.editor.IStandaloneCodeEditor) {
     editorRef.current = editor;
+    setHeight(editor.getContentHeight());
     editor.onDidContentSizeChange(({ contentHeight }) =>
       setHeight(contentHeight)
     );


### PR DESCRIPTION
Fixes #834 

Set the height when the editor is initialized.