### PR TITLE
chore: test: Change import to import type, jsapi-shim to jsapi-types where possible

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26198,7 +26198,6 @@
         "@deephaven/icons": "file:../icons",
         "@deephaven/iris-grid": "file:../iris-grid",
         "@deephaven/jsapi-bootstrap": "file:../jsapi-bootstrap",
-        "@deephaven/jsapi-shim": "file:../jsapi-shim",
         "@deephaven/jsapi-types": "file:../jsapi-types",
         "@deephaven/jsapi-utils": "file:../jsapi-utils",
         "@deephaven/log": "file:../log",
@@ -26223,6 +26222,7 @@
         "shortid": "^2.2.16"
       },
       "devDependencies": {
+        "@deephaven/jsapi-shim": "file:../jsapi-shim",
         "@deephaven/mocks": "file:../mocks",
         "@deephaven/tsconfig": "file:../tsconfig"
       },
@@ -26774,7 +26774,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@deephaven/filters": "file:../filters",
-        "@deephaven/jsapi-shim": "file:../jsapi-shim",
         "@deephaven/jsapi-types": "file:../jsapi-types",
         "@deephaven/log": "file:../log",
         "@deephaven/utils": "file:../utils",
@@ -26783,6 +26782,7 @@
         "shortid": "^2.2.16"
       },
       "devDependencies": {
+        "@deephaven/jsapi-shim": "file:../jsapi-shim",
         "@deephaven/tsconfig": "file:../tsconfig"
       },
       "engines": {

--- a/packages/app-utils/src/components/AppBootstrap.test.tsx
+++ b/packages/app-utils/src/components/AppBootstrap.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { AUTH_HANDLER_TYPE_ANONYMOUS } from '@deephaven/auth-plugins';
 import { ApiContext } from '@deephaven/jsapi-bootstrap';
 import { BROADCAST_LOGIN_MESSAGE } from '@deephaven/jsapi-utils';
-import {
+import type {
   CoreClient,
   IdeConnection,
   dh as DhType,

--- a/packages/app-utils/src/utils/ConnectUtils.ts
+++ b/packages/app-utils/src/utils/ConnectUtils.ts
@@ -1,4 +1,4 @@
-import { ConnectOptions } from '@deephaven/jsapi-types';
+import type { ConnectOptions } from '@deephaven/jsapi-types';
 
 /**
  * Get the base URL of the API

--- a/packages/auth-plugins/src/AuthPluginAnonymous.test.tsx
+++ b/packages/auth-plugins/src/AuthPluginAnonymous.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { act, render, screen } from '@testing-library/react';
 import { ApiContext, ClientContext } from '@deephaven/jsapi-bootstrap';
 import { dh } from '@deephaven/jsapi-shim';
-import { CoreClient } from '@deephaven/jsapi-types';
+import type { CoreClient } from '@deephaven/jsapi-types';
 import AuthPluginAnonymous from './AuthPluginAnonymous';
 import { AUTH_HANDLER_TYPE_ANONYMOUS as AUTH_TYPE } from './AuthHandlerTypes';
 import { AuthConfigMap } from './AuthPlugin';

--- a/packages/auth-plugins/src/AuthPluginBase.test.tsx
+++ b/packages/auth-plugins/src/AuthPluginBase.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { act, render, screen } from '@testing-library/react';
 import { ClientContext } from '@deephaven/jsapi-bootstrap';
-import { CoreClient } from '@deephaven/jsapi-types';
+import type { CoreClient } from '@deephaven/jsapi-types';
 import { TestUtils } from '@deephaven/utils';
 import AuthPluginBase from './AuthPluginBase';
 

--- a/packages/auth-plugins/src/AuthPluginBase.tsx
+++ b/packages/auth-plugins/src/AuthPluginBase.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { LoadingOverlay } from '@deephaven/components';
 import { useClient } from '@deephaven/jsapi-bootstrap';
 import Log from '@deephaven/log';
-import { LoginOptions } from '@deephaven/jsapi-types';
+import type { LoginOptions } from '@deephaven/jsapi-types';
 import { CanceledPromiseError, getErrorMessage } from '@deephaven/utils';
 import AuthenticationError from './AuthenticationError';
 

--- a/packages/auth-plugins/src/AuthPluginParent.test.tsx
+++ b/packages/auth-plugins/src/AuthPluginParent.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { act, render, screen } from '@testing-library/react';
 import { ApiContext, ClientContext } from '@deephaven/jsapi-bootstrap';
 import { dh } from '@deephaven/jsapi-shim';
-import { CoreClient, LoginOptions } from '@deephaven/jsapi-types';
+import type { CoreClient, LoginOptions } from '@deephaven/jsapi-types';
 import AuthPluginParent from './AuthPluginParent';
 import { AuthConfigMap } from './AuthPlugin';
 

--- a/packages/auth-plugins/src/AuthPluginParent.tsx
+++ b/packages/auth-plugins/src/AuthPluginParent.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { LoginOptions } from '@deephaven/jsapi-types';
+import type { LoginOptions } from '@deephaven/jsapi-types';
 import {
   LOGIN_OPTIONS_REQUEST,
   requestParentResponse,

--- a/packages/auth-plugins/src/AuthPluginPsk.test.tsx
+++ b/packages/auth-plugins/src/AuthPluginPsk.test.tsx
@@ -4,7 +4,7 @@ import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ApiContext, ClientContext } from '@deephaven/jsapi-bootstrap';
 import { dh } from '@deephaven/jsapi-shim';
-import { CoreClient } from '@deephaven/jsapi-types';
+import type { CoreClient } from '@deephaven/jsapi-types';
 import AuthPluginPsk from './AuthPluginPsk';
 import { AUTH_HANDLER_TYPE_PSK as AUTH_TYPE } from './AuthHandlerTypes';
 import { AuthConfigMap } from './AuthPlugin';

--- a/packages/chart/src/ChartTestUtils.ts
+++ b/packages/chart/src/ChartTestUtils.ts
@@ -1,10 +1,11 @@
-import dh, {
+import dh from '@deephaven/jsapi-shim';
+import type {
   Axis,
   Chart,
   Figure,
   Series,
   SeriesDataSource,
-} from '@deephaven/jsapi-shim';
+} from '@deephaven/jsapi-types';
 
 class ChartTestUtils {
   static DEFAULT_CHART_TITLE = 'Chart Title';

--- a/packages/chart/src/ChartTestUtils.ts
+++ b/packages/chart/src/ChartTestUtils.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   AxisFormatType,
   AxisPosition,
   AxisType,

--- a/packages/chart/src/ChartTestUtils.ts
+++ b/packages/chart/src/ChartTestUtils.ts
@@ -1,12 +1,10 @@
 import type {
+  Axis,
   AxisFormatType,
   AxisPosition,
   AxisType,
-  dh as DhType,
-} from '@deephaven/jsapi-types';
-import type {
-  Axis,
   Chart,
+  dh as DhType,
   Figure,
   Series,
   SeriesDataSource,

--- a/packages/chart/src/ChartTestUtils.ts
+++ b/packages/chart/src/ChartTestUtils.ts
@@ -1,4 +1,9 @@
-import dh from '@deephaven/jsapi-shim';
+import {
+  AxisFormatType,
+  AxisPosition,
+  AxisType,
+  dh as DhType,
+} from '@deephaven/jsapi-types';
 import type {
   Axis,
   Chart,
@@ -16,73 +21,85 @@ class ChartTestUtils {
 
   static DEFAULT_SERIES_NAME = 'MySeries';
 
-  static makeAxis({
+  private dh: DhType;
+
+  constructor(dh: DhType) {
+    this.dh = dh;
+  }
+
+  makeAxis({
     label = 'Axis',
-    type = dh.plot.AxisType.X,
-    position = dh.plot.AxisPosition.BOTTOM,
-    formatType = dh.Axis.FORMAT_TYPE_NUMBER,
+    type = undefined,
+    position = undefined,
+    formatType = undefined,
     formatPattern = '###,###0.00',
     log = false,
+  }: {
+    label?: string;
+    type?: AxisType;
+    position?: AxisPosition;
+    formatType?: AxisFormatType;
+    formatPattern?: string;
+    log?: boolean;
   } = {}): Axis {
+    const { dh } = this;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     return new (dh as any).Axis({
       label,
-      type,
-      position,
-      formatType,
+      type: type ?? dh.plot.AxisType.X,
+      position: position ?? dh.plot.AxisPosition.BOTTOM,
+      formatType: formatType ?? dh.Axis.FORMAT_TYPE_NUMBER,
       formatPattern,
       log,
     });
   }
 
-  static makeDefaultAxes(): Axis[] {
+  makeDefaultAxes(): Axis[] {
+    const { dh } = this;
     return [
-      ChartTestUtils.makeAxis({
+      this.makeAxis({
         label: ChartTestUtils.DEFAULT_X_TITLE,
         type: dh.plot.AxisType.X,
       }),
-      ChartTestUtils.makeAxis({
+      this.makeAxis({
         label: ChartTestUtils.DEFAULT_Y_TITLE,
         type: dh.plot.AxisType.Y,
       }),
     ];
   }
 
-  static makeSource({
-    axis = ChartTestUtils.makeAxis(),
-  }: {
-    axis: Axis;
-  }): SeriesDataSource {
+  makeSource({ axis = this.makeAxis() }: { axis: Axis }): SeriesDataSource {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    return new (dh as any).SeriesDataSource({ axis, type: axis.type });
+    return new (this.dh as any).SeriesDataSource({ axis, type: axis.type });
   }
 
-  static makeDefaultSources(): SeriesDataSource[] {
-    const axes = ChartTestUtils.makeDefaultAxes();
-    return axes.map(axis => ChartTestUtils.makeSource({ axis }));
+  makeDefaultSources(): SeriesDataSource[] {
+    const axes = this.makeDefaultAxes();
+    return axes.map(axis => this.makeSource({ axis }));
   }
 
-  static makeSeries({
+  makeSeries({
     name = ChartTestUtils.DEFAULT_SERIES_NAME,
-    plotStyle = dh.plot.SeriesPlotStyle.SCATTER,
-    sources = ChartTestUtils.makeDefaultSources(),
+    plotStyle = null,
+    sources = this.makeDefaultSources(),
     lineColor = null,
     shapeColor = null,
   } = {}): Series {
+    const { dh } = this;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     return new (dh as any).Series(
       name,
-      plotStyle,
+      plotStyle ?? dh.plot.SeriesPlotStyle.SCATTER,
       sources,
       lineColor,
       shapeColor
     );
   }
 
-  static makeChart({
+  makeChart({
     title = ChartTestUtils.DEFAULT_CHART_TITLE,
-    series = [ChartTestUtils.makeSeries()],
-    axes = ChartTestUtils.makeDefaultAxes(),
+    series = [this.makeSeries()],
+    axes = this.makeDefaultAxes(),
     showLegend = null,
     rowspan = 1,
     colspan = 1,
@@ -99,7 +116,7 @@ class ChartTestUtils {
     column?: number;
   } = {}): Chart {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    return new (dh as any).Chart({
+    return new (this.dh as any).Chart({
       title,
       series,
       axes,
@@ -111,14 +128,14 @@ class ChartTestUtils {
     });
   }
 
-  static makeFigure({
+  makeFigure({
     title = 'Figure',
-    charts = [ChartTestUtils.makeChart()],
+    charts = [this.makeChart()],
     rows = 1,
     cols = 1,
   } = {}): Figure {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    return new (dh as any).plot.Figure({ title, charts, rows, cols });
+    return new (this.dh as any).plot.Figure({ title, charts, rows, cols });
   }
 }
 

--- a/packages/chart/src/ChartUtils.test.ts
+++ b/packages/chart/src/ChartUtils.test.ts
@@ -6,6 +6,7 @@ import ChartTestUtils from './ChartTestUtils';
 import ChartTheme from './ChartTheme';
 
 const chartUtils = new ChartUtils(dh);
+const chartTestUtils = new ChartTestUtils(dh);
 
 function makeFormatter() {
   return new Formatter(dh);
@@ -176,13 +177,13 @@ describe('number format string translations', () => {
 describe('updating layout axes', () => {
   function makeTwinAxes() {
     return [
-      ChartTestUtils.makeAxis({ label: 'X Axis' }),
-      ChartTestUtils.makeAxis({
+      chartTestUtils.makeAxis({ label: 'X Axis' }),
+      chartTestUtils.makeAxis({
         label: 'Y Axis',
         type: dh.plot.AxisType.Y,
         position: dh.plot.AxisPosition.RIGHT,
       }),
-      ChartTestUtils.makeAxis({
+      chartTestUtils.makeAxis({
         label: 'Y2 Axis',
         type: dh.plot.AxisType.Y,
         position: dh.plot.AxisPosition.LEFT,
@@ -228,8 +229,8 @@ describe('updating layout axes', () => {
   it('removes stale axes', () => {
     const layout = {};
     const axes = makeTwinAxes();
-    const chart = ChartTestUtils.makeChart({ axes });
-    const figure = ChartTestUtils.makeFigure({ charts: [chart] });
+    const chart = chartTestUtils.makeChart({ axes });
+    const figure = chartTestUtils.makeFigure({ charts: [chart] });
     chartUtils.updateFigureAxes(layout, figure);
     expect(layout).toEqual(
       expect.objectContaining({
@@ -256,25 +257,25 @@ describe('updating layout axes', () => {
 
   describe('multiple axes', () => {
     const axes = [
-      ChartTestUtils.makeAxis({ label: 'X Axis' }),
-      ChartTestUtils.makeAxis({
+      chartTestUtils.makeAxis({ label: 'X Axis' }),
+      chartTestUtils.makeAxis({
         label: 'Y Axis',
         type: dh.plot.AxisType.Y,
         position: dh.plot.AxisPosition.RIGHT,
       }),
-      ChartTestUtils.makeAxis({
+      chartTestUtils.makeAxis({
         label: 'Y2 Axis',
         type: dh.plot.AxisType.Y,
         position: dh.plot.AxisPosition.RIGHT,
       }),
-      ChartTestUtils.makeAxis({
+      chartTestUtils.makeAxis({
         label: 'Y3 Axis',
         type: dh.plot.AxisType.Y,
         position: dh.plot.AxisPosition.RIGHT,
       }),
     ];
-    const chart = ChartTestUtils.makeChart({ axes });
-    const figure = ChartTestUtils.makeFigure({ charts: [chart] });
+    const chart = chartTestUtils.makeChart({ axes });
+    const figure = chartTestUtils.makeFigure({ charts: [chart] });
     const width = 400;
     const height = 1000;
     const expectedDomain = [0, 0.5];
@@ -324,12 +325,12 @@ describe('handles subplots and columns/rows correctly', () => {
   const halfYMargin = ChartUtils.AXIS_SIZE_PX / height / 2;
 
   it('handles row location correctly', () => {
-    const axes = ChartTestUtils.makeDefaultAxes();
+    const axes = chartTestUtils.makeDefaultAxes();
     const charts = [
-      ChartTestUtils.makeChart({ axes, row: 0 }),
-      ChartTestUtils.makeChart({ axes, row: 1 }),
+      chartTestUtils.makeChart({ axes, row: 0 }),
+      chartTestUtils.makeChart({ axes, row: 1 }),
     ];
-    const figure = ChartTestUtils.makeFigure({ charts, rows: 2 });
+    const figure = chartTestUtils.makeFigure({ charts, rows: 2 });
     expect(
       chartUtils.getChartBounds(figure, charts[0], width, height)
     ).toEqual({ bottom: 0.5 + halfYMargin, top: 1, left: 0, right: 1 });
@@ -339,12 +340,12 @@ describe('handles subplots and columns/rows correctly', () => {
   });
 
   it('handles column location correctly', () => {
-    const axes = ChartTestUtils.makeDefaultAxes();
+    const axes = chartTestUtils.makeDefaultAxes();
     const charts = [
-      ChartTestUtils.makeChart({ axes, column: 0 }),
-      ChartTestUtils.makeChart({ axes, column: 1 }),
+      chartTestUtils.makeChart({ axes, column: 0 }),
+      chartTestUtils.makeChart({ axes, column: 1 }),
     ];
-    const figure = ChartTestUtils.makeFigure({ charts, cols: 2 });
+    const figure = chartTestUtils.makeFigure({ charts, cols: 2 });
     expect(
       chartUtils.getChartBounds(figure, charts[0], width, height)
     ).toEqual({ bottom: 0, top: 1, left: 0, right: 0.5 - halfXMargin });
@@ -354,13 +355,13 @@ describe('handles subplots and columns/rows correctly', () => {
   });
 
   it('handles colspan', () => {
-    const axes = ChartTestUtils.makeDefaultAxes();
+    const axes = chartTestUtils.makeDefaultAxes();
     const charts = [
-      ChartTestUtils.makeChart({ axes, column: 0 }),
-      ChartTestUtils.makeChart({ axes, column: 1 }),
-      ChartTestUtils.makeChart({ axes, row: 1, colspan: 2 }),
+      chartTestUtils.makeChart({ axes, column: 0 }),
+      chartTestUtils.makeChart({ axes, column: 1 }),
+      chartTestUtils.makeChart({ axes, row: 1, colspan: 2 }),
     ];
-    const figure = ChartTestUtils.makeFigure({ charts, cols: 2, rows: 2 });
+    const figure = chartTestUtils.makeFigure({ charts, cols: 2, rows: 2 });
     expect(chartUtils.getChartBounds(figure, charts[0], width, height)).toEqual(
       {
         bottom: 0.5 + halfYMargin,
@@ -383,13 +384,13 @@ describe('handles subplots and columns/rows correctly', () => {
   });
 
   it('handles rowspan', () => {
-    const axes = ChartTestUtils.makeDefaultAxes();
+    const axes = chartTestUtils.makeDefaultAxes();
     const charts = [
-      ChartTestUtils.makeChart({ axes, row: 0 }),
-      ChartTestUtils.makeChart({ axes, row: 1 }),
-      ChartTestUtils.makeChart({ axes, column: 1, rowspan: 2 }),
+      chartTestUtils.makeChart({ axes, row: 0 }),
+      chartTestUtils.makeChart({ axes, row: 1 }),
+      chartTestUtils.makeChart({ axes, column: 1, rowspan: 2 }),
     ];
-    const figure = ChartTestUtils.makeFigure({ charts, cols: 2, rows: 2 });
+    const figure = chartTestUtils.makeFigure({ charts, cols: 2, rows: 2 });
     expect(chartUtils.getChartBounds(figure, charts[0], width, height)).toEqual(
       {
         bottom: 0.5 + halfYMargin,

--- a/packages/chart/src/FigureChartModel.test.ts
+++ b/packages/chart/src/FigureChartModel.test.ts
@@ -3,6 +3,8 @@ import { PlotData } from 'plotly.js';
 import ChartTestUtils from './ChartTestUtils';
 import FigureChartModel from './FigureChartModel';
 
+const chartTestUtils = new ChartTestUtils(dh);
+
 beforeEach(() => {
   jest.useFakeTimers();
 });
@@ -12,7 +14,7 @@ afterEach(() => {
 });
 
 it('populates the layout properly', () => {
-  const figure = ChartTestUtils.makeFigure();
+  const figure = chartTestUtils.makeFigure();
   const model = new FigureChartModel(dh, figure);
 
   expect(model.getLayout()).toEqual(
@@ -35,7 +37,7 @@ it('populates the layout properly', () => {
 });
 
 it('populates series data properly', () => {
-  const figure = ChartTestUtils.makeFigure();
+  const figure = chartTestUtils.makeFigure();
   const model = new FigureChartModel(dh, figure);
 
   expect(model.getData()).toEqual([
@@ -53,12 +55,12 @@ it('populates series data properly', () => {
 });
 
 it('populates horizontal series properly', () => {
-  const axes = ChartTestUtils.makeDefaultAxes();
-  let sources = axes.map(axis => ChartTestUtils.makeSource({ axis }));
+  const axes = chartTestUtils.makeDefaultAxes();
+  let sources = axes.map(axis => chartTestUtils.makeSource({ axis }));
   sources = [sources[1], sources[0]];
-  const series = ChartTestUtils.makeSeries({ sources });
-  const chart = ChartTestUtils.makeChart({ series: [series], axes });
-  const figure = ChartTestUtils.makeFigure({ charts: [chart] });
+  const series = chartTestUtils.makeSeries({ sources });
+  const chart = chartTestUtils.makeChart({ series: [series], axes });
+  const figure = chartTestUtils.makeFigure({ charts: [chart] });
 
   const model = new FigureChartModel(dh, figure);
 
@@ -68,11 +70,11 @@ it('populates horizontal series properly', () => {
 });
 
 it('converts histograms properly to bars', () => {
-  const series = ChartTestUtils.makeSeries({
+  const series = chartTestUtils.makeSeries({
     plotStyle: dh.plot.SeriesPlotStyle.HISTOGRAM,
   });
-  const chart = ChartTestUtils.makeChart({ series: [series] });
-  const figure = ChartTestUtils.makeFigure({ charts: [chart] });
+  const chart = chartTestUtils.makeChart({ series: [series] });
+  const figure = chartTestUtils.makeFigure({ charts: [chart] });
   const model = new FigureChartModel(dh, figure);
 
   expect(model.getData()).toEqual([
@@ -91,13 +93,13 @@ it('converts histograms properly to bars', () => {
 it('handles colors on line charts properly', () => {
   const lineColor = '#123fff';
   const shapeColor = '#abc999';
-  const series = ChartTestUtils.makeSeries({
+  const series = chartTestUtils.makeSeries({
     plotStyle: dh.plot.SeriesPlotStyle.LINE,
     lineColor,
     shapeColor,
   });
-  const chart = ChartTestUtils.makeChart({ series: [series] });
-  const figure = ChartTestUtils.makeFigure({ charts: [chart] });
+  const chart = chartTestUtils.makeChart({ series: [series] });
+  const figure = chartTestUtils.makeFigure({ charts: [chart] });
   const model = new FigureChartModel(dh, figure);
 
   expect(model.getData()).toEqual([
@@ -114,12 +116,12 @@ it('handles colors on line charts properly', () => {
 
 it('handles colors on bar charts properly', () => {
   const lineColor = '#badfad';
-  const series = ChartTestUtils.makeSeries({
+  const series = chartTestUtils.makeSeries({
     plotStyle: dh.plot.SeriesPlotStyle.BAR,
     lineColor,
   });
-  const chart = ChartTestUtils.makeChart({ series: [series] });
-  const figure = ChartTestUtils.makeFigure({ charts: [chart] });
+  const chart = chartTestUtils.makeChart({ series: [series] });
+  const figure = chartTestUtils.makeFigure({ charts: [chart] });
   const model = new FigureChartModel(dh, figure);
 
   expect(model.getData()).toEqual([
@@ -133,20 +135,20 @@ it('handles colors on bar charts properly', () => {
 
 describe('axis transform tests', () => {
   it('handles log x-axis properly', () => {
-    const xAxis = ChartTestUtils.makeAxis({
+    const xAxis = chartTestUtils.makeAxis({
       label: ChartTestUtils.DEFAULT_X_TITLE,
       type: dh.plot.AxisType.X,
       log: true,
     });
-    const yAxis = ChartTestUtils.makeAxis({
+    const yAxis = chartTestUtils.makeAxis({
       label: ChartTestUtils.DEFAULT_Y_TITLE,
       type: dh.plot.AxisType.Y,
     });
     const axes = [xAxis, yAxis];
-    const sources = axes.map(axis => ChartTestUtils.makeSource({ axis }));
-    const series = ChartTestUtils.makeSeries({ sources });
-    const chart = ChartTestUtils.makeChart({ series: [series], axes });
-    const figure = ChartTestUtils.makeFigure({ charts: [chart] });
+    const sources = axes.map(axis => chartTestUtils.makeSource({ axis }));
+    const series = chartTestUtils.makeSeries({ sources });
+    const chart = chartTestUtils.makeChart({ series: [series], axes });
+    const figure = chartTestUtils.makeFigure({ charts: [chart] });
     const model = new FigureChartModel(dh, figure);
 
     expect(model.getLayout().xaxis).toMatchObject({
@@ -158,20 +160,20 @@ describe('axis transform tests', () => {
   });
 
   it('handles log y-axis properly', () => {
-    const xAxis = ChartTestUtils.makeAxis({
+    const xAxis = chartTestUtils.makeAxis({
       label: ChartTestUtils.DEFAULT_X_TITLE,
       type: dh.plot.AxisType.X,
     });
-    const yAxis = ChartTestUtils.makeAxis({
+    const yAxis = chartTestUtils.makeAxis({
       label: ChartTestUtils.DEFAULT_Y_TITLE,
       type: dh.plot.AxisType.Y,
       log: true,
     });
     const axes = [xAxis, yAxis];
-    const sources = axes.map(axis => ChartTestUtils.makeSource({ axis }));
-    const series = ChartTestUtils.makeSeries({ sources });
-    const chart = ChartTestUtils.makeChart({ series: [series], axes });
-    const figure = ChartTestUtils.makeFigure({ charts: [chart] });
+    const sources = axes.map(axis => chartTestUtils.makeSource({ axis }));
+    const series = chartTestUtils.makeSeries({ sources });
+    const chart = chartTestUtils.makeChart({ series: [series], axes });
+    const figure = chartTestUtils.makeFigure({ charts: [chart] });
     const model = new FigureChartModel(dh, figure);
 
     expect(model.getLayout().xaxis).not.toMatchObject({
@@ -185,27 +187,27 @@ describe('axis transform tests', () => {
 
 describe('multiple axes', () => {
   it('handles two y-axes properly', () => {
-    const xaxis = ChartTestUtils.makeAxis({
+    const xaxis = chartTestUtils.makeAxis({
       label: 'x1',
       type: dh.plot.AxisType.X,
       position: dh.plot.AxisPosition.BOTTOM,
     });
 
-    const yaxis1 = ChartTestUtils.makeAxis({
+    const yaxis1 = chartTestUtils.makeAxis({
       label: 'y1',
       type: dh.plot.AxisType.Y,
       position: dh.plot.AxisPosition.LEFT,
     });
 
-    const yaxis2 = ChartTestUtils.makeAxis({
+    const yaxis2 = chartTestUtils.makeAxis({
       label: 'y2',
       type: dh.plot.AxisType.Y,
       position: dh.plot.AxisPosition.RIGHT,
     });
     const axes = [xaxis, yaxis1, yaxis2];
 
-    const chart = ChartTestUtils.makeChart({ axes });
-    const figure = ChartTestUtils.makeFigure({ charts: [chart] });
+    const chart = chartTestUtils.makeChart({ axes });
+    const figure = chartTestUtils.makeFigure({ charts: [chart] });
     const model = new FigureChartModel(dh, figure);
 
     const layout = model.getLayout();
@@ -234,25 +236,25 @@ describe('multiple axes', () => {
   });
 
   it('handles multiple y-axes on the same side properly', () => {
-    const xaxis = ChartTestUtils.makeAxis({
+    const xaxis = chartTestUtils.makeAxis({
       label: 'x1',
       type: dh.plot.AxisType.X,
       position: dh.plot.AxisPosition.BOTTOM,
     });
 
-    const yaxis1 = ChartTestUtils.makeAxis({
+    const yaxis1 = chartTestUtils.makeAxis({
       label: 'y1',
       type: dh.plot.AxisType.Y,
       position: dh.plot.AxisPosition.RIGHT,
     });
 
-    const yaxis2 = ChartTestUtils.makeAxis({
+    const yaxis2 = chartTestUtils.makeAxis({
       label: 'y2',
       type: dh.plot.AxisType.Y,
       position: dh.plot.AxisPosition.RIGHT,
     });
 
-    const yaxis3 = ChartTestUtils.makeAxis({
+    const yaxis3 = chartTestUtils.makeAxis({
       label: 'y3',
       type: dh.plot.AxisType.Y,
       position: dh.plot.AxisPosition.RIGHT,
@@ -260,8 +262,8 @@ describe('multiple axes', () => {
 
     const axes = [xaxis, yaxis1, yaxis2, yaxis3];
 
-    const chart = ChartTestUtils.makeChart({ axes });
-    const figure = ChartTestUtils.makeFigure({ charts: [chart] });
+    const chart = chartTestUtils.makeChart({ axes });
+    const figure = chartTestUtils.makeFigure({ charts: [chart] });
     const model = new FigureChartModel(dh, figure);
 
     const layout = model.getLayout();
@@ -303,27 +305,27 @@ describe('multiple axes', () => {
   });
 
   it('handles two x-axes properly', () => {
-    const xaxis1 = ChartTestUtils.makeAxis({
+    const xaxis1 = chartTestUtils.makeAxis({
       label: 'x1',
       type: dh.plot.AxisType.X,
       position: dh.plot.AxisPosition.BOTTOM,
     });
 
-    const xaxis2 = ChartTestUtils.makeAxis({
+    const xaxis2 = chartTestUtils.makeAxis({
       label: 'x2',
       type: dh.plot.AxisType.X,
       position: dh.plot.AxisPosition.TOP,
     });
 
-    const yaxis = ChartTestUtils.makeAxis({
+    const yaxis = chartTestUtils.makeAxis({
       label: 'y1',
       type: dh.plot.AxisType.Y,
       position: dh.plot.AxisPosition.LEFT,
     });
     const axes = [xaxis1, xaxis2, yaxis];
 
-    const chart = ChartTestUtils.makeChart({ axes });
-    const figure = ChartTestUtils.makeFigure({ charts: [chart] });
+    const chart = chartTestUtils.makeChart({ axes });
+    const figure = chartTestUtils.makeFigure({ charts: [chart] });
     const model = new FigureChartModel(dh, figure);
 
     const layout = model.getLayout();
@@ -352,25 +354,25 @@ describe('multiple axes', () => {
   });
 
   it('handles multiple x-axes on the same side properly', () => {
-    const xaxis = ChartTestUtils.makeAxis({
+    const xaxis = chartTestUtils.makeAxis({
       label: 'x1',
       type: dh.plot.AxisType.X,
       position: dh.plot.AxisPosition.TOP,
     });
 
-    const xaxis2 = ChartTestUtils.makeAxis({
+    const xaxis2 = chartTestUtils.makeAxis({
       label: 'x2',
       type: dh.plot.AxisType.X,
       position: dh.plot.AxisPosition.TOP,
     });
 
-    const xaxis3 = ChartTestUtils.makeAxis({
+    const xaxis3 = chartTestUtils.makeAxis({
       label: 'x3',
       type: dh.plot.AxisType.X,
       position: dh.plot.AxisPosition.TOP,
     });
 
-    const yaxis = ChartTestUtils.makeAxis({
+    const yaxis = chartTestUtils.makeAxis({
       label: 'y1',
       type: dh.plot.AxisType.Y,
       position: dh.plot.AxisPosition.LEFT,
@@ -378,8 +380,8 @@ describe('multiple axes', () => {
 
     const axes = [xaxis, xaxis2, xaxis3, yaxis];
 
-    const chart = ChartTestUtils.makeChart({ axes });
-    const figure = ChartTestUtils.makeFigure({ charts: [chart] });
+    const chart = chartTestUtils.makeChart({ axes });
+    const figure = chartTestUtils.makeFigure({ charts: [chart] });
     const model = new FigureChartModel(dh, figure);
 
     const layout = model.getLayout();
@@ -422,9 +424,9 @@ describe('multiple axes', () => {
 });
 
 it('adds new series', () => {
-  const series1 = ChartTestUtils.makeSeries({ name: 'S1' });
-  const chart = ChartTestUtils.makeChart({ series: [series1] });
-  const figure = ChartTestUtils.makeFigure({
+  const series1 = chartTestUtils.makeSeries({ name: 'S1' });
+  const chart = chartTestUtils.makeChart({ series: [series1] });
+  const figure = chartTestUtils.makeFigure({
     charts: [chart],
   });
   const model = new FigureChartModel(dh, figure);
@@ -437,7 +439,7 @@ it('adds new series', () => {
     }),
   ]);
 
-  const series2 = ChartTestUtils.makeSeries({ name: 'S2' });
+  const series2 = chartTestUtils.makeSeries({ name: 'S2' });
   chart.series = [...chart.series, series2];
 
   figure.fireEvent(dh.plot.Figure.EVENT_SERIES_ADDED, series2);
@@ -458,9 +460,9 @@ it('adds new series', () => {
 
 describe('legend visibility', () => {
   function testLegend(showLegend: boolean | null): Partial<PlotData>[] {
-    const series1 = ChartTestUtils.makeSeries({ name: 'S1' });
-    const chart = ChartTestUtils.makeChart({ series: [series1], showLegend });
-    const figure = ChartTestUtils.makeFigure({
+    const series1 = chartTestUtils.makeSeries({ name: 'S1' });
+    const chart = chartTestUtils.makeChart({ series: [series1], showLegend });
+    const figure = chartTestUtils.makeFigure({
       charts: [chart],
     });
     const model = new FigureChartModel(dh, figure);

--- a/packages/code-studio/src/components/DateInput.tsx
+++ b/packages/code-studio/src/components/DateInput.tsx
@@ -1,5 +1,6 @@
 import React, { useState, ReactElement } from 'react';
-import dh, { DateWrapper } from '@deephaven/jsapi-shim';
+import dh from '@deephaven/jsapi-shim';
+import type { DateWrapper } from '@deephaven/jsapi-types';
 import Log from '@deephaven/log';
 import { MaskedInput, SelectionSegment } from '@deephaven/components';
 

--- a/packages/code-studio/src/main/AppMainContainer.test.tsx
+++ b/packages/code-studio/src/main/AppMainContainer.test.tsx
@@ -2,11 +2,12 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { ToolType } from '@deephaven/dashboard-core-plugins';
-import dh, {
+import dh from '@deephaven/jsapi-shim';
+import type {
   IdeConnection,
   IdeSession,
   VariableChanges,
-} from '@deephaven/jsapi-shim';
+} from '@deephaven/jsapi-types';
 import { TestUtils } from '@deephaven/utils';
 import { Workspace } from '@deephaven/redux';
 import userEvent from '@testing-library/user-event';

--- a/packages/code-studio/src/main/AppMainContainer.tsx
+++ b/packages/code-studio/src/main/AppMainContainer.tsx
@@ -69,12 +69,13 @@ import {
   dhPanels,
   vsDebugDisconnect,
 } from '@deephaven/icons';
-import dh, {
+import dh from '@deephaven/jsapi-shim';
+import type {
   IdeConnection,
   IdeSession,
   VariableDefinition,
   VariableTypeUnion,
-} from '@deephaven/jsapi-shim';
+} from '@deephaven/jsapi-types';
 import { SessionConfig } from '@deephaven/jsapi-utils';
 import Log from '@deephaven/log';
 import {

--- a/packages/code-studio/src/main/WidgetList.tsx
+++ b/packages/code-studio/src/main/WidgetList.tsx
@@ -14,7 +14,7 @@ import {
   vsPreview,
   vsRefresh,
 } from '@deephaven/icons';
-import { VariableDefinition } from '@deephaven/jsapi-shim';
+import type { VariableDefinition } from '@deephaven/jsapi-types';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import './WidgetList.scss';
 

--- a/packages/code-studio/src/settings/ColumnSpecificSectionContent.tsx
+++ b/packages/code-studio/src/settings/ColumnSpecificSectionContent.tsx
@@ -19,7 +19,7 @@ import {
   TableColumnFormat,
   FormattingRule,
 } from '@deephaven/jsapi-utils';
-import { dh as DhType } from '@deephaven/jsapi-types';
+import type { dh as DhType } from '@deephaven/jsapi-types';
 import {
   getApi,
   getDefaultDateTimeFormat,

--- a/packages/code-studio/src/settings/FormattingSectionContent.tsx
+++ b/packages/code-studio/src/settings/FormattingSectionContent.tsx
@@ -16,7 +16,7 @@ import {
   DecimalColumnFormatter,
   TableUtils,
 } from '@deephaven/jsapi-utils';
-import { dh as DhType } from '@deephaven/jsapi-types';
+import type { dh as DhType } from '@deephaven/jsapi-types';
 import Log from '@deephaven/log';
 import {
   getApi,

--- a/packages/code-studio/src/settings/SettingsUtils.tsx
+++ b/packages/code-studio/src/settings/SettingsUtils.tsx
@@ -6,7 +6,7 @@ import {
   TableColumnFormat,
   FormattingRule,
 } from '@deephaven/jsapi-utils';
-import { dh as DhType } from '@deephaven/jsapi-types';
+import type { dh as DhType } from '@deephaven/jsapi-types';
 import Log from '@deephaven/log';
 
 const log = Log.module('SettingsUtils');

--- a/packages/code-studio/src/storage/grpc/GrpcFileStorage.ts
+++ b/packages/code-studio/src/storage/grpc/GrpcFileStorage.ts
@@ -9,7 +9,7 @@ import {
   FileStorageTable,
   FileUtils,
 } from '@deephaven/file-explorer';
-import { StorageService } from '@deephaven/jsapi-shim';
+import type { StorageService } from '@deephaven/jsapi-types';
 import Log from '@deephaven/log';
 import GrpcFileStorageTable from './GrpcFileStorageTable';
 

--- a/packages/code-studio/src/storage/grpc/GrpcFileStorageTable.test.ts
+++ b/packages/code-studio/src/storage/grpc/GrpcFileStorageTable.test.ts
@@ -1,5 +1,5 @@
 import { FileUtils } from '@deephaven/file-explorer';
-import { ItemDetails, StorageService } from '@deephaven/jsapi-shim';
+import type { ItemDetails, StorageService } from '@deephaven/jsapi-types';
 import GrpcFileStorageTable from './GrpcFileStorageTable';
 
 let storageService: StorageService;

--- a/packages/code-studio/src/storage/grpc/GrpcFileStorageTable.ts
+++ b/packages/code-studio/src/storage/grpc/GrpcFileStorageTable.ts
@@ -19,7 +19,7 @@ import {
   FileStorageTable,
   FileUtils,
 } from '@deephaven/file-explorer';
-import { StorageService } from '@deephaven/jsapi-shim';
+import type { StorageService } from '@deephaven/jsapi-types';
 import debounce from 'lodash.debounce';
 
 const log = Log.module('GrpcFileStorageTable');

--- a/packages/code-studio/src/storage/grpc/GrpcLayoutStorage.ts
+++ b/packages/code-studio/src/storage/grpc/GrpcLayoutStorage.ts
@@ -1,4 +1,4 @@
-import { StorageService } from '@deephaven/jsapi-shim';
+import type { StorageService } from '@deephaven/jsapi-types';
 import LayoutStorage, { ExportedLayout } from '../LayoutStorage';
 
 export class GrpcLayoutStorage implements LayoutStorage {

--- a/packages/code-studio/src/styleguide/MockIrisGridTreeModel.ts
+++ b/packages/code-studio/src/styleguide/MockIrisGridTreeModel.ts
@@ -21,7 +21,7 @@ import type {
   Column,
   CustomColumn,
   ValueTypeUnion,
-} from '@deephaven/jsapi-shim';
+} from '@deephaven/jsapi-types';
 import { Formatter } from '@deephaven/jsapi-utils';
 
 // We need to cast our CustomEvent so it's happy with event-target-shim

--- a/packages/console/src/Console.tsx
+++ b/packages/console/src/Console.tsx
@@ -21,7 +21,7 @@ import type {
   VariableChanges,
   VariableDefinition,
   VariableTypeUnion,
-} from '@deephaven/jsapi-shim';
+} from '@deephaven/jsapi-types';
 import Log from '@deephaven/log';
 import { assertNotNull, Pending, PromiseUtils } from '@deephaven/utils';
 import ConsoleHistory from './console-history/ConsoleHistory';

--- a/packages/console/src/ConsoleInput.tsx
+++ b/packages/console/src/ConsoleInput.tsx
@@ -8,7 +8,7 @@ import {
   PromiseUtils,
 } from '@deephaven/utils';
 import { ViewportData } from '@deephaven/storage';
-import { IdeSession } from '@deephaven/jsapi-shim';
+import type { IdeSession } from '@deephaven/jsapi-types';
 import {
   CommandHistoryStorage,
   CommandHistoryStorageItem,

--- a/packages/console/src/ConsoleMenu.tsx
+++ b/packages/console/src/ConsoleMenu.tsx
@@ -19,7 +19,7 @@ import {
   vsTriangleDown,
 } from '@deephaven/icons';
 import Log from '@deephaven/log';
-import { VariableDefinition } from '@deephaven/jsapi-shim';
+import type { VariableDefinition } from '@deephaven/jsapi-types';
 import memoize from 'memoize-one';
 import './ConsoleMenu.scss';
 import ConsoleUtils from './common/ConsoleUtils';

--- a/packages/console/src/ConsoleStatusBar.tsx
+++ b/packages/console/src/ConsoleStatusBar.tsx
@@ -1,6 +1,7 @@
 import React, { PureComponent, ReactElement, ReactNode } from 'react';
 import classNames from 'classnames';
-import dh, { IdeSession, VariableDefinition } from '@deephaven/jsapi-shim';
+import dh from '@deephaven/jsapi-shim';
+import type { IdeSession, VariableDefinition } from '@deephaven/jsapi-types';
 import { DropdownAction, Tooltip } from '@deephaven/components';
 import { CanceledPromiseError, Pending } from '@deephaven/utils';
 import ConsoleMenu from './ConsoleMenu';

--- a/packages/console/src/HeapUsage.tsx
+++ b/packages/console/src/HeapUsage.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState, ReactElement, useRef } from 'react';
 import classNames from 'classnames';
 import { Tooltip } from '@deephaven/components';
-import { QueryConnectable } from '@deephaven/jsapi-shim';
+import type { QueryConnectable } from '@deephaven/jsapi-types';
 import { Plot, ChartTheme } from '@deephaven/chart';
 import Log from '@deephaven/log';
 import './HeapUsage.scss';

--- a/packages/console/src/common/ConsoleUtils.ts
+++ b/packages/console/src/common/ConsoleUtils.ts
@@ -1,5 +1,6 @@
 import ShellQuote, { ParseEntry, ControlOperator } from 'shell-quote';
-import dh, { VariableTypeUnion } from '@deephaven/jsapi-shim';
+import dh from '@deephaven/jsapi-shim';
+import type { VariableTypeUnion } from '@deephaven/jsapi-types';
 
 class ConsoleUtils {
   static hasComment(arg: ParseEntry): arg is { comment: string } {

--- a/packages/console/src/console-history/ConsoleHistory.tsx
+++ b/packages/console/src/console-history/ConsoleHistory.tsx
@@ -2,7 +2,7 @@
  * Console display for use in the Iris environment.
  */
 import React, { Component, ReactElement } from 'react';
-import { VariableDefinition } from '@deephaven/jsapi-shim';
+import type { VariableDefinition } from '@deephaven/jsapi-types';
 import ConsoleHistoryItem from './ConsoleHistoryItem';
 
 import './ConsoleHistory.scss';

--- a/packages/console/src/console-history/ConsoleHistoryItem.tsx
+++ b/packages/console/src/console-history/ConsoleHistoryItem.tsx
@@ -4,7 +4,7 @@
 import React, { PureComponent, ReactElement } from 'react';
 import { Button } from '@deephaven/components';
 import Log from '@deephaven/log';
-import { VariableDefinition } from '@deephaven/jsapi-shim';
+import type { VariableDefinition } from '@deephaven/jsapi-types';
 import classNames from 'classnames';
 import { Code, ObjectIcon } from '../common';
 import ConsoleHistoryItemResult from './ConsoleHistoryItemResult';

--- a/packages/console/src/console-history/ConsoleHistoryTypes.tsx
+++ b/packages/console/src/console-history/ConsoleHistoryTypes.tsx
@@ -1,5 +1,5 @@
 import { CancelablePromise } from '@deephaven/utils';
-import { VariableChanges } from '@deephaven/jsapi-shim';
+import type { VariableChanges } from '@deephaven/jsapi-types';
 
 export type ConsoleHistoryError =
   | string

--- a/packages/console/src/csv/CsvParser.ts
+++ b/packages/console/src/csv/CsvParser.ts
@@ -1,7 +1,7 @@
 import Papa, { ParseLocalConfig, Parser, ParseResult } from 'papaparse';
 import Log from '@deephaven/log';
 import { assertNotNull, DbNameValidator } from '@deephaven/utils';
-import { IdeSession, Table } from '@deephaven/jsapi-shim';
+import type { IdeSession, Table } from '@deephaven/jsapi-types';
 import type { JSZipObject } from 'jszip';
 import CsvTypeParser from './CsvTypeParser';
 import { CsvTypes } from './CsvFormats';

--- a/packages/console/src/log/LogView.tsx
+++ b/packages/console/src/log/LogView.tsx
@@ -2,7 +2,7 @@ import React, { PureComponent, ReactElement } from 'react';
 import { Button, DropdownActions, DropdownMenu } from '@deephaven/components';
 import { vsGear, dhTrashUndo } from '@deephaven/icons';
 import { assertNotNull } from '@deephaven/utils';
-import { IdeSession, LogItem } from '@deephaven/jsapi-shim';
+import type { IdeSession, LogItem } from '@deephaven/jsapi-types';
 import { Placement } from 'popper.js';
 import * as monaco from 'monaco-editor';
 import ConsoleUtils from '../common/ConsoleUtils';

--- a/packages/console/src/monaco/MonacoProviders.test.tsx
+++ b/packages/console/src/monaco/MonacoProviders.test.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import * as monaco from 'monaco-editor';
-import dh, { DocumentRange, Position } from '@deephaven/jsapi-shim';
+import dh from '@deephaven/jsapi-shim';
+import type { DocumentRange, Position } from '@deephaven/jsapi-types';
 import MonacoProviders from './MonacoProviders';
 
 const DEFAULT_LANGUAGE = 'test';

--- a/packages/console/src/monaco/MonacoProviders.tsx
+++ b/packages/console/src/monaco/MonacoProviders.tsx
@@ -4,7 +4,11 @@
 import { PureComponent } from 'react';
 import * as monaco from 'monaco-editor';
 import Log from '@deephaven/log';
-import { DocumentRange, IdeSession, Position } from '@deephaven/jsapi-shim';
+import type {
+  DocumentRange,
+  IdeSession,
+  Position,
+} from '@deephaven/jsapi-types';
 
 const log = Log.module('MonacoCompletionProvider');
 

--- a/packages/console/src/monaco/MonacoUtils.ts
+++ b/packages/console/src/monaco/MonacoUtils.ts
@@ -3,7 +3,7 @@
  * Exports a function for initializing monaco with the deephaven theme/config
  */
 import { Shortcut } from '@deephaven/components';
-import { IdeSession } from '@deephaven/jsapi-shim';
+import type { IdeSession } from '@deephaven/jsapi-types';
 import { assertNotNull } from '@deephaven/utils';
 import { find as linkifyFind } from 'linkifyjs';
 import * as monaco from 'monaco-editor';

--- a/packages/console/src/notebook/ScriptEditor.tsx
+++ b/packages/console/src/notebook/ScriptEditor.tsx
@@ -4,7 +4,7 @@
 import React, { Component, ReactElement, RefObject } from 'react';
 import { LoadingOverlay, ShortcutRegistry } from '@deephaven/components';
 import Log from '@deephaven/log';
-import { IdeSession } from '@deephaven/jsapi-shim';
+import type { IdeSession } from '@deephaven/jsapi-types';
 import { assertNotNull } from '@deephaven/utils';
 import { editor, IDisposable } from 'monaco-editor';
 import Editor from './Editor';

--- a/packages/dashboard-core-plugins/package.json
+++ b/packages/dashboard-core-plugins/package.json
@@ -33,7 +33,6 @@
     "@deephaven/icons": "file:../icons",
     "@deephaven/iris-grid": "file:../iris-grid",
     "@deephaven/jsapi-bootstrap": "file:../jsapi-bootstrap",
-    "@deephaven/jsapi-shim": "file:../jsapi-shim",
     "@deephaven/jsapi-types": "file:../jsapi-types",
     "@deephaven/jsapi-utils": "file:../jsapi-utils",
     "@deephaven/log": "file:../log",
@@ -64,6 +63,7 @@
   },
   "devDependencies": {
     "@deephaven/mocks": "file:../mocks",
+    "@deephaven/jsapi-shim": "file:../jsapi-shim",
     "@deephaven/tsconfig": "file:../tsconfig"
   },
   "files": [

--- a/packages/dashboard-core-plugins/src/ChartBuilderPlugin.tsx
+++ b/packages/dashboard-core-plugins/src/ChartBuilderPlugin.tsx
@@ -6,7 +6,7 @@ import {
   LayoutUtils,
   useListener,
 } from '@deephaven/dashboard';
-import { SeriesPlotStyle, Table } from '@deephaven/jsapi-shim';
+import type { SeriesPlotStyle, Table } from '@deephaven/jsapi-types';
 import shortid from 'shortid';
 import { IrisGridEvent } from './events';
 import { ChartPanel } from './panels';

--- a/packages/dashboard-core-plugins/src/ChartBuilderPlugin.tsx
+++ b/packages/dashboard-core-plugins/src/ChartBuilderPlugin.tsx
@@ -6,6 +6,7 @@ import {
   LayoutUtils,
   useListener,
 } from '@deephaven/dashboard';
+import { useApi } from '@deephaven/jsapi-bootstrap';
 import type { SeriesPlotStyle, Table } from '@deephaven/jsapi-types';
 import shortid from 'shortid';
 import { IrisGridEvent } from './events';
@@ -22,6 +23,7 @@ export function ChartBuilderPlugin(
 ): JSX.Element | null {
   assertIsDashboardPluginProps(props);
   const { id, layout } = props;
+  const dh = useApi();
   const handleCreateChart = useCallback(
     ({
       metadata,
@@ -66,7 +68,7 @@ export function ChartBuilderPlugin(
       const { root } = layout;
       LayoutUtils.openComponent({ root, config });
     },
-    [id, layout]
+    [dh, id, layout]
   );
 
   useListener(layout.eventHub, IrisGridEvent.CREATE_CHART, handleCreateChart);

--- a/packages/dashboard-core-plugins/src/GridPlugin.tsx
+++ b/packages/dashboard-core-plugins/src/GridPlugin.tsx
@@ -1,4 +1,4 @@
-import React, { DragEvent, useCallback, useEffect } from 'react';
+import React, { DragEvent, useCallback, useEffect, useMemo } from 'react';
 import {
   assertIsDashboardPluginProps,
   DashboardPluginComponentProps,
@@ -8,15 +8,10 @@ import {
   useListener,
 } from '@deephaven/dashboard';
 import { IrisGridModelFactory, IrisGridThemeType } from '@deephaven/iris-grid';
+import { useApi } from '@deephaven/jsapi-bootstrap';
 import type { Table, VariableDefinition } from '@deephaven/jsapi-types';
 import shortid from 'shortid';
 import { IrisGridPanel, IrisGridPanelProps } from './panels';
-
-const SUPPORTED_TYPES: string[] = [
-  dh.VariableType.TABLE,
-  dh.VariableType.TREETABLE,
-  dh.VariableType.HIERARCHICALTABLE,
-];
 
 export type GridPluginProps = Partial<DashboardPluginComponentProps> & {
   getDownloadWorker?: () => Promise<ServiceWorker>;
@@ -36,6 +31,15 @@ export function GridPlugin(props: GridPluginProps): JSX.Element | null {
     hydrate,
     theme,
   } = props;
+  const dh = useApi();
+  const supportedTypes: string[] = useMemo(
+    () => [
+      dh.VariableType.TABLE,
+      dh.VariableType.TREETABLE,
+      dh.VariableType.HIERARCHICALTABLE,
+    ],
+    [dh]
+  );
   const handlePanelOpen = useCallback(
     ({
       dragEvent,
@@ -49,10 +53,9 @@ export function GridPlugin(props: GridPluginProps): JSX.Element | null {
       widget: VariableDefinition;
     }) => {
       const { name, type } = widget;
-      if (!SUPPORTED_TYPES.includes(type)) {
+      if (!supportedTypes.includes(type)) {
         return;
       }
-
       const metadata = { name, table: name, type: widget.type };
       const makeApi = () => Promise.resolve(dh);
       const makeModel = () =>
@@ -79,7 +82,7 @@ export function GridPlugin(props: GridPluginProps): JSX.Element | null {
       const { root } = layout;
       LayoutUtils.openComponent({ root, config, dragEvent });
     },
-    [getDownloadWorker, id, layout, loadPlugin, theme]
+    [dh, getDownloadWorker, id, layout, loadPlugin, supportedTypes, theme]
   );
 
   useEffect(

--- a/packages/dashboard-core-plugins/src/GridPlugin.tsx
+++ b/packages/dashboard-core-plugins/src/GridPlugin.tsx
@@ -8,7 +8,7 @@ import {
   useListener,
 } from '@deephaven/dashboard';
 import { IrisGridModelFactory, IrisGridThemeType } from '@deephaven/iris-grid';
-import { Table, VariableDefinition } from '@deephaven/jsapi-shim';
+import type { Table, VariableDefinition } from '@deephaven/jsapi-types';
 import shortid from 'shortid';
 import { IrisGridPanel, IrisGridPanelProps } from './panels';
 

--- a/packages/dashboard-core-plugins/src/PandasPlugin.tsx
+++ b/packages/dashboard-core-plugins/src/PandasPlugin.tsx
@@ -8,6 +8,7 @@ import {
   useListener,
 } from '@deephaven/dashboard';
 import { IrisGridModelFactory } from '@deephaven/iris-grid';
+import { useApi } from '@deephaven/jsapi-bootstrap';
 import type { Table } from '@deephaven/jsapi-types';
 import shortid from 'shortid';
 import { PandasPanel, PandasPanelProps } from './panels';
@@ -19,6 +20,8 @@ export type PandasPluginProps = Partial<DashboardPluginComponentProps> & {
 export function PandasPlugin(props: PandasPluginProps): JSX.Element | null {
   assertIsDashboardPluginProps(props);
   const { hydrate, id, layout, registerComponent } = props;
+
+  const dh = useApi();
 
   const handlePanelOpen = useCallback(
     ({ dragEvent, fetch, panelId = shortid.generate(), widget }) => {

--- a/packages/dashboard-core-plugins/src/PandasPlugin.tsx
+++ b/packages/dashboard-core-plugins/src/PandasPlugin.tsx
@@ -51,7 +51,7 @@ export function PandasPlugin(props: PandasPluginProps): JSX.Element | null {
       const { root } = layout;
       LayoutUtils.openComponent({ root, config, dragEvent });
     },
-    [id, layout]
+    [dh, id, layout]
   );
 
   useEffect(

--- a/packages/dashboard-core-plugins/src/controls/dropdown-filter/DropdownFilter.test.tsx
+++ b/packages/dashboard-core-plugins/src/controls/dropdown-filter/DropdownFilter.test.tsx
@@ -9,6 +9,8 @@ type MakeContainerProps = Partial<DropdownFilterProps> & {
   ref?: React.RefObject<DropdownFilter>;
 };
 
+const irisGridTestUtils = new IrisGridTestUtils(dh);
+
 function makeContainer({
   column,
   columns = [],
@@ -109,7 +111,7 @@ it('mounts properly with no columns correctly', () => {
 });
 
 describe('options when source is selected', () => {
-  const columns = IrisGridTestUtils.makeColumns();
+  const columns = irisGridTestUtils.makeColumns();
   const column = columns[1];
   const source = makeSource({
     columnName: columns[0].name,
@@ -442,9 +444,9 @@ describe('options when source is selected', () => {
 
 it('differentiates between columns with the same name by adding type', () => {
   const columns = [
-    IrisGridTestUtils.makeColumn('C0', 'java.lang.Double'),
-    IrisGridTestUtils.makeColumn('C1', 'java.lang.Double'),
-    IrisGridTestUtils.makeColumn('C1', 'java.lang.Float'),
+    irisGridTestUtils.makeColumn('C0', 'java.lang.Double'),
+    irisGridTestUtils.makeColumn('C1', 'java.lang.Double'),
+    irisGridTestUtils.makeColumn('C1', 'java.lang.Float'),
   ];
   const source = makeSource({
     columnName: columns[0].name,

--- a/packages/dashboard-core-plugins/src/controls/dropdown-filter/DropdownFilter.tsx
+++ b/packages/dashboard-core-plugins/src/controls/dropdown-filter/DropdownFilter.tsx
@@ -13,7 +13,7 @@ import React, {
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Button, CardFlip, SocketedButton } from '@deephaven/components';
 import { vsGear } from '@deephaven/icons';
-import { Column } from '@deephaven/jsapi-shim';
+import type { Column } from '@deephaven/jsapi-types';
 import { TableUtils } from '@deephaven/jsapi-utils';
 import memoizee from 'memoizee';
 import memoize from 'memoize-one';

--- a/packages/dashboard-core-plugins/src/controls/input-filter/InputFilter.tsx
+++ b/packages/dashboard-core-plugins/src/controls/input-filter/InputFilter.tsx
@@ -13,7 +13,7 @@ import React, {
 import { Button, CardFlip } from '@deephaven/components';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { vsGear } from '@deephaven/icons';
-import { Column } from '@deephaven/jsapi-shim';
+import type { Column } from '@deephaven/jsapi-types';
 import memoizee from 'memoizee';
 import debounce from 'lodash.debounce';
 import Log from '@deephaven/log';

--- a/packages/dashboard-core-plugins/src/panels/CommandHistoryPanel.tsx
+++ b/packages/dashboard-core-plugins/src/panels/CommandHistoryPanel.tsx
@@ -12,7 +12,7 @@ import Log from '@deephaven/log';
 import { getCommandHistoryStorage, RootState } from '@deephaven/redux';
 import { assertNotNull, Pending } from '@deephaven/utils';
 import type { Container, EventEmitter } from '@deephaven/golden-layout';
-import { IdeSession } from '@deephaven/jsapi-shim';
+import type { IdeSession } from '@deephaven/jsapi-types';
 import { ConsoleEvent, NotebookEvent } from '../events';
 import './CommandHistoryPanel.scss';
 import Panel from './Panel';

--- a/packages/dashboard-core-plugins/src/panels/ConsolePanel.tsx
+++ b/packages/dashboard-core-plugins/src/panels/ConsolePanel.tsx
@@ -11,7 +11,7 @@ import {
   HeapUsage,
 } from '@deephaven/console';
 import { PanelEvent } from '@deephaven/dashboard';
-import { IdeSession, VariableDefinition } from '@deephaven/jsapi-shim';
+import type { IdeSession, VariableDefinition } from '@deephaven/jsapi-types';
 import { SessionWrapper } from '@deephaven/jsapi-utils';
 import Log from '@deephaven/log';
 import {

--- a/packages/dashboard-core-plugins/src/panels/FileExplorerPanel.tsx
+++ b/packages/dashboard-core-plugins/src/panels/FileExplorerPanel.tsx
@@ -10,7 +10,7 @@ import FileExplorer, {
 } from '@deephaven/file-explorer';
 import React, { ReactNode } from 'react';
 import { connect, ConnectedProps } from 'react-redux';
-import { IdeSession } from '@deephaven/jsapi-shim';
+import type { IdeSession } from '@deephaven/jsapi-types';
 import Panel from './Panel';
 import { NotebookEvent } from '../events';
 import './FileExplorerPanel.scss';

--- a/packages/dashboard-core-plugins/src/panels/FilterSetManagerPanel.tsx
+++ b/packages/dashboard-core-plugins/src/panels/FilterSetManagerPanel.tsx
@@ -7,7 +7,7 @@ import {
 } from '@deephaven/dashboard';
 import Log from '@deephaven/log';
 import type { Container, EventEmitter } from '@deephaven/golden-layout';
-import { TableTemplate } from '@deephaven/jsapi-shim';
+import type { TableTemplate } from '@deephaven/jsapi-types';
 import { RootState } from '@deephaven/redux';
 import {
   AdvancedFilter,

--- a/packages/dashboard-core-plugins/src/panels/LogPanel.tsx
+++ b/packages/dashboard-core-plugins/src/panels/LogPanel.tsx
@@ -3,7 +3,7 @@
 import React, { PureComponent } from 'react';
 import { connect } from 'react-redux';
 import { LogView } from '@deephaven/console';
-import { IdeSession } from '@deephaven/jsapi-shim';
+import type { IdeSession } from '@deephaven/jsapi-types';
 import Log from '@deephaven/log';
 import type { Container, EventEmitter } from '@deephaven/golden-layout';
 import { RootState } from '@deephaven/redux';

--- a/packages/dashboard-core-plugins/src/panels/NotebookPanel.tsx
+++ b/packages/dashboard-core-plugins/src/panels/NotebookPanel.tsx
@@ -47,7 +47,7 @@ import type {
   Tab,
   CloseOptions,
 } from '@deephaven/golden-layout';
-import { IdeSession } from '@deephaven/jsapi-shim';
+import type { IdeSession } from '@deephaven/jsapi-types';
 import { ConsoleEvent, NotebookEvent } from '../events';
 import { getDashboardSessionWrapper } from '../redux';
 import Panel from './Panel';

--- a/packages/dashboard-core-plugins/src/panels/Panel.tsx
+++ b/packages/dashboard-core-plugins/src/panels/Panel.tsx
@@ -24,7 +24,7 @@ import type {
 } from '@deephaven/golden-layout';
 import { assertNotNull } from '@deephaven/utils';
 import Log from '@deephaven/log';
-import { IdeSession } from '@deephaven/jsapi-shim';
+import type { IdeSession } from '@deephaven/jsapi-types';
 import { ConsoleEvent, InputFilterEvent, TabEvent } from '../events';
 import PanelContextMenu from './PanelContextMenu';
 import RenameDialog from './RenameDialog';

--- a/packages/dashboard-core-plugins/src/redux/actions.ts
+++ b/packages/dashboard-core-plugins/src/redux/actions.ts
@@ -4,7 +4,7 @@ import { updateDashboardData } from '@deephaven/dashboard';
 import { SessionWrapper } from '@deephaven/jsapi-utils';
 import { RootState } from '@deephaven/redux';
 import { Action } from 'redux';
-import { IdeConnection } from '@deephaven/jsapi-shim';
+import type { IdeConnection } from '@deephaven/jsapi-types';
 import { getLinksForDashboard } from './selectors';
 import { FilterSet } from '../panels';
 import { Link } from '../linker/LinkerUtils';

--- a/packages/dashboard-core-plugins/src/redux/selectors.ts
+++ b/packages/dashboard-core-plugins/src/redux/selectors.ts
@@ -1,5 +1,5 @@
 import { getDashboardData } from '@deephaven/dashboard';
-import { Column, IdeConnection, Table } from '@deephaven/jsapi-shim';
+import type { Column, IdeConnection, Table } from '@deephaven/jsapi-types';
 import { SessionWrapper } from '@deephaven/jsapi-utils';
 import { RootState } from '@deephaven/redux';
 import { FilterChangeEvent } from '../FilterPlugin';

--- a/packages/embed-chart/src/App.tsx
+++ b/packages/embed-chart/src/App.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { Chart, ChartModel, ChartModelFactory } from '@deephaven/chart'; // chart is used to display Deephaven charts
 import { ContextMenuRoot, LoadingOverlay } from '@deephaven/components'; // Use the loading spinner from the Deephaven components package
-import type { IdeConnection } from '@deephaven/jsapi-types'; // Import the shim to use the JS API
+import type { dh as DhType, IdeConnection } from '@deephaven/jsapi-types';
 import Log from '@deephaven/log';
 import './App.scss'; // Styles for in this app
 import { useApi } from '@deephaven/jsapi-bootstrap';
@@ -11,11 +11,12 @@ const log = Log.module('EmbedChart.App');
 
 /**
  * Load an existing Deephaven figure with the connection provided
+ * @param dh JSAPI instance
  * @param connection The Deephaven session object
  * @param name Name of the figure to load
  * @returns Deephaven figure
  */
-async function loadFigure(connection: IdeConnection, name: string) {
+async function loadFigure(dh: DhType, connection: IdeConnection, name: string) {
   log.info(`Fetching figure ${name}...`);
 
   const definition = { name, type: dh.VariableType.FIGURE };
@@ -55,7 +56,7 @@ function App(): JSX.Element {
           log.debug('Loading figure', name, '...');
 
           // Load the figure up.
-          const figure = await loadFigure(connection, name);
+          const figure = await loadFigure(dh, connection, name);
 
           // Create the `ChartModel` for use with the `Chart` component
           log.debug(`Creating model...`);

--- a/packages/embed-grid/src/App.tsx
+++ b/packages/embed-grid/src/App.tsx
@@ -7,7 +7,8 @@ import {
   IrisGridModel,
   IrisGridModelFactory,
 } from '@deephaven/iris-grid'; // iris-grid is used to display Deephaven tables
-import dh, { IdeConnection, Sort, Table } from '@deephaven/jsapi-shim'; // Import the shim to use the JS API
+import dh from '@deephaven/jsapi-shim'; // Import the shim to use the JS API
+import type { IdeConnection, Sort, Table } from '@deephaven/jsapi-types';
 import { fetchVariableDefinition, TableUtils } from '@deephaven/jsapi-utils';
 import Log from '@deephaven/log';
 import './App.scss'; // Styles for in this app

--- a/packages/iris-grid/src/AdvancedFilterCreator.test.tsx
+++ b/packages/iris-grid/src/AdvancedFilterCreator.test.tsx
@@ -13,6 +13,8 @@ import { AdvancedFilterOptions } from './CommonTypes';
 import IrisGridTestUtils from './IrisGridTestUtils';
 import IrisGridModel from './IrisGridModel';
 
+const irisGridTestUtils = new IrisGridTestUtils(dh);
+
 // let mockFilterHandlers = [];
 // let mockSelectedType;
 // let mockValue;
@@ -51,8 +53,8 @@ function makeAdvancedFilterCreatorWrapper(
       invertSelection: false,
       selectedValues: [],
     },
-    model: IrisGridTestUtils.makeModel(dh),
-    column: IrisGridTestUtils.makeColumn(),
+    model: irisGridTestUtils.makeModel(),
+    column: irisGridTestUtils.makeColumn(),
     formatter: new Formatter(dh),
   }
 ) {

--- a/packages/iris-grid/src/AdvancedFilterCreator.test.tsx
+++ b/packages/iris-grid/src/AdvancedFilterCreator.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Formatter, TableUtils } from '@deephaven/jsapi-utils';
 import { render } from '@testing-library/react';
-import { Column } from '@deephaven/jsapi-types';
+import type { Column } from '@deephaven/jsapi-types';
 // import userEvent from '@testing-library/user-event';
 import dh from '@deephaven/jsapi-shim';
 // import {

--- a/packages/iris-grid/src/AdvancedFilterCreator.tsx
+++ b/packages/iris-grid/src/AdvancedFilterCreator.tsx
@@ -21,7 +21,12 @@ import {
 import { Button, ContextActionUtils } from '@deephaven/components';
 import Log from '@deephaven/log';
 import { CancelablePromise, PromiseUtils } from '@deephaven/utils';
-import type { Column, FilterCondition, Table } from '@deephaven/jsapi-types';
+import type {
+  Column,
+  dh as DhType,
+  FilterCondition,
+  Table,
+} from '@deephaven/jsapi-types';
 import shortid from 'shortid';
 import AdvancedFilterCreatorFilterItem from './AdvancedFilterCreatorFilterItem';
 import AdvancedFilterCreatorSelectValue from './AdvancedFilterCreatorSelectValue';
@@ -37,6 +42,7 @@ type FilterChangeHandler = (
 ) => void;
 
 interface AdvancedFilterCreatorProps {
+  dh: DhType;
   model: IrisGridModel;
   column: Column;
   onFilterChange: (
@@ -446,7 +452,14 @@ class AdvancedFilterCreator extends PureComponent<
   }
 
   render(): JSX.Element {
-    const { column, model, sortDirection, formatter, tableUtils } = this.props;
+    const {
+      column,
+      dh,
+      model,
+      sortDirection,
+      formatter,
+      tableUtils,
+    } = this.props;
     const {
       filterItems,
       filterOperators,

--- a/packages/iris-grid/src/IrisGrid.test.tsx
+++ b/packages/iris-grid/src/IrisGrid.test.tsx
@@ -24,6 +24,8 @@ const DEFAULT_SETTINGS: Settings = {
   truncateNumbersWithPound: false,
 };
 
+const irisGridTestUtils = new IrisGridTestUtils(dh);
+
 function makeMockCanvas() {
   return {
     clientWidth: VIEW_SIZE,
@@ -53,7 +55,7 @@ function createNodeMock(element) {
 }
 
 function makeComponent(
-  model = IrisGridTestUtils.makeModel(dh),
+  model = irisGridTestUtils.makeModel(),
   settings = DEFAULT_SETTINGS
 ) {
   const testRenderer = TestRenderer.create(
@@ -198,9 +200,8 @@ it('handles undefined operator, should default to eq', () => {
 
 it('should set gotoValueSelectedColumnName to empty string if no columns are given', () => {
   const component = makeComponent(
-    IrisGridTestUtils.makeModel(
-      dh,
-      IrisGridTestUtils.makeTable({
+    irisGridTestUtils.makeModel(
+      irisGridTestUtils.makeTable({
         columns: [],
       })
     )

--- a/packages/iris-grid/src/IrisGrid.tsx
+++ b/packages/iris-grid/src/IrisGrid.tsx
@@ -1032,19 +1032,23 @@ export class IrisGrid extends Component<IrisGridProps, IrisGridState> {
       advancedFilterOptions: AdvancedFilterOptions | undefined,
       sortDirection: SortDirection | undefined,
       formatter: Formatter
-    ) => (
-      <AdvancedFilterCreator
-        model={model}
-        column={column}
-        onFilterChange={this.handleAdvancedFilterChange}
-        onSortChange={this.handleAdvancedFilterSortChange}
-        onDone={this.handleAdvancedFilterDone}
-        options={advancedFilterOptions}
-        sortDirection={sortDirection}
-        formatter={formatter}
-        tableUtils={this.tableUtils}
-      />
-    ),
+    ) => {
+      const { dh } = this.props;
+      return (
+        <AdvancedFilterCreator
+          dh={dh}
+          model={model}
+          column={column}
+          onFilterChange={this.handleAdvancedFilterChange}
+          onSortChange={this.handleAdvancedFilterSortChange}
+          onDone={this.handleAdvancedFilterDone}
+          options={advancedFilterOptions}
+          sortDirection={sortDirection}
+          formatter={formatter}
+          tableUtils={this.tableUtils}
+        />
+      );
+    },
     { max: 50 }
   );
 
@@ -4310,6 +4314,7 @@ export class IrisGrid extends Component<IrisGridProps, IrisGridState> {
           assertNotNull(this.handleConditionalFormatEditorUpdate);
           return (
             <ConditionalFormatEditor
+              dh={dh}
               columns={model.columns}
               rule={conditionalFormatPreview}
               onUpdate={this.handleConditionalFormatEditorUpdate}

--- a/packages/iris-grid/src/IrisGridCopyHandler.test.tsx
+++ b/packages/iris-grid/src/IrisGridCopyHandler.test.tsx
@@ -17,6 +17,8 @@ const mockedCopyToClipboard = copyToClipboard as jest.MockedFunction<
 
 jest.useFakeTimers();
 
+const irisGridTestUtils = new IrisGridTestUtils(dh);
+
 const DEFAULT_EXPECTED_TEXT = `0,0\t0,1\t0,2\t0,3\t0,4
 1,0\t1,1\t1,2\t1,3\t1,4
 2,0\t2,1\t2,2\t2,3\t2,4
@@ -31,7 +33,7 @@ function makeCopyOperation(
   ranges = GridTestUtils.makeRanges(),
   includeHeaders = false,
   movedColumns = [],
-  userColumnWidths = IrisGridTestUtils.makeUserColumnWidths()
+  userColumnWidths = irisGridTestUtils.makeUserColumnWidths()
 ): CopyOperation {
   return {
     ranges,
@@ -42,7 +44,7 @@ function makeCopyOperation(
 }
 
 function makeModel() {
-  const model = IrisGridTestUtils.makeModel(dh);
+  const model = irisGridTestUtils.makeModel();
   model.textSnapshot = makeSnapshotFn();
   return model;
 }

--- a/packages/iris-grid/src/IrisGridCopyHandler.test.tsx
+++ b/packages/iris-grid/src/IrisGridCopyHandler.test.tsx
@@ -33,7 +33,7 @@ function makeCopyOperation(
   ranges = GridTestUtils.makeRanges(),
   includeHeaders = false,
   movedColumns = [],
-  userColumnWidths = irisGridTestUtils.makeUserColumnWidths()
+  userColumnWidths = IrisGridTestUtils.makeUserColumnWidths()
 ): CopyOperation {
   return {
     ranges,

--- a/packages/iris-grid/src/IrisGridModel.test.ts
+++ b/packages/iris-grid/src/IrisGridModel.test.ts
@@ -13,21 +13,23 @@ import { UITotalsTableConfig } from './CommonTypes';
 
 jest.useFakeTimers();
 
+const irisGridTestUtils = new IrisGridTestUtils(dh);
+
 describe('viewport and subscription tests', () => {
   let table: Table;
   let subscription: TableViewportSubscription;
   let model: IrisGridModel;
 
   beforeEach(() => {
-    table = IrisGridTestUtils.makeTable();
-    subscription = IrisGridTestUtils.makeSubscription(table);
+    table = irisGridTestUtils.makeTable();
+    subscription = irisGridTestUtils.makeSubscription(table);
     table.setViewport = jest.fn(() => subscription);
     table.applyFilter = jest.fn(val => val);
     table.applySort = jest.fn(val => val);
     table.applyCustomColumns = jest.fn(val => val as string[]);
     subscription.setViewport = jest.fn();
     subscription.close = jest.fn();
-    model = IrisGridTestUtils.makeModel(dh, table);
+    model = irisGridTestUtils.makeModel(table);
   });
 
   it('applies viewport to existing subscription', () => {
@@ -70,15 +72,15 @@ describe('viewport and subscription tests', () => {
     expect(subscription.close).not.toHaveBeenCalled();
     jest.clearAllMocks();
 
-    model.filter = [IrisGridTestUtils.makeFilter()];
+    model.filter = [irisGridTestUtils.makeFilter()];
     jest.runAllTimers();
     expect(table.setViewport).toHaveBeenCalledTimes(1);
     expect(subscription.setViewport).not.toHaveBeenCalled();
     expect(subscription.close).toHaveBeenCalled();
 
     jest.clearAllMocks();
-    model.filter = [IrisGridTestUtils.makeFilter()];
-    model.sort = [IrisGridTestUtils.makeSort()];
+    model.filter = [irisGridTestUtils.makeFilter()];
+    model.sort = [irisGridTestUtils.makeSort()];
     model.customColumns = ['A=i'];
     jest.runAllTimers();
     expect(subscription.close).toHaveBeenCalled();
@@ -124,16 +126,16 @@ describe('viewport and subscription tests', () => {
 });
 
 it('updates the model correctly when adding and removing a rollup config', async () => {
-  const table = IrisGridTestUtils.makeTable();
-  const rollupTable = IrisGridTestUtils.makeTable();
-  const rollupConfig = IrisGridTestUtils.makeRollupTableConfig();
+  const table = irisGridTestUtils.makeTable();
+  const rollupTable = irisGridTestUtils.makeTable();
+  const rollupConfig = irisGridTestUtils.makeRollupTableConfig();
 
   const mock = jest.fn(() =>
     Promise.resolve((rollupTable as unknown) as TreeTable)
   );
 
   table.rollup = mock;
-  const model = IrisGridTestUtils.makeModel(dh, table);
+  const model = irisGridTestUtils.makeModel(table);
 
   expect(mock).not.toHaveBeenCalled();
 
@@ -149,9 +151,9 @@ it('updates the model correctly when adding and removing a rollup config', async
 });
 
 it('closes the table correctly when the model is closed', () => {
-  const table = IrisGridTestUtils.makeTable();
+  const table = irisGridTestUtils.makeTable();
   table.close = jest.fn();
-  const model = IrisGridTestUtils.makeModel(dh, table);
+  const model = irisGridTestUtils.makeModel(table);
 
   model.close();
 
@@ -170,14 +172,14 @@ describe('totals table tests', () => {
   let model: IrisGridModel;
 
   beforeEach(() => {
-    table = IrisGridTestUtils.makeTable();
-    totalsTable = IrisGridTestUtils.makeTable();
+    table = irisGridTestUtils.makeTable();
+    totalsTable = irisGridTestUtils.makeTable();
 
     table.close = jest.fn();
     table.getTotalsTable = jest.fn(() => Promise.resolve(totalsTable));
     totalsTable.close = jest.fn();
 
-    model = IrisGridTestUtils.makeModel(dh, table);
+    model = irisGridTestUtils.makeModel(table);
   });
 
   it('opens a totals table correctly and closes it when done', async () => {
@@ -220,20 +222,15 @@ describe('pending new rows tests', () => {
   let model: IrisGridModel;
 
   beforeEach(() => {
-    table = IrisGridTestUtils.makeTable({
-      columns: IrisGridTestUtils.makeColumns(),
+    table = irisGridTestUtils.makeTable({
+      columns: irisGridTestUtils.makeColumns(),
       size: TABLE_SIZE,
     });
     table.close = jest.fn();
 
-    inputTable = IrisGridTestUtils.makeInputTable(table.columns.slice(0, 3));
+    inputTable = irisGridTestUtils.makeInputTable(table.columns.slice(0, 3));
 
-    model = IrisGridTestUtils.makeModel(
-      dh,
-      table,
-      new Formatter(dh),
-      inputTable
-    );
+    model = irisGridTestUtils.makeModel(table, new Formatter(dh), inputTable);
     model.pendingRowCount = PENDING_ROW_COUNT;
   });
 

--- a/packages/iris-grid/src/IrisGridPartitionSelector.test.tsx
+++ b/packages/iris-grid/src/IrisGridPartitionSelector.test.tsx
@@ -1,16 +1,18 @@
 import React from 'react';
 import { render } from '@testing-library/react';
+import dh from '@deephaven/jsapi-shim';
 import IrisGridPartitionSelector from './IrisGridPartitionSelector';
 import IrisGridTestUtils from './IrisGridTestUtils';
 
 function makeIrisGridPartitionSelector(
-  table = IrisGridTestUtils.makeTable(),
+  table = new IrisGridTestUtils(dh).makeTable(),
   onChange = jest.fn(),
   onDone = jest.fn(),
   getFormattedString = jest.fn(value => `${value}`)
 ) {
   return render(
     <IrisGridPartitionSelector
+      dh={dh}
       table={table}
       columnName="0"
       getFormattedString={getFormattedString}

--- a/packages/iris-grid/src/IrisGridTableModelTemplate.ts
+++ b/packages/iris-grid/src/IrisGridTableModelTemplate.ts
@@ -321,6 +321,7 @@ class IrisGridTableModelTemplate<
   }
 
   addTotalsListeners(totalsTable: TotalsTable): void {
+    const { dh } = this;
     totalsTable.addEventListener(
       dh.Table.EVENT_UPDATED,
       this.handleTotalsUpdate
@@ -331,6 +332,7 @@ class IrisGridTableModelTemplate<
   }
 
   removeTotalsListeners(totalsTable: TotalsTable): void {
+    const { dh } = this;
     totalsTable.removeEventListener(
       dh.Table.EVENT_UPDATED,
       this.handleTotalsUpdate

--- a/packages/iris-grid/src/IrisGridTestUtils.ts
+++ b/packages/iris-grid/src/IrisGridTestUtils.ts
@@ -30,21 +30,27 @@ class IrisGridTestUtils {
     return value;
   }
 
-  static makeColumn(
+  private dh: DhType;
+
+  constructor(dh: DhType) {
+    this.dh = dh;
+  }
+
+  makeColumn(
     name?: string,
     type: string = IrisGridTestUtils.DEFAULT_TYPE,
     index = 0
   ): Column {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    return new (dh as any).Column({ index, name, type });
+    return new (this.dh as any).Column({ index, name, type });
   }
 
-  static makeRollupTableConfig(): RollupConfig {
+  makeRollupTableConfig(): RollupConfig {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    return new (dh as any).RollupTableConfig();
+    return new (this.dh as any).RollupTableConfig();
   }
 
-  static makeColumns(count = 5, prefix = ''): Column[] {
+  makeColumns(count = 5, prefix = ''): Column[] {
     const columns = [];
     for (let i = 0; i < count; i += 1) {
       columns.push(
@@ -62,9 +68,9 @@ class IrisGridTestUtils {
     return userColumnWidths;
   }
 
-  static makeRow(i: number): Row {
+  makeRow(i: number): Row {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const row = new (dh as any).Row({ index: i, name: `${i}` });
+    const row = new (this.dh as any).Row({ index: i, name: `${i}` });
 
     row.get = jest.fn(column =>
       IrisGridTestUtils.valueForCell(i, column.index)
@@ -73,60 +79,63 @@ class IrisGridTestUtils {
     return row;
   }
 
-  static makeFilter(): FilterCondition {
+  makeFilter(): FilterCondition {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    return new (dh as any).FilterCondition();
+    return new (this.dh as any).FilterCondition();
   }
 
-  static makeSort(): Sort {
+  makeSort(): Sort {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    return new (dh as any).Sort();
+    return new (this.dh as any).Sort();
   }
 
-  static makeTable({
-    columns = IrisGridTestUtils.makeColumns(),
+  makeTable({
+    columns = this.makeColumns(),
     size = 1000000000,
     sort = [],
     layoutHints = {} as LayoutHints,
   } = {}): Table {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const table = new (dh as any).Table({ columns, size, sort });
+    const table = new (this.dh as any).Table({ columns, size, sort });
     table.copy = jest.fn(() => Promise.resolve(table));
     table.freeze = jest.fn(() => Promise.resolve(table));
     table.layoutHints = layoutHints;
     return table;
   }
 
-  static makeTreeTable(
-    columns = IrisGridTestUtils.makeColumns(),
+  makeTreeTable(
+    columns = this.makeColumns(),
     size = 1000000000,
     sort = []
   ): TreeTable {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const table = new (dh as any).TreeTable({ columns, size, sort });
+    const table = new (this.dh as any).TreeTable({ columns, size, sort });
     table.copy = jest.fn(() => Promise.resolve(table));
     return table;
   }
 
-  static makeInputTable(keyColumns: Column[] = []): InputTable {
+  makeInputTable(keyColumns: Column[] = []): InputTable {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    return new (dh as any).InputTable(keyColumns);
+    return new (this.dh as any).InputTable(keyColumns);
   }
 
-  static makeSubscription(
-    table = IrisGridTestUtils.makeTable()
-  ): TableViewportSubscription {
+  makeSubscription(table = this.makeTable()): TableViewportSubscription {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    return new (dh as any).TableViewportSubscription({ table });
+    return new (this.dh as any).TableViewportSubscription({ table });
   }
 
-  static makeModel(
-    dh: DhType,
-    table = IrisGridTestUtils.makeTable(),
-    formatter = new Formatter(dh),
+  makeModel(
+    table = this.makeTable(),
+    formatter: Formatter | null = null,
     inputTable: InputTable | null = null
   ): IrisGridProxyModel {
-    return new IrisGridProxyModel(dh, table, formatter, inputTable);
+    const { dh } = this;
+    return new IrisGridProxyModel(
+      dh,
+      table,
+      formatter ?? new Formatter(dh),
+      inputTable
+    );
   }
 }
 

--- a/packages/iris-grid/src/IrisGridUtils.test.ts
+++ b/packages/iris-grid/src/IrisGridUtils.test.ts
@@ -12,6 +12,7 @@ import IrisGridUtils, {
 } from './IrisGridUtils';
 
 const irisGridUtils = new IrisGridUtils(dh);
+const irisGridTestUtils = new IrisGridTestUtils(dh);
 
 function makeFilter() {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -38,7 +39,7 @@ function makeTable({
   return new (dh as any).Table({ columns, sort });
 }
 function makeColumn(index: number): Column {
-  return IrisGridTestUtils.makeColumn(
+  return irisGridTestUtils.makeColumn(
     `${index}`,
     IrisGridTestUtils.DEFAULT_TYPE,
     index
@@ -47,7 +48,7 @@ function makeColumn(index: number): Column {
 
 describe('quickfilters tests', () => {
   it('exports/imports empty list', () => {
-    const table = IrisGridTestUtils.makeTable();
+    const table = irisGridTestUtils.makeTable();
     const filters = new Map();
     const exportedFilters = IrisGridUtils.dehydrateQuickFilters(filters);
     expect(exportedFilters).toEqual([]);
@@ -382,7 +383,7 @@ describe('remove columns in moved columns', () => {
 });
 
 describe('getPrevVisibleColumns', () => {
-  const columns = IrisGridTestUtils.makeColumns(5);
+  const columns = irisGridTestUtils.makeColumns(5);
   it('returns [] for startIndex < 0', () => {
     expect(IrisGridUtils.getPrevVisibleColumns(columns, -1, 1, [], [])).toEqual(
       []
@@ -407,7 +408,7 @@ describe('getPrevVisibleColumns', () => {
 });
 
 describe('getNextVisibleColumns', () => {
-  const columns = IrisGridTestUtils.makeColumns(5);
+  const columns = irisGridTestUtils.makeColumns(5);
   it('returns [] for startIndex >= columns.length', () => {
     expect(
       IrisGridUtils.getNextVisibleColumns(columns, columns.length, 1, [], [])

--- a/packages/iris-grid/src/IrisGridUtils.ts
+++ b/packages/iris-grid/src/IrisGridUtils.ts
@@ -1653,7 +1653,7 @@ class IrisGridUtils {
       if (partitionColumn) {
         const partitionFilter = partitionColumn
           .filter()
-          .eq(dh.FilterValue.ofString(partition));
+          .eq(this.dh.FilterValue.ofString(partition));
         filters = [partitionFilter, ...filters];
       }
     }

--- a/packages/iris-grid/src/PartitionSelectorSearch.test.tsx
+++ b/packages/iris-grid/src/PartitionSelectorSearch.test.tsx
@@ -6,8 +6,10 @@ import type { Table } from '@deephaven/jsapi-types';
 import PartitionSelectorSearch from './PartitionSelectorSearch';
 import IrisGridTestUtils from './IrisGridTestUtils';
 
+const irisGridTestUtils = new IrisGridTestUtils(dh);
+
 function makePartitionSelectorSearch({
-  table = IrisGridTestUtils.makeTable(),
+  table = irisGridTestUtils.makeTable(),
   onSelect = jest.fn(),
   getFormattedString = jest.fn(value => `${value}`),
 } = {}) {
@@ -35,7 +37,7 @@ it('mounts and unmounts properly', () => {
 
 it('updates filters when input is changed', async () => {
   const user = userEvent.setup({ delay: null });
-  const table = IrisGridTestUtils.makeTable();
+  const table = irisGridTestUtils.makeTable();
   table.applyFilter = jest.fn();
 
   const component = makePartitionSelectorSearch({ table });
@@ -61,7 +63,7 @@ it('updates filters when input is changed', async () => {
 it('selects the first item when enter is pressed', async () => {
   const user = userEvent.setup({ delay: null });
   const onSelect = jest.fn();
-  const table = IrisGridTestUtils.makeTable();
+  const table = irisGridTestUtils.makeTable();
   const component = makePartitionSelectorSearch({ onSelect, table });
 
   (table as Table).fireViewportUpdate();

--- a/packages/iris-grid/src/sidebar/ChartBuilder.test.tsx
+++ b/packages/iris-grid/src/sidebar/ChartBuilder.test.tsx
@@ -7,13 +7,14 @@ import IrisGridTestUtils from '../IrisGridTestUtils';
 
 const COLUMN_NAMES = ['A', 'B', 'C', 'D'];
 
+const irisGridTestUtils = new IrisGridTestUtils(dh);
+
 function makeChartBuilderWrapper({
   onChange = () => null,
   onSubmit = () => null,
-  model = IrisGridTestUtils.makeModel(
-    dh,
-    IrisGridTestUtils.makeTable({
-      columns: COLUMN_NAMES.map(name => IrisGridTestUtils.makeColumn(name)),
+  model = irisGridTestUtils.makeModel(
+    irisGridTestUtils.makeTable({
+      columns: COLUMN_NAMES.map(name => irisGridTestUtils.makeColumn(name)),
     })
   ),
 } = {}) {

--- a/packages/iris-grid/src/sidebar/CustomColumnBuilder.test.tsx
+++ b/packages/iris-grid/src/sidebar/CustomColumnBuilder.test.tsx
@@ -9,8 +9,10 @@ import CustomColumnBuilder, {
 import IrisGridTestUtils from '../IrisGridTestUtils';
 import IrisGridModel from '../IrisGridModel';
 
+const irisGridTestUtils = new IrisGridTestUtils(dh);
+
 function Builder({
-  model = IrisGridTestUtils.makeModel(dh),
+  model = irisGridTestUtils.makeModel(),
   customColumns = [],
   onSave = jest.fn(),
   onCancel = jest.fn(),
@@ -45,7 +47,7 @@ test('Calls on save', async () => {
 test('Switches to loader button while saving', async () => {
   jest.useFakeTimers();
   const user = userEvent.setup({ delay: null });
-  const model = IrisGridTestUtils.makeModel(dh);
+  const model = irisGridTestUtils.makeModel();
   const mockSave = jest.fn(() =>
     setTimeout(() => {
       model.dispatchEvent(
@@ -100,7 +102,7 @@ test('Ignores deleted formulas on save', async () => {
   // This test instead creates the new text, saves, then removes it to test the same behavior
   jest.useFakeTimers();
   const user = userEvent.setup({ delay: null });
-  const model = IrisGridTestUtils.makeModel(dh);
+  const model = irisGridTestUtils.makeModel();
   const mockSave = jest.fn(() =>
     setTimeout(() => {
       model.dispatchEvent(
@@ -151,7 +153,7 @@ test('Deletes columns', async () => {
 
 test('Displays request failure message', async () => {
   const user = userEvent.setup();
-  const model = IrisGridTestUtils.makeModel(dh);
+  const model = irisGridTestUtils.makeModel();
   render(<Builder model={model} customColumns={['foo=bar']} />);
 
   // Should ignore this since not in saving state

--- a/packages/iris-grid/src/sidebar/TableCsvExporter.test.tsx
+++ b/packages/iris-grid/src/sidebar/TableCsvExporter.test.tsx
@@ -5,14 +5,15 @@ import dh from '@deephaven/jsapi-shim';
 import TableCsvExporter from './TableCsvExporter';
 import IrisGridTestUtils from '../IrisGridTestUtils';
 
+const irisGridTestUtils = new IrisGridTestUtils(dh);
 const COLUMN_NAMES = ['A', 'B', 'C', 'D'];
-const TABLE = IrisGridTestUtils.makeTable({
-  columns: COLUMN_NAMES.map(name => IrisGridTestUtils.makeColumn(name)),
+const TABLE = irisGridTestUtils.makeTable({
+  columns: COLUMN_NAMES.map(name => irisGridTestUtils.makeColumn(name)),
   size: 100,
 });
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const BAD_TABLE = IrisGridTestUtils.makeTable({
-  columns: COLUMN_NAMES.map(name => IrisGridTestUtils.makeColumn(name)),
+const BAD_TABLE = irisGridTestUtils.makeTable({
+  columns: COLUMN_NAMES.map(name => irisGridTestUtils.makeColumn(name)),
   size: 100,
 });
 BAD_TABLE.freeze = jest.fn(() =>
@@ -31,7 +32,7 @@ function makeTableCsvExporterWrapper({
   selectedRanges = [],
   userColumnWidths = IrisGridTestUtils.makeUserColumnWidths(),
   movedColumns = [],
-  model = IrisGridTestUtils.makeModel(dh, TABLE),
+  model = irisGridTestUtils.makeModel(TABLE),
 } = {}) {
   return render(
     <TableCsvExporter
@@ -74,7 +75,7 @@ it('cancels download when something goes wrong', async () => {
   const onDownloadStart = jest.fn();
   const onDownload = jest.fn();
   const onCancel = jest.fn();
-  const model = IrisGridTestUtils.makeModel(dh, BAD_TABLE);
+  const model = irisGridTestUtils.makeModel(BAD_TABLE);
   makeTableCsvExporterWrapper({
     onDownloadStart,
     onDownload,

--- a/packages/iris-grid/src/sidebar/conditional-formatting/ConditionalFormatEditor.tsx
+++ b/packages/iris-grid/src/sidebar/conditional-formatting/ConditionalFormatEditor.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useState } from 'react';
 import classNames from 'classnames';
 import { Button } from '@deephaven/components';
+import type { dh as DhType } from '@deephaven/jsapi-types';
 import Log from '@deephaven/log';
 import { FormatColumnWhereIcon, FormatRowWhereIcon } from '../icons';
 import ColumnFormatEditor from './ColumnFormatEditor';
@@ -23,6 +24,7 @@ export type UpdateCallback = (rule?: FormattingRule) => void;
 export type CancelCallback = () => void;
 
 export interface ConditionalFormatEditorProps {
+  dh: DhType;
   columns: readonly ModelColumn[];
   rule?: FormattingRule;
   onCancel?: CancelCallback;
@@ -57,6 +59,7 @@ function ConditionalFormatEditor(
 ): JSX.Element {
   const {
     columns: originalColumns,
+    dh,
     onSave = DEFAULT_CALLBACK,
     onUpdate = DEFAULT_CALLBACK,
     onCancel = DEFAULT_CALLBACK,

--- a/packages/iris-grid/src/sidebar/conditional-formatting/ConditionalFormattingUtils.test.ts
+++ b/packages/iris-grid/src/sidebar/conditional-formatting/ConditionalFormattingUtils.test.ts
@@ -11,6 +11,8 @@ import {
   StringCondition,
 } from './ConditionalFormattingUtils';
 
+const irisGridTestUtils = new IrisGridTestUtils(dh);
+
 jest.mock('./ConditionalFormattingAPIUtils', () => ({
   makeTernaryFormatRule: jest.fn(
     (rule, prevRule = null) =>
@@ -22,7 +24,7 @@ jest.mock('./ConditionalFormattingAPIUtils', () => ({
 
 describe('getFormatColumns', () => {
   function makeColumns(count = 5): Column[] {
-    return IrisGridTestUtils.makeColumns(count);
+    return irisGridTestUtils.makeColumns(count);
   }
 
   function makeFormatRule({

--- a/packages/iris-grid/src/sidebar/visibility-ordering-builder/VisibilityOrderingBuilder.test.tsx
+++ b/packages/iris-grid/src/sidebar/visibility-ordering-builder/VisibilityOrderingBuilder.test.tsx
@@ -92,7 +92,6 @@ function BuilderWithNestedGroups({
 
 function makeModel() {
   return irisGridTestUtils.makeModel(
-    dh,
     irisGridTestUtils.makeTable({ columns: COLUMNS })
   );
 }

--- a/packages/iris-grid/src/sidebar/visibility-ordering-builder/VisibilityOrderingBuilder.test.tsx
+++ b/packages/iris-grid/src/sidebar/visibility-ordering-builder/VisibilityOrderingBuilder.test.tsx
@@ -13,10 +13,12 @@ import { flattenTree, getTreeItems } from './sortable-tree/utilities';
 
 jest.useFakeTimers();
 
+const irisGridTestUtils = new IrisGridTestUtils(dh);
+
 const ALL_PREFIX = 'Test';
 const COLUMN_PREFIX = 'TestColumn';
 const GROUP_PREFIX = 'TestGroup';
-const COLUMNS = IrisGridTestUtils.makeColumns(10, COLUMN_PREFIX);
+const COLUMNS = irisGridTestUtils.makeColumns(10, COLUMN_PREFIX);
 const SELECTED_CLASS = 'isSelected';
 const COLUMN_HEADER_GROUPS: ColumnGroup[] = [
   {
@@ -89,16 +91,15 @@ function BuilderWithNestedGroups({
 }
 
 function makeModel() {
-  return IrisGridTestUtils.makeModel(
+  return irisGridTestUtils.makeModel(
     dh,
-    IrisGridTestUtils.makeTable({ columns: COLUMNS })
+    irisGridTestUtils.makeTable({ columns: COLUMNS })
   );
 }
 
 function makeModelWithGroups(groups = COLUMN_HEADER_GROUPS) {
-  return IrisGridTestUtils.makeModel(
-    dh,
-    IrisGridTestUtils.makeTable({
+  return irisGridTestUtils.makeModel(
+    irisGridTestUtils.makeTable({
       columns: COLUMNS,
       layoutHints: { columnGroups: groups },
     })
@@ -157,9 +158,8 @@ test('Renders all children', () => {
 });
 
 test('Renders immovable items', () => {
-  const model = IrisGridTestUtils.makeModel(
-    dh,
-    IrisGridTestUtils.makeTable({
+  const model = irisGridTestUtils.makeModel(
+    irisGridTestUtils.makeTable({
       columns: COLUMNS,
       layoutHints: {
         frozenColumns: [`${COLUMN_PREFIX}2`, `${COLUMN_PREFIX}4`],
@@ -181,10 +181,9 @@ test('Renders immovable items', () => {
 });
 
 test('Renders a grid of only immovable items', () => {
-  const model = IrisGridTestUtils.makeModel(
-    dh,
-    IrisGridTestUtils.makeTable({
-      columns: IrisGridTestUtils.makeColumns(1, COLUMN_PREFIX),
+  const model = irisGridTestUtils.makeModel(
+    irisGridTestUtils.makeTable({
+      columns: irisGridTestUtils.makeColumns(1, COLUMN_PREFIX),
       layoutHints: {
         frozenColumns: [`${COLUMN_PREFIX}0`],
       },

--- a/packages/iris-grid/src/sidebar/visibility-ordering-builder/VisibilityOrderingBuilderUtils.test.ts
+++ b/packages/iris-grid/src/sidebar/visibility-ordering-builder/VisibilityOrderingBuilderUtils.test.ts
@@ -12,9 +12,10 @@ import {
   getTreeItems,
 } from './sortable-tree/utilities';
 
+const irisGridTestUtils = new IrisGridTestUtils(dh);
 const COLUMN_PREFIX = 'TestColumn';
 const GROUP_PREFIX = 'TestGroup';
-const COLUMNS = IrisGridTestUtils.makeColumns(10, COLUMN_PREFIX);
+const COLUMNS = irisGridTestUtils.makeColumns(10, COLUMN_PREFIX);
 const SINGLE_HEADER_GROUPS: ColumnGroup[] = [
   {
     name: `${GROUP_PREFIX}OneAndThree`,
@@ -47,9 +48,8 @@ const NESTED_COLUMN_HEADER_GROUPS: ColumnGroup[] = [
 ];
 
 function makeTreeItems(groups: ColumnGroup[] = []) {
-  const model = IrisGridTestUtils.makeModel(
-    dh,
-    IrisGridTestUtils.makeTable({
+  const model = irisGridTestUtils.makeModel(
+    irisGridTestUtils.makeTable({
       columns: COLUMNS,
       layoutHints: { columnGroups: groups },
     })

--- a/packages/jsapi-bootstrap/src/ClientBootstrap.tsx
+++ b/packages/jsapi-bootstrap/src/ClientBootstrap.tsx
@@ -1,5 +1,5 @@
 import React, { createContext } from 'react';
-import { ConnectOptions, CoreClient } from '@deephaven/jsapi-types';
+import type { ConnectOptions, CoreClient } from '@deephaven/jsapi-types';
 import useCreateClient from './useCreateClient';
 
 export const ClientContext = createContext<CoreClient | null>(null);

--- a/packages/jsapi-bootstrap/src/useCreateClient.ts
+++ b/packages/jsapi-bootstrap/src/useCreateClient.ts
@@ -1,4 +1,4 @@
-import { ConnectOptions, CoreClient } from '@deephaven/jsapi-types';
+import type { ConnectOptions, CoreClient } from '@deephaven/jsapi-types';
 import { useEffect, useMemo } from 'react';
 import useApi from './useApi';
 

--- a/packages/jsapi-components/src/HookTestUtils.tsx
+++ b/packages/jsapi-components/src/HookTestUtils.tsx
@@ -1,0 +1,13 @@
+import React, { ReactNode } from 'react';
+import { ApiContext } from '@deephaven/jsapi-bootstrap';
+import type { dh as DhType } from '@deephaven/jsapi-types';
+
+export function makeApiContextWrapper(dh: DhType) {
+  return function ApiContextWrapper({ children }: { children?: ReactNode }) {
+    return <ApiContext.Provider value={dh}>{children}</ApiContext.Provider>;
+  };
+}
+
+export default {
+  makeApiContextWrapper,
+};

--- a/packages/jsapi-components/src/index.ts
+++ b/packages/jsapi-components/src/index.ts
@@ -1,3 +1,4 @@
+export * from './HookTestUtils';
 export { default as TableInput } from './TableInput';
 export * from './RefreshTokenBootstrap';
 export * from './RefreshTokenUtils';

--- a/packages/jsapi-components/src/useDebouncedViewportSearch.test.tsx
+++ b/packages/jsapi-components/src/useDebouncedViewportSearch.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { renderHook } from '@testing-library/react-hooks';
 import type {
   Column,
@@ -9,17 +8,15 @@ import type {
 import dh from '@deephaven/jsapi-shim';
 import { TableUtils } from '@deephaven/jsapi-utils';
 import { TestUtils } from '@deephaven/utils';
-import { ApiContext } from '@deephaven/jsapi-bootstrap';
 import useDebouncedViewportSearch, {
   DEBOUNCE_VIEWPORT_SEARCH_MS,
 } from './useDebouncedViewportSearch';
 import { UseViewportDataResult } from './useViewportData';
+import { makeApiContextWrapper } from './HookTestUtils';
 
 const tableUtils = new TableUtils(dh);
 
-const wrapper = ({ children }) => (
-  <ApiContext.Provider value={dh}>{children}</ApiContext.Provider>
-);
+const wrapper = makeApiContextWrapper(dh);
 
 // Mock js api objects
 const column = TestUtils.createMockProxy<Column>({

--- a/packages/jsapi-components/src/useSelectDistinctTable.ts
+++ b/packages/jsapi-components/src/useSelectDistinctTable.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect } from 'react';
-import { Table, TreeTable } from '@deephaven/jsapi-types';
+import type { Table, TreeTable } from '@deephaven/jsapi-types';
 import { usePromiseFactory } from '@deephaven/react-hooks';
 
 /**

--- a/packages/jsapi-components/src/useSetPaddedViewportCallback.ts
+++ b/packages/jsapi-components/src/useSetPaddedViewportCallback.ts
@@ -1,5 +1,5 @@
 import { useCallback } from 'react';
-import { Table, TreeTable } from '@deephaven/jsapi-types';
+import type { Table, TreeTable } from '@deephaven/jsapi-types';
 import { getSize, padFirstAndLastRow } from '@deephaven/jsapi-utils';
 
 /**

--- a/packages/jsapi-components/src/useTable.test.ts
+++ b/packages/jsapi-components/src/useTable.test.ts
@@ -1,6 +1,6 @@
 import { renderHook, act } from '@testing-library/react-hooks';
-import type { Column } from '@deephaven/jsapi-shim';
 import dh from '@deephaven/jsapi-shim';
+import type { Column } from '@deephaven/jsapi-types';
 import ColumnNameError from './ColumnNameError';
 import TableDisconnectError from './TableDisconnectError';
 

--- a/packages/jsapi-components/src/useTable.ts
+++ b/packages/jsapi-components/src/useTable.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 import { useApi } from '@deephaven/jsapi-bootstrap';
-import { Column, Row, Table } from '@deephaven/jsapi-types';
+import type { Column, Row, Table } from '@deephaven/jsapi-types';
 import Log from '@deephaven/log';
 import useTableListener from './useTableListener';
 import ColumnNameError from './ColumnNameError';

--- a/packages/jsapi-components/src/useTableColumn.ts
+++ b/packages/jsapi-components/src/useTableColumn.ts
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { Column, Table } from '@deephaven/jsapi-types';
+import type { Column, Table } from '@deephaven/jsapi-types';
 import useTable from './useTable';
 
 /**

--- a/packages/jsapi-components/src/useTableListener.test.ts
+++ b/packages/jsapi-components/src/useTableListener.test.ts
@@ -1,5 +1,5 @@
 import { renderHook } from '@testing-library/react-hooks';
-import { Evented } from '@deephaven/jsapi-types';
+import type { Evented } from '@deephaven/jsapi-types';
 import useTableListener from './useTableListener';
 
 const eventName = 'mock.event';

--- a/packages/jsapi-components/src/useTableListener.ts
+++ b/packages/jsapi-components/src/useTableListener.ts
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { Evented, EventListener } from '@deephaven/jsapi-types';
+import type { Evented, EventListener } from '@deephaven/jsapi-types';
 import Log from '@deephaven/log';
 
 const log = Log.module('useTableListener');

--- a/packages/jsapi-components/src/useTableSize.test.ts
+++ b/packages/jsapi-components/src/useTableSize.test.ts
@@ -1,5 +1,5 @@
 import { act, renderHook } from '@testing-library/react-hooks';
-import { Table } from '@deephaven/jsapi-shim';
+import type { Table } from '@deephaven/jsapi-types';
 import { TestUtils } from '@deephaven/utils';
 import useTableSize from './useTableSize';
 import useTableListener from './useTableListener';

--- a/packages/jsapi-components/src/useTableSize.test.ts
+++ b/packages/jsapi-components/src/useTableSize.test.ts
@@ -1,17 +1,21 @@
 import { act, renderHook } from '@testing-library/react-hooks';
+import dh from '@deephaven/jsapi-shim';
 import type { Table } from '@deephaven/jsapi-types';
 import { TestUtils } from '@deephaven/utils';
 import useTableSize from './useTableSize';
 import useTableListener from './useTableListener';
+import { makeApiContextWrapper } from './HookTestUtils';
 
 jest.mock('./useTableListener');
+
+const wrapper = makeApiContextWrapper(dh);
 
 beforeEach(() => {
   jest.clearAllMocks();
 });
 
 it.each([null, undefined])('should return 0 if no table', table => {
-  const { result } = renderHook(() => useTableSize(table));
+  const { result } = renderHook(() => useTableSize(table), { wrapper });
   expect(result.current).toEqual(0);
 });
 
@@ -19,7 +23,7 @@ it('should return the size of the given table', () => {
   const size = 10;
   const table = TestUtils.createMockProxy<Table>({ size });
 
-  const { result } = renderHook(() => useTableSize(table));
+  const { result } = renderHook(() => useTableSize(table), { wrapper });
 
   expect(result.current).toEqual(size);
 });
@@ -31,7 +35,7 @@ it('should re-render if dh.Table.EVENT_SIZECHANGED event occurs', () => {
     size: initialSize,
   } as unknown) as Table;
 
-  const { result } = renderHook(() => useTableSize(table));
+  const { result } = renderHook(() => useTableSize(table), { wrapper });
 
   const [eventEmitter, eventName, onSizeChangeHandler] =
     TestUtils.extractCallArgs(useTableListener, 0) ?? [];

--- a/packages/jsapi-components/src/useTableSize.ts
+++ b/packages/jsapi-components/src/useTableSize.ts
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useApi } from '@deephaven/jsapi-bootstrap';
 import type { Table, TreeTable } from '@deephaven/jsapi-types';
 import { getSize } from '@deephaven/jsapi-utils';
 import useTableListener from './useTableListener';
@@ -14,6 +15,8 @@ export default function useTableSize(
   table: Table | TreeTable | null | undefined
 ): number {
   const [, forceRerender] = useState(0);
+
+  const dh = useApi();
 
   useTableListener(table, dh.Table.EVENT_SIZECHANGED, () => {
     forceRerender(i => i + 1);

--- a/packages/jsapi-components/src/useTableUtils.test.tsx
+++ b/packages/jsapi-components/src/useTableUtils.test.tsx
@@ -1,13 +1,10 @@
-import React from 'react';
-import { ApiContext } from '@deephaven/jsapi-bootstrap';
 import dh from '@deephaven/jsapi-shim';
 import { TableUtils } from '@deephaven/jsapi-utils';
 import { renderHook } from '@testing-library/react-hooks';
+import { makeApiContextWrapper } from './HookTestUtils';
 import useTableUtils from './useTableUtils';
 
-const wrapper = ({ children }) => (
-  <ApiContext.Provider value={dh}>{children}</ApiContext.Provider>
-);
+const wrapper = makeApiContextWrapper(dh);
 
 it('should return a TableUtils instance based on the current dh api context', () => {
   const { result } = renderHook(() => useTableUtils(), { wrapper });

--- a/packages/jsapi-components/src/useViewportData.test.tsx
+++ b/packages/jsapi-components/src/useViewportData.test.tsx
@@ -1,7 +1,5 @@
-import React from 'react';
 import { act, renderHook } from '@testing-library/react-hooks';
 import type { FilterCondition, Table } from '@deephaven/jsapi-types';
-import { ApiContext } from '@deephaven/jsapi-bootstrap';
 import dh from '@deephaven/jsapi-shim';
 import {
   OnTableUpdatedEvent,
@@ -11,6 +9,7 @@ import {
 import { TestUtils } from '@deephaven/utils';
 import useTableSize from './useTableSize';
 import useViewportData, { UseViewportDataProps } from './useViewportData';
+import { makeApiContextWrapper } from './HookTestUtils';
 
 jest.mock('./useTableSize');
 
@@ -56,9 +55,7 @@ const optionsUseDefaults: UseViewportDataProps<unknown, Table> = {
   table,
 };
 
-const wrapper: React.FC<Table> = ({ children }) => (
-  <ApiContext.Provider value={dh}>{children}</ApiContext.Provider>
-);
+const wrapper: React.FC<Table> = makeApiContextWrapper(dh);
 
 beforeEach(() => {
   jest.clearAllMocks();

--- a/packages/jsapi-utils/package.json
+++ b/packages/jsapi-utils/package.json
@@ -22,7 +22,6 @@
   },
   "dependencies": {
     "@deephaven/filters": "file:../filters",
-    "@deephaven/jsapi-shim": "file:../jsapi-shim",
     "@deephaven/jsapi-types": "file:../jsapi-types",
     "@deephaven/log": "file:../log",
     "@deephaven/utils": "file:../utils",
@@ -31,6 +30,7 @@
     "shortid": "^2.2.16"
   },
   "devDependencies": {
+    "@deephaven/jsapi-shim": "file:../jsapi-shim",
     "@deephaven/tsconfig": "file:../tsconfig"
   },
   "files": [

--- a/packages/jsapi-utils/src/ConnectionUtils.ts
+++ b/packages/jsapi-utils/src/ConnectionUtils.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   IdeConnection,
   VariableChanges,
   VariableDefinition,

--- a/packages/jsapi-utils/src/TableUtils.test.ts
+++ b/packages/jsapi-utils/src/TableUtils.test.ts
@@ -27,6 +27,7 @@ const EXPECT_TIME_ZONE_PARAM = expect.objectContaining({
   id: DEFAULT_TIME_ZONE_ID,
 });
 const tableUtils = new TableUtils(dh);
+const irisGridTestUtils = new IrisGridTestUtils(dh);
 
 /**
  * Sends a mock event to the last registered event handler with the given event
@@ -385,7 +386,7 @@ describe('quick filter tests', () => {
 
   function makeFilterColumn(type = 'string'): MockColumn {
     const filter = makeFilter();
-    const column = IrisGridTestUtils.makeColumn('test placeholder', type, 13);
+    const column = irisGridTestUtils.makeColumn('test placeholder', type, 13);
     column.filter = jest.fn(() => filter);
     return column as MockColumn;
   }

--- a/packages/jsapi-utils/src/TableUtils.ts
+++ b/packages/jsapi-utils/src/TableUtils.ts
@@ -1340,6 +1340,7 @@ export class TableUtils {
     value: string,
     timeZone: string
   ): FilterCondition | null {
+    const { dh } = this;
     if (TableUtils.isDateType(column.type)) {
       return this.makeQuickDateFilterWithOperation(
         column,

--- a/packages/jsapi-utils/src/ViewportDataUtils.ts
+++ b/packages/jsapi-utils/src/ViewportDataUtils.ts
@@ -1,6 +1,6 @@
 import { ListData } from '@react-stately/data';
 import clamp from 'lodash.clamp';
-import { Column, Row, Table, TreeTable } from '@deephaven/jsapi-shim';
+import type { Column, Row, Table, TreeTable } from '@deephaven/jsapi-types';
 import Log from '@deephaven/log';
 
 export interface KeyedItem<T> {

--- a/packages/jsapi-utils/src/formatters/DateTimeColumnFormatter.test.ts
+++ b/packages/jsapi-utils/src/formatters/DateTimeColumnFormatter.test.ts
@@ -1,4 +1,5 @@
-import dh, { TimeZone } from '@deephaven/jsapi-shim';
+import dh from '@deephaven/jsapi-shim';
+import type { TimeZone } from '@deephaven/jsapi-types';
 import DateTimeColumnFormatter from './DateTimeColumnFormatter';
 import { TableColumnFormat } from './TableColumnFormatter';
 


### PR DESCRIPTION
- Change `import` to `import type`, `jsapi-shim` to `jsapi-types` where possible.
- Move `jsapi-shim` to `devDependencies`.
- Convert `ChartTestUtils` static methods to instance methods, fix unit tests.