### PR TITLE
fix: Fix column data appearing incorrectly when multiplier null

### DIFF
--- a/__mocks__/dh-core.js
+++ b/__mocks__/dh-core.js
@@ -1812,11 +1812,10 @@ class NumberFormat {
   }
 
   static format(pattern, number) {
-    if (pattern.indexOf('.') >= 0) {
-      return number.toFixed(4);
-    } else {
-      return number.toFixed(0);
-    }
+    const decimalIndex = pattern.indexOf('.');
+    const decimalCount =
+      decimalIndex >= 0 ? pattern.length - decimalIndex - 1 : 0;
+    return number.toFixed(decimalCount);
   }
 }
 

--- a/packages/code-studio/src/storage/LocalWorkspaceStorage.ts
+++ b/packages/code-studio/src/storage/LocalWorkspaceStorage.ts
@@ -38,18 +38,7 @@ export class LocalWorkspaceStorage implements WorkspaceStorage {
       settings: {
         defaultDateTimeFormat:
           DateTimeColumnFormatter.DEFAULT_DATETIME_FORMAT_STRING,
-        formatter: [
-          {
-            columnType: 'decimal',
-            columnName: 'Bid',
-            format: {
-              label: '',
-              type: 'type-global',
-              formatString: '###,##0.00###',
-              multiplier: null,
-            },
-          },
-        ],
+        formatter: [],
         timeZone: DateTimeColumnFormatter.DEFAULT_TIME_ZONE_ID,
         showTimeZone: false,
         showTSeparator: true,

--- a/packages/code-studio/src/storage/LocalWorkspaceStorage.ts
+++ b/packages/code-studio/src/storage/LocalWorkspaceStorage.ts
@@ -38,7 +38,18 @@ export class LocalWorkspaceStorage implements WorkspaceStorage {
       settings: {
         defaultDateTimeFormat:
           DateTimeColumnFormatter.DEFAULT_DATETIME_FORMAT_STRING,
-        formatter: [],
+        formatter: [
+          {
+            columnType: 'decimal',
+            columnName: 'Bid',
+            format: {
+              label: '',
+              type: 'type-global',
+              formatString: '###,##0.00###',
+              multiplier: null,
+            },
+          },
+        ],
         timeZone: DateTimeColumnFormatter.DEFAULT_TIME_ZONE_ID,
         showTimeZone: false,
         showTSeparator: true,

--- a/packages/jsapi-utils/src/formatters/DecimalColumnFormatter.test.ts
+++ b/packages/jsapi-utils/src/formatters/DecimalColumnFormatter.test.ts
@@ -1,0 +1,41 @@
+import DecimalColumnFormatter from './DecimalColumnFormatter';
+
+describe('multiplier tests', () => {
+  const formatter = new DecimalColumnFormatter();
+  const value = 10.4;
+  it('handles null multiplier correctly', () => {
+    expect(
+      formatter.format(value, {
+        multiplier: null,
+      })
+    ).toBe('10.4000');
+  });
+  it('handles undefined multiplier correctly', () => {
+    expect(
+      formatter.format(value, {
+        multiplier: undefined,
+      })
+    ).toBe('10.4000');
+  });
+  it('ignores 0 multiplier correctly', () => {
+    expect(
+      formatter.format(value, {
+        multiplier: 0,
+      })
+    ).toBe('10.4000');
+  });
+  it('handles 1 multiplier correctly', () => {
+    expect(
+      formatter.format(value, {
+        multiplier: 1,
+      })
+    ).toBe('10.4000');
+  });
+  it('handles 2 multiplier correctly', () => {
+    expect(
+      formatter.format(value, {
+        multiplier: 2,
+      })
+    ).toBe('20.8000');
+  });
+});

--- a/packages/jsapi-utils/src/formatters/DecimalColumnFormatter.ts
+++ b/packages/jsapi-utils/src/formatters/DecimalColumnFormatter.ts
@@ -8,7 +8,7 @@ import TableColumnFormatter, {
 const log = Log.module('DecimalColumnFormatter');
 
 export type DecimalColumnFormat = TableColumnFormat & {
-  multiplier?: number;
+  multiplier?: number | null;
 };
 
 export type DecimalColumnFormatterOptions = {
@@ -175,7 +175,7 @@ export class DecimalColumnFormatter extends TableColumnFormatter<number> {
         ? format.formatString
         : this.defaultFormatString;
     const value =
-      format.multiplier !== undefined && format.multiplier !== 0
+      format.multiplier != null && format.multiplier !== 0
         ? valueParam * format.multiplier
         : valueParam;
     try {

--- a/packages/jsapi-utils/src/formatters/IntegerColumnFormatter.test.ts
+++ b/packages/jsapi-utils/src/formatters/IntegerColumnFormatter.test.ts
@@ -1,0 +1,41 @@
+import IntegerColumnFormatter from './IntegerColumnFormatter';
+
+describe('multiplier tests', () => {
+  const formatter = new IntegerColumnFormatter();
+  const value = 10;
+  it('handles null multiplier correctly', () => {
+    expect(
+      formatter.format(value, {
+        multiplier: null,
+      })
+    ).toBe('10');
+  });
+  it('handles undefined multiplier correctly', () => {
+    expect(
+      formatter.format(value, {
+        multiplier: undefined,
+      })
+    ).toBe('10');
+  });
+  it('ignores 0 multiplier correctly', () => {
+    expect(
+      formatter.format(value, {
+        multiplier: 0,
+      })
+    ).toBe('10');
+  });
+  it('handles 1 multiplier correctly', () => {
+    expect(
+      formatter.format(value, {
+        multiplier: 1,
+      })
+    ).toBe('10');
+  });
+  it('handles 2 multiplier correctly', () => {
+    expect(
+      formatter.format(value, {
+        multiplier: 2,
+      })
+    ).toBe('20');
+  });
+});

--- a/packages/jsapi-utils/src/formatters/IntegerColumnFormatter.ts
+++ b/packages/jsapi-utils/src/formatters/IntegerColumnFormatter.ts
@@ -8,7 +8,7 @@ import TableColumnFormatter, {
 const log = Log.module('IntegerColumnFormatter');
 
 export type IntegerColumnFormat = TableColumnFormat & {
-  multiplier?: number;
+  multiplier?: number | null;
 };
 
 export type IntegerColumnFormatterOptions = {
@@ -150,7 +150,7 @@ export class IntegerColumnFormatter extends TableColumnFormatter<number> {
         ? format.formatString
         : this.defaultFormatString;
     const value =
-      format.multiplier !== undefined && format.multiplier !== 0
+      format.multiplier != null && format.multiplier !== 0
         ? valueParam * format.multiplier
         : valueParam;
     try {


### PR DESCRIPTION
- Issue with Formatting values - Enterprise uses `multiplier: null` for the default settings, but in Community we only expected `undefined` or `number`.
- Just handle when `multiplier` is `null` as well
- Fixes #1193
- Tested by manually adding a formatter with `multiplier: null` in LocalWorkspaceStorage, e.g.:
```
        formatter: [
          {
            columnType: 'decimal',
            columnName: 'Bid',
            format: {
              label: '',
              type: 'type-global',
              formatString: '###,##0.00###',
              multiplier: null,
            },
          },
        ],
```
