### PR TITLE
build: Remove the "Validate PR title" name from the job

### DIFF
--- a/.github/workflows/conventional-pr-check.yml
+++ b/.github/workflows/conventional-pr-check.yml
@@ -9,7 +9,6 @@ on:
 
 jobs:
   pr-check:
-    name: Validate PR title
     runs-on: ubuntu-22.04
     steps:
       - uses: amannn/action-semantic-pull-request@v5


### PR DESCRIPTION
- We use the job id `pr-check` as the required status
- Workflow name is already defined as `Conventional PR`
