### PR TITLE
Existing rows in append-only tables cannot be edited

### DIFF
--- a/packages/iris-grid/src/IrisGridTableModelTemplate.ts
+++ b/packages/iris-grid/src/IrisGridTableModelTemplate.ts
@@ -1552,7 +1552,11 @@ class IrisGridTableModelTemplate<
       range.startRow <
         this.floatingTopRowCount + this.table.size + this.pendingRowCount &&
       range.endRow <
-        this.floatingTopRowCount + this.table.size + this.pendingRowCount
+        this.floatingTopRowCount + this.table.size + this.pendingRowCount &&
+      (this.inputTable.keyColumns.length !== 0 ||
+        (this.inputTable.keyColumns.length === 0 &&
+          this.isPendingRow(range.startRow) &&
+          this.isPendingRow(range.endRow)))
     );
   }
 


### PR DESCRIPTION
Fixes #990 

Allow only pendingRow changes if there are no key columns.