### PR TITLE
feat: Instants and ZonedDateTimes should be treated as DateTimes

### DIFF
--- a/packages/jsapi-utils/src/TableUtils.ts
+++ b/packages/jsapi-utils/src/TableUtils.ts
@@ -312,6 +312,8 @@ export class TableUtils {
       case 'io.deephaven.db.tables.utils.DBDateTime':
       case 'io.deephaven.time.DateTime':
       case 'com.illumon.iris.db.tables.utils.DBDateTime':
+      case 'java.time.Instant':
+      case 'java.time.ZonedDateTime':
       case TableUtils.dataType.DATETIME:
         return TableUtils.dataType.DATETIME;
       case 'double':
@@ -351,6 +353,8 @@ export class TableUtils {
     switch (columnType) {
       case 'io.deephaven.db.tables.utils.DBDateTime':
       case 'io.deephaven.time.DateTime':
+      case 'java.time.Instant':
+      case 'java.time.ZonedDateTime':
       case 'com.illumon.iris.db.tables.utils.DBDateTime':
         return true;
       default:


### PR DESCRIPTION
deephaven/deephaven-core#3385 is a port of DH-11692 which adds `Instant` and `ZonedDateTime` support to the engine. I've similarly encoded these types over Barrage as a `long` (as a nanosecond since epoch). The encoding of Zones will actually need to be implemented at a future date as the best implementation requires (encourages?) a much larger refactoring of ColumnSource types. See deephaven/deephaven-core#3455 for more information.

I was able to get the web-client-ui to display these types with this small patch.