### PR TITLE
feat: Improve plugin load error handling

### DIFF
--- a/packages/code-studio/src/main/AppInit.tsx
+++ b/packages/code-studio/src/main/AppInit.tsx
@@ -73,6 +73,10 @@ async function loadPlugins(): Promise<DeephavenPluginModuleMap> {
       `${import.meta.env.VITE_MODULE_PLUGINS_URL}/manifest.json`
     );
 
+    if (!Array.isArray(manifest.plugins)) {
+      throw new Error('Plugin manifest JSON does not contain plugins array');
+    }
+
     log.debug('Plugin manifest loaded:', manifest);
     const pluginPromises: Promise<unknown>[] = [];
     for (let i = 0; i < manifest.plugins.length; i += 1) {

--- a/packages/code-studio/src/main/AppInit.tsx
+++ b/packages/code-studio/src/main/AppInit.tsx
@@ -74,7 +74,7 @@ async function loadPlugins(): Promise<DeephavenPluginModuleMap> {
     );
 
     log.debug('Plugin manifest loaded:', manifest);
-    const pluginPromises: Promise<DeephavenPluginModule>[] = [];
+    const pluginPromises: Promise<unknown>[] = [];
     for (let i = 0; i < manifest.plugins.length; i += 1) {
       const { name, main } = manifest.plugins[i];
       const pluginMainUrl = `${
@@ -89,7 +89,7 @@ async function loadPlugins(): Promise<DeephavenPluginModuleMap> {
       const module = pluginModules[i];
       const { name } = manifest.plugins[i];
       if (module.status === 'fulfilled') {
-        pluginMap.set(name, module.value);
+        pluginMap.set(name, module.value as DeephavenPluginModule);
       } else {
         log.error(`Unable to load plugin ${name}`, module.reason);
       }

--- a/packages/code-studio/src/main/AppInit.tsx
+++ b/packages/code-studio/src/main/AppInit.tsx
@@ -80,10 +80,10 @@ async function loadPlugins(): Promise<DeephavenPluginModuleMap> {
     log.debug('Plugin manifest loaded:', manifest);
     const pluginPromises: Promise<unknown>[] = [];
     for (let i = 0; i < manifest.plugins.length; i += 1) {
-      const { name, main } = manifest.plugins[i];
+      const { main } = manifest.plugins[i];
       const pluginMainUrl = `${
         import.meta.env.VITE_MODULE_PLUGINS_URL
-      }/${name}/${main}`;
+      }/${main}`;
       pluginPromises.push(PluginUtils.loadModulePlugin(pluginMainUrl));
     }
     const pluginModules = await Promise.allSettled(pluginPromises);

--- a/packages/code-studio/src/main/AppInit.tsx
+++ b/packages/code-studio/src/main/AppInit.tsx
@@ -80,10 +80,10 @@ async function loadPlugins(): Promise<DeephavenPluginModuleMap> {
     log.debug('Plugin manifest loaded:', manifest);
     const pluginPromises: Promise<unknown>[] = [];
     for (let i = 0; i < manifest.plugins.length; i += 1) {
-      const { main } = manifest.plugins[i];
+      const { name, main } = manifest.plugins[i];
       const pluginMainUrl = `${
         import.meta.env.VITE_MODULE_PLUGINS_URL
-      }/${main}`;
+      }/${name}/${main}`;
       pluginPromises.push(PluginUtils.loadModulePlugin(pluginMainUrl));
     }
     const pluginModules = await Promise.allSettled(pluginPromises);

--- a/packages/code-studio/src/plugins/PluginUtils.tsx
+++ b/packages/code-studio/src/plugins/PluginUtils.tsx
@@ -60,7 +60,7 @@ class PluginUtils {
   ): Promise<{ plugins: { name: string; main: string }[] }> {
     const res = await fetch(jsonUrl);
     if (!res.ok) {
-      throw res.statusText;
+      throw new Error(res.statusText);
     }
     try {
       return await res.json();

--- a/packages/code-studio/src/plugins/PluginUtils.tsx
+++ b/packages/code-studio/src/plugins/PluginUtils.tsx
@@ -1,5 +1,4 @@
 import React, { ForwardRefExoticComponent } from 'react';
-import { DeephavenPluginModule } from '@deephaven/redux';
 import Log from '@deephaven/log';
 import RemoteComponent from './RemoteComponent';
 import loadRemoteModule from './loadRemoteModule';
@@ -46,9 +45,7 @@ class PluginUtils {
    * @param pluginUrl The URL of the plugin to load
    * @returns The loaded module
    */
-  static async loadModulePlugin(
-    pluginUrl: string
-  ): Promise<DeephavenPluginModule> {
+  static async loadModulePlugin(pluginUrl: string): Promise<unknown> {
     const myModule = await loadRemoteModule(pluginUrl);
     return myModule;
   }

--- a/packages/code-studio/src/plugins/PluginUtils.tsx
+++ b/packages/code-studio/src/plugins/PluginUtils.tsx
@@ -65,7 +65,7 @@ class PluginUtils {
     try {
       return await res.json();
     } catch {
-      throw new Error('Plugin manifest could not be parsed as JSON');
+      throw new Error('Could not be parsed as JSON');
     }
   }
 }

--- a/packages/code-studio/src/plugins/PluginUtils.tsx
+++ b/packages/code-studio/src/plugins/PluginUtils.tsx
@@ -58,22 +58,15 @@ class PluginUtils {
   static async loadJson(
     jsonUrl: string
   ): Promise<{ plugins: { name: string; main: string }[] }> {
-    return fetch(jsonUrl).then(res => {
-      if (!res.ok) {
-        if (res.status !== 404) {
-          // The browser already logs an error for 404
-          log.error(`Error loading plugins from ${jsonUrl}:`, res.statusText);
-        }
-        return { plugins: [] };
-      }
-
-      try {
-        return res.json();
-      } catch {
-        log.error('Plugin manifest could not be converted to JSON');
-        return { plugins: [] };
-      }
-    });
+    const res = await fetch(jsonUrl);
+    if (!res.ok) {
+      throw res.statusText;
+    }
+    try {
+      return await res.json();
+    } catch {
+      throw new Error('Plugin manifest could not be parsed as JSON');
+    }
   }
 }
 

--- a/packages/code-studio/src/plugins/PluginUtils.tsx
+++ b/packages/code-studio/src/plugins/PluginUtils.tsx
@@ -67,7 +67,12 @@ class PluginUtils {
         return { plugins: [] };
       }
 
-      return res.json();
+      try {
+        return res.json();
+      } catch {
+        log.error('Plugin manifest could not be converted to JSON');
+        return { plugins: [] };
+      }
     });
   }
 }

--- a/packages/code-studio/vite.config.ts
+++ b/packages/code-studio/vite.config.ts
@@ -131,7 +131,6 @@ export default defineConfig(({ mode }) => {
       },
     },
     optimizeDeps: {
-      force: true,
       esbuildOptions: {
         // Some packages need this to start properly if they reference global
         define: {

--- a/packages/code-studio/vite.config.ts
+++ b/packages/code-studio/vite.config.ts
@@ -131,6 +131,7 @@ export default defineConfig(({ mode }) => {
       },
     },
     optimizeDeps: {
+      force: true,
       esbuildOptions: {
         // Some packages need this to start properly if they reference global
         define: {


### PR DESCRIPTION
Loads plugins individually instead of failing to register if any plugin fails to load. Previously if any plugin failed to load for any reason then no plugins were registered.

Does some validation on if the manifest file exists and the structure of it so that the errors are more descriptive. Does not throw a 2nd error about `Unexpected token <` if there is no manifest file