### PR TITLE
Update e2e tests to use the latest `edge` release

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
     branches: [main]
 env:
-  DOCKER_TAG: latest
+  DOCKER_TAG: edge
 jobs:
   build:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
The latest `edge` release may have functionality we need for e2e testing. By using the latest `edge` as well we can pick up on issues in deephaven-core earlier.