### PR TITLE
fix: Move @deephaven/redux to be a dependency instead

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25697,12 +25697,12 @@
         "@deephaven/jsapi-bootstrap": "file:../jsapi-bootstrap",
         "@deephaven/jsapi-types": "file:../jsapi-types",
         "@deephaven/log": "file:../log",
+        "@deephaven/redux": "file:../redux",
         "@paciolan/remote-component": "2.13.0",
         "@paciolan/remote-module-loader": "^3.0.2",
         "fira": "mozilla/fira#4.202"
       },
       "devDependencies": {
-        "@deephaven/redux": "file:../redux",
         "react": "^17.x",
         "react-dom": "^17.x",
         "react-redux": "^7.x",
@@ -25712,7 +25712,6 @@
         "node": ">=16"
       },
       "peerDependencies": {
-        "@deephaven/redux": "file:../redux",
         "react": "^17.x",
         "react-dom": "^17.x",
         "react-redux": "^7.x",
@@ -26123,6 +26122,7 @@
         "@deephaven/golden-layout": "file:../golden-layout",
         "@deephaven/log": "file:../log",
         "@deephaven/react-hooks": "file:../react-hooks",
+        "@deephaven/redux": "file:../redux",
         "@deephaven/utils": "file:../utils",
         "deep-equal": "^2.0.5",
         "lodash.ismatch": "^4.1.1",
@@ -26132,7 +26132,6 @@
       },
       "devDependencies": {
         "@deephaven/mocks": "file:../mocks",
-        "@deephaven/redux": "file:../redux",
         "@deephaven/tsconfig": "file:../tsconfig",
         "@types/lodash.ismatch": "^4.4.0"
       },
@@ -26140,7 +26139,6 @@
         "node": ">=16"
       },
       "peerDependencies": {
-        "@deephaven/redux": "file:../redux",
         "react": "^17.0.0",
         "react-dom": "^17.0.0",
         "react-redux": "^7.2.4"

--- a/packages/app-utils/package.json
+++ b/packages/app-utils/package.json
@@ -22,7 +22,6 @@
     "build:babel": "babel ./src --out-dir ./dist --extensions \".ts,.tsx,.js,.jsx\" --source-maps --root-mode upward"
   },
   "devDependencies": {
-    "@deephaven/redux": "file:../redux",
     "react": "^17.x",
     "react-dom": "^17.x",
     "react-redux": "^7.x",
@@ -34,12 +33,12 @@
     "@deephaven/jsapi-bootstrap": "file:../jsapi-bootstrap",
     "@deephaven/jsapi-types": "file:../jsapi-types",
     "@deephaven/log": "file:../log",
+    "@deephaven/redux": "file:../redux",
     "@paciolan/remote-component": "2.13.0",
     "@paciolan/remote-module-loader": "^3.0.2",
     "fira": "mozilla/fira#4.202"
   },
   "peerDependencies": {
-    "@deephaven/redux": "file:../redux",
     "react": "^17.x",
     "react-dom": "^17.x",
     "react-redux": "^7.x",

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -26,6 +26,7 @@
     "@deephaven/golden-layout": "file:../golden-layout",
     "@deephaven/log": "file:../log",
     "@deephaven/react-hooks": "file:../react-hooks",
+    "@deephaven/redux": "file:../redux",
     "@deephaven/utils": "file:../utils",
     "deep-equal": "^2.0.5",
     "lodash.ismatch": "^4.1.1",
@@ -34,14 +35,12 @@
     "shortid": "^2.2.16"
   },
   "peerDependencies": {
-    "@deephaven/redux": "file:../redux",
     "react": "^17.0.0",
     "react-dom": "^17.0.0",
     "react-redux": "^7.2.4"
   },
   "devDependencies": {
     "@deephaven/mocks": "file:../mocks",
-    "@deephaven/redux": "file:../redux",
     "@deephaven/tsconfig": "file:../tsconfig",
     "@types/lodash.ismatch": "^4.4.0"
   },


### PR DESCRIPTION
- Issue when trying to do an `npm install` in another project that depended on @deephaven/dashboard, as the peerDependency would not resolve the "file:../redux" path
  - Not sure if lerna or npm should automatically be replacing those at publish time?
- Was adding redux as a peerDep because we only want one instance of the redux store; otherwise weird bugs can occur that are difficult to track down
- It was already the case with @deephaven/dashboard-core-plugins that it was just a dependency, not a peerDependency. Enterprise handled it just by doing deduplication
- Just move @deephaven/redux to be a dependency instead of a peerDependency
