### PR TITLE
fix: DH-14732: Cherry-pick arrow keys not selecting next autocomplete item in console

### DIFF
--- a/packages/console/src/ConsoleInput.jsx
+++ b/packages/console/src/ConsoleInput.jsx
@@ -162,7 +162,11 @@ export class ConsoleInput extends PureComponent {
       const { commandEditor, commandHistoryIndex } = this;
       const { lineNumber } = commandEditor.getPosition();
       const model = commandEditor.getModel();
-      if (keyEvent.keyCode === monaco.KeyCode.UpArrow && lineNumber === 1) {
+      if (
+        keyEvent.keyCode === monaco.KeyCode.UpArrow &&
+        !this.isSuggestionMenuPopulated() &&
+        lineNumber === 1
+      ) {
         if (commandHistoryIndex != null) {
           this.loadCommand(commandHistoryIndex + 1);
         } else {
@@ -178,6 +182,7 @@ export class ConsoleInput extends PureComponent {
 
       if (
         keyEvent.keyCode === monaco.KeyCode.DownArrow &&
+        !this.isSuggestionMenuPopulated() &&
         lineNumber === model.getLineCount()
       ) {
         if (commandHistoryIndex != null && commandHistoryIndex > 0) {


### PR DESCRIPTION
Cherry pick of #629

When there is autocomplete in the console, the up/down arrows were not cycling through the suggestions

You can use this docker-compose.yml config and run with `VERSION=0.13.0 docker compose up`

```
version: "3.4"

services:
  server:
    image: ghcr.io/deephaven/server:${VERSION:-latest}
    expose:
      - '8080'
    volumes:
      - ./data:/data
      - api-cache:/cache
    environment:
      - JAVA_TOOL_OPTIONS=-Xmx4g -Ddeephaven.console.type=python

  web:
    image: ghcr.io/deephaven/web:${VERSION:-latest}
    expose:
      - '80'
    volumes:
      - ./data:/data
      - web-tmp:/tmp

  grpc-proxy:
    image: ghcr.io/deephaven/grpc-proxy:${VERSION:-latest}
    environment:
      - BACKEND_ADDR=server:8080
    depends_on:
      - server
    expose:
      - '8080'

  envoy:
    image: ghcr.io/deephaven/envoy:${VERSION:-latest}
    depends_on:
      - web
      - grpc-proxy
      - server
    ports:
      - "${DEEPHAVEN_PORT:-10000}:10000"

volumes:
    web-tmp:
    api-cache:
```