### PR TITLE
fix: Pasting with smart quotes causes double paste in monaco

### DIFF
--- a/packages/code-studio/src/main/AppMainContainer.tsx
+++ b/packages/code-studio/src/main/AppMainContainer.tsx
@@ -583,13 +583,12 @@ export class AppMainContainer extends Component<
 
   // eslint-disable-next-line class-methods-use-this
   handlePaste(event: ClipboardEvent<HTMLDivElement>): void {
-    let element = event.currentTarget.parentElement;
-
-    while (element != null) {
-      if (element.classList.contains('monaco-editor')) {
-        return;
-      }
-      element = element.parentElement;
+    if (
+      event.target instanceof HTMLElement &&
+      event.target.closest('.monaco-editor')
+    ) {
+      // Skip if this is inside a monaco editor
+      return;
     }
 
     const { clipboardData } = event;


### PR DESCRIPTION
Fixes #1050 

Don't think I can add a test easily since paste events were giving trouble in e2e tests and monaco doesn't play nicely w/ unit tests

