### PR TITLE
fix: DH-14657 Better disconnect handling

### DIFF
--- a/packages/code-studio/src/main/AppMainContainer.tsx
+++ b/packages/code-studio/src/main/AppMainContainer.tsx
@@ -948,7 +948,7 @@ export class AppMainContainer extends Component<
         />
         <DebouncedModal
           isOpen={isDisconnected && !isAuthFailed}
-          debounceMs={5000}
+          debounceMs={250}
         >
           <InfoModal
             icon={vsDebugDisconnect}

--- a/packages/code-studio/src/main/AppMainContainer.tsx
+++ b/packages/code-studio/src/main/AppMainContainer.tsx
@@ -22,6 +22,7 @@ import {
   InfoModal,
   LoadingSpinner,
   BasicModal,
+  DebouncedModal,
 } from '@deephaven/components';
 import {
   IrisGridModel,
@@ -550,14 +551,17 @@ export class AppMainContainer extends Component<
   }
 
   handleDisconnect() {
+    log.info('Disconnected from server');
     this.setState({ isDisconnected: true });
   }
 
   handleReconnect() {
+    log.info('Reconnected to server');
     this.setState({ isDisconnected: false });
   }
 
   handleReconnectAuthFailed() {
+    log.warn('Reconnect authentication failed');
     this.setState({ isAuthFailed: true });
   }
 
@@ -942,16 +946,18 @@ export class AppMainContainer extends Component<
           style={{ display: 'none' }}
           onChange={this.handleImportLayoutFiles}
         />
-        <InfoModal
-          isOpen={isDisconnected && !isAuthFailed}
-          icon={vsDebugDisconnect}
-          title={
-            <>
-              <LoadingSpinner /> Attempting to reconnect...
-            </>
-          }
-          subtitle="Please check your network connection."
-        />
+        <DebouncedModal isOpen={isDisconnected && !isAuthFailed}>
+          <InfoModal
+            isOpen={isDisconnected && !isAuthFailed}
+            icon={vsDebugDisconnect}
+            title={
+              <>
+                <LoadingSpinner /> Attempting to reconnect...
+              </>
+            }
+            subtitle="Please check your network connection."
+          />
+        </DebouncedModal>
         <BasicModal
           confirmButtonText="Refresh"
           onConfirm={AppMainContainer.handleRefresh}

--- a/packages/code-studio/src/main/AppMainContainer.tsx
+++ b/packages/code-studio/src/main/AppMainContainer.tsx
@@ -946,9 +946,11 @@ export class AppMainContainer extends Component<
           style={{ display: 'none' }}
           onChange={this.handleImportLayoutFiles}
         />
-        <DebouncedModal isOpen={isDisconnected && !isAuthFailed}>
+        <DebouncedModal
+          isOpen={isDisconnected && !isAuthFailed}
+          debounceMs={5000}
+        >
           <InfoModal
-            isOpen={isDisconnected && !isAuthFailed}
             icon={vsDebugDisconnect}
             title={
               <>

--- a/packages/components/src/modal/DebouncedModal.test.tsx
+++ b/packages/components/src/modal/DebouncedModal.test.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { DEFAULT_DEBOUNCE_MS } from '@deephaven/react-hooks';
 import { act, render, screen } from '@testing-library/react';
 import DebouncedModal from './DebouncedModal';
 import Modal from './Modal';
@@ -10,6 +9,7 @@ const children = (
     <div>{mockChildText}</div>
   </Modal>
 );
+const DEFAULT_DEBOUNCE_MS = 250;
 
 beforeAll(() => {
   jest.useFakeTimers();
@@ -22,47 +22,73 @@ afterAll(() => {
 describe('display modal after debounce', () => {
   it('should render the modal after the debounce time has passed', () => {
     const { rerender } = render(
-      <DebouncedModal isOpen={false}>{children}</DebouncedModal>
-    );
-    expect(screen.queryByTestId('debounced-modal-backdrop')).toBeNull();
-    expect(screen.queryByText(mockChildText)).toBeNull();
-
-    act(() => {
-      rerender(<DebouncedModal isOpen>{children}</DebouncedModal>);
-    });
-    expect(screen.queryByTestId('debounced-modal-backdrop')).not.toBeNull();
-    expect(screen.queryByText(mockChildText)).toBeNull();
-
-    act(() => {
-      jest.advanceTimersByTime(DEFAULT_DEBOUNCE_MS);
-    });
-    expect(screen.queryByTestId('debounced-modal-backdrop')).not.toBeNull();
-    expect(screen.queryByText(mockChildText)).not.toBeNull();
-  });
-
-  it('should not block interaction if set to false', () => {
-    const { rerender } = render(
-      <DebouncedModal isOpen={false} blockInteraction={false}>
+      <DebouncedModal isOpen={false} debounceMs={DEFAULT_DEBOUNCE_MS}>
         {children}
       </DebouncedModal>
     );
-    expect(screen.queryByTestId('debounced-modal-backdrop')).toBeNull();
-    expect(screen.queryByText(mockChildText)).toBeNull();
+    expect(
+      screen.queryByTestId('debounced-modal-backdrop')
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText(mockChildText)).not.toBeInTheDocument();
 
     act(() => {
       rerender(
-        <DebouncedModal isOpen blockInteraction={false}>
+        <DebouncedModal isOpen debounceMs={DEFAULT_DEBOUNCE_MS}>
           {children}
         </DebouncedModal>
       );
     });
-    expect(screen.queryByTestId('debounced-modal-backdrop')).toBeNull();
-    expect(screen.queryByText(mockChildText)).toBeNull();
+    expect(
+      screen.queryByTestId('debounced-modal-backdrop')
+    ).toBeInTheDocument();
+    expect(screen.queryByText(mockChildText)).not.toBeInTheDocument();
+
+    act(() => {
+      jest.advanceTimersByTime(DEFAULT_DEBOUNCE_MS);
+    });
+    expect(
+      screen.queryByTestId('debounced-modal-backdrop')
+    ).toBeInTheDocument();
+    expect(screen.queryByText(mockChildText)).toBeInTheDocument();
+  });
+
+  it('should not block interaction if set to false', () => {
+    const { rerender } = render(
+      <DebouncedModal
+        isOpen={false}
+        blockInteraction={false}
+        debounceMs={DEFAULT_DEBOUNCE_MS}
+      >
+        {children}
+      </DebouncedModal>
+    );
+    expect(
+      screen.queryByTestId('debounced-modal-backdrop')
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText(mockChildText)).not.toBeInTheDocument();
+
+    act(() => {
+      rerender(
+        <DebouncedModal
+          isOpen
+          blockInteraction={false}
+          debounceMs={DEFAULT_DEBOUNCE_MS}
+        >
+          {children}
+        </DebouncedModal>
+      );
+    });
+    expect(
+      screen.queryByTestId('debounced-modal-backdrop')
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText(mockChildText)).not.toBeInTheDocument();
 
     act(() => {
       jest.advanceTimersByTime(DEFAULT_DEBOUNCE_MS + 5);
     });
-    expect(screen.queryByTestId('debounced-modal-backdrop')).toBeNull();
-    expect(screen.queryByText(mockChildText)).not.toBeNull();
+    expect(
+      screen.queryByTestId('debounced-modal-backdrop')
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText(mockChildText)).toBeInTheDocument();
   });
 });

--- a/packages/components/src/modal/DebouncedModal.test.tsx
+++ b/packages/components/src/modal/DebouncedModal.test.tsx
@@ -2,6 +2,14 @@ import React from 'react';
 import { DEFAULT_DEBOUNCE_MS } from '@deephaven/react-hooks';
 import { act, render, screen } from '@testing-library/react';
 import DebouncedModal from './DebouncedModal';
+import Modal from './Modal';
+
+const mockChildText = 'Mock Child';
+const children = (
+  <Modal>
+    <div>{mockChildText}</div>
+  </Modal>
+);
 
 beforeAll(() => {
   jest.useFakeTimers();
@@ -13,8 +21,6 @@ afterAll(() => {
 
 describe('display modal after debounce', () => {
   it('should render the modal after the debounce time has passed', () => {
-    const mockChildText = 'Mock Child';
-    const children = <div>{mockChildText}</div>;
     const { rerender } = render(
       <DebouncedModal isOpen={false}>{children}</DebouncedModal>
     );
@@ -35,8 +41,6 @@ describe('display modal after debounce', () => {
   });
 
   it('should not block interaction if set to false', () => {
-    const mockChildText = 'Mock Child';
-    const children = <div>{mockChildText}</div>;
     const { rerender } = render(
       <DebouncedModal isOpen={false} blockInteraction={false}>
         {children}

--- a/packages/components/src/modal/DebouncedModal.test.tsx
+++ b/packages/components/src/modal/DebouncedModal.test.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { DEFAULT_DEBOUNCE_MS } from '@deephaven/react-hooks';
+import { act, render, screen } from '@testing-library/react';
+import DebouncedModal from './DebouncedModal';
+
+beforeAll(() => {
+  jest.useFakeTimers();
+});
+
+afterAll(() => {
+  jest.useRealTimers();
+});
+
+describe('display modal after debounce', () => {
+  it('should render the modal after the debounce time has passed', () => {
+    const mockChildText = 'Mock Child';
+    const children = <div>{mockChildText}</div>;
+    const { rerender } = render(
+      <DebouncedModal isOpen={false}>{children}</DebouncedModal>
+    );
+    expect(screen.queryByTestId('debounced-modal-backdrop')).toBeNull();
+    expect(screen.queryByText(mockChildText)).toBeNull();
+
+    act(() => {
+      rerender(<DebouncedModal isOpen>{children}</DebouncedModal>);
+    });
+    expect(screen.queryByTestId('debounced-modal-backdrop')).not.toBeNull();
+    expect(screen.queryByText(mockChildText)).toBeNull();
+
+    act(() => {
+      jest.advanceTimersByTime(DEFAULT_DEBOUNCE_MS);
+    });
+    expect(screen.queryByTestId('debounced-modal-backdrop')).not.toBeNull();
+    expect(screen.queryByText(mockChildText)).not.toBeNull();
+  });
+
+  it('should not block interaction if set to false', () => {
+    const mockChildText = 'Mock Child';
+    const children = <div>{mockChildText}</div>;
+    const { rerender } = render(
+      <DebouncedModal isOpen={false} blockInteraction={false}>
+        {children}
+      </DebouncedModal>
+    );
+    expect(screen.queryByTestId('debounced-modal-backdrop')).toBeNull();
+    expect(screen.queryByText(mockChildText)).toBeNull();
+
+    act(() => {
+      rerender(
+        <DebouncedModal isOpen blockInteraction={false}>
+          {children}
+        </DebouncedModal>
+      );
+    });
+    expect(screen.queryByTestId('debounced-modal-backdrop')).toBeNull();
+    expect(screen.queryByText(mockChildText)).toBeNull();
+
+    act(() => {
+      jest.advanceTimersByTime(DEFAULT_DEBOUNCE_MS + 5);
+    });
+    expect(screen.queryByTestId('debounced-modal-backdrop')).toBeNull();
+    expect(screen.queryByText(mockChildText)).not.toBeNull();
+  });
+});

--- a/packages/components/src/modal/DebouncedModal.tsx
+++ b/packages/components/src/modal/DebouncedModal.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { DEFAULT_DEBOUNCE_MS, useDebouncedValue } from '@deephaven/react-hooks';
+import { useDebouncedValue } from '@deephaven/react-hooks';
 
 export type DebouncedModalProps = {
   /** Whether to block interaction immediately */
@@ -9,7 +9,7 @@ export type DebouncedModalProps = {
   children: React.ReactElement;
 
   /** Time to debounce */
-  debounceMs?: number;
+  debounceMs: number;
 
   /**
    * Will render the `children` `debounceMs` after `isOpen` is set to `true.
@@ -25,7 +25,7 @@ export type DebouncedModalProps = {
 function DebouncedModal({
   blockInteraction = true,
   children,
-  debounceMs = DEFAULT_DEBOUNCE_MS,
+  debounceMs,
   isOpen = false,
 }: DebouncedModalProps) {
   const debouncedIsOpen = useDebouncedValue(isOpen, debounceMs);

--- a/packages/components/src/modal/DebouncedModal.tsx
+++ b/packages/components/src/modal/DebouncedModal.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { DEFAULT_DEBOUNCE_MS, useDebouncedValue } from '@deephaven/react-hooks';
+
+export type DebouncedModalProps = {
+  /** Whether to block interaction immediately */
+  blockInteraction?: boolean;
+
+  /** Children to render after the alloted debounce time */
+  children: React.ReactNode;
+
+  /** Time to debounce */
+  debounceMs?: number;
+
+  /**
+   * Will render the `children` `debounceMs` after `isOpen` is set to `true.
+   * Will stop rendering immediately after `isOpen` is set to `false`.
+   */
+  isOpen: boolean;
+};
+
+/**
+ * Display a modal after a debounce time. Blocks the screen from interaction immediately,
+ * but then waits the set debounce time before rendering the modal.
+ */
+function DebouncedModal({
+  blockInteraction = true,
+  children,
+  debounceMs = DEFAULT_DEBOUNCE_MS,
+  isOpen,
+}: DebouncedModalProps) {
+  const debouncedIsOpen = useDebouncedValue(isOpen, debounceMs);
+
+  return (
+    <>
+      {blockInteraction && isOpen && (
+        <div
+          className="modal-backdrop transparent"
+          data-testid="debounced-modal-backdrop"
+        />
+      )}
+      {isOpen && debouncedIsOpen && children}
+    </>
+  );
+}
+
+export default DebouncedModal;

--- a/packages/components/src/modal/DebouncedModal.tsx
+++ b/packages/components/src/modal/DebouncedModal.tsx
@@ -6,7 +6,7 @@ export type DebouncedModalProps = {
   blockInteraction?: boolean;
 
   /** Children to render after the alloted debounce time */
-  children: React.ReactNode;
+  children: React.ReactElement;
 
   /** Time to debounce */
   debounceMs?: number;
@@ -15,7 +15,7 @@ export type DebouncedModalProps = {
    * Will render the `children` `debounceMs` after `isOpen` is set to `true.
    * Will stop rendering immediately after `isOpen` is set to `false`.
    */
-  isOpen: boolean;
+  isOpen?: boolean;
 };
 
 /**
@@ -26,7 +26,7 @@ function DebouncedModal({
   blockInteraction = true,
   children,
   debounceMs = DEFAULT_DEBOUNCE_MS,
-  isOpen,
+  isOpen = false,
 }: DebouncedModalProps) {
   const debouncedIsOpen = useDebouncedValue(isOpen, debounceMs);
 
@@ -34,11 +34,12 @@ function DebouncedModal({
     <>
       {blockInteraction && isOpen && (
         <div
-          className="modal-backdrop transparent"
+          className="modal-backdrop"
+          style={{ backgroundColor: 'transparent' }}
           data-testid="debounced-modal-backdrop"
         />
       )}
-      {isOpen && debouncedIsOpen && children}
+      {React.cloneElement(children, { isOpen: isOpen && debouncedIsOpen })}
     </>
   );
 }

--- a/packages/components/src/modal/InfoModal.tsx
+++ b/packages/components/src/modal/InfoModal.tsx
@@ -6,13 +6,26 @@ import ModalBody from './ModalBody';
 import './InfoModal.scss';
 
 type InfoModalProps = {
+  /** Class name to give the info modal */
   className?: string;
+
+  /** Icon to display in the modal */
   icon?: IconProp;
+
+  /** Title to display in the modal */
   title: React.ReactNode;
+
+  /** Subtitle/detail to display in the modal */
   subtitle?: React.ReactNode;
+
+  /** Whether the modal is open/visible or not. */
   isOpen: boolean;
 };
 
+/**
+ * A modal that displays a message with an icon. Can be used for informational messages, warnings, or errors.
+ * Does not have any buttons and cannot be dismissed.
+ */
 function InfoModal({
   className,
   icon,

--- a/packages/components/src/modal/InfoModal.tsx
+++ b/packages/components/src/modal/InfoModal.tsx
@@ -19,7 +19,7 @@ type InfoModalProps = {
   subtitle?: React.ReactNode;
 
   /** Whether the modal is open/visible or not. */
-  isOpen: boolean;
+  isOpen?: boolean;
 };
 
 /**
@@ -29,7 +29,7 @@ type InfoModalProps = {
 function InfoModal({
   className,
   icon,
-  isOpen,
+  isOpen = false,
   subtitle,
   title,
 }: InfoModalProps): JSX.Element {

--- a/packages/components/src/modal/index.ts
+++ b/packages/components/src/modal/index.ts
@@ -1,3 +1,4 @@
+export { default as DebouncedModal } from './DebouncedModal';
 export { default as InfoModal } from './InfoModal';
 export { default as Modal } from './Modal';
 export { default as ModalBody } from './ModalBody';

--- a/packages/react-hooks/src/index.ts
+++ b/packages/react-hooks/src/index.ts
@@ -7,3 +7,4 @@ export type {
   UsePromiseFactoryOptions,
   UsePromiseFactoryResult,
 } from './usePromiseFactory';
+export * from './useDebouncedValue';

--- a/packages/react-hooks/src/useDebouncedValue.test.ts
+++ b/packages/react-hooks/src/useDebouncedValue.test.ts
@@ -1,6 +1,7 @@
 import { act, renderHook } from '@testing-library/react-hooks';
-import useDebouncedValue, { DEFAULT_DEBOUNCE_MS } from './useDebouncedValue';
+import useDebouncedValue from './useDebouncedValue';
 
+const DEFAULT_DEBOUNCE_MS = 100;
 beforeEach(() => {
   jest.useFakeTimers();
 });
@@ -11,26 +12,32 @@ afterAll(() => {
 
 it('should return the initial value', () => {
   const value = 'mock value';
-  const { result } = renderHook(() => useDebouncedValue(value));
+  const { result } = renderHook(() =>
+    useDebouncedValue(value, DEFAULT_DEBOUNCE_MS)
+  );
   expect(result.current).toBe(value);
 });
 
 it('should return the initial value after the debounce time has elapsed', () => {
   const value = 'mock value';
-  const { result, rerender } = renderHook(() => useDebouncedValue(value));
+  const { result, rerender } = renderHook(() =>
+    useDebouncedValue(value, DEFAULT_DEBOUNCE_MS)
+  );
   expect(result.current).toBe(value);
+  expect(result.all.length).toBe(1);
   rerender();
   act(() => {
     jest.advanceTimersByTime(DEFAULT_DEBOUNCE_MS);
   });
   expect(result.current).toBe(value);
+  expect(result.all.length).toBe(2);
 });
 
 it('should return the updated value after the debounce time has elapsed', () => {
   const value = 'mock value';
   const newValue = 'mock new value';
   const { result, rerender } = renderHook((val = value) =>
-    useDebouncedValue(val)
+    useDebouncedValue(val, DEFAULT_DEBOUNCE_MS)
   );
   expect(result.current).toBe(value);
   rerender(newValue);
@@ -45,7 +52,7 @@ it('should not return an intermediate value if the debounce time has not elapsed
   const intermediateValue = 'mock intermediate value';
   const newValue = 'mock new value';
   const { result, rerender } = renderHook((val = value) =>
-    useDebouncedValue(val)
+    useDebouncedValue(val, DEFAULT_DEBOUNCE_MS)
   );
   expect(result.current).toBe(value);
   rerender(intermediateValue);

--- a/packages/react-hooks/src/useDebouncedValue.test.ts
+++ b/packages/react-hooks/src/useDebouncedValue.test.ts
@@ -21,7 +21,7 @@ it('should return the initial value after the debounce time has elapsed', () => 
   expect(result.current).toBe(value);
   rerender();
   act(() => {
-    jest.advanceTimersByTime(DEFAULT_DEBOUNCE_MS + 5);
+    jest.advanceTimersByTime(DEFAULT_DEBOUNCE_MS);
   });
   expect(result.current).toBe(value);
 });
@@ -35,7 +35,7 @@ it('should return the updated value after the debounce time has elapsed', () => 
   expect(result.current).toBe(value);
   rerender(newValue);
   act(() => {
-    jest.advanceTimersByTime(DEFAULT_DEBOUNCE_MS + 5);
+    jest.advanceTimersByTime(DEFAULT_DEBOUNCE_MS);
   });
   expect(result.current).toBe(newValue);
 });
@@ -59,7 +59,7 @@ it('should not return an intermediate value if the debounce time has not elapsed
   });
   expect(result.current).toBe(value);
   act(() => {
-    jest.advanceTimersByTime(DEFAULT_DEBOUNCE_MS + 5);
+    jest.advanceTimersByTime(DEFAULT_DEBOUNCE_MS);
   });
   expect(result.current).toBe(newValue);
 });

--- a/packages/react-hooks/src/useDebouncedValue.test.ts
+++ b/packages/react-hooks/src/useDebouncedValue.test.ts
@@ -9,45 +9,57 @@ afterAll(() => {
   jest.useRealTimers();
 });
 
-// it('should return the initial value', () => {
-//   const value = 'mock value';
-//   const { result } = renderHook(() => useDebouncedValue(value));
-//   expect(result.current).toBe(value);
-// });
+it('should return the initial value', () => {
+  const value = 'mock value';
+  const { result } = renderHook(() => useDebouncedValue(value));
+  expect(result.current).toBe(value);
+});
 
-// it('should return the initial value after the debounce time has elapsed', () => {
-//   const value = 'mock value';
-//   const { result, rerender } = renderHook(() => useDebouncedValue(value));
-//   expect(result.current).toBe(value);
-//   rerender();
-//   jest.advanceTimersByTime(DEFAULT_DEBOUNCE_MS + 5);
-//   expect(result.current).toBe(value);
-// });
+it('should return the initial value after the debounce time has elapsed', () => {
+  const value = 'mock value';
+  const { result, rerender } = renderHook(() => useDebouncedValue(value));
+  expect(result.current).toBe(value);
+  rerender();
+  act(() => {
+    jest.advanceTimersByTime(DEFAULT_DEBOUNCE_MS + 5);
+  });
+  expect(result.current).toBe(value);
+});
 
-it('should return the updated value after the debounce time has elapsed', async () => {
+it('should return the updated value after the debounce time has elapsed', () => {
   const value = 'mock value';
   const newValue = 'mock new value';
-  const {
-    result,
-    rerender,
-    waitForNextUpdate,
-  } = renderHook(({ val = value } = {}) => useDebouncedValue(val));
+  const { result, rerender } = renderHook((val = value) =>
+    useDebouncedValue(val)
+  );
   expect(result.current).toBe(value);
-  console.log('MJB rerendering new value');
   rerender(newValue);
-  jest.advanceTimersByTime(DEFAULT_DEBOUNCE_MS + 5);
-  console.log('MJB after timers');
-  await waitForNextUpdate();
+  act(() => {
+    jest.advanceTimersByTime(DEFAULT_DEBOUNCE_MS + 5);
+  });
   expect(result.current).toBe(newValue);
 });
 
-// it('should not return an intermediate value if the debounce time has not elapsed', () => {
-//   const value = 'mock value';
-//   const intermediateValue = 'mock intermediate value';
-//   const newValue = 'mock new value';
-//   const { result, rerender } = renderHook(() => useDebouncedValue(value));
-//   expect(result.current).toBe(value);
-//   rerender(newValue);
-//   jest.advanceTimersByTime(DEFAULT_DEBOUNCE_MS + 5);
-//   expect(result.current).toBe(newValue);
-// });
+it('should not return an intermediate value if the debounce time has not elapsed', () => {
+  const value = 'mock value';
+  const intermediateValue = 'mock intermediate value';
+  const newValue = 'mock new value';
+  const { result, rerender } = renderHook((val = value) =>
+    useDebouncedValue(val)
+  );
+  expect(result.current).toBe(value);
+  rerender(intermediateValue);
+  act(() => {
+    jest.advanceTimersByTime(DEFAULT_DEBOUNCE_MS - 5);
+  });
+  expect(result.current).toBe(value);
+  rerender(newValue);
+  act(() => {
+    jest.advanceTimersByTime(DEFAULT_DEBOUNCE_MS - 5);
+  });
+  expect(result.current).toBe(value);
+  act(() => {
+    jest.advanceTimersByTime(DEFAULT_DEBOUNCE_MS + 5);
+  });
+  expect(result.current).toBe(newValue);
+});

--- a/packages/react-hooks/src/useDebouncedValue.test.ts
+++ b/packages/react-hooks/src/useDebouncedValue.test.ts
@@ -1,0 +1,53 @@
+import { act, renderHook } from '@testing-library/react-hooks';
+import useDebouncedValue, { DEFAULT_DEBOUNCE_MS } from './useDebouncedValue';
+
+beforeEach(() => {
+  jest.useFakeTimers();
+});
+
+afterAll(() => {
+  jest.useRealTimers();
+});
+
+// it('should return the initial value', () => {
+//   const value = 'mock value';
+//   const { result } = renderHook(() => useDebouncedValue(value));
+//   expect(result.current).toBe(value);
+// });
+
+// it('should return the initial value after the debounce time has elapsed', () => {
+//   const value = 'mock value';
+//   const { result, rerender } = renderHook(() => useDebouncedValue(value));
+//   expect(result.current).toBe(value);
+//   rerender();
+//   jest.advanceTimersByTime(DEFAULT_DEBOUNCE_MS + 5);
+//   expect(result.current).toBe(value);
+// });
+
+it('should return the updated value after the debounce time has elapsed', async () => {
+  const value = 'mock value';
+  const newValue = 'mock new value';
+  const {
+    result,
+    rerender,
+    waitForNextUpdate,
+  } = renderHook(({ val = value } = {}) => useDebouncedValue(val));
+  expect(result.current).toBe(value);
+  console.log('MJB rerendering new value');
+  rerender(newValue);
+  jest.advanceTimersByTime(DEFAULT_DEBOUNCE_MS + 5);
+  console.log('MJB after timers');
+  await waitForNextUpdate();
+  expect(result.current).toBe(newValue);
+});
+
+// it('should not return an intermediate value if the debounce time has not elapsed', () => {
+//   const value = 'mock value';
+//   const intermediateValue = 'mock intermediate value';
+//   const newValue = 'mock new value';
+//   const { result, rerender } = renderHook(() => useDebouncedValue(value));
+//   expect(result.current).toBe(value);
+//   rerender(newValue);
+//   jest.advanceTimersByTime(DEFAULT_DEBOUNCE_MS + 5);
+//   expect(result.current).toBe(newValue);
+// });

--- a/packages/react-hooks/src/useDebouncedValue.ts
+++ b/packages/react-hooks/src/useDebouncedValue.ts
@@ -12,16 +12,12 @@ export function useDebouncedValue<T>(
   value: T,
   debounceMs = DEFAULT_DEBOUNCE_MS
 ) {
-  console.log('render', value);
   const [debouncedValue, setDebouncedValue] = useState<T>(value);
   useEffect(() => {
-    console.log('MJB setting timeout', value);
     const timeoutId = setTimeout(() => {
-      console.log('MJB setting debounced value');
       setDebouncedValue(value);
     }, debounceMs);
     return () => {
-      console.log('MJB clearing timeout');
       clearTimeout(timeoutId);
     };
   }, [value, debounceMs]);

--- a/packages/react-hooks/src/useDebouncedValue.ts
+++ b/packages/react-hooks/src/useDebouncedValue.ts
@@ -3,7 +3,9 @@ import { useEffect, useState } from 'react';
 export const DEFAULT_DEBOUNCE_MS = 250;
 
 /**
- * Debounces a value. Returns the value after the debounce time has elapsed.
+ * Debounces a value.
+ * Returns the initial value immediately.
+ * Returns the latest value after no changes have occurred for the debounce duration.
  * @param value Value to debounce
  * @param debounceMs Amount of time to debounce
  * @returns The debounced value

--- a/packages/react-hooks/src/useDebouncedValue.ts
+++ b/packages/react-hooks/src/useDebouncedValue.ts
@@ -1,7 +1,5 @@
 import { useEffect, useState } from 'react';
 
-export const DEFAULT_DEBOUNCE_MS = 250;
-
 /**
  * Debounces a value.
  * Returns the initial value immediately.
@@ -10,10 +8,7 @@ export const DEFAULT_DEBOUNCE_MS = 250;
  * @param debounceMs Amount of time to debounce
  * @returns The debounced value
  */
-export function useDebouncedValue<T>(
-  value: T,
-  debounceMs = DEFAULT_DEBOUNCE_MS
-) {
+export function useDebouncedValue<T>(value: T, debounceMs: number) {
   const [debouncedValue, setDebouncedValue] = useState<T>(value);
   useEffect(() => {
     const timeoutId = setTimeout(() => {

--- a/packages/react-hooks/src/useDebouncedValue.ts
+++ b/packages/react-hooks/src/useDebouncedValue.ts
@@ -1,0 +1,32 @@
+import { useEffect, useState } from 'react';
+
+export const DEFAULT_DEBOUNCE_MS = 250;
+
+/**
+ * Debounces a value. Returns the value after the debounce time has elapsed.
+ * @param value Value to debounce
+ * @param debounceMs Amount of time to debounce
+ * @returns The debounced value
+ */
+export function useDebouncedValue<T>(
+  value: T,
+  debounceMs = DEFAULT_DEBOUNCE_MS
+) {
+  console.log('render', value);
+  const [debouncedValue, setDebouncedValue] = useState<T>(value);
+  useEffect(() => {
+    console.log('MJB setting timeout', value);
+    const timeoutId = setTimeout(() => {
+      console.log('MJB setting debounced value');
+      setDebouncedValue(value);
+    }, debounceMs);
+    return () => {
+      console.log('MJB clearing timeout');
+      clearTimeout(timeoutId);
+    };
+  }, [value, debounceMs]);
+
+  return debouncedValue;
+}
+
+export default useDebouncedValue;


### PR DESCRIPTION
- In some cases, the API disconnects and the reconnects almost immediately afterwards, causing the "Reconnecting..." modal to appear and be distracting
- Rather than have the API lie about whether it's connected or not, UI debounces when it displays the modal, just blocking interaction with a transparent modal for the duration of the disconnection if it reconnects immediately
- Also added logging so we can see when connected/disconnected, in case this is further observed
- Tested using the steps in #1149 , and also manually setting the `debounceMs` to `5000` to be able to react to it