### PR TITLE
ci: Add dist-tag for publish

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,5 +2,10 @@
   "packages": ["packages/*"],
   "useWorkspaces": true,
   "useNx": false,
-  "version": "0.31.1"
+  "version": "0.31.1",
+  "command": {
+    "version": {
+      "distTag": "v0.31"
+    }
+  }
 }

--- a/lerna.json
+++ b/lerna.json
@@ -4,7 +4,7 @@
   "useNx": false,
   "version": "0.31.1",
   "command": {
-    "version": {
+    "publish": {
       "distTag": "v0.31"
     }
   }


### PR DESCRIPTION
This should hopefully make the lerna publish command use the `v0.31` tag instead of `latest` when the publish action runs.

Will not prevent the GitHub release from being tagged latest. Didn't see any flags in lerna to create a GitHub release and not auto tag it as latest