### PR TITLE
refactor: Replace usage of Column.index with column name

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+__mocks__/dh-core.js

--- a/packages/dashboard-core-plugins/src/panels/ChartPanel.tsx
+++ b/packages/dashboard-core-plugins/src/panels/ChartPanel.tsx
@@ -24,6 +24,7 @@ import {
   DehydratedSort,
   DehydratedAdvancedFilter,
   DehydratedQuickFilter,
+  LegacyDehydratedSort,
 } from '@deephaven/iris-grid';
 import dh, {
   FigureDescriptor,
@@ -107,7 +108,7 @@ export interface ChartPanelTableSettings {
   quickFilters?: readonly DehydratedQuickFilter[];
   advancedFilters?: readonly DehydratedAdvancedFilter[];
   inputFilters?: readonly InputFilter[];
-  sorts?: readonly DehydratedSort[];
+  sorts?: readonly (DehydratedSort | LegacyDehydratedSort)[];
   partition?: unknown;
   partitionColumn?: string;
 }

--- a/packages/iris-grid/src/IrisGrid.tsx
+++ b/packages/iris-grid/src/IrisGrid.tsx
@@ -2654,7 +2654,8 @@ export class IrisGrid extends Component<IrisGridProps, IrisGridState> {
     const { model } = this.props;
     const columnIndex = model.getColumnIndexByName(column.name);
     assertNotNull(columnIndex);
-    const oldSort = TableUtils.getSortForColumn(model.sort, columnIndex);
+    const columnName = model.columns[columnIndex].name;
+    const oldSort = TableUtils.getSortForColumn(model.sort, columnName);
     let newSort = null;
 
     if (oldSort == null || oldSort.direction !== direction) {
@@ -2667,7 +2668,7 @@ export class IrisGrid extends Component<IrisGridProps, IrisGridState> {
 
     const sorts = TableUtils.setSortForColumn(
       model.sort,
-      columnIndex,
+      columnName,
       newSort,
       addToExisting
     );
@@ -4153,7 +4154,7 @@ export class IrisGrid extends Component<IrisGridProps, IrisGridState> {
             const column = model.columns[modelColumn];
             const advancedFilter = advancedFilters.get(modelColumn);
             const { options: advancedFilterOptions } = advancedFilter || {};
-            const sort = TableUtils.getSortForColumn(model.sort, modelColumn);
+            const sort = TableUtils.getSortForColumn(model.sort, column.name);
             const sortDirection = sort ? sort.direction : null;
             const element = (
               <div

--- a/packages/iris-grid/src/IrisGridRenderer.ts
+++ b/packages/iris-grid/src/IrisGridRenderer.ts
@@ -450,7 +450,13 @@ class IrisGridRenderer extends GridRenderer {
       return;
     }
 
-    const sort = TableUtils.getSortForColumn(model.sort, modelColumn);
+    const columnName = model.columns[modelColumn]?.name;
+
+    if (columnName == null) {
+      return;
+    }
+
+    const sort = TableUtils.getSortForColumn(model.sort, columnName);
 
     if (!sort) {
       return;

--- a/packages/iris-grid/src/IrisGridUtils.test.ts
+++ b/packages/iris-grid/src/IrisGridUtils.test.ts
@@ -157,8 +157,8 @@ describe('sort exporting/importing', () => {
     const table = makeTable({ columns, sort });
     const exportedSort = IrisGridUtils.dehydrateSort(sort);
     expect(exportedSort).toEqual([
-      { column: 3, isAbs: false, direction: 'ASC' },
-      { column: 7, isAbs: true, direction: 'DESC' },
+      { columnName: columns[3].name, isAbs: false, direction: 'ASC' },
+      { columnName: columns[7].name, isAbs: true, direction: 'DESC' },
     ]);
 
     const importedSort = IrisGridUtils.hydrateSort(table.columns, exportedSort);

--- a/packages/iris-grid/src/IrisGridUtils.test.ts
+++ b/packages/iris-grid/src/IrisGridUtils.test.ts
@@ -5,7 +5,7 @@ import { DateUtils } from '@deephaven/jsapi-utils';
 import type { AdvancedFilter } from './CommonTypes';
 import { FilterData } from './IrisGrid';
 import IrisGridTestUtils from './IrisGridTestUtils';
-import IrisGridUtils from './IrisGridUtils';
+import IrisGridUtils, { DehydratedSort } from './IrisGridUtils';
 
 function makeFilter() {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -156,10 +156,11 @@ describe('sort exporting/importing', () => {
     const sort = [columns[3].sort(), columns[7].sort().abs().desc()];
     const table = makeTable({ columns, sort });
     const exportedSort = IrisGridUtils.dehydrateSort(sort);
-    expect(exportedSort).toEqual([
-      { columnName: columns[3].name, isAbs: false, direction: 'ASC' },
-      { columnName: columns[7].name, isAbs: true, direction: 'DESC' },
-    ]);
+    const expectExportedSort: DehydratedSort[] = [
+      { column: columns[3].name, isAbs: false, direction: 'ASC' },
+      { column: columns[7].name, isAbs: true, direction: 'DESC' },
+    ];
+    expect(exportedSort).toEqual(expectExportedSort);
 
     const importedSort = IrisGridUtils.hydrateSort(table.columns, exportedSort);
     expect(importedSort).toEqual([

--- a/packages/iris-grid/src/IrisGridUtils.test.ts
+++ b/packages/iris-grid/src/IrisGridUtils.test.ts
@@ -156,11 +156,10 @@ describe('sort exporting/importing', () => {
     const sort = [columns[3].sort(), columns[7].sort().abs().desc()];
     const table = makeTable({ columns, sort });
     const exportedSort = IrisGridUtils.dehydrateSort(sort);
-    const expectExportedSort: DehydratedSort[] = [
+    expect(exportedSort).toEqual<DehydratedSort[]>([
       { column: columns[3].name, isAbs: false, direction: 'ASC' },
       { column: columns[7].name, isAbs: true, direction: 'DESC' },
-    ];
-    expect(exportedSort).toEqual(expectExportedSort);
+    ]);
 
     const importedSort = IrisGridUtils.hydrateSort(table.columns, exportedSort);
     expect(importedSort).toEqual([

--- a/packages/iris-grid/src/IrisGridUtils.ts
+++ b/packages/iris-grid/src/IrisGridUtils.ts
@@ -97,11 +97,18 @@ export type DehydratedUserColumnWidth = [ColumnName, number];
 
 export type DehydratedUserRowHeight = [number, number];
 
-export type DehydratedSort = {
-  column: ColumnName | ModelIndex;
+/** @deprecated Use `DehydratedSort` instead */
+export interface LegacyDehydratedSort {
+  column: ModelIndex;
   isAbs: boolean;
   direction: SortDirection;
-};
+}
+
+export interface DehydratedSort {
+  column: ColumnName;
+  isAbs: boolean;
+  direction: SortDirection;
+}
 
 export interface DehydratedIrisGridState {
   advancedFilters: readonly DehydratedAdvancedFilter[];
@@ -785,7 +792,7 @@ class IrisGridUtils {
    */
   static hydrateSort(
     columns: readonly Column[],
-    sorts: readonly DehydratedSort[]
+    sorts: readonly (DehydratedSort | LegacyDehydratedSort)[]
   ): Sort[] {
     return (
       sorts
@@ -873,7 +880,7 @@ class IrisGridUtils {
       quickFilters?: readonly DehydratedQuickFilter[];
       advancedFilters?: readonly DehydratedAdvancedFilter[];
       inputFilters?: readonly InputFilter[];
-      sorts?: readonly DehydratedSort[];
+      sorts?: readonly (DehydratedSort | LegacyDehydratedSort)[];
       partition?: unknown;
       partitionColumn?: ColumnName;
     },

--- a/packages/iris-grid/src/IrisGridUtils.ts
+++ b/packages/iris-grid/src/IrisGridUtils.ts
@@ -98,7 +98,7 @@ export type DehydratedUserColumnWidth = [ColumnName, number];
 export type DehydratedUserRowHeight = [number, number];
 
 export type DehydratedSort = {
-  columnName: ColumnName;
+  column: ColumnName | ModelIndex;
   isAbs: boolean;
   direction: SortDirection;
 };
@@ -770,7 +770,7 @@ class IrisGridUtils {
     return sorts.map(sort => {
       const { column, isAbs, direction } = sort;
       return {
-        columnName: column.name,
+        column: column.name,
         isAbs,
         direction,
       };
@@ -790,11 +790,16 @@ class IrisGridUtils {
     return (
       sorts
         .map(sort => {
-          const { columnName, isAbs, direction } = sort;
+          const { column: columnIndexOrName, isAbs, direction } = sort;
           if (direction === TableUtils.sortDirection.reverse) {
             return dh.Table.reverse();
           }
-          const column = IrisGridUtils.getColumnByName(columns, columnName);
+
+          const column =
+            typeof columnIndexOrName === 'string'
+              ? IrisGridUtils.getColumnByName(columns, columnIndexOrName)
+              : IrisGridUtils.getColumn(columns, columnIndexOrName);
+
           if (column != null) {
             let columnSort = column.sort();
             if (isAbs) {

--- a/packages/iris-grid/src/IrisGridUtils.ts
+++ b/packages/iris-grid/src/IrisGridUtils.ts
@@ -98,7 +98,7 @@ export type DehydratedUserColumnWidth = [ColumnName, number];
 export type DehydratedUserRowHeight = [number, number];
 
 export type DehydratedSort = {
-  column: ModelIndex;
+  columnName: ColumnName;
   isAbs: boolean;
   direction: SortDirection;
 };
@@ -770,7 +770,7 @@ class IrisGridUtils {
     return sorts.map(sort => {
       const { column, isAbs, direction } = sort;
       return {
-        column: column.index,
+        columnName: column.name,
         isAbs,
         direction,
       };
@@ -790,11 +790,11 @@ class IrisGridUtils {
     return (
       sorts
         .map(sort => {
-          const { column: columnIndex, isAbs, direction } = sort;
+          const { columnName, isAbs, direction } = sort;
           if (direction === TableUtils.sortDirection.reverse) {
             return dh.Table.reverse();
           }
-          const column = IrisGridUtils.getColumn(columns, columnIndex);
+          const column = IrisGridUtils.getColumnByName(columns, columnName);
           if (column != null) {
             let columnSort = column.sort();
             if (isAbs) {

--- a/packages/iris-grid/src/mousehandlers/IrisGridContextMenuHandler.tsx
+++ b/packages/iris-grid/src/mousehandlers/IrisGridContextMenuHandler.tsx
@@ -229,7 +229,7 @@ class IrisGridContextMenuHandler extends GridMouseHandler {
     } = theme;
 
     const modelSort = model.sort;
-    const columnSort = TableUtils.getSortForColumn(modelSort, modelIndex);
+    const columnSort = TableUtils.getSortForColumn(modelSort, column.name);
     const hasReverse = reverseType !== TableUtils.REVERSE_TYPE.NONE;
     const { userColumnWidths } = metrics;
     const isColumnHidden = [...userColumnWidths.values()].some(

--- a/packages/jsapi-types/src/dh.types.ts
+++ b/packages/jsapi-types/src/dh.types.ts
@@ -524,11 +524,6 @@ export interface OneClick {
 }
 
 export interface Column {
-  /**
-   * @deprecated
-   */
-  readonly index: number;
-
   readonly type: string;
   readonly name: string;
   readonly description: string;

--- a/packages/jsapi-utils/src/TableUtils.test.ts
+++ b/packages/jsapi-utils/src/TableUtils.test.ts
@@ -1504,11 +1504,12 @@ describe('Sorting', () => {
 
   describe('getSortIndex', () => {
     it.each([
-      // sort, columnIndex, expected
+      // sort, columnName, expected
       [sortList.empty, 'name_999', null],
+      [sortList.hasThree, 'non-existing', null],
       [sortList.hasThree, 'name_999', 2],
     ] as [readonly Sort[], string, number | null][])(
-      'should return index of sort for given column index: %s, %s',
+      'should return index of sort for matching column name: %s, %s',
       (sort, columnName, expected) => {
         expect(TableUtils.getSortIndex(sort, columnName)).toEqual(expected);
       }
@@ -1517,11 +1518,12 @@ describe('Sorting', () => {
 
   describe('getSortForColumn', () => {
     it.each([
-      // sort, columnIndex, expected
+      // sort, columnName, expected
       [sortList.empty, 'name_999', null],
+      [sortList.hasThree, 'non-existing', null],
       [sortList.hasThree, 'name_999', sortList.hasThree[2]],
     ] as [readonly Sort[], string, number | null][])(
-      'should return sort for given column index: %s, %s',
+      'should return sort for matching column name: %s, %s',
       (sort, columnName, expected) => {
         expect(TableUtils.getSortForColumn(sort, columnName)).toEqual(expected);
       }

--- a/packages/jsapi-utils/src/TableUtils.test.ts
+++ b/packages/jsapi-utils/src/TableUtils.test.ts
@@ -1505,12 +1505,12 @@ describe('Sorting', () => {
   describe('getSortIndex', () => {
     it.each([
       // sort, columnIndex, expected
-      [sortList.empty, 999, null],
-      [sortList.hasThree, 999, 2],
-    ] as [readonly Sort[], number, number | null][])(
+      [sortList.empty, 'name_999', null],
+      [sortList.hasThree, 'name_999', 2],
+    ] as [readonly Sort[], string, number | null][])(
       'should return index of sort for given column index: %s, %s',
-      (sort, columnIndex, expected) => {
-        expect(TableUtils.getSortIndex(sort, columnIndex)).toEqual(expected);
+      (sort, columnName, expected) => {
+        expect(TableUtils.getSortIndex(sort, columnName)).toEqual(expected);
       }
     );
   });
@@ -1518,14 +1518,12 @@ describe('Sorting', () => {
   describe('getSortForColumn', () => {
     it.each([
       // sort, columnIndex, expected
-      [sortList.empty, 999, null],
-      [sortList.hasThree, 999, sortList.hasThree[2]],
-    ] as [readonly Sort[], number, number | null][])(
+      [sortList.empty, 'name_999', null],
+      [sortList.hasThree, 'name_999', sortList.hasThree[2]],
+    ] as [readonly Sort[], string, number | null][])(
       'should return sort for given column index: %s, %s',
-      (sort, columnIndex, expected) => {
-        expect(TableUtils.getSortForColumn(sort, columnIndex)).toEqual(
-          expected
-        );
+      (sort, columnName, expected) => {
+        expect(TableUtils.getSortForColumn(sort, columnName)).toEqual(expected);
       }
     );
   });

--- a/packages/jsapi-utils/src/TableUtils.test.ts
+++ b/packages/jsapi-utils/src/TableUtils.test.ts
@@ -14,6 +14,7 @@ import TableUtils from './TableUtils';
 import DateUtils from './DateUtils';
 // eslint-disable-next-line import/no-relative-packages
 import IrisGridTestUtils from '../../iris-grid/src/IrisGridTestUtils';
+import { ColumnName } from './Formatter';
 
 const DEFAULT_TIME_ZONE_ID = 'America/New_York';
 const EXPECT_TIME_ZONE_PARAM = expect.objectContaining({
@@ -1503,12 +1504,14 @@ describe('Sorting', () => {
   };
 
   describe('getSortIndex', () => {
-    it.each([
-      // sort, columnName, expected
+    // sort, columnName, expected
+    const testCases: [Sort[], ColumnName, number | null][] = [
       [sortList.empty, 'name_999', null],
       [sortList.hasThree, 'non-existing', null],
       [sortList.hasThree, 'name_999', 2],
-    ] as [readonly Sort[], string, number | null][])(
+    ];
+
+    it.each(testCases)(
       'should return index of sort for matching column name: %s, %s',
       (sort, columnName, expected) => {
         expect(TableUtils.getSortIndex(sort, columnName)).toEqual(expected);
@@ -1517,12 +1520,14 @@ describe('Sorting', () => {
   });
 
   describe('getSortForColumn', () => {
-    it.each([
-      // sort, columnName, expected
+    // sort, columnName, expected
+    const testCases: [Sort[], ColumnName, Sort | null][] = [
       [sortList.empty, 'name_999', null],
       [sortList.hasThree, 'non-existing', null],
       [sortList.hasThree, 'name_999', sortList.hasThree[2]],
-    ] as [readonly Sort[], string, number | null][])(
+    ];
+
+    it.each(testCases)(
       'should return sort for matching column name: %s, %s',
       (sort, columnName, expected) => {
         expect(TableUtils.getSortForColumn(sort, columnName)).toEqual(expected);

--- a/packages/jsapi-utils/src/TableUtils.ts
+++ b/packages/jsapi-utils/src/TableUtils.ts
@@ -88,7 +88,7 @@ export class TableUtils {
 
   static getSortIndex(
     sort: readonly Sort[],
-    columnName: string
+    columnName: ColumnName
   ): number | null {
     for (let i = 0; i < sort.length; i += 1) {
       const s = sort[i];
@@ -107,7 +107,7 @@ export class TableUtils {
    */
   static getSortForColumn(
     tableSort: readonly Sort[],
-    columnName: string
+    columnName: ColumnName
   ): Sort | null {
     const sortIndex = TableUtils.getSortIndex(tableSort, columnName);
     if (sortIndex != null) {
@@ -272,7 +272,7 @@ export class TableUtils {
    */
   static setSortForColumn(
     tableSort: readonly Sort[],
-    columnName: string,
+    columnName: ColumnName,
     sort: Sort | null,
     addToExisting = false
   ): Sort[] {

--- a/packages/jsapi-utils/src/TableUtils.ts
+++ b/packages/jsapi-utils/src/TableUtils.ts
@@ -88,11 +88,11 @@ export class TableUtils {
 
   static getSortIndex(
     sort: readonly Sort[],
-    columnIndex: number
+    columnName: string
   ): number | null {
     for (let i = 0; i < sort.length; i += 1) {
       const s = sort[i];
-      if (s.column?.index === columnIndex) {
+      if (s.column?.name === columnName) {
         return i;
       }
     }
@@ -102,14 +102,14 @@ export class TableUtils {
 
   /**
    * @param tableSort The sorts from the table to get the sort from
-   * @param columnIndex The index of the column to get the sort for
+   * @param columnName The name of the column to get the sort for
    * @returns The sort for the column, or null if it's not sorted
    */
   static getSortForColumn(
     tableSort: readonly Sort[],
-    columnIndex: number
+    columnName: string
   ): Sort | null {
-    const sortIndex = TableUtils.getSortIndex(tableSort, columnIndex);
+    const sortIndex = TableUtils.getSortIndex(tableSort, columnName);
     if (sortIndex != null) {
       return tableSort[sortIndex];
     }
@@ -166,7 +166,7 @@ export class TableUtils {
       return null;
     }
 
-    const sort = TableUtils.getSortForColumn(sorts, columnIndex);
+    const sort = TableUtils.getSortForColumn(sorts, columns[columnIndex].name);
     if (sort === null) {
       return columns[columnIndex].sort().asc();
     }
@@ -229,7 +229,7 @@ export class TableUtils {
 
     return TableUtils.setSortForColumn(
       sorts,
-      columnIndex,
+      columns[columnIndex].name,
       newSort,
       addToExisting
     );
@@ -256,7 +256,7 @@ export class TableUtils {
 
     return TableUtils.setSortForColumn(
       sorts,
-      modelColumn,
+      columns[modelColumn].name,
       newSort,
       addToExisting
     );
@@ -265,18 +265,18 @@ export class TableUtils {
   /**
    * Sets the sort for the given column *and* removes any reverses
    * @param tableSort The current sorts from IrisGrid.state
-   * @param columnIndex The column index to apply the sort to
+   * @param columnName The column name to apply the sort to
    * @param sort The sort object to add
    * @param addToExisting Add this sort to the existing sort
    * @returns Returns the modified array of sorts - removing reverses
    */
   static setSortForColumn(
     tableSort: readonly Sort[],
-    columnIndex: number,
+    columnName: string,
     sort: Sort | null,
     addToExisting = false
   ): Sort[] {
-    const sortIndex = TableUtils.getSortIndex(tableSort, columnIndex);
+    const sortIndex = TableUtils.getSortIndex(tableSort, columnName);
     let sorts: Sort[] = [];
     if (addToExisting) {
       sorts = sorts.concat(


### PR DESCRIPTION
resolves #965

BREAKING CHANGE: Removed index property from dh.types Column type. IrisGridUtils.dehydrateSort now returns column name instead of index. TableUtils now expects column name instead of index for functions that don't have access to a columns array.