### PR TITLE
Fix resizing/hiding layout hint hidden columns. Fix resetting layout hints

### DIFF
--- a/packages/grid/src/GridMetricCalculator.ts
+++ b/packages/grid/src/GridMetricCalculator.ts
@@ -137,6 +137,12 @@ export class GridMetricCalculator {
   /** The maximum column width as a percentage of the full grid */
   static MAX_COLUMN_WIDTH = 0.8;
 
+  /** The initial row heights if any overrides from the default calculated values */
+  public initialRowHeights: ReadonlyMap<ModelIndex, number>; // Readonly so it should be safe to make public
+
+  /** The initial column widths if any overrides from the default calculated values */
+  public initialColumnWidths: ReadonlyMap<ModelIndex, number>; // Readonly so it should be safe to make public
+
   /** User set column widths */
   protected userColumnWidths: ModelSizeMap;
 
@@ -174,6 +180,8 @@ export class GridMetricCalculator {
     modelColumns = new Map(),
     movedRows = [] as MoveOperation[],
     movedColumns = [] as MoveOperation[],
+    initialRowHeights = new Map(),
+    initialColumnWidths = new Map(),
   } = {}) {
     this.userColumnWidths = userColumnWidths;
     this.userRowHeights = userRowHeights;
@@ -186,6 +194,8 @@ export class GridMetricCalculator {
     this.modelColumns = modelColumns;
     this.movedRows = movedRows;
     this.movedColumns = movedColumns;
+    this.initialRowHeights = initialRowHeights;
+    this.initialColumnWidths = initialColumnWidths;
   }
 
   /**
@@ -1487,17 +1497,15 @@ export class GridMetricCalculator {
    * Get the size from the provided size map of the specified item
    * @param modelIndex The model index to get the size for
    * @param userSizes The user set sizes
-   * @param calculateSize Method to calculate the size for this item
+   * @param getDefaultSize Method to get the default size for this item
    * @returns The size from the provided size map of the specified item
    */
   getVisibleItemSize(
     modelIndex: ModelIndex,
     userSizes: ModelSizeMap,
-    calculateSize: () => number
+    getDefaultSize: () => number
   ): number {
-    // Always re-calculate the size of the item so the calculated size maps are populated
-    const calculatedSize = calculateSize();
-    return userSizes.get(modelIndex) ?? calculatedSize;
+    return userSizes.get(modelIndex) ?? getDefaultSize();
   }
 
   /**
@@ -1508,10 +1516,15 @@ export class GridMetricCalculator {
    */
   getVisibleRowHeight(row: VisibleIndex, state: GridMetricState): number {
     const modelRow = this.getModelRow(row, state);
+    const calculatedHeight = this.calculateRowHeight(row, modelRow, state); // Need to call this so calculated map is always populated
 
-    return this.getVisibleItemSize(modelRow, this.userRowHeights, () =>
-      this.calculateRowHeight(row, modelRow, state)
-    );
+    return this.getVisibleItemSize(modelRow, this.userRowHeights, () => {
+      const initialHeight = this.initialRowHeights.get(modelRow);
+      if (initialHeight !== undefined) {
+        return initialHeight;
+      }
+      return calculatedHeight;
+    });
   }
 
   /**
@@ -1530,15 +1543,22 @@ export class GridMetricCalculator {
   ): number {
     const modelColumn = this.getModelColumn(column, state);
 
-    return this.getVisibleItemSize(modelColumn, this.userColumnWidths, () =>
-      this.calculateColumnWidth(
-        column,
-        modelColumn,
-        state,
-        firstColumn,
-        treePaddingX
-      )
+    // Need to call this so calculated map is always populated
+    const calculatedWidth = this.calculateColumnWidth(
+      column,
+      modelColumn,
+      state,
+      firstColumn,
+      treePaddingX
     );
+
+    return this.getVisibleItemSize(modelColumn, this.userColumnWidths, () => {
+      const initialWidth = this.initialColumnWidths.get(modelColumn);
+      if (initialWidth !== undefined) {
+        return initialWidth;
+      }
+      return calculatedWidth;
+    });
   }
 
   /**

--- a/packages/grid/src/mouse-handlers/GridColumnSeparatorMouseHandler.ts
+++ b/packages/grid/src/mouse-handlers/GridColumnSeparatorMouseHandler.ts
@@ -64,6 +64,8 @@ class GridColumnSeparatorMouseHandler extends GridSeparatorMouseHandler {
 
   calculatedSizesProperty = 'calculatedColumnWidths' as const;
 
+  initialSizesProperty = 'initialColumnWidths' as const;
+
   modelIndexesProperty = 'modelColumns' as const;
 
   firstIndexProperty = 'firstColumn' as const;

--- a/packages/grid/src/mouse-handlers/GridRowSeparatorMouseHandler.ts
+++ b/packages/grid/src/mouse-handlers/GridRowSeparatorMouseHandler.ts
@@ -43,6 +43,8 @@ class GridRowSeparatorMouseHandler extends GridSeparatorMouseHandler {
 
   calculatedSizesProperty = 'calculatedRowHeights' as const;
 
+  initialSizesProperty = 'initialRowHeights' as const;
+
   modelIndexesProperty = 'modelRows' as const;
 
   firstIndexProperty = 'firstRow' as const;

--- a/packages/iris-grid/src/IrisGrid.tsx
+++ b/packages/iris-grid/src/IrisGrid.tsx
@@ -42,6 +42,7 @@ import {
   isEditableGridModel,
   BoundedAxisRange,
   isExpandableGridModel,
+  getOrThrow,
 } from '@deephaven/grid';
 import {
   dhEye,
@@ -579,6 +580,9 @@ export class IrisGrid extends Component<IrisGridProps, IrisGridState> {
     this.handleColumnVisibilityChanged = this.handleColumnVisibilityChanged.bind(
       this
     );
+    this.handleColumnVisibilityReset = this.handleColumnVisibilityReset.bind(
+      this
+    );
     this.handleCrossColumnSearch = this.handleCrossColumnSearch.bind(this);
     this.handleRollupChange = this.handleRollupChange.bind(this);
     this.handleOverflowClose = this.handleOverflowClose.bind(this);
@@ -709,6 +713,12 @@ export class IrisGrid extends Component<IrisGridProps, IrisGridState> {
       userColumnWidths: new Map(userColumnWidths),
       userRowHeights: new Map(userRowHeights),
       movedColumns,
+      initialColumnWidths: new Map(
+        model?.layoutHints?.hiddenColumns?.map(name => [
+          model.getColumnIndexByName(name),
+          0,
+        ])
+      ),
     });
     const searchColumns = selectedSearchColumns ?? [];
     const searchFilter = CrossColumnSearch.createSearchFilter(
@@ -1115,10 +1125,15 @@ export class IrisGrid extends Component<IrisGridProps, IrisGridState> {
   );
 
   getCachedHiddenColumns = memoize(
-    (hiddenColumns: ModelIndex[]) => hiddenColumns,
+    (
+      metricCalculator: IrisGridMetricCalculator,
+      userColumnWidths: ModelSizeMap
+    ) =>
+      IrisGridUtils.getHiddenColumns(
+        new Map([...metricCalculator.initialColumnWidths, ...userColumnWidths])
+      ),
     {
       max: 1,
-      normalizer: ([hiddenColumns]) => hiddenColumns.join(),
     }
   );
 
@@ -2170,10 +2185,23 @@ export class IrisGrid extends Component<IrisGridProps, IrisGridState> {
     modelIndexes: ModelIndex[],
     isVisible: boolean
   ): void {
-    const { metricCalculator } = this.state;
+    const { metricCalculator, metrics } = this.state;
+    assertNotNull(metrics);
     if (isVisible) {
       modelIndexes.forEach(modelIndex => {
-        metricCalculator.resetColumnWidth(modelIndex);
+        const defaultWidth = metricCalculator.initialColumnWidths.get(
+          modelIndex
+        );
+        const calculatedWidth = getOrThrow(
+          metrics.calculatedColumnWidths,
+          modelIndex
+        );
+
+        if (defaultWidth !== calculatedWidth) {
+          metricCalculator.setColumnWidth(modelIndex, calculatedWidth);
+        } else {
+          metricCalculator.resetColumnWidth(modelIndex);
+        }
       });
     } else {
       modelIndexes.forEach(modelIndex => {
@@ -2181,6 +2209,20 @@ export class IrisGrid extends Component<IrisGridProps, IrisGridState> {
       });
     }
     this.grid?.forceUpdate();
+  }
+
+  handleColumnVisibilityReset(): void {
+    const { metricCalculator, metrics } = this.state;
+    const { model } = this.props;
+    assertNotNull(metrics);
+    for (let i = 0; i < metrics.columnCount; i += 1) {
+      metricCalculator.resetColumnWidth(i);
+    }
+    this.handleMovedColumnsChanged(model.initialMovedColumns);
+    this.handleHeaderGroupsChanged(model.initialColumnHeaderGroups);
+    this.setState({
+      frozenColumns: model.layoutHints?.frozenColumns ?? [],
+    });
   }
 
   handleCrossColumnSearch(
@@ -3884,6 +3926,11 @@ export class IrisGrid extends Component<IrisGridProps, IrisGridState> {
       advancedSettings.size > 0
     );
 
+    const hiddenColumns = this.getCachedHiddenColumns(
+      metricCalculator,
+      userColumnWidths
+    );
+
     const openOptionsStack = openOptions.map(option => {
       switch (option.type) {
         case OptionType.CHART_BUILDER:
@@ -3900,9 +3947,10 @@ export class IrisGrid extends Component<IrisGridProps, IrisGridState> {
             <VisibilityOrderingBuilder
               model={model}
               movedColumns={movedColumns}
-              userColumnWidths={userColumnWidths}
+              hiddenColumns={hiddenColumns}
               columnHeaderGroups={columnHeaderGroups}
               onColumnVisibilityChanged={this.handleColumnVisibilityChanged}
+              onReset={this.handleColumnVisibilityReset}
               onMovedColumnsChanged={this.handleMovedColumnsChanged}
               onColumnHeaderGroupChanged={this.handleHeaderGroupsChanged}
               key={OptionType.VISIBILITY_ORDERING_BUILDER}
@@ -4007,10 +4055,6 @@ export class IrisGrid extends Component<IrisGridProps, IrisGridState> {
           throw Error(`Unexpected option type ${option.type}`);
       }
     });
-
-    const hiddenColumns = this.getCachedHiddenColumns(
-      IrisGridUtils.getHiddenColumns(userColumnWidths)
-    );
 
     return (
       <div className="iris-grid" role="presentation">

--- a/packages/iris-grid/src/IrisGridMetricCalculator.ts
+++ b/packages/iris-grid/src/IrisGridMetricCalculator.ts
@@ -1,5 +1,5 @@
 import { GridMetricCalculator, ModelSizeMap } from '@deephaven/grid';
-import type { VisibleIndex, GridMetricState } from '@deephaven/grid';
+import type { GridMetricState } from '@deephaven/grid';
 import type { FilterCondition, Sort } from '@deephaven/jsapi-shim';
 import { TableUtils } from '@deephaven/jsapi-utils';
 import type IrisGridModel from './IrisGridModel';
@@ -23,33 +23,6 @@ export interface IrisGridMetricState extends GridMetricState {
  * Call getMetrics() with the state to get metrics
  */
 class IrisGridMetricCalculator extends GridMetricCalculator {
-  getVisibleColumnWidth(
-    column: VisibleIndex,
-    state: IrisGridMetricState,
-    firstColumn: VisibleIndex = this.getFirstColumn(state),
-    treePaddingX = this.calculateTreePaddingX(state)
-  ): number {
-    const { model } = state;
-    const hiddenColumns = model.layoutHints?.hiddenColumns ?? [];
-    const modelColumn = this.getModelColumn(column, state);
-
-    // Need to make sure super is called so column width is always re-calculated correctly
-    const columnWidth = super.getVisibleColumnWidth(
-      column,
-      state,
-      firstColumn,
-      treePaddingX
-    );
-    const hasUserSetWidth = this.userColumnWidths.has(modelColumn);
-    if (
-      !hasUserSetWidth &&
-      hiddenColumns.includes(model.columns[modelColumn]?.name)
-    ) {
-      return 0;
-    }
-    return columnWidth;
-  }
-
   getGridY(state: IrisGridMetricState): number {
     let gridY = super.getGridY(state);
     const {

--- a/packages/iris-grid/src/IrisGridTableModelTemplate.ts
+++ b/packages/iris-grid/src/IrisGridTableModelTemplate.ts
@@ -697,15 +697,17 @@ class IrisGridTableModelTemplate<
         movedColumns = GridUtils.moveRange(visibleRange, toIndex, movedColumns);
       };
 
-      if (
-        this.frontColumns.length ||
-        this.backColumns.length ||
-        this.frozenColumns.length
-      ) {
+      const {
+        frontColumns = [],
+        backColumns = [],
+        frozenColumns = [],
+      } = layoutHints;
+
+      if (frontColumns.length || backColumns.length || frozenColumns.length) {
         const usedColumns = new Set();
 
         let frontIndex = 0;
-        this.frozenColumns.forEach(name => {
+        frozenColumns.forEach(name => {
           if (usedColumns.has(name)) {
             throw new Error(
               `Column specified in multiple layout hints: ${name}`
@@ -714,7 +716,7 @@ class IrisGridTableModelTemplate<
           moveColumn(name, frontIndex);
           frontIndex += 1;
         });
-        this.frontColumns.forEach(name => {
+        frontColumns.forEach(name => {
           if (usedColumns.has(name)) {
             throw new Error(
               `Column specified in multiple layout hints: ${name}`
@@ -725,7 +727,7 @@ class IrisGridTableModelTemplate<
         });
 
         let backIndex = this.columnMap.size - 1;
-        this.backColumns.forEach(name => {
+        backColumns.forEach(name => {
           if (usedColumns.has(name)) {
             throw new Error(
               `Column specified in multiple layout hints: ${name}`


### PR DESCRIPTION
Fixes #1038, Fixes #526

Also fixes an undocumented issue where reset in the column visibility sidebar would not reset frozen columns to their initial state. Now the reset button from the visibility and ordering menu will reset frozen columns as well. Basically resetting to the initial state from the query.