### PR TITLE
fix: DH-14237: down arrow in console not returning to blank field

### DIFF
--- a/packages/console/src/ConsoleInput.tsx
+++ b/packages/console/src/ConsoleInput.tsx
@@ -218,7 +218,7 @@ export class ConsoleInput extends PureComponent<
       const { lineNumber } = position;
       const model = commandEditor?.getModel();
       if (
-        keyEvent.keyCode === monaco.KeyCode.UpArrow &&
+        keyEvent.code === 'ArrowUp' &&
         !this.isSuggestionMenuPopulated() &&
         lineNumber === 1
       ) {
@@ -236,7 +236,7 @@ export class ConsoleInput extends PureComponent<
       }
 
       if (
-        keyEvent.keyCode === monaco.KeyCode.DownArrow &&
+        keyEvent.code === 'ArrowDown' &&
         !this.isSuggestionMenuPopulated() &&
         lineNumber === model?.getLineCount()
       ) {
@@ -380,7 +380,7 @@ export class ConsoleInput extends PureComponent<
    * @param index The index to load. Null to load command started in the editor and not in the history
    */
   loadCommand(index: number | null): void {
-    if (index === null || index >= this.history.length) {
+    if (index !== null && index >= this.history.length) {
       return;
     }
 


### PR DESCRIPTION
Fixes DH-14237

Was incorrectly converted in #646 

Switched the arrow keys to use `code` instead of `keyCode` because RTL user-event does not set `keyCode` which is a deprecated property