### PR TITLE
fix: Aggregations should be available when creating a rollup

### DIFF
--- a/packages/iris-grid/src/IrisGrid.tsx
+++ b/packages/iris-grid/src/IrisGrid.tsx
@@ -4195,7 +4195,7 @@ export class IrisGrid extends Component<IrisGridProps, IrisGridState> {
       model.isCustomColumnsAvailable,
       model.isFormatColumnsAvailable,
       model.isRollupAvailable,
-      model.isTotalsAvailable,
+      model.isTotalsAvailable || isRollup,
       model.isSelectDistinctAvailable,
       model.isExportAvailable,
       this.toggleFilterBarAction,


### PR DESCRIPTION
- When there is a rollup config, aggregations go through the rollup config
  - https://github.com/deephaven/web-client-ui/blob/a069543812b6c544957ebf664e0918e98a3affbf/packages/iris-grid/src/IrisGrid.tsx#L1288
- Allow aggregations to be accessed when using a rollup config
