### PR TITLE
fix: add word-break to long column names in column tooltip

### DIFF
--- a/packages/iris-grid/src/ColumnStatistics.scss
+++ b/packages/iris-grid/src/ColumnStatistics.scss
@@ -12,6 +12,7 @@
 .column-statistics-title {
   padding-top: $spacer-1;
   font-weight: 500;
+  word-break: break-all;
   .column-statistics-copy {
     margin-left: 2px;
     margin-top: -2px;
@@ -23,8 +24,6 @@
   color: $gray-400;
   font-weight: normal;
   user-select: none;
-  text-overflow: ellipsis;
-  overflow: hidden;
   white-space: nowrap;
 }
 


### PR DESCRIPTION
resolves: #1283