### PR TITLE
fix: Restrict link parsing so it requires protocol

### DIFF
--- a/packages/console/src/monaco/MonacoUtils.test.ts
+++ b/packages/console/src/monaco/MonacoUtils.test.ts
@@ -158,17 +158,17 @@ describe('provideLinks', () => {
       getLineCount: jest.fn(() => 2),
       getLineContent: jest.fn(lineNumber =>
         lineNumber === 1
-          ? 'google.com http://www.example.com/'
+          ? 'https://google.com http://www.example.com/'
           : 'mail@gmail.com'
       ),
     } as unknown) as monaco.editor.ITextModel;
 
     const expectedValue = {
       links: [
-        { url: 'http://google.com', range: new monaco.Range(1, 1, 1, 11) },
+        { url: 'https://google.com', range: new monaco.Range(1, 1, 1, 19) },
         {
           url: 'http://www.example.com/',
-          range: new monaco.Range(1, 12, 1, 35),
+          range: new monaco.Range(1, 20, 1, 43),
         },
         { url: 'mailto:mail@gmail.com', range: new monaco.Range(2, 1, 2, 15) },
       ],

--- a/packages/console/src/monaco/MonacoUtils.ts
+++ b/packages/console/src/monaco/MonacoUtils.ts
@@ -463,7 +463,14 @@ class MonacoUtils {
 
     for (let i = 1; i <= model.getLineCount(); i += 1) {
       const lineText = model.getLineContent(i);
-      const tokens = linkifyFind(lineText);
+      const originalTokens = linkifyFind(lineText);
+
+      const tokens = originalTokens.filter(token => {
+        if (token.type === 'url') {
+          return /^https?:\/\//.test(token.value);
+        }
+        return true;
+      });
       // map the tokens to the ranges - you know the line number now, use the token start/end as the startColumn/endColumn
       tokens.forEach(token => {
         newTokens.push({

--- a/packages/grid/src/GridModel.ts
+++ b/packages/grid/src/GridModel.ts
@@ -1,10 +1,9 @@
 import { EventTarget, Event } from 'event-target-shim';
-import { find as linkifyFind } from 'linkifyjs';
 import type { IColumnHeaderGroup } from './ColumnHeaderGroup';
 import { ModelIndex } from './GridMetrics';
 import { GridColor, GridTheme, NullableGridColor } from './GridTheme';
 import memoizeClear from './memoizeClear';
-import { Token } from './GridUtils';
+import GridUtils, { Token } from './GridUtils';
 
 const LINK_TRUNCATION_LENGTH = 5000;
 
@@ -209,14 +208,7 @@ abstract class GridModel<
     (text: string, visibleLength: number): Token[] => {
       // If no text is truncated, then directly search in text
       if (visibleLength >= text.length) {
-        const tokens = linkifyFind(text);
-
-        return tokens.filter(token => {
-          if (token.type === 'url') {
-            return /^https?:\/\//.test(token.value);
-          }
-          return true;
-        });
+        return GridUtils.findTokensWithProtocolInText(text);
       }
 
       // To check for links, we should check to the first space after the truncatedText length
@@ -231,14 +223,7 @@ abstract class GridModel<
       }
       const contentToCheckForLinks = text.substring(0, lengthOfContent);
 
-      const tokens = linkifyFind(contentToCheckForLinks);
-
-      return tokens.filter(token => {
-        if (token.type === 'url') {
-          return /^https?:\/\//.test(token.value);
-        }
-        return true;
-      });
+      return GridUtils.findTokensWithProtocolInText(contentToCheckForLinks);
     }
   );
 }

--- a/packages/grid/src/GridModel.ts
+++ b/packages/grid/src/GridModel.ts
@@ -209,7 +209,14 @@ abstract class GridModel<
     (text: string, visibleLength: number): Token[] => {
       // If no text is truncated, then directly search in text
       if (visibleLength >= text.length) {
-        return linkifyFind(text);
+        const tokens = linkifyFind(text);
+
+        return tokens.filter(token => {
+          if (token.type === 'url') {
+            return /^https?:\/\//.test(token.value);
+          }
+          return true;
+        });
       }
 
       // To check for links, we should check to the first space after the truncatedText length
@@ -223,7 +230,15 @@ abstract class GridModel<
         lengthOfContent = Math.min(LINK_TRUNCATION_LENGTH, text.length);
       }
       const contentToCheckForLinks = text.substring(0, lengthOfContent);
-      return linkifyFind(contentToCheckForLinks);
+
+      const tokens = linkifyFind(contentToCheckForLinks);
+
+      return tokens.filter(token => {
+        if (token.type === 'url') {
+          return /^https?:\/\//.test(token.value);
+        }
+        return true;
+      });
     }
   );
 }

--- a/packages/grid/src/GridRenderer.test.tsx
+++ b/packages/grid/src/GridRenderer.test.tsx
@@ -107,7 +107,11 @@ describe('getTokenBoxesForVisibleCell', () => {
     renderState = makeMockGridRenderState({
       model: new MockGridModel({
         editedData: [
-          ['google.com', 'google', 'google.com youtube.com email@gmail.com'],
+          [
+            'https://google.com',
+            'google',
+            'http://google.com youtube.com email@gmail.com',
+          ],
         ],
       }),
     });
@@ -128,11 +132,11 @@ describe('getTokenBoxesForVisibleCell', () => {
 
     const expectedValue: LinkToken = {
       type: 'url',
-      value: 'google.com',
-      href: 'http://google.com',
+      value: 'https://google.com',
+      href: 'https://google.com',
       isLink: true,
       start: 0,
-      end: 10,
+      end: 18,
     };
 
     expect(tokens).not.toBeNull();
@@ -145,35 +149,27 @@ describe('getTokenBoxesForVisibleCell', () => {
     const expectedValue: LinkToken[] = [
       {
         type: 'url',
-        value: 'google.com',
+        value: 'http://google.com',
         isLink: true,
         href: 'http://google.com',
         start: 0,
-        end: 10,
+        end: 17,
       },
-      {
-        type: 'url',
-        value: 'youtube.com',
-        isLink: true,
-        href: 'http://youtube.com',
-        start: 11,
-        end: 22,
-      },
+
       {
         type: 'email',
         value: 'email@gmail.com',
         isLink: true,
         href: 'mailto:email@gmail.com',
-        start: 23,
-        end: 38,
+        start: 30,
+        end: 45,
       },
     ];
 
     expect(tokens).not.toBeNull();
-    expect(tokens?.length).toBe(3);
+    expect(tokens?.length).toBe(2);
     expect(tokens?.[0].token).toEqual(expectedValue[0]);
     expect(tokens?.[1].token).toEqual(expectedValue[1]);
-    expect(tokens?.[2].token).toEqual(expectedValue[2]);
   });
 
   it('should return empty array if there are no tokens', () => {

--- a/packages/grid/src/GridUtils.ts
+++ b/packages/grid/src/GridUtils.ts
@@ -1,5 +1,6 @@
 import React from 'react';
 import clamp from 'lodash.clamp';
+import { find as linkifyFind } from 'linkifyjs';
 import { EMPTY_ARRAY } from '@deephaven/utils';
 import GridRange, { GridRangeIndex } from './GridRange';
 import {
@@ -1438,6 +1439,22 @@ export class GridUtils {
       y2: newBottom,
       token: tokenBox.token,
     };
+  }
+
+  /**
+   * Finds tokens in text (urls, emails) that start with https:// or http://
+   * @param text The text to search in
+   * @returns An array of tokens
+   */
+  static findTokensWithProtocolInText(text: string): Token[] {
+    const tokens = linkifyFind(text);
+
+    return tokens.filter(token => {
+      if (token.type === 'url') {
+        return /^https?:\/\//.test(token.value);
+      }
+      return true;
+    });
   }
 }
 

--- a/packages/grid/src/MockGridModel.test.ts
+++ b/packages/grid/src/MockGridModel.test.ts
@@ -3,15 +3,15 @@ import MockGridModel from './MockGridModel';
 
 describe('tokensForCell', () => {
   it('should return tokens for a cell', () => {
-    const model = new MockGridModel({ editedData: [['google.com']] });
+    const model = new MockGridModel({ editedData: [['https://google.com']] });
     const expectedValue: LinkToken[] = [
       {
         type: 'url',
-        value: 'google.com',
+        value: 'https://google.com',
         isLink: true,
-        href: 'http://google.com',
+        href: 'https://google.com',
         start: 0,
-        end: 10,
+        end: 18,
       },
     ];
 
@@ -21,41 +21,34 @@ describe('tokensForCell', () => {
   });
 
   it('should return multiple tokens for a cell', () => {
-    const text = 'google.com youtube.com blah@gmail.com';
+    const text = 'https://google.com youtube.com blah@gmail.com';
     const model = new MockGridModel({ editedData: [[text]] });
     const expectedValue: LinkToken[] = [
       {
         type: 'url',
-        value: 'google.com',
+        value: 'https://google.com',
         isLink: true,
-        href: 'http://google.com',
+        href: 'https://google.com',
         start: 0,
-        end: 10,
+        end: 18,
       },
-      {
-        type: 'url',
-        value: 'youtube.com',
-        isLink: true,
-        href: 'http://youtube.com',
-        start: 11,
-        end: 22,
-      },
+
       {
         type: 'email',
         value: 'blah@gmail.com',
         isLink: true,
         href: 'mailto:blah@gmail.com',
-        start: 23,
-        end: 37,
+        start: 31,
+        end: 45,
       },
     ];
 
     const tokens = model.tokensForCell(0, 0, text.length);
-    expect(tokens).toHaveLength(3);
+    expect(tokens).toHaveLength(2);
     expect(tokens).toEqual(expectedValue);
   });
 
-  it('should an empty array for a cell with no tokens', () => {
+  it('should return an empty array for a cell with no tokens', () => {
     const text = 'google youtube';
     const model = new MockGridModel({ editedData: [[text]] });
     const expectedValue: LinkToken[] = [];


### PR DESCRIPTION
Fixes #1252 

Urls require `https://` or `http://`.