### PR TITLE
fix: Select distinct throwing for tables with multiple columns

### DIFF
--- a/packages/iris-grid/src/IrisGrid.tsx
+++ b/packages/iris-grid/src/IrisGrid.tsx
@@ -4206,8 +4206,9 @@ export class IrisGrid extends Component<IrisGridProps, IrisGridState> {
           if (modelColumn != null) {
             const column = model.columns[modelColumn];
             if (column == null) {
+              // Grid metrics is likely out of sync with model
               log.warn(
-                `Column does not exist at index: ${modelColumn}. This is likely caused by grid metrics being out of sync during a render`
+                `Column does not exist at index ${modelColumn} for column array of length ${model.columns.length}`
               );
               // eslint-disable-next-line no-continue
               continue;

--- a/packages/iris-grid/src/IrisGrid.tsx
+++ b/packages/iris-grid/src/IrisGrid.tsx
@@ -4205,6 +4205,13 @@ export class IrisGrid extends Component<IrisGridProps, IrisGridState> {
           const modelColumn = this.getModelColumn(columnIndex);
           if (modelColumn != null) {
             const column = model.columns[modelColumn];
+            if (column == null) {
+              log.warn(
+                `Column does not exist at index: ${modelColumn}. This is likely caused by grid metrics being out of sync during a render`
+              );
+              // eslint-disable-next-line no-continue
+              continue;
+            }
             const advancedFilter = advancedFilters.get(modelColumn);
             const { options: advancedFilterOptions } = advancedFilter || {};
             const sort = TableUtils.getSortForColumn(model.sort, column.name);


### PR DESCRIPTION
Fixes #1275 

The true issue is we modify `IrisGridProxyModel.model` but there's no update propagated to `IrisGrid` because it receives the proxy model which does not actually change. This causes the potential for out of sync model/metrics