### PR TITLE
fix: DH-14439 Fix QueryMonitor breaking on "null" in default search filter

### DIFF
--- a/packages/jsapi-utils/src/TableUtils.test.ts
+++ b/packages/jsapi-utils/src/TableUtils.test.ts
@@ -1595,6 +1595,14 @@ describe('quick filter tests', () => {
       testTextFilter('=null', FilterType.isNull);
     });
 
+    it('handles in/starts with/ends with null cases', () => {
+      testInvokeFilter('~null', 'matches', '(?s)(?i).*\\Qnull\\E.*');
+      testInvokeFilter('null*', 'matches', '(?s)(?i)^\\Qnull\\E.*');
+      testInvokeFilter('=null*', 'matches', '(?s)(?i)^\\Qnull\\E.*');
+      testInvokeFilter('*null', 'matches', '(?s)(?i).*\\Qnull\\E$');
+      testInvokeFilter('=*null', 'matches', '(?s)(?i).*\\Qnull\\E$');
+    });
+
     it('handles not null cases', () => {
       const column = makeFilterColumn();
       const filter = column.filter() as MockFilter;

--- a/packages/jsapi-utils/src/TableUtils.ts
+++ b/packages/jsapi-utils/src/TableUtils.ts
@@ -678,7 +678,7 @@ export class TableUtils {
         case '!':
           return filter.isNull().not();
         default:
-          return null;
+        // For all other operations, treat null as a string value
       }
     }
 


### PR DESCRIPTION
Allow null in match filters on string columns, treat it as a regular string value.

### Testing steps:

Run this query:
```
from deephaven import empty_table
a = [None, 'Null', 'null - starts with', 'ends with null', 'null', 'ABC']
test_table = empty_table(6).update(formulas=["X = (String)a[i]"])
```

Filter using quick filters treating `null` as a string:
- `*null`, `=*null`, `!=*null` - ends with, does not end with
- `null*`, `=null*`, `!=null*` - starts with, does not start with
- `~null`, `!~null` - contains/does not contain

Special cases treating `null` as a `null` value:
- `=null`, `!=null`