### PR TITLE
feat: remove click handler setting onTabContentFocusIn

### DIFF
--- a/packages/golden-layout/src/controls/Tab.ts
+++ b/packages/golden-layout/src/controls/Tab.ts
@@ -184,7 +184,9 @@ export default class Tab {
     // being erroneously marked as focused if the user's DOM element
     // is removed and they click another tab. To prevent this, we
     // remove existing "lm_focusin" classes first.
-    $('lm_focusin').removeClass('lm_focusin');
+    $('.lm_focusin', this._layoutManager.root.element).removeClass(
+      'lm_focusin'
+    );
 
     this.element.addClass('lm_focusin');
   }

--- a/packages/golden-layout/src/controls/Tab.ts
+++ b/packages/golden-layout/src/controls/Tab.ts
@@ -83,11 +83,6 @@ export default class Tab {
       this.contentItem.container._contentElement
         .on('focusin', this._onTabContentFocusIn)
         .on('focusout', this._onTabContentFocusOut);
-      this.contentItem.container._contentElement[0].addEventListener(
-        'click',
-        this._onTabContentFocusIn,
-        true // capture, so it occurs before onClick from react events
-      );
 
       this.contentItem.container.tab = this;
       this.contentItem.container.emit('tab', this);
@@ -181,25 +176,16 @@ export default class Tab {
 
   /**
    * Callback when the contentItem is focused in
-   *
-   * Why [0].focus():
-   * https://github.com/jquery/jquery/commit/fe5f04de8fde9c69ed48283b99280aa6df3795c7
-   * From jquery source: "If this is an inner synthetic event for an event with a bubbling surrogate (focus or blur),
-   * assume that the surrogate already propagated from triggering the native event and prevent that from happening
-   * again here. This technically gets the ordering wrong w.r.t. to `.trigger()` (in which the bubbling surrogate
-   * propagates *after* the non-bubbling base), but that seems less bad than duplication."
    */
   _onTabContentFocusIn() {
-    if (
-      isComponent(this.contentItem) &&
-      !this.contentItem.container._contentElement[0].contains(
-        document.activeElement
-      )
-    ) {
-      // jquery 3.4.0 and later, jquery method optimizes out the focus from
-      // happening in proper order. Can use HTMLElement.focus() to avoid.
-      this.contentItem.container._contentElement[0].focus(); // [0] needed to use dom focus, not jquery method
-    }
+    // Ensure only one tab is marked as having focus at a time.
+    // In Firefox, if the focused element is removed from the DOM,
+    // the focusout event won't trigger. This can result in two tabs
+    // being erroneously marked as focused if the user's DOM element
+    // is removed and they click another tab. To prevent this, we
+    // remove existing "lm_focusin" classes first.
+    $('lm_focusin').removeClass('lm_focusin');
+
     this.element.addClass('lm_focusin');
   }
 


### PR DESCRIPTION
OnTabContentFocusIn is used to set a class on the tab to highlight which tab currently has focus so the user knows where any keyboard input or shortcuts used will be applied. This was being set by both focusin and any clicks inside the tab, with clicks triggering an addtional call to focus.

Both handlers were commited at the same time, but I can't think of any reason we were actually setting the focus on click. The click itsellf should do that. My best guess is tabindex=-1 wasn't on the parent at the time (during development as it was also added in the same commit) or maybe browser support at the time? It all came in under one commit.

I have tested in chrome (win & mac), firefox (win) and safari (mac) and clicking on or anywher within any panel (tables, plots, one clicks, console, notebooks, log panel, command history, file exporer) all still set the focus as expected.

Additionally I addressed a firefox edge case around focus and an item being removed from the dom.