### PR TITLE
Overwriting file keeps old tab open with old contents

### DIFF
--- a/packages/dashboard-core-plugins/src/ConsolePlugin.tsx
+++ b/packages/dashboard-core-plugins/src/ConsolePlugin.tsx
@@ -249,7 +249,7 @@ export function ConsolePlugin(
         if (panelId === existingPanelId) {
           log.debug(`Update tab title for file ${fileId}`);
           const { itemName } = fileMetadata;
-          renameFilePanel(fileId, FileUtils.getBaseName(itemName));
+          renameFilePanel(fileId, itemName);
         } else {
           log.error(
             `File ${fileId} already associated with a different tab ${existingPanelId}`
@@ -298,7 +298,7 @@ export function ConsolePlugin(
   );
 
   const closeFilePanel = useCallback(
-    fileMetadata => {
+    (fileMetadata, isOverwrite = false) => {
       log.debug('closeFilePanel', fileMetadata);
       const { id: fileId } = fileMetadata;
       let panelId = null;
@@ -313,7 +313,7 @@ export function ConsolePlugin(
         return;
       }
       unregisterFilePanel(fileMetadata, isPreview);
-      LayoutUtils.closeComponent(layout.root, { id: panelId });
+      LayoutUtils.closeComponent(layout.root, { id: panelId }, isOverwrite);
     },
     [layout.root, openFileMap, previewFileMap, unregisterFilePanel]
   );

--- a/packages/dashboard-core-plugins/src/ConsolePlugin.tsx
+++ b/packages/dashboard-core-plugins/src/ConsolePlugin.tsx
@@ -68,14 +68,50 @@ export function ConsolePlugin(
   } = props;
   const notebookIndex = useRef(0);
   // Map from file ID to panel ID
-  const [openFileMap] = useState(new Map<string, string>());
-  const [previewFileMap] = useState(new Map<string, string>());
+  const [openFileMap, setOpenFileMap] = useState(new Map<string, string>());
+  const [previewFileMap, setPreviewFileMap] = useState(
+    new Map<string, string>()
+  );
 
   const dispatch = useDispatch();
 
   const getConsolePanel = useCallback(
     () => panelManager.getLastUsedPanelOfType(ConsolePanel),
     [panelManager]
+  );
+
+  const addOpenFileMapEntry = useCallback(
+    (key: string, value: string) => {
+      setOpenFileMap(map => new Map(map.set(key, value)));
+    },
+    [setOpenFileMap]
+  );
+
+  const deleteOpenFileMapEntry = useCallback(
+    (key: string) => {
+      setOpenFileMap(map => {
+        map.delete(key);
+        return new Map(map);
+      });
+    },
+    [setOpenFileMap]
+  );
+
+  const addPreviewFileMapEntry = useCallback(
+    (key: string, value: string) => {
+      setPreviewFileMap(map => new Map(map.set(key, value)));
+    },
+    [setPreviewFileMap]
+  );
+
+  const deletePreviewFileMapEntry = useCallback(
+    (key: string) => {
+      setPreviewFileMap(map => {
+        map.delete(key);
+        return new Map(map);
+      });
+    },
+    [setPreviewFileMap]
   );
 
   const handleSendCommand = useCallback(
@@ -149,16 +185,16 @@ export function ConsolePlugin(
       let panelId;
       if (openFileMap.has(oldName)) {
         panelId = openFileMap.get(oldName);
-        openFileMap.delete(oldName);
+        deleteOpenFileMapEntry(oldName);
         if (panelId != null) {
-          openFileMap.set(newName, panelId);
+          addOpenFileMapEntry(newName, panelId);
         }
       }
       if (previewFileMap.has(oldName)) {
         panelId = previewFileMap.get(oldName);
-        previewFileMap.delete(oldName);
+        deletePreviewFileMapEntry(oldName);
         if (panelId != null) {
-          previewFileMap.set(newName, panelId);
+          addPreviewFileMapEntry(newName, panelId);
         }
       }
 
@@ -169,7 +205,15 @@ export function ConsolePlugin(
 
       renamePanel(panelId, FileUtils.getBaseName(newName));
     },
-    [openFileMap, previewFileMap, renamePanel]
+    [
+      openFileMap,
+      previewFileMap,
+      renamePanel,
+      addOpenFileMapEntry,
+      addPreviewFileMapEntry,
+      deleteOpenFileMapEntry,
+      deletePreviewFileMapEntry,
+    ]
   );
 
   /**
@@ -197,7 +241,7 @@ export function ConsolePlugin(
       }
       const { id: fileId } = fileMetadata;
       if (isPreview) {
-        previewFileMap.set(fileId, panelId);
+        addPreviewFileMapEntry(fileId, panelId);
         return;
       }
       if (openFileMap.has(fileId)) {
@@ -214,14 +258,21 @@ export function ConsolePlugin(
         return;
       }
 
-      openFileMap.set(fileId, panelId);
+      addOpenFileMapEntry(fileId, panelId);
 
       // De-register preview tab
       if (previewFileMap.has(fileId)) {
-        previewFileMap.delete(fileId);
+        deletePreviewFileMapEntry(fileId);
       }
     },
-    [openFileMap, previewFileMap, renameFilePanel]
+    [
+      openFileMap,
+      previewFileMap,
+      renameFilePanel,
+      addOpenFileMapEntry,
+      addPreviewFileMapEntry,
+      deletePreviewFileMapEntry,
+    ]
   );
 
   const unregisterFilePanel = useCallback(
@@ -238,12 +289,12 @@ export function ConsolePlugin(
       }
       const { id: fileId } = fileMetadata;
       if (isPreview) {
-        previewFileMap.delete(fileId);
+        deletePreviewFileMapEntry(fileId);
         return;
       }
-      openFileMap.delete(fileId);
+      deleteOpenFileMapEntry(fileId);
     },
-    [openFileMap, previewFileMap]
+    [deleteOpenFileMapEntry, deletePreviewFileMapEntry]
   );
 
   const closeFilePanel = useCallback(

--- a/packages/dashboard-core-plugins/src/ConsolePlugin.tsx
+++ b/packages/dashboard-core-plugins/src/ConsolePlugin.tsx
@@ -11,6 +11,7 @@ import {
   useListener,
 } from '@deephaven/dashboard';
 import { FileUtils } from '@deephaven/file-explorer';
+import { CloseOptions } from '@deephaven/golden-layout';
 import Log from '@deephaven/log';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useDispatch } from 'react-redux';
@@ -298,7 +299,7 @@ export function ConsolePlugin(
   );
 
   const closeFilePanel = useCallback(
-    (fileMetadata, isOverwrite = false) => {
+    (fileMetadata, options?: CloseOptions) => {
       log.debug('closeFilePanel', fileMetadata);
       const { id: fileId } = fileMetadata;
       let panelId = null;
@@ -313,7 +314,7 @@ export function ConsolePlugin(
         return;
       }
       unregisterFilePanel(fileMetadata, isPreview);
-      LayoutUtils.closeComponent(layout.root, { id: panelId }, isOverwrite);
+      LayoutUtils.closeComponent(layout.root, { id: panelId }, options);
     },
     [layout.root, openFileMap, previewFileMap, unregisterFilePanel]
   );

--- a/packages/dashboard-core-plugins/src/panels/NotebookPanel.tsx
+++ b/packages/dashboard-core-plugins/src/panels/NotebookPanel.tsx
@@ -351,7 +351,7 @@ class NotebookPanel extends Component<NotebookPanelProps, NotebookPanelState> {
   initTabCloseOverride() {
     const { glContainer } = this.props;
     glContainer.beforeClose((options?: CloseOptions) => {
-      if (options !== undefined && options.force === true) {
+      if (options?.force === true) {
         return true;
       }
 

--- a/packages/dashboard-core-plugins/src/panels/NotebookPanel.tsx
+++ b/packages/dashboard-core-plugins/src/panels/NotebookPanel.tsx
@@ -607,9 +607,11 @@ class NotebookPanel extends Component<NotebookPanelProps, NotebookPanelState> {
    */
   handleOverwrite(fileName: string): void {
     const { glEventHub } = this.props;
-    const { panelState } = this.state;
 
-    glEventHub.emit(NotebookEvent.RENAME_FILE, fileName, fileName, panelState);
+    glEventHub.emit(NotebookEvent.CLOSE_FILE, {
+      id: fileName,
+      itemName: fileName,
+    });
     this.focus();
   }
 
@@ -828,7 +830,11 @@ class NotebookPanel extends Component<NotebookPanelProps, NotebookPanelState> {
     this.setState({ showSaveAsModal: false });
   }
 
-  handleSaveAsSubmit(name: string): void {
+  handleSaveAsSubmit(name: string, isOverwrite = false): void {
+    if (isOverwrite) {
+      this.handleOverwrite(name);
+    }
+
     log.debug('handleSaveAsSubmit', name);
     const { fileMetadata } = this.state;
     if (!fileMetadata) {
@@ -1258,7 +1264,6 @@ class NotebookPanel extends Component<NotebookPanelProps, NotebookPanelState> {
             title={isExistingItem ? 'Rename' : 'Save file as'}
             onSubmit={this.handleSaveAsSubmit}
             onCancel={this.handleSaveAsCancel}
-            onOverwrite={this.handleOverwrite}
             notifyOnExtensionChange
             storage={fileStorage}
           />

--- a/packages/dashboard-core-plugins/src/panels/NotebookPanel.tsx
+++ b/packages/dashboard-core-plugins/src/panels/NotebookPanel.tsx
@@ -41,13 +41,7 @@ import classNames from 'classnames';
 import debounce from 'lodash.debounce';
 import Log from '@deephaven/log';
 import { assertNotNull, Pending, PromiseUtils } from '@deephaven/utils';
-import type {
-  Container,
-  EventEmitter,
-  Tab,
-  Component as glComponent,
-} from '@deephaven/golden-layout';
-import { isComponent } from '@deephaven/golden-layout';
+import type { Container, EventEmitter, Tab } from '@deephaven/golden-layout';
 import { IdeSession } from '@deephaven/jsapi-shim';
 import { ConsoleEvent, NotebookEvent } from '../events';
 import { getDashboardSessionWrapper } from '../redux';
@@ -608,8 +602,8 @@ class NotebookPanel extends Component<NotebookPanelProps, NotebookPanelState> {
   }
 
   /**
-   * Close overwritten tabs
-   * @params {string} fileName = The name of the file to be overwritten
+   * Closes overwritten tabs
+   * @param fileName The name of the file to be overwritten
    */
   handleOverwrite(fileName: string): void {
     const { glEventHub } = this.props;

--- a/packages/dashboard/src/layout/LayoutUtils.ts
+++ b/packages/dashboard/src/layout/LayoutUtils.ts
@@ -574,7 +574,11 @@ class LayoutUtils {
    * @param root The GoldenLayout root to search and close the component in
    * @param config The GoldenLayout component config definition to close, eg. { component: 'IrisGridPanel', id: 'table-t' }
    */
-  static closeComponent(root: ContentItem, config: LayoutConfig): void {
+  static closeComponent(
+    root: ContentItem,
+    config: LayoutConfig,
+    isOverwrite = false
+  ): void {
     const stack = LayoutUtils.getStackForRoot(
       root,
       config,
@@ -597,8 +601,8 @@ class LayoutUtils {
         // container property exists on a contentItem if contentItem is a component,
         // however, this is not included in the types for a contentitem, thus the casting
         ((oldContentItem as unknown) as {
-          container: { close: () => void };
-        }).container.close();
+          container: { close: (isOverwrite?: boolean) => void };
+        }).container.close(isOverwrite);
       } else {
         stack.removeChild(oldContentItem);
       }

--- a/packages/dashboard/src/layout/LayoutUtils.ts
+++ b/packages/dashboard/src/layout/LayoutUtils.ts
@@ -603,7 +603,7 @@ class LayoutUtils {
     const maintainFocusElement = document.activeElement; // attempt to retain focus after dom manipulation, which can break focus
     if (oldContentItem) {
       if (isComponent(oldContentItem)) {
-        oldContentItem.container.close(closeOptions ?? undefined);
+        oldContentItem.container.close(closeOptions);
       } else {
         stack.removeChild(oldContentItem);
       }

--- a/packages/dashboard/src/layout/LayoutUtils.ts
+++ b/packages/dashboard/src/layout/LayoutUtils.ts
@@ -3,7 +3,11 @@ import shortid from 'shortid';
 import isMatch from 'lodash.ismatch';
 import { DragEvent } from 'react';
 import Log from '@deephaven/log';
-import GoldenLayout, { isRoot, isStack } from '@deephaven/golden-layout';
+import GoldenLayout, {
+  isComponent,
+  isRoot,
+  isStack,
+} from '@deephaven/golden-layout';
 import type {
   ComponentConfig,
   Config,
@@ -14,6 +18,7 @@ import type {
   ReactComponentConfig,
   Stack,
   Tab,
+  CloseOptions,
 } from '@deephaven/golden-layout';
 import { assertNotNull } from '@deephaven/utils';
 import GoldenLayoutThemeExport from './GoldenLayoutThemeExport';
@@ -577,7 +582,7 @@ class LayoutUtils {
   static closeComponent(
     root: ContentItem,
     config: LayoutConfig,
-    isOverwrite = false
+    closeOptions?: CloseOptions
   ): void {
     const stack = LayoutUtils.getStackForRoot(
       root,
@@ -597,12 +602,8 @@ class LayoutUtils {
     const oldContentItem = LayoutUtils.getContentItemInStack(stack, config);
     const maintainFocusElement = document.activeElement; // attempt to retain focus after dom manipulation, which can break focus
     if (oldContentItem) {
-      if (oldContentItem.isComponent) {
-        // container property exists on a contentItem if contentItem is a component,
-        // however, this is not included in the types for a contentitem, thus the casting
-        ((oldContentItem as unknown) as {
-          container: { close: (isOverwrite?: boolean) => void };
-        }).container.close(isOverwrite);
+      if (isComponent(oldContentItem)) {
+        oldContentItem.container.close(closeOptions ?? undefined);
       } else {
         stack.removeChild(oldContentItem);
       }

--- a/packages/file-explorer/src/NewItemModal.tsx
+++ b/packages/file-explorer/src/NewItemModal.tsx
@@ -33,9 +33,8 @@ export type NewItemModalProps = typeof NewItemModal.defaultProps & {
   title: string;
   defaultValue: string;
   type: FileType;
-  onSubmit: (name: string) => void;
+  onSubmit: (name: string, isOverwrite?: boolean) => void;
   onCancel: () => void;
-  onOverwrite?: (fileName: string) => void;
   placeholder: string;
   storage: FileStorage;
   notifyOnExtensionChange?: boolean;
@@ -70,7 +69,7 @@ class NewItemModal extends PureComponent<NewItemModalProps, NewItemModalState> {
     defaultValue: '/',
     notifyOnExtensionChange: false,
     placeholder: '',
-    onSubmit: (name: string): void => undefined,
+    onSubmit: (name: string, isOverwrite?: boolean): void => undefined,
     onCancel: (): void => undefined,
   };
 
@@ -295,14 +294,11 @@ class NewItemModal extends PureComponent<NewItemModalProps, NewItemModalState> {
 
   handleOverwriteConfirm(): void {
     this.setState({ showOverwriteModal: false });
-    const { onSubmit, onOverwrite } = this.props;
+    const { onSubmit } = this.props;
     const { path, value } = this.state;
     log.debug('handleOverwriteConfirm', path, value);
 
-    if (onOverwrite) {
-      onOverwrite(value);
-    }
-    onSubmit(`${path}${value}`);
+    onSubmit(`${path}${value}`, true);
   }
 
   handleExtensionChangeCancel(): void {

--- a/packages/file-explorer/src/NewItemModal.tsx
+++ b/packages/file-explorer/src/NewItemModal.tsx
@@ -35,6 +35,7 @@ export type NewItemModalProps = typeof NewItemModal.defaultProps & {
   type: FileType;
   onSubmit: (name: string) => void;
   onCancel: () => void;
+  onOverwrite?: (fileName: string) => void;
   placeholder: string;
   storage: FileStorage;
   notifyOnExtensionChange?: boolean;
@@ -294,9 +295,13 @@ class NewItemModal extends PureComponent<NewItemModalProps, NewItemModalState> {
 
   handleOverwriteConfirm(): void {
     this.setState({ showOverwriteModal: false });
-    const { onSubmit } = this.props;
+    const { onSubmit, onOverwrite } = this.props;
     const { path, value } = this.state;
     log.debug('handleOverwriteConfirm', path, value);
+
+    if (onOverwrite) {
+      onOverwrite(value);
+    }
     onSubmit(`${path}${value}`);
   }
 

--- a/packages/golden-layout/src/container/ItemContainer.ts
+++ b/packages/golden-layout/src/container/ItemContainer.ts
@@ -10,6 +10,7 @@ import type LayoutManager from '../LayoutManager';
 import EventEmitter from '../utils/EventEmitter';
 
 export type CloseOptions = { force?: boolean };
+
 export default class ItemContainer<
   C extends ComponentConfig | ReactComponentConfig = ComponentConfig
 > extends EventEmitter {
@@ -154,16 +155,11 @@ export default class ItemContainer<
    * @param options Options to pass into the beforeClose handler
    */
   close(options?: CloseOptions) {
-    if (this.beforeCloseHandler) {
-      // Only close if the beforeCloseHandler returns true
-      if (this.beforeCloseHandler(options)) {
-        if (this._config.isClosable) {
-          this.emit('close');
-          this.parent.close();
-        }
-      }
-    } else if (this._config.isClosable) {
-      // If there is no handler, proceed as normal and close if the container is closable
+    // Not closable, don't do anything
+    if (!this._config.isClosable) return;
+
+    // If beforeCloseHandler returns true or if the handler doesn't exist, close
+    if (this.beforeCloseHandler?.(options) ?? true) {
       this.emit('close');
       this.parent.close();
     }
@@ -173,7 +169,7 @@ export default class ItemContainer<
    * Sets the beforeCloseHandler to callback
    * @param callback Callback function to call before closing
    */
-  beforeClose(callback: (options?: CloseOptions) => boolean) {
+  beforeClose(callback: ((options?: CloseOptions) => boolean) | null) {
     this.beforeCloseHandler = callback;
   }
 

--- a/packages/golden-layout/src/container/index.ts
+++ b/packages/golden-layout/src/container/index.ts
@@ -1,2 +1,3 @@
 export { default as ItemContainer } from './ItemContainer';
 export { default as Container } from './ItemContainer';
+export type { CloseOptions } from './ItemContainer';


### PR DESCRIPTION
Fixes #1017 

Overwritten tabs are now closed upon confirming the overwrite modal. 