### PR TITLE
fix: Scrolling horizontally in Linker mode renders empty cells

### DIFF
--- a/packages/iris-grid/src/IrisGridRenderer.ts
+++ b/packages/iris-grid/src/IrisGridRenderer.ts
@@ -255,9 +255,8 @@ class IrisGridRenderer extends GridRenderer {
 
     const { allColumnWidths, allColumnXs, maxY } = metrics;
 
-    const x = allColumnXs.get(hoverSelectColumn);
-    const columnWidth = allColumnWidths.get(hoverSelectColumn);
-    if (x == null || columnWidth == null) return;
+    const x = getOrThrow(allColumnXs, hoverSelectColumn);
+    const columnWidth = getOrThrow(allColumnWidths, hoverSelectColumn);
 
     context.fillStyle = theme.linkerColumnHoverBackgroundColor;
     context.fillRect(x, 0, columnWidth, maxY);

--- a/packages/iris-grid/src/IrisGridRenderer.ts
+++ b/packages/iris-grid/src/IrisGridRenderer.ts
@@ -257,8 +257,7 @@ class IrisGridRenderer extends GridRenderer {
 
     const x = allColumnXs.get(hoverSelectColumn);
     const columnWidth = allColumnWidths.get(hoverSelectColumn);
-    assertNotNull(x);
-    assertNotNull(columnWidth);
+    if (x == null || columnWidth == null) return;
 
     context.fillStyle = theme.linkerColumnHoverBackgroundColor;
     context.fillRect(x, 0, columnWidth, maxY);

--- a/packages/iris-grid/src/mousehandlers/IrisGridColumnSelectMouseHandler.ts
+++ b/packages/iris-grid/src/mousehandlers/IrisGridColumnSelectMouseHandler.ts
@@ -90,8 +90,10 @@ class IrisGridColumnSelectMouseHandler extends GridMouseHandler {
 
     if (this.isValidColumn(tableColumn)) {
       this.cursor = columnAllowedCursor;
+      this.irisGrid.setState({ hoverSelectColumn: column });
     } else {
       this.cursor = columnNotAllowedCursor;
+      this.irisGrid.setState({ hoverSelectColumn: null });
     }
 
     // don't block wheel event from scrolling


### PR DESCRIPTION
Fixes #1146 

Changed `assertNotNull` to `getOrThrow` and update `hoverSelectColumn` on scroll so the highlighted column will change on scroll.