### PR TITLE
ci: Update workflows to run on PRs and pushes to release branches

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -4,9 +4,13 @@ name: Build and End-to-end Tests
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
+      - 'release/**'
   pull_request:
-    branches: [main]
+    branches:
+      - main
+      - 'release/**'
 env:
   DOCKER_TAG: edge
 jobs:

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -4,9 +4,13 @@ name: Unit Tests
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
+      - 'release/**'
   pull_request:
-    branches: [main]
+    branches:
+      - main
+      - 'release/**'
 jobs:
   unit:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
This updates the actions to run on `release/` branches for PRs and pushes.

I believe this will need to be cherry-picked back to the release branches

The double star for the wildcard is from the GitHub docs [here](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#using-filters). Single star works as well, but would not run on `release/v0.19/something` if that ever occurred.