### PR TITLE
fix: DH-14240 hasHeaders false should hide header bar

### DIFF
--- a/packages/golden-layout/src/items/Stack.ts
+++ b/packages/golden-layout/src/items/Stack.ts
@@ -588,11 +588,12 @@ export default class Stack extends AbstractContentItem {
       ? this._header.show
       : undefined;
 
+    this.header.element.toggle(!!this._header.show);
+
     if (!side) {
       return;
     }
 
-    this.header.element.toggle(!!this._header.show);
     this._side = side;
     this._sided = ['right', 'left'].indexOf(this._side.toString()) >= 0;
     this.element.removeClass('lm_left lm_right lm_bottom');


### PR DESCRIPTION
Enterprise uses golden-layout hasHeaders: false in layout config for query monitor. A check  added as part of typescript conversion was preventing headers from being set to display none when it was false (toggle is a jquery method that hides/shows based on a boolean).