### PR TITLE
fix: DH-12163 - Column grouping sidebar test failure fixes

### DIFF
--- a/packages/iris-grid/src/sidebar/visibility-ordering-builder/VisibilityOrderingBuilder.test.tsx
+++ b/packages/iris-grid/src/sidebar/visibility-ordering-builder/VisibilityOrderingBuilder.test.tsx
@@ -877,7 +877,16 @@ test('Shows validation error for new group on blur when never typed in', async (
 
 test('Search columns', async () => {
   const user = userEvent.setup({ delay: null });
-  render(<BuilderWithGroups />);
+
+  const model = makeModelWithGroups([
+    ...COLUMN_HEADER_GROUPS,
+    {
+      name: `${ColumnHeaderGroup.NEW_GROUP_PREFIX}Test`,
+      children: [COLUMNS[9].name],
+    },
+  ]);
+
+  render(<BuilderWithGroups model={model} />);
 
   const searchInput = screen.getByPlaceholderText('Search');
 
@@ -890,19 +899,20 @@ test('Search columns', async () => {
   expectSelection([1, 2, 3, 4, 5, 6]);
 
   await user.type(searchInput, 'One');
-
   jest.advanceTimersByTime(500);
-
   expectSelection([1, 2, 3]);
 
   await user.clear(searchInput);
-
   jest.advanceTimersByTime(500);
-
   expectSelection([]);
 
   await user.type(searchInput, 'asdf');
+  jest.advanceTimersByTime(500);
+  expectSelection([]);
 
+  await user.clear(searchInput);
+  jest.advanceTimersByTime(500);
+  await user.type(searchInput, ColumnHeaderGroup.NEW_GROUP_PREFIX);
   jest.advanceTimersByTime(500);
   expectSelection([]);
 });

--- a/packages/iris-grid/src/sidebar/visibility-ordering-builder/VisibilityOrderingBuilder.test.tsx
+++ b/packages/iris-grid/src/sidebar/visibility-ordering-builder/VisibilityOrderingBuilder.test.tsx
@@ -844,6 +844,35 @@ test('Only allows 1 new group at a time', async () => {
   expect(mockGroupHandler).toBeCalledWith([
     expect.objectContaining(groupObject),
   ]);
+
+  createGroupBtn.focus();
+  expect(screen.queryAllByText('Invalid name').length).toBe(1);
+});
+
+test('Shows validation error for new group on blur when never typed in', async () => {
+  const user = userEvent.setup({ delay: null });
+
+  const model = makeModelWithGroups([
+    {
+      children: [`${COLUMN_PREFIX}0`, `${COLUMN_PREFIX}1`],
+      name: `${ColumnHeaderGroup.NEW_GROUP_PREFIX}Test`,
+    },
+  ]);
+
+  const mockGroupHandler = jest.fn();
+
+  render(
+    <Builder
+      model={model}
+      columnHeaderGroups={model.columnHeaderGroups}
+      onColumnHeaderGroupChanged={mockGroupHandler}
+    />
+  );
+
+  expect(screen.queryAllByText('Invalid name').length).toBe(0);
+
+  await selectItems(user, [2]);
+  expect(screen.queryAllByText('Invalid name').length).toBe(1);
 });
 
 test('Search columns', async () => {

--- a/packages/iris-grid/src/sidebar/visibility-ordering-builder/VisibilityOrderingBuilder.tsx
+++ b/packages/iris-grid/src/sidebar/visibility-ordering-builder/VisibilityOrderingBuilder.tsx
@@ -151,8 +151,10 @@ class VisibilityOrderingBuilder extends Component<
 
   searchColumns(searchFilter: string): void {
     const flattenedItems = flattenTree(this.getTreeItems());
-    const itemsMatch = flattenedItems.filter(({ id }) =>
-      id.toLowerCase().includes(searchFilter.toLowerCase())
+    const itemsMatch = flattenedItems.filter(
+      ({ id, data }) =>
+        !(data.group?.isNew ?? false) &&
+        id.toLowerCase().includes(searchFilter.toLowerCase())
     );
 
     const columnsMatch = itemsMatch.map(({ id }) => id);

--- a/packages/iris-grid/src/sidebar/visibility-ordering-builder/VisibilityOrderingGroup.tsx
+++ b/packages/iris-grid/src/sidebar/visibility-ordering-builder/VisibilityOrderingGroup.tsx
@@ -83,11 +83,11 @@ export default function VisibilityOrderingGroup(
          * Firefox seems to ignore the first click back into the window and emit no event
          * So opening a color picker when another is open requires 2 clicks in Firefox
          */
-        window.addEventListener('focus', colorInputBlurHandler, true);
+        window.addEventListener('click', colorInputBlurHandler, true);
       }
 
       return () =>
-        window.removeEventListener('focus', colorInputBlurHandler, true);
+        window.removeEventListener('click', colorInputBlurHandler, true);
     },
     [isColorInputOpen, colorInputBlurHandler]
   );


### PR DESCRIPTION
- Does not select new groups when searching
- Shows validation error if you create a new group and blur without typing anything into the name field
- Prevents Firefox on Mac from getting stuck in a bad state where color pickers can't be opened. The bug occurs when multiple color inputs are on the screen at once and the user clicks between the without closing the previous picker