### PR TITLE
feat: Double click notebook tab to remove its preview status

### DIFF
--- a/packages/dashboard-core-plugins/src/panels/NotebookPanel.tsx
+++ b/packages/dashboard-core-plugins/src/panels/NotebookPanel.tsx
@@ -957,9 +957,12 @@ class NotebookPanel extends Component<NotebookPanelProps, NotebookPanelState> {
     });
   }
 
-  handlePanelTabClick(): void {
+  handlePanelTabClick(e: MouseEvent): void {
     log.debug('handlePanelTabClick');
     this.focus();
+    if (e.detail === 2) {
+      this.removePreviewStatus();
+    }
   }
 
   /**

--- a/packages/golden-layout/src/controls/Tab.ts
+++ b/packages/golden-layout/src/controls/Tab.ts
@@ -236,7 +236,6 @@ export default class Tab {
         isComponent(this.contentItem)
       ) {
         this.header.parent.setActiveContentItem(this.contentItem);
-        this.contentItem.container.emit('tabClicked');
       } else if (
         isComponent(this.contentItem) &&
         !this.contentItem.container._contentElement[0].contains(
@@ -246,10 +245,10 @@ export default class Tab {
         // if no focus inside put focus onto the container
         // so focusin always fires for tabclicks
         this.contentItem.container._contentElement.focus();
+      }
 
-        // still emit tab clicked event, so panels can also
-        // do it's own focus handling if desired
-        this.contentItem.container.emit('tabClicked');
+      if (isComponent(this.contentItem)) {
+        this.contentItem.container.emit('tabClicked', event);
       }
 
       // might have been called from the dropdown


### PR DESCRIPTION
Something I noticed while working on #1189 is that we didn't support double clicking the tab to promote from preview to normal state like VSCode does. This PR lets you double click the tab of a notebook in preview to change it from preview state to normal state.

Tested double clicking preview notebook, non-preview notebook, and opening other notebooks in preview after promoting via double click