### PR TITLE
fix: Handling no columns

### DIFF
--- a/packages/iris-grid/src/IrisGrid.test.tsx
+++ b/packages/iris-grid/src/IrisGrid.test.tsx
@@ -10,7 +10,7 @@ class MockPath2D {
   addPath = jest.fn();
 }
 
-window.Path2D = MockPath2D;
+window.Path2D = (MockPath2D as unknown) as new () => Path2D;
 
 const VIEW_SIZE = 5000;
 
@@ -61,7 +61,8 @@ function makeComponent(
       createNodeMock,
     }
   );
-  return testRenderer.getInstance();
+  return testRenderer.getInstance() as TestRenderer.ReactTestInstance &
+    IrisGrid;
 }
 
 function keyDown(key, component, extraArgs?) {
@@ -192,4 +193,16 @@ it('handles undefined operator, should default to eq', () => {
     expect.anything(),
     'any'
   );
+});
+
+it('should set gotoValueSelectedColumnName to empty string if no columns are given', () => {
+  const component = makeComponent(
+    IrisGridTestUtils.makeModel(
+      IrisGridTestUtils.makeTable({
+        columns: [],
+      })
+    )
+  );
+
+  expect(component.state.gotoValueSelectedColumnName).toEqual('');
 });

--- a/packages/iris-grid/src/IrisGrid.tsx
+++ b/packages/iris-grid/src/IrisGrid.tsx
@@ -850,7 +850,7 @@ export class IrisGrid extends Component<IrisGridProps, IrisGridState> {
       gotoRowError: '',
       gotoValueError: '',
 
-      gotoValueSelectedColumnName: model.columns[0].name,
+      gotoValueSelectedColumnName: model.columns[0]?.name ?? '',
       gotoValueSelectedFilter: FilterType.eq,
       gotoValue: '',
       columnHeaderGroups: columnHeaderGroups ?? model.initialColumnHeaderGroups,


### PR DESCRIPTION
Added graceful handling to IrisGrid for tables with no columns.

fixes #1169