### PR TITLE
fix: Add react-dom, redux and react-redux to remote component dependencies

### DIFF
--- a/packages/code-studio/src/remote-component.config.js
+++ b/packages/code-studio/src/remote-component.config.js
@@ -5,8 +5,14 @@
  * Dependencies for Remote Components
  */
 import react from 'react';
+import * as redux from 'redux';
+import * as reactRedux from 'react-redux';
+import ReactDOM from 'react-dom';
 
 // eslint-disable-next-line import/prefer-default-export
 export const resolve = {
   react,
+  'react-dom': ReactDOM,
+  redux,
+  'react-redux': reactRedux,
 };


### PR DESCRIPTION
Allows plugins to connect to the store and to not have to bundle `react-dom` 
