### PR TITLE
fix: Context menu does not appear when right-clicking IrisGrid component in styleguide

### DIFF
--- a/packages/iris-grid/src/mousehandlers/IrisGridContextMenuHandler.tsx
+++ b/packages/iris-grid/src/mousehandlers/IrisGridContextMenuHandler.tsx
@@ -797,8 +797,8 @@ class IrisGridContextMenuHandler extends GridMouseHandler {
 
     ContextActions.triggerMenu(
       irisGrid.gridWrapper,
-      event.pageX,
-      event.pageY,
+      event.clientX,
+      event.clientY,
       actions
     );
     return true;


### PR DESCRIPTION
Fixes #1065 

Context menu was being rendered but it was rendered based on the page x and y, so since you have to scroll to the bottom to see IrisGrid, the context menu was being rendered off the screen.