### PR TITLE
build: Add sideEffects to package.json files

### DIFF
--- a/packages/chart/package.json
+++ b/packages/chart/package.json
@@ -48,7 +48,7 @@
     "dist"
   ],
   "sideEffects": [
-    "*.scss"
+    "*.css"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -58,7 +58,7 @@
     "css"
   ],
   "sideEffects": [
-    "*.scss"
+    "*.css"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/dashboard-core-plugins/package.json
+++ b/packages/dashboard-core-plugins/package.json
@@ -67,6 +67,9 @@
   "files": [
     "dist"
   ],
+  "sideEffects": [
+    "*.css"
+  ],
   "publishConfig": {
     "access": "public"
   }

--- a/packages/file-explorer/package.json
+++ b/packages/file-explorer/package.json
@@ -43,6 +43,9 @@
   "files": [
     "dist"
   ],
+  "sideEffects": [
+    "*.css"
+  ],
   "publishConfig": {
     "access": "public"
   }

--- a/packages/filters/package.json
+++ b/packages/filters/package.json
@@ -26,6 +26,7 @@
   "files": [
     "dist"
   ],
+  "sideEffects": false,
   "publishConfig": {
     "access": "public"
   }

--- a/packages/golden-layout/package.json
+++ b/packages/golden-layout/package.json
@@ -42,6 +42,9 @@
     "scss",
     "css"
   ],
+  "sideEffects": [
+    "*.css"
+  ],
   "publishConfig": {
     "access": "public"
   },

--- a/packages/grid/package.json
+++ b/packages/grid/package.json
@@ -30,6 +30,9 @@
   "files": [
     "dist"
   ],
+  "sideEffects": [
+    "*.css"
+  ],
   "dependencies": {
     "@deephaven/utils": "file:../utils",
     "classnames": "^2.3.1",

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -9,6 +9,7 @@
   "files": [
     "dist"
   ],
+  "sideEffects": false,
   "scripts": {
     "prestart": "npm run build",
     "start": "npm run watch",

--- a/packages/iris-grid/package.json
+++ b/packages/iris-grid/package.json
@@ -63,7 +63,7 @@
     "dist"
   ],
   "sideEffects": [
-    "*.scss"
+    "*.css"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/jsapi-bootstrap/package.json
+++ b/packages/jsapi-bootstrap/package.json
@@ -35,6 +35,7 @@
   "files": [
     "dist"
   ],
+  "sideEffects": false,
   "publishConfig": {
     "access": "public"
   }

--- a/packages/jsapi-components/package.json
+++ b/packages/jsapi-components/package.json
@@ -41,6 +41,9 @@
   "files": [
     "dist"
   ],
+  "sideEffects": [
+    "*.css"
+  ],
   "publishConfig": {
     "access": "public"
   }

--- a/packages/jsapi-shim/package.json
+++ b/packages/jsapi-shim/package.json
@@ -30,6 +30,7 @@
   "files": [
     "dist"
   ],
+  "sideEffects": false,
   "publishConfig": {
     "access": "public"
   }

--- a/packages/jsapi-types/package.json
+++ b/packages/jsapi-types/package.json
@@ -26,6 +26,7 @@
   "files": [
     "dist"
   ],
+  "sideEffects": false,
   "publishConfig": {
     "access": "public"
   }

--- a/packages/jsapi-utils/package.json
+++ b/packages/jsapi-utils/package.json
@@ -33,6 +33,7 @@
   "files": [
     "dist"
   ],
+  "sideEffects": false,
   "publishConfig": {
     "access": "public"
   }

--- a/packages/log/package.json
+++ b/packages/log/package.json
@@ -29,6 +29,7 @@
   "files": [
     "dist"
   ],
+  "sideEffects": false,
   "publishConfig": {
     "access": "public"
   }

--- a/packages/pouch-storage/package.json
+++ b/packages/pouch-storage/package.json
@@ -39,6 +39,7 @@
   "files": [
     "dist"
   ],
+  "sideEffects": false,
   "publishConfig": {
     "access": "public"
   }

--- a/packages/react-hooks/package.json
+++ b/packages/react-hooks/package.json
@@ -33,6 +33,7 @@
   "files": [
     "dist"
   ],
+  "sideEffects": false,
   "publishConfig": {
     "access": "public"
   }

--- a/packages/redux/package.json
+++ b/packages/redux/package.json
@@ -36,6 +36,7 @@
   "files": [
     "dist"
   ],
+  "sideEffects": false,
   "publishConfig": {
     "access": "public"
   }

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -34,6 +34,7 @@
   "files": [
     "dist"
   ],
+  "sideEffects": false,
   "publishConfig": {
     "access": "public"
   }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -24,6 +24,7 @@
   "files": [
     "dist"
   ],
+  "sideEffects": false,
   "publishConfig": {
     "access": "public"
   }


### PR DESCRIPTION
Fixes #1206 

@vbabich you mentioned waiting until JS API was de-globalized, but I don't think that matters. sideEffects will let tree shaking algorithms remove code that doesn't cause any mutations when imported.

Basically if you had an unused import that cannot be removed without breaking things, then that is a sideEffect. JS API stuff doesn't actually do anything but read global state which is not a sideEffect. If we had to do `import @deephaven/jsapi` to make the API load in global scope (like the non-module JS API but that's included as a script tag in the HTML), then that would be considered a sideEffect