### PR TITLE
build: Fix the dist-tag for canary builds

### DIFF
--- a/.github/workflows/publish-alpha.yml
+++ b/.github/workflows/publish-alpha.yml
@@ -29,6 +29,6 @@ jobs:
       - run: npm run build
       # Need the --no-verify-access access flag since we use an automation token. Otherwise publish step fails
       # https://github.com/lerna/lerna/issues/2788
-      - run: ./node_modules/.bin/lerna publish --no-verify-access --canary --force-publish=\* --preid ${{ github.event.inputs.preid }} --yes
+      - run: ./node_modules/.bin/lerna publish --no-verify-access --canary --force-publish=\* --preid ${{ github.event.inputs.preid }} --dist-tag canary --yes
         env:
           NODE_AUTH_TOKEN: ${{ secrets.DEEPHAVENBOT_NPM_TOKEN }}


### PR DESCRIPTION
- Was defaulting to `latest`, which is incorrect
