### PR TITLE
feat: Update @vscode/codicons to v0.0.33

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -91,7 +91,7 @@
         "@types/react-window": "^1.8.5",
         "@types/shell-quote": "^1.7.1",
         "@types/shortid": "0.0.29",
-        "@vscode/codicons": "0.0.32",
+        "@vscode/codicons": "0.0.33",
         "chokidar-cli": "^2.1.0",
         "cross-env": "^7.0.2",
         "eslint": "^8.29.0",
@@ -7206,9 +7206,9 @@
       }
     },
     "node_modules/@vscode/codicons": {
-      "version": "0.0.32",
-      "resolved": "https://registry.npmjs.org/@vscode/codicons/-/codicons-0.0.32.tgz",
-      "integrity": "sha512-3lgSTWhAzzWN/EPURoY4ZDBEA80OPmnaknNujA3qnI4Iu7AONWd9xF3iE4L+4prIe8E3TUnLQ4pxoaFTEEZNwg==",
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/@vscode/codicons/-/codicons-0.0.33.tgz",
+      "integrity": "sha512-VdgpnD75swH9hpXjd34VBgQ2w2quK63WljodlUcOoJDPKiV+rPjHrcUc2sjLCNKxhl6oKqmsZgwOWcDAY2GKKQ==",
       "dev": true
     },
     "node_modules/@yarnpkg/lockfile": {
@@ -32565,9 +32565,9 @@
       }
     },
     "@vscode/codicons": {
-      "version": "0.0.32",
-      "resolved": "https://registry.npmjs.org/@vscode/codicons/-/codicons-0.0.32.tgz",
-      "integrity": "sha512-3lgSTWhAzzWN/EPURoY4ZDBEA80OPmnaknNujA3qnI4Iu7AONWd9xF3iE4L+4prIe8E3TUnLQ4pxoaFTEEZNwg==",
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/@vscode/codicons/-/codicons-0.0.33.tgz",
+      "integrity": "sha512-VdgpnD75swH9hpXjd34VBgQ2w2quK63WljodlUcOoJDPKiV+rPjHrcUc2sjLCNKxhl6oKqmsZgwOWcDAY2GKKQ==",
       "dev": true
     },
     "@yarnpkg/lockfile": {

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "@types/react-window": "^1.8.5",
     "@types/shell-quote": "^1.7.1",
     "@types/shortid": "0.0.29",
-    "@vscode/codicons": "0.0.32",
+    "@vscode/codicons": "0.0.33",
     "chokidar-cli": "^2.1.0",
     "cross-env": "^7.0.2",
     "eslint": "^8.29.0",

--- a/packages/components/src/LoadingSpinner.tsx
+++ b/packages/components/src/LoadingSpinner.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import classNames from 'classnames';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { vsCircleLargeOutline, vsLoading } from '@deephaven/icons';
+import { vsCircleLarge, vsLoading } from '@deephaven/icons';
 import './LoadingSpinner.scss';
 
 type LoadingSpinnerProps = {
@@ -18,7 +18,7 @@ function LoadingSpinner({
       className={classNames('loading-spinner fa-layers', className)}
       data-testid={dataTestId}
     >
-      <FontAwesomeIcon icon={vsCircleLargeOutline} className="text-white-50" />
+      <FontAwesomeIcon icon={vsCircleLarge} className="text-white-50" />
       <FontAwesomeIcon icon={vsLoading} className="text-primary" spin />
     </div>
   );

--- a/packages/components/src/context-actions/__snapshots__/ContextActions.test.tsx.snap
+++ b/packages/components/src/context-actions/__snapshots__/ContextActions.test.tsx.snap
@@ -37,8 +37,8 @@ exports[`renders a menu from a promise returned from a function 1`] = `
         >
           <svg
             aria-hidden="true"
-            className="svg-inline--fa fa-circle-large-outline text-white-50"
-            data-icon="circle-large-outline"
+            className="svg-inline--fa fa-circle-large text-white-50"
+            data-icon="circle-large"
             data-prefix="vs"
             focusable="false"
             role="img"
@@ -206,8 +206,8 @@ exports[`renders an empty menu for a rejected promise 1`] = `
         >
           <svg
             aria-hidden="true"
-            className="svg-inline--fa fa-circle-large-outline text-white-50"
-            data-icon="circle-large-outline"
+            className="svg-inline--fa fa-circle-large text-white-50"
+            data-icon="circle-large"
             data-prefix="vs"
             focusable="false"
             role="img"

--- a/packages/dashboard-core-plugins/src/panels/ChartPanel.test.tsx
+++ b/packages/dashboard-core-plugins/src/panels/ChartPanel.test.tsx
@@ -102,7 +102,7 @@ function callErrorFunction() {
 
 function expectLoading(container) {
   expect(
-    container.querySelector("[data-icon='circle-large-outline']")
+    container.querySelector("[data-icon='circle-large']")
   ).toBeInTheDocument();
   expect(container.querySelector("[data-icon='loading']")).toBeInTheDocument();
 }

--- a/packages/dashboard-core-plugins/src/panels/IrisGridPanel.test.tsx
+++ b/packages/dashboard-core-plugins/src/panels/IrisGridPanel.test.tsx
@@ -81,7 +81,7 @@ function makeIrisGridPanelWrapper(
 async function expectLoading(container) {
   await waitFor(() =>
     expect(
-      container.querySelector("[data-icon='circle-large-outline']")
+      container.querySelector("[data-icon='circle-large']")
     ).toBeInTheDocument()
   );
   expect(container.querySelector("[data-icon='loading']")).toBeInTheDocument();


### PR DESCRIPTION
Update adds several new icons see https://github.com/microsoft/vscode-codicons/releases/tag/0.0.33 for changes.

They renamed circle-large-outline to circle-large for naming consistency. I've fixed our usage of vsCircleLargeOutline to vsCircleLarge for the renamed icon (no change in visuals).

BREAKING CHANGE: `vsCircleLargeOutline` icon renamed to `vsCircleLarge`