### PR TITLE
feat: De-globalize JSAPI in Console package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26163,6 +26163,7 @@
       "dependencies": {
         "@deephaven/components": "file:../components",
         "@deephaven/golden-layout": "file:../golden-layout",
+        "@deephaven/jsapi-bootstrap": "file:../jsapi-bootstrap",
         "@deephaven/log": "file:../log",
         "@deephaven/react-hooks": "file:../react-hooks",
         "@deephaven/redux": "file:../redux",
@@ -28409,6 +28410,7 @@
       "requires": {
         "@deephaven/components": "file:../components",
         "@deephaven/golden-layout": "file:../golden-layout",
+        "@deephaven/jsapi-bootstrap": "file:../jsapi-bootstrap",
         "@deephaven/log": "file:../log",
         "@deephaven/mocks": "file:../mocks",
         "@deephaven/react-hooks": "file:../react-hooks",

--- a/package-lock.json
+++ b/package-lock.json
@@ -26122,7 +26122,7 @@
         "@deephaven/chart": "file:../chart",
         "@deephaven/components": "file:../components",
         "@deephaven/icons": "file:../icons",
-        "@deephaven/jsapi-shim": "file:../jsapi-shim",
+        "@deephaven/jsapi-bootstrap": "file:../icons",
         "@deephaven/log": "file:../log",
         "@deephaven/storage": "file:../storage",
         "@deephaven/utils": "file:../utils",
@@ -26140,6 +26140,7 @@
         "shell-quote": "^1.7.2"
       },
       "devDependencies": {
+        "@deephaven/jsapi-shim": "file:../jsapi-shim",
         "@deephaven/mocks": "file:../mocks",
         "@deephaven/tsconfig": "file:../tsconfig"
       },
@@ -26150,6 +26151,10 @@
         "react": "^17.x",
         "react-dom": "^17.x"
       }
+    },
+    "packages/console/node_modules/@deephaven/jsapi-bootstrap": {
+      "resolved": "packages/icons",
+      "link": true
     },
     "packages/dashboard": {
       "name": "@deephaven/dashboard",
@@ -28367,6 +28372,7 @@
         "@deephaven/chart": "file:../chart",
         "@deephaven/components": "file:../components",
         "@deephaven/icons": "file:../icons",
+        "@deephaven/jsapi-bootstrap": "file:../icons",
         "@deephaven/jsapi-shim": "file:../jsapi-shim",
         "@deephaven/log": "file:../log",
         "@deephaven/mocks": "file:../mocks",
@@ -28385,6 +28391,17 @@
         "popper.js": "^1.16.1",
         "prop-types": "^15.7.2",
         "shell-quote": "^1.7.2"
+      },
+      "dependencies": {
+        "@deephaven/jsapi-bootstrap": {
+          "version": "file:packages/icons",
+          "requires": {
+            "@fortawesome/fontawesome-common-types": "^6.1.1",
+            "svg-parser": "^2.0.4",
+            "svg-path-tools": "^1.0.0",
+            "svgo": "^3.0.2"
+          }
+        }
       }
     },
     "@deephaven/dashboard": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -25834,6 +25834,7 @@
         "babel-plugin-transform-rename-import": "^2.3.0"
       }
     },
+    "packages/bootstrap": {},
     "packages/chart": {
       "name": "@deephaven/chart",
       "version": "0.38.0",
@@ -26122,7 +26123,7 @@
         "@deephaven/chart": "file:../chart",
         "@deephaven/components": "file:../components",
         "@deephaven/icons": "file:../icons",
-        "@deephaven/jsapi-bootstrap": "file:../icons",
+        "@deephaven/jsapi-bootstrap": "file:../jsapi-bootstrap",
         "@deephaven/log": "file:../log",
         "@deephaven/storage": "file:../storage",
         "@deephaven/utils": "file:../utils",
@@ -26153,7 +26154,7 @@
       }
     },
     "packages/console/node_modules/@deephaven/jsapi-bootstrap": {
-      "resolved": "packages/icons",
+      "resolved": "packages/bootstrap",
       "link": true
     },
     "packages/dashboard": {
@@ -28373,7 +28374,7 @@
         "@deephaven/chart": "file:../chart",
         "@deephaven/components": "file:../components",
         "@deephaven/icons": "file:../icons",
-        "@deephaven/jsapi-bootstrap": "file:../icons",
+        "@deephaven/jsapi-bootstrap": "file:../jsapi-bootstrap",
         "@deephaven/jsapi-shim": "file:../jsapi-shim",
         "@deephaven/log": "file:../log",
         "@deephaven/mocks": "file:../mocks",
@@ -28395,13 +28396,7 @@
       },
       "dependencies": {
         "@deephaven/jsapi-bootstrap": {
-          "version": "file:packages/icons",
-          "requires": {
-            "@fortawesome/fontawesome-common-types": "^6.1.1",
-            "svg-parser": "^2.0.4",
-            "svg-path-tools": "^1.0.0",
-            "svgo": "^3.0.2"
-          }
+          "version": "file:packages/bootstrap"
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -25834,7 +25834,6 @@
         "babel-plugin-transform-rename-import": "^2.3.0"
       }
     },
-    "packages/bootstrap": {},
     "packages/chart": {
       "name": "@deephaven/chart",
       "version": "0.38.0",
@@ -26152,10 +26151,6 @@
         "react": "^17.x",
         "react-dom": "^17.x"
       }
-    },
-    "packages/console/node_modules/@deephaven/jsapi-bootstrap": {
-      "resolved": "packages/bootstrap",
-      "link": true
     },
     "packages/dashboard": {
       "name": "@deephaven/dashboard",
@@ -28393,11 +28388,6 @@
         "popper.js": "^1.16.1",
         "prop-types": "^15.7.2",
         "shell-quote": "^1.7.2"
-      },
-      "dependencies": {
-        "@deephaven/jsapi-bootstrap": {
-          "version": "file:packages/bootstrap"
-        }
       }
     },
     "@deephaven/dashboard": {

--- a/packages/app-utils/src/components/ConnectionBootstrap.tsx
+++ b/packages/app-utils/src/components/ConnectionBootstrap.tsx
@@ -1,7 +1,7 @@
 import React, { createContext, useEffect, useState } from 'react';
 import { LoadingOverlay } from '@deephaven/components';
 import { useApi, useClient } from '@deephaven/jsapi-bootstrap';
-import { IdeConnection } from '@deephaven/jsapi-types';
+import type { IdeConnection } from '@deephaven/jsapi-types';
 import Log from '@deephaven/log';
 
 const log = Log.module('@deephaven/jsapi-components.ConnectionBootstrap');

--- a/packages/chart/src/Chart.tsx
+++ b/packages/chart/src/Chart.tsx
@@ -7,7 +7,6 @@ import {
   dhWarningFilled,
   IconDefinition,
 } from '@deephaven/icons';
-import type { dh as DhType } from '@deephaven/jsapi-types';
 import {
   Formatter,
   FormatterUtils,
@@ -36,7 +35,6 @@ type FormatterSettings = ColumnFormatSettings &
   };
 
 interface ChartProps {
-  dh: DhType;
   model: ChartModel;
   settings: FormatterSettings;
   isActive: boolean;
@@ -507,16 +505,14 @@ export class Chart extends Component<ChartProps, ChartState> {
   }
 
   updateFormatter(): void {
-    const { dh } = this.props;
+    const { model } = this.props;
     const formatter = new Formatter(
-      dh,
+      model.dh,
       this.columnFormats,
       this.dateTimeFormatterOptions,
       this.decimalFormatOptions,
       this.integerFormatOptions
     );
-
-    const { model } = this.props;
     model.setFormatter(formatter);
   }
 

--- a/packages/chart/src/ChartModel.ts
+++ b/packages/chart/src/ChartModel.ts
@@ -1,6 +1,7 @@
 /* eslint class-methods-use-this: "off" */
 /* eslint no-unused-vars: "off" */
 
+import type { dh as DhType } from '@deephaven/jsapi-types';
 import { Formatter } from '@deephaven/jsapi-utils';
 import { Layout, PlotData } from 'plotly.js';
 import { FilterColumnMap, FilterMap } from './ChartUtils';
@@ -28,10 +29,13 @@ class ChartModel {
 
   static EVENT_LOADFINISHED = 'ChartModel.EVENT_LOADFINISHED';
 
-  constructor() {
+  constructor(dh: DhType) {
+    this.dh = dh;
     this.listeners = [];
     this.isDownsamplingDisabled = false;
   }
+
+  dh: DhType;
 
   listeners: ((event: ChartEvent) => void)[];
 

--- a/packages/chart/src/FigureChartModel.ts
+++ b/packages/chart/src/FigureChartModel.ts
@@ -46,7 +46,7 @@ class FigureChartModel extends ChartModel {
     settings: Partial<ChartModelSettings> = {},
     theme: typeof ChartTheme = ChartTheme
   ) {
-    super();
+    super(dh);
 
     this.handleFigureUpdated = this.handleFigureUpdated.bind(this);
     this.handleFigureDisconnected = this.handleFigureDisconnected.bind(this);

--- a/packages/chart/src/MockChartModel.js
+++ b/packages/chart/src/MockChartModel.js
@@ -167,7 +167,7 @@ class MockChartModel extends ChartModel {
       filterFields = [],
     } = {}
   ) {
-    super();
+    super(dh);
 
     this.data = data;
     this.layout = layout;

--- a/packages/code-studio/src/main/AppInit.tsx
+++ b/packages/code-studio/src/main/AppInit.tsx
@@ -280,6 +280,7 @@ AppInit.propTypes = {
   workspaceStorage: PropTypes.shape({ close: PropTypes.func }),
 
   setActiveTool: PropTypes.func.isRequired,
+  setApi: PropTypes.func.isRequired,
   setCommandHistoryStorage: PropTypes.func.isRequired,
   setDashboardData: PropTypes.func.isRequired,
   setFileStorage: PropTypes.func.isRequired,

--- a/packages/code-studio/src/main/AppInit.tsx
+++ b/packages/code-studio/src/main/AppInit.tsx
@@ -126,6 +126,7 @@ function AppInit(props: AppInitProps) {
         try {
           const sessionDetails = await getSessionDetails();
           const sessionWrapper = await loadSessionWrapper(
+            api,
             connection,
             sessionDetails
           );

--- a/packages/code-studio/src/main/AppMainContainer.test.tsx
+++ b/packages/code-studio/src/main/AppMainContainer.test.tsx
@@ -2,6 +2,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { ToolType } from '@deephaven/dashboard-core-plugins';
+import { ApiContext } from '@deephaven/jsapi-bootstrap';
 import dh from '@deephaven/jsapi-shim';
 import type {
   IdeConnection,
@@ -69,27 +70,29 @@ function renderAppMainContainer({
   plugins = new Map(),
 } = {}) {
   return render(
-    <AppMainContainer
-      dashboardData={dashboardData as AppDashboardData}
-      layoutStorage={layoutStorage as LayoutStorage}
-      saveWorkspace={saveWorkspace}
-      updateDashboardData={updateDashboardData}
-      updateWorkspaceData={updateWorkspaceData}
-      user={user}
-      workspace={workspace as Workspace}
-      workspaceStorage={workspaceStorage}
-      activeTool={activeTool}
-      setActiveTool={setActiveTool}
-      setDashboardIsolatedLinkerPanelId={setDashboardIsolatedLinkerPanelId}
-      client={client}
-      serverConfigValues={serverConfigValues}
-      dashboardOpenedPanelMaps={dashboardOpenedPanelMaps}
-      connection={connection}
-      session={(session as unknown) as IdeSession}
-      sessionConfig={sessionConfig}
-      match={match}
-      plugins={plugins}
-    />
+    <ApiContext.Provider value={dh}>
+      <AppMainContainer
+        dashboardData={dashboardData as AppDashboardData}
+        layoutStorage={layoutStorage as LayoutStorage}
+        saveWorkspace={saveWorkspace}
+        updateDashboardData={updateDashboardData}
+        updateWorkspaceData={updateWorkspaceData}
+        user={user}
+        workspace={workspace as Workspace}
+        workspaceStorage={workspaceStorage}
+        activeTool={activeTool}
+        setActiveTool={setActiveTool}
+        setDashboardIsolatedLinkerPanelId={setDashboardIsolatedLinkerPanelId}
+        client={client}
+        serverConfigValues={serverConfigValues}
+        dashboardOpenedPanelMaps={dashboardOpenedPanelMaps}
+        connection={connection}
+        session={(session as unknown) as IdeSession}
+        sessionConfig={sessionConfig}
+        match={match}
+        plugins={plugins}
+      />
+    </ApiContext.Provider>
   );
 }
 let mockProp = {};

--- a/packages/code-studio/src/main/AppMainContainer.tsx
+++ b/packages/code-studio/src/main/AppMainContainer.tsx
@@ -756,7 +756,6 @@ export class AppMainContainer extends Component<
       getDownloadWorker: DownloadServiceWorkerUtils.getServiceWorker,
       loadPlugin: this.handleLoadTablePlugin,
       localDashboardId: id,
-      makeApi: () => Promise.resolve(dh),
       makeModel: () => createGridModel(dh, connection, props.metadata, type),
     };
   }
@@ -766,7 +765,6 @@ export class AppMainContainer extends Component<
     return {
       ...props,
       localDashboardId: id,
-      makeApi: () => Promise.resolve(dh),
       makeModel: () => {
         const { metadata, panelState } = props;
         return createChartModel(dh, connection, metadata, panelState);

--- a/packages/code-studio/src/styleguide/Charts.tsx
+++ b/packages/code-studio/src/styleguide/Charts.tsx
@@ -10,7 +10,7 @@ function Charts(): ReactElement {
     <div>
       <h2 className="ui-title">Chart</h2>
       <div style={{ height: 500 }}>
-        <Chart dh={dh} model={model as ChartModel} />
+        <Chart model={model as ChartModel} />
       </div>
     </div>
   );

--- a/packages/code-studio/src/styleguide/Grids.tsx
+++ b/packages/code-studio/src/styleguide/Grids.tsx
@@ -53,7 +53,7 @@ function Grids(): ReactElement {
         </div>
         <h2 className="ui-title">Iris Grid</h2>
         <div style={{ height: 500 }}>
-          <IrisGrid dh={dh} model={irisGridModel} />
+          <IrisGrid model={irisGridModel} />
         </div>
       </ThemeContext.Provider>
     </div>

--- a/packages/code-studio/src/styleguide/Grids.tsx
+++ b/packages/code-studio/src/styleguide/Grids.tsx
@@ -16,13 +16,13 @@ import AsyncExample from './grid-examples/AsyncExample';
 import DataBarExample from './grid-examples/DataBarExample';
 
 function Grids(): ReactElement {
+  const dh = useApi();
   const [irisGridModel] = useState(
-    new MockIrisGridTreeModel(new MockTreeGridModel())
+    new MockIrisGridTreeModel(dh, new MockTreeGridModel())
   );
   const [model] = useState(new MockGridModel());
   const [theme] = useState<Partial<GridThemeType>>({ autoSelectRow: true });
   const [contextTheme] = useState<Partial<GridThemeType>>({ rowHeight: 40 });
-  const dh = useApi();
 
   return (
     <div>

--- a/packages/code-studio/src/styleguide/MockIrisGridTreeModel.ts
+++ b/packages/code-studio/src/styleguide/MockIrisGridTreeModel.ts
@@ -20,6 +20,7 @@ import {
 import type {
   Column,
   CustomColumn,
+  dh as DhType,
   ValueTypeUnion,
 } from '@deephaven/jsapi-types';
 import { Formatter } from '@deephaven/jsapi-utils';
@@ -44,8 +45,8 @@ class MockIrisGridTreeModel
 
   protected editedData: string[][];
 
-  constructor(model = new MockTreeGridModel()) {
-    super();
+  constructor(dh: DhType, model = new MockTreeGridModel()) {
+    super(dh);
 
     this.model = model;
     this.editedData = [];

--- a/packages/console/package.json
+++ b/packages/console/package.json
@@ -26,7 +26,7 @@
     "@deephaven/chart": "file:../chart",
     "@deephaven/components": "file:../components",
     "@deephaven/icons": "file:../icons",
-    "@deephaven/jsapi-shim": "file:../jsapi-shim",
+    "@deephaven/jsapi-bootstrap": "file:../icons",
     "@deephaven/log": "file:../log",
     "@deephaven/storage": "file:../storage",
     "@deephaven/utils": "file:../utils",
@@ -48,6 +48,7 @@
     "react-dom": "^17.x"
   },
   "devDependencies": {
+    "@deephaven/jsapi-shim": "file:../jsapi-shim",
     "@deephaven/mocks": "file:../mocks",
     "@deephaven/tsconfig": "file:../tsconfig"
   },

--- a/packages/console/package.json
+++ b/packages/console/package.json
@@ -26,7 +26,7 @@
     "@deephaven/chart": "file:../chart",
     "@deephaven/components": "file:../components",
     "@deephaven/icons": "file:../icons",
-    "@deephaven/jsapi-bootstrap": "file:../icons",
+    "@deephaven/jsapi-bootstrap": "file:../jsapi-bootstrap",
     "@deephaven/log": "file:../log",
     "@deephaven/storage": "file:../storage",
     "@deephaven/utils": "file:../utils",

--- a/packages/console/src/Console.test.tsx
+++ b/packages/console/src/Console.test.tsx
@@ -37,6 +37,7 @@ function makeConsoleWrapper(consoleRef = React.createRef<Console>()) {
   const commandHistoryStorage = makeMockCommandHistoryStorage();
   return render(
     <Console
+      dh={dh}
       ref={consoleRef}
       commandHistoryStorage={commandHistoryStorage}
       focusCommandHistory={() => undefined}

--- a/packages/console/src/Console.tsx
+++ b/packages/console/src/Console.tsx
@@ -974,6 +974,7 @@ export class Console extends PureComponent<ConsoleProps, ConsoleState> {
       >
         <div className="console-pane" ref={this.consolePane}>
           <ConsoleStatusBar
+            dh={dh}
             session={session}
             overflowActions={this.handleOverflowActions}
             openObject={openObject}

--- a/packages/console/src/Console.tsx
+++ b/packages/console/src/Console.tsx
@@ -14,8 +14,8 @@ import classNames from 'classnames';
 import memoize from 'memoize-one';
 import throttle from 'lodash.throttle';
 import type { JSZipObject } from 'jszip';
-import dh from '@deephaven/jsapi-shim';
 import type {
+  dh as DhType,
   IdeSession,
   LogItem,
   VariableChanges,
@@ -53,6 +53,7 @@ const DEFAULT_SETTINGS: Settings = {
 } as const;
 
 interface ConsoleProps {
+  dh: DhType;
   statusBarChildren: ReactNode;
   settings: Partial<Settings>;
   focusCommandHistory: () => void;
@@ -215,7 +216,7 @@ export class Console extends PureComponent<ConsoleProps, ConsoleState> {
   componentDidMount(): void {
     this.initConsoleLogging();
 
-    const { session } = this.props;
+    const { dh, session } = this.props;
     session.addEventListener(
       dh.IdeSession.EVENT_COMMANDSTARTED,
       this.handleCommandStarted
@@ -234,7 +235,7 @@ export class Console extends PureComponent<ConsoleProps, ConsoleState> {
   }
 
   componentWillUnmount(): void {
-    const { session } = this.props;
+    const { dh, session } = this.props;
 
     session.removeEventListener(
       dh.IdeSession.EVENT_COMMANDSTARTED,
@@ -733,7 +734,13 @@ export class Console extends PureComponent<ConsoleProps, ConsoleState> {
   }
 
   handleOpenCsvTable(title: string): void {
-    const { openObject, commandHistoryStorage, language, scope } = this.props;
+    const {
+      dh,
+      openObject,
+      commandHistoryStorage,
+      language,
+      scope,
+    } = this.props;
     const { consoleHistory, objectMap } = this.state;
     const object = { name: title, title, type: dh.VariableType.TABLE };
     const isExistingObject = objectMap.has(title);
@@ -941,6 +948,7 @@ export class Console extends PureComponent<ConsoleProps, ConsoleState> {
   render(): ReactElement {
     const {
       actions,
+      dh,
       historyChildren,
       language,
       statusBarChildren,

--- a/packages/console/src/ConsoleMenu.tsx
+++ b/packages/console/src/ConsoleMenu.tsx
@@ -19,7 +19,7 @@ import {
   vsTriangleDown,
 } from '@deephaven/icons';
 import Log from '@deephaven/log';
-import type { VariableDefinition } from '@deephaven/jsapi-types';
+import type { dh as DhType, VariableDefinition } from '@deephaven/jsapi-types';
 import memoize from 'memoize-one';
 import './ConsoleMenu.scss';
 import ConsoleUtils from './common/ConsoleUtils';
@@ -27,6 +27,7 @@ import ConsoleUtils from './common/ConsoleUtils';
 const log = Log.module('ConsoleMenu');
 
 interface ConsoleMenuProps {
+  dh: DhType;
   openObject: (object: VariableDefinition) => void;
   objects: VariableDefinition[];
   overflowActions: () => DropdownAction[];
@@ -103,8 +104,9 @@ class ConsoleMenu extends PureComponent<ConsoleMenuProps, ConsoleMenuState> {
       filterText: string,
       openObject: (object: VariableDefinition) => void
     ): DropdownAction[] => {
+      const { dh } = this.props;
       const tables = objects.filter(object =>
-        ConsoleUtils.isTableType(object.type)
+        ConsoleUtils.isTableType(dh, object.type)
       );
       return ConsoleMenu.makeItemActions(
         tables,
@@ -124,8 +126,9 @@ class ConsoleMenu extends PureComponent<ConsoleMenuProps, ConsoleMenuState> {
       filterText: string,
       openObject: (object: VariableDefinition) => void
     ): DropdownAction[] => {
+      const { dh } = this.props;
       const widgets = objects.filter(object =>
-        ConsoleUtils.isWidgetType(object.type)
+        ConsoleUtils.isWidgetType(dh, object.type)
       );
       return ConsoleMenu.makeItemActions(
         widgets,

--- a/packages/console/src/ConsoleStatusBar.test.tsx
+++ b/packages/console/src/ConsoleStatusBar.test.tsx
@@ -15,6 +15,7 @@ function makeConsoleStatusBarWrapper(
   const session = new (dh as any).IdeSession('test');
   const wrapper = render(
     <ConsoleStatusBar
+      dh={dh}
       session={session}
       openObject={() => undefined}
       objects={[]}

--- a/packages/console/src/ConsoleStatusBar.tsx
+++ b/packages/console/src/ConsoleStatusBar.tsx
@@ -1,7 +1,10 @@
 import React, { PureComponent, ReactElement, ReactNode } from 'react';
 import classNames from 'classnames';
-import dh from '@deephaven/jsapi-shim';
-import type { IdeSession, VariableDefinition } from '@deephaven/jsapi-types';
+import type {
+  dh as DhType,
+  IdeSession,
+  VariableDefinition,
+} from '@deephaven/jsapi-types';
 import { DropdownAction, Tooltip } from '@deephaven/components';
 import { CanceledPromiseError, Pending } from '@deephaven/utils';
 import ConsoleMenu from './ConsoleMenu';
@@ -9,6 +12,7 @@ import './ConsoleStatusBar.scss';
 
 interface ConsoleStatusBarProps {
   children: ReactNode;
+  dh: DhType;
   session: IdeSession;
   openObject: (object: VariableDefinition) => void;
   objects: VariableDefinition[];
@@ -54,7 +58,7 @@ export class ConsoleStatusBar extends PureComponent<
   pending: Pending;
 
   startListening(): void {
-    const { session } = this.props;
+    const { dh, session } = this.props;
     session.addEventListener(
       dh.IdeSession.EVENT_COMMANDSTARTED,
       this.handleCommandStarted
@@ -62,7 +66,7 @@ export class ConsoleStatusBar extends PureComponent<
   }
 
   stopListening(): void {
-    const { session } = this.props;
+    const { dh, session } = this.props;
     session.removeEventListener(
       dh.IdeSession.EVENT_COMMANDSTARTED,
       this.handleCommandStarted
@@ -96,7 +100,7 @@ export class ConsoleStatusBar extends PureComponent<
   }
 
   render(): ReactElement {
-    const { children, openObject, overflowActions, objects } = this.props;
+    const { children, dh, openObject, overflowActions, objects } = this.props;
     const { isDisconnected, isCommandRunning } = this.state;
 
     let statusIconClass = null;
@@ -123,6 +127,7 @@ export class ConsoleStatusBar extends PureComponent<
         </div>
         {children}
         <ConsoleMenu
+          dh={dh}
           overflowActions={overflowActions}
           openObject={openObject}
           objects={objects}

--- a/packages/console/src/common/ConsoleUtils.ts
+++ b/packages/console/src/common/ConsoleUtils.ts
@@ -1,6 +1,5 @@
 import ShellQuote, { ParseEntry, ControlOperator } from 'shell-quote';
-import dh from '@deephaven/jsapi-shim';
-import type { VariableTypeUnion } from '@deephaven/jsapi-types';
+import type { dh as DhType, VariableTypeUnion } from '@deephaven/jsapi-types';
 
 class ConsoleUtils {
   static hasComment(arg: ParseEntry): arg is { comment: string } {
@@ -53,7 +52,7 @@ class ConsoleUtils {
     return `${hours}:${minutes}:${seconds}.${milliseconds}`;
   }
 
-  static isTableType(type: VariableTypeUnion): boolean {
+  static isTableType(dh: DhType, type: VariableTypeUnion): boolean {
     return (
       type === dh.VariableType.TABLE ||
       type === dh.VariableType.TREETABLE ||
@@ -61,7 +60,7 @@ class ConsoleUtils {
     );
   }
 
-  static isWidgetType(type: VariableTypeUnion): boolean {
+  static isWidgetType(dh: DhType, type: VariableTypeUnion): boolean {
     return (
       type === dh.VariableType.FIGURE ||
       type === dh.VariableType.OTHERWIDGET ||
@@ -69,15 +68,17 @@ class ConsoleUtils {
     );
   }
 
-  static isOpenableType(type: VariableTypeUnion): boolean {
-    return ConsoleUtils.isTableType(type) || ConsoleUtils.isWidgetType(type);
+  static isOpenableType(dh: DhType, type: VariableTypeUnion): boolean {
+    return (
+      ConsoleUtils.isTableType(dh, type) || ConsoleUtils.isWidgetType(dh, type)
+    );
   }
 
-  static isFigureType(type: VariableTypeUnion): boolean {
+  static isFigureType(dh: DhType, type: VariableTypeUnion): boolean {
     return type === dh.VariableType.FIGURE;
   }
 
-  static isPandas(type: VariableTypeUnion): boolean {
+  static isPandas(dh: DhType, type: VariableTypeUnion): boolean {
     return type === dh.VariableType.PANDAS;
   }
 }

--- a/packages/console/src/common/ObjectIcon.tsx
+++ b/packages/console/src/common/ObjectIcon.tsx
@@ -1,13 +1,14 @@
 import React from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { dhPandas, dhTable, vsGraph, vsPreview } from '@deephaven/icons';
-import dh from '@deephaven/jsapi-shim';
+import { useApi } from '@deephaven/jsapi-bootstrap';
 
 export type ObjectIconProps = {
   type: string;
 };
 
 function ObjectIcon({ type }: ObjectIconProps): JSX.Element {
+  const dh = useApi();
   switch (type) {
     case dh.VariableType.TABLE:
     case dh.VariableType.TABLEMAP:

--- a/packages/console/tsconfig.json
+++ b/packages/console/tsconfig.json
@@ -7,13 +7,13 @@
   "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.js", "src/**/*.jsx"],
   "exclude": ["node_modules", "src/**/*.test.*", "src/**/__mocks__/*"],
   "references": [
+    { "path": "../chart" },
     { "path": "../components" },
     { "path": "../jsapi-bootstrap" },
     { "path": "../jsapi-types" },
     { "path": "../jsapi-shim" },
     { "path": "../log" },
     { "path": "../storage" },
-    { "path": "../utils" },
-    { "path": "../chart" }
+    { "path": "../utils" }
   ]
 }

--- a/packages/console/tsconfig.json
+++ b/packages/console/tsconfig.json
@@ -11,6 +11,12 @@
       "path": "../components"
     },
     {
+      "path": "../jsapi-bootstrap"
+    },
+    {
+      "path": "../jsapi-types"
+    },
+    {
       "path": "../jsapi-shim"
     },
     {

--- a/packages/console/tsconfig.json
+++ b/packages/console/tsconfig.json
@@ -7,29 +7,13 @@
   "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.js", "src/**/*.jsx"],
   "exclude": ["node_modules", "src/**/*.test.*", "src/**/__mocks__/*"],
   "references": [
-    {
-      "path": "../components"
-    },
-    {
-      "path": "../jsapi-bootstrap"
-    },
-    {
-      "path": "../jsapi-types"
-    },
-    {
-      "path": "../jsapi-shim"
-    },
-    {
-      "path": "../log"
-    },
-    {
-      "path": "../storage"
-    },
-    {
-      "path": "../utils"
-    },
-    {
-      "path": "../chart"
-    }
+    { "path": "../components" },
+    { "path": "../jsapi-bootstrap" },
+    { "path": "../jsapi-types" },
+    { "path": "../jsapi-shim" },
+    { "path": "../log" },
+    { "path": "../storage" },
+    { "path": "../utils" },
+    { "path": "../chart" }
   ]
 }

--- a/packages/dashboard-core-plugins/src/ChartBuilderPlugin.tsx
+++ b/packages/dashboard-core-plugins/src/ChartBuilderPlugin.tsx
@@ -46,7 +46,6 @@ export function ChartBuilderPlugin(
       table: Table;
     }) => {
       const { settings } = metadata;
-      const makeApi = () => Promise.resolve(dh);
       const makeModel = () =>
         ChartModelFactory.makeModelFromSettings(dh, settings, table);
       const title = ChartUtils.titleFromSettings(settings);
@@ -58,7 +57,6 @@ export function ChartBuilderPlugin(
           localDashboardId: id,
           id: panelId,
           metadata,
-          makeApi,
           makeModel,
         },
         title,

--- a/packages/dashboard-core-plugins/src/ChartPlugin.tsx
+++ b/packages/dashboard-core-plugins/src/ChartPlugin.tsx
@@ -41,7 +41,6 @@ export function ChartPlugin(props: ChartPluginProps): JSX.Element | null {
       }
 
       const metadata = { name, figure: name };
-      const makeApi = () => Promise.resolve(dh);
       const makeModel = () =>
         fetch().then((figure: Figure) =>
           ChartModelFactory.makeModel(dh, undefined, figure)
@@ -53,7 +52,6 @@ export function ChartPlugin(props: ChartPluginProps): JSX.Element | null {
           localDashboardId: id,
           id: panelId,
           metadata,
-          makeApi,
           makeModel,
         },
         title: name,

--- a/packages/dashboard-core-plugins/src/GridPlugin.tsx
+++ b/packages/dashboard-core-plugins/src/GridPlugin.tsx
@@ -57,7 +57,6 @@ export function GridPlugin(props: GridPluginProps): JSX.Element | null {
         return;
       }
       const metadata = { name, table: name, type: widget.type };
-      const makeApi = () => Promise.resolve(dh);
       const makeModel = () =>
         fetch().then((table: Table) =>
           IrisGridModelFactory.makeModel(dh, table)
@@ -71,7 +70,6 @@ export function GridPlugin(props: GridPluginProps): JSX.Element | null {
           localDashboardId: id,
           id: panelId,
           metadata,
-          makeApi,
           makeModel,
           theme,
         },

--- a/packages/dashboard-core-plugins/src/panels/ChartPanel.test.tsx
+++ b/packages/dashboard-core-plugins/src/panels/ChartPanel.test.tsx
@@ -66,7 +66,6 @@ function makeChartPanelWrapper({
   glContainer = makeGlComponent(),
   glEventHub = makeGlComponent(),
   columnSelectionValidator = undefined,
-  makeApi = () => Promise.resolve(dh),
   makeModel = () => Promise.resolve(makeChartModel()),
   metadata = { figure: 'testFigure' },
   inputFilters = [],
@@ -80,7 +79,6 @@ function makeChartPanelWrapper({
 } = {}) {
   return (
     <ChartPanel
-      makeApi={makeApi}
       columnSelectionValidator={columnSelectionValidator}
       makeModel={makeModel}
       metadata={metadata as ChartPanelMetadata}
@@ -495,11 +493,8 @@ it('adds listeners to the source table when passed in and linked', async () => {
   const model = makeChartModel();
   const modelPromise = Promise.resolve(model);
   const makeModel = () => modelPromise;
-  const apiPromise = Promise.resolve(dh);
-  const makeApi = () => apiPromise;
   const { rerender } = render(
     makeChartPanelWrapper({
-      makeApi,
       makeModel,
       metadata: { settings: { isLinked: true } },
       source: null,
@@ -509,7 +504,6 @@ it('adds listeners to the source table when passed in and linked', async () => {
   const source = makeTable();
   rerender(
     makeChartPanelWrapper({
-      makeApi,
       makeModel,
       metadata: { settings: { isLinked: true } },
       source,

--- a/packages/dashboard-core-plugins/src/panels/ChartPanel.tsx
+++ b/packages/dashboard-core-plugins/src/panels/ChartPanel.tsx
@@ -456,10 +456,7 @@ export class ChartPanel extends Component<ChartPanelProps, ChartPanelState> {
   startListeningToSource(table: TableTemplate): void {
     log.debug('startListeningToSource', table);
     const { model } = this.state;
-    if (model == null) {
-      log.error('Model is not defined');
-      return;
-    }
+    assertNotNull(model);
     const { dh } = model;
     table.addEventListener(
       dh.Table.EVENT_CUSTOMCOLUMNSCHANGED,
@@ -478,10 +475,7 @@ export class ChartPanel extends Component<ChartPanelProps, ChartPanelState> {
   stopListeningToSource(table: TableTemplate): void {
     log.debug('stopListeningToSource', table);
     const { model } = this.state;
-    if (model == null) {
-      log.error('Model is not defined');
-      return;
-    }
+    assertNotNull(model);
     const { dh } = model;
     table.removeEventListener(
       dh.Table.EVENT_CUSTOMCOLUMNSCHANGED,

--- a/packages/dashboard-core-plugins/src/panels/ChartPanel.tsx
+++ b/packages/dashboard-core-plugins/src/panels/ChartPanel.tsx
@@ -125,7 +125,6 @@ export interface GLChartPanelState {
   figure?: string;
 }
 export interface ChartPanelProps {
-  makeApi: () => Promise<DhType>;
   glContainer: Container;
   glEventHub: EventEmitter;
   metadata: ChartPanelMetadata;
@@ -345,17 +344,12 @@ export class ChartPanel extends Component<ChartPanelProps, ChartPanelState> {
   initModel(): void {
     this.setState({ isLoading: true, isLoaded: false, error: undefined });
 
-    const { makeApi, makeModel } = this.props;
+    const { makeModel } = this.props;
+
     this.pending
-      .add(makeApi())
-      .then(dh => {
-        this.setState({ dh });
+      .add(makeModel(), resolved => {
+        resolved.close();
       })
-      .then(() =>
-        this.pending.add(makeModel(), resolved => {
-          resolved.close();
-        })
-      )
       .then(this.handleLoadSuccess, this.handleLoadError);
   }
 
@@ -581,6 +575,7 @@ export class ChartPanel extends Component<ChartPanelProps, ChartPanelState> {
     this.setState(
       {
         model,
+        dh: model.dh,
         isLoaded: true,
       },
       () => {

--- a/packages/dashboard-core-plugins/src/panels/ConsolePanel.test.tsx
+++ b/packages/dashboard-core-plugins/src/panels/ConsolePanel.test.tsx
@@ -39,7 +39,7 @@ function makeSessionWrapper({
   connection = makeConnection(),
   session = makeSession(),
 } = {}): SessionWrapper {
-  return { session, connection, config };
+  return { session, connection, config, dh };
 }
 
 function makeEventHub() {

--- a/packages/dashboard-core-plugins/src/panels/ConsolePanel.tsx
+++ b/packages/dashboard-core-plugins/src/panels/ConsolePanel.tsx
@@ -321,7 +321,7 @@ export class ConsolePanel extends PureComponent<
       unzip,
     } = this.props;
     const { consoleSettings, error, objectMap } = this.state;
-    const { config, session, connection, details = {} } = sessionWrapper;
+    const { config, session, connection, details = {}, dh } = sessionWrapper;
     const { workerName, processInfoId } = details;
     const { id: sessionId, type: language } = config;
 
@@ -338,6 +338,7 @@ export class ConsolePanel extends PureComponent<
       >
         {session != null && (
           <Console
+            dh={dh}
             ref={this.consoleRef}
             settings={consoleSettings}
             session={session}

--- a/packages/dashboard-core-plugins/src/panels/IrisGridPanel.test.tsx
+++ b/packages/dashboard-core-plugins/src/panels/IrisGridPanel.test.tsx
@@ -50,13 +50,8 @@ function makeMakeModel(table = makeTable()) {
     );
 }
 
-function makeMakeApi() {
-  return () => dh;
-}
-
 function makeIrisGridPanelWrapper(
   makeModel = makeMakeModel(),
-  makeApi = makeMakeApi(),
   metadata = { table: 'table' },
   glContainer = makeGlComponent(),
   glEventHub = makeGlComponent(),
@@ -69,7 +64,6 @@ function makeIrisGridPanelWrapper(
 ) {
   return render(
     <IrisGridPanel
-      makeApi={makeApi}
       makeModel={makeModel}
       metadata={metadata}
       glContainer={(glContainer as unknown) as Container}

--- a/packages/dashboard-core-plugins/src/panels/IrisGridPanel.tsx
+++ b/packages/dashboard-core-plugins/src/panels/IrisGridPanel.tsx
@@ -1302,7 +1302,6 @@ export class IrisGridPanel extends PureComponent<
             customColumnFormatMap={customColumnFormatMap}
             columnSelectionValidator={this.isColumnSelectionValid}
             conditionalFormats={conditionalFormats}
-            dh={model.dh}
             inputFilters={this.getGridInputFilters(model.columns, inputFilters)}
             applyInputFiltersOnInit={panelState == null}
             isFilterBarShown={isFilterBarShown}

--- a/packages/dashboard-core-plugins/src/panels/IrisGridPanel.tsx
+++ b/packages/dashboard-core-plugins/src/panels/IrisGridPanel.tsx
@@ -63,7 +63,6 @@ import {
 import { ContextAction, ContextMenuRoot } from '@deephaven/components';
 import type {
   Column,
-  dh as DhType,
   FilterCondition,
   Sort,
   VariableTypeUnion,
@@ -130,7 +129,6 @@ export interface IrisGridPanelProps {
   glEventHub: EventEmitter;
   metadata: Metadata;
   panelState: PanelState | null;
-  makeApi: () => DhType | Promise<DhType>;
   makeModel: () => IrisGridModel | Promise<IrisGridModel>;
   inputFilters: InputFilter[];
   links: Link[];
@@ -249,7 +247,6 @@ export class IrisGridPanel extends PureComponent<
     const { panelState } = props;
 
     this.pluginState = null;
-    this.dh = null;
     this.irisGridUtils = null;
 
     this.state = {
@@ -344,8 +341,6 @@ export class IrisGridPanel extends PureComponent<
   gridState?: GridState;
 
   pluginState: unknown;
-
-  private dh: DhType | null;
 
   private irisGridUtils: IrisGridUtils | null;
 
@@ -529,17 +524,12 @@ export class IrisGridPanel extends PureComponent<
 
   initModel(): void {
     this.setState({ isModelReady: false, isLoading: true, error: null });
-    const { makeApi, makeModel } = this.props;
+    const { makeModel } = this.props;
     if (this.modelPromise != null) {
       this.modelPromise.cancel();
     }
-    this.modelPromise = PromiseUtils.makeCancelable(
-      Promise.resolve(makeApi()).then(dh => {
-        this.dh = dh;
-        this.irisGridUtils = new IrisGridUtils(dh);
-        return makeModel();
-      }),
-      resolved => resolved.close()
+    this.modelPromise = PromiseUtils.makeCancelable(makeModel(), resolved =>
+      resolved.close()
     );
     this.modelPromise.then(this.handleLoadSuccess).catch(this.handleLoadError);
   }
@@ -548,7 +538,7 @@ export class IrisGridPanel extends PureComponent<
     const model = modelParam;
     const { panelState, irisGridStateOverrides } = this.state;
     const modelQueue: ((m: IrisGridModel) => void)[] = [];
-
+    this.irisGridUtils = new IrisGridUtils(model.dh);
     if (panelState != null) {
       const { irisGridState } = panelState;
       const {
@@ -1205,7 +1195,6 @@ export class IrisGridPanel extends PureComponent<
   }
 
   render(): ReactElement {
-    const { dh } = this;
     const {
       children,
       glContainer,
@@ -1298,7 +1287,7 @@ export class IrisGridPanel extends PureComponent<
           />
         )}
       >
-        {isModelReady && model && dh && (
+        {isModelReady && model && (
           <IrisGrid
             advancedFilters={advancedFilters}
             aggregationSettings={aggregationSettings}
@@ -1313,7 +1302,7 @@ export class IrisGridPanel extends PureComponent<
             customColumnFormatMap={customColumnFormatMap}
             columnSelectionValidator={this.isColumnSelectionValid}
             conditionalFormats={conditionalFormats}
-            dh={dh}
+            dh={model.dh}
             inputFilters={this.getGridInputFilters(model.columns, inputFilters)}
             applyInputFiltersOnInit={panelState == null}
             isFilterBarShown={isFilterBarShown}

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "@deephaven/components": "file:../components",
     "@deephaven/golden-layout": "file:../golden-layout",
+    "@deephaven/jsapi-bootstrap": "file:../jsapi-bootstrap",
     "@deephaven/log": "file:../log",
     "@deephaven/react-hooks": "file:../react-hooks",
     "@deephaven/redux": "file:../redux",

--- a/packages/dashboard/src/Dashboard.test.tsx
+++ b/packages/dashboard/src/Dashboard.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render, RenderResult } from '@testing-library/react';
+import { ApiContext } from '@deephaven/jsapi-bootstrap';
 import Dashboard, { DashboardProps } from './Dashboard';
 
 const mockDispatch = jest.fn();
@@ -20,16 +21,18 @@ function makeDashboard({
   onLayoutConfigChange,
 }: DashboardProps = {}): RenderResult {
   return render(
-    <Dashboard
-      id={id}
-      fallbackComponent={fallbackComponent}
-      layoutSettings={layoutSettings}
-      layoutConfig={layoutConfig}
-      onLayoutConfigChange={onLayoutConfigChange}
-      onGoldenLayoutChange={onGoldenLayoutChange}
-    >
-      {children}
-    </Dashboard>
+    <ApiContext.Provider value={dh}>
+      <Dashboard
+        id={id}
+        fallbackComponent={fallbackComponent}
+        layoutSettings={layoutSettings}
+        layoutConfig={layoutConfig}
+        onLayoutConfigChange={onLayoutConfigChange}
+        onGoldenLayoutChange={onGoldenLayoutChange}
+      >
+        {children}
+      </Dashboard>
+    </ApiContext.Provider>
   );
 }
 

--- a/packages/dashboard/src/DashboardLayout.tsx
+++ b/packages/dashboard/src/DashboardLayout.tsx
@@ -13,6 +13,7 @@ import type {
   ItemConfigType,
   ReactComponentConfig,
 } from '@deephaven/golden-layout';
+import { ApiContext, useApi } from '@deephaven/jsapi-bootstrap';
 import Log from '@deephaven/log';
 import { usePrevious } from '@deephaven/react-hooks';
 import { RootState } from '@deephaven/redux';
@@ -79,6 +80,7 @@ export function DashboardLayout({
   hydrate = hydrateDefault,
   dehydrate = dehydrateDefault,
 }: DashboardLayoutProps): JSX.Element {
+  const dh = useApi();
   const dispatch = useDispatch();
   const data =
     useSelector<RootState>(state => getDashboardData(state, id)) ??
@@ -123,15 +125,17 @@ export function DashboardLayout({
         // eslint-disable-next-line react/prop-types
         const { glContainer, glEventHub } = props;
         return (
-          <Provider store={store}>
-            <PanelErrorBoundary
-              glContainer={glContainer}
-              glEventHub={glEventHub}
-            >
-              {/* eslint-disable-next-line react/jsx-props-no-spreading */}
-              <CType {...props} ref={ref} />
-            </PanelErrorBoundary>
-          </Provider>
+          <ApiContext.Provider value={dh}>
+            <Provider store={store}>
+              <PanelErrorBoundary
+                glContainer={glContainer}
+                glEventHub={glEventHub}
+              >
+                {/* eslint-disable-next-line react/jsx-props-no-spreading */}
+                <CType {...props} ref={ref} />
+              </PanelErrorBoundary>
+            </Provider>
+          </ApiContext.Provider>
         );
       }
 
@@ -141,7 +145,7 @@ export function DashboardLayout({
       dehydrateMap.set(name, componentDehydrate);
       return cleanup;
     },
-    [hydrate, dehydrate, hydrateMap, dehydrateMap, layout, store]
+    [dh, hydrate, dehydrate, hydrateMap, dehydrateMap, layout, store]
   );
   const hydrateComponent = useCallback(
     (name, props) => (hydrateMap.get(name) ?? FALLBACK_CALLBACK)(props, id),

--- a/packages/dashboard/src/DashboardLayout.tsx
+++ b/packages/dashboard/src/DashboardLayout.tsx
@@ -9,12 +9,10 @@ import PropTypes from 'prop-types';
 import GoldenLayout from '@deephaven/golden-layout';
 import type {
   Container,
-  EventEmitter,
   ItemConfigType,
   ReactComponentConfig,
 } from '@deephaven/golden-layout';
 import { ApiContext, useApi } from '@deephaven/jsapi-bootstrap';
-import type { dh as DhType } from '@deephaven/jsapi-types';
 import Log from '@deephaven/log';
 import { usePrevious } from '@deephaven/react-hooks';
 import { RootState } from '@deephaven/redux';
@@ -33,6 +31,7 @@ import {
   PanelComponentType,
   PanelDehydrateFunction,
   PanelHydrateFunction,
+  PanelProps,
 } from './DashboardPlugin';
 
 export type DashboardLayoutConfig = ItemConfigType[];
@@ -113,10 +112,7 @@ export function DashboardLayout({
         componentDehydrate
       );
 
-      function renderComponent(
-        props: { dh: DhType; glContainer: Container; glEventHub: EventEmitter },
-        ref: unknown
-      ) {
+      function renderComponent(props: PanelProps, ref: unknown) {
         // Cast it to an `any` type so we can pass the ref in correctly.
         // ComponentType doesn't seem to work right, ReactNode is also incorrect
         // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/dashboard/src/DashboardPlugin.ts
+++ b/packages/dashboard/src/DashboardPlugin.ts
@@ -12,6 +12,7 @@ import type {
   EventEmitter,
   Container,
 } from '@deephaven/golden-layout';
+import type { dh as DhType } from '@deephaven/jsapi-types';
 import PanelManager from './PanelManager';
 
 /**
@@ -65,6 +66,7 @@ export function isWrappedComponent<
 }
 
 export type PanelProps = {
+  dh?: DhType;
   glContainer: Container;
   glEventHub: EventEmitter;
 };

--- a/packages/dashboard/tsconfig.json
+++ b/packages/dashboard/tsconfig.json
@@ -4,35 +4,15 @@
     "rootDir": "src/",
     "outDir": "dist/"
   },
-  "include": [
-    "src/**/*.ts",
-    "src/**/*.tsx",
-    "src/**/*.js",
-    "src/**/*.jsx"
-  ],
-  "exclude": [
-    "node_modules",
-    "src/**/*.test.*",
-    "src/**/__mocks__/*"
-  ],
+  "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.js", "src/**/*.jsx"],
+  "exclude": ["node_modules", "src/**/*.test.*", "src/**/__mocks__/*"],
   "references": [
-    {
-      "path": "../components"
-    },
-    {
-      "path": "../golden-layout"
-    },
-    {
-      "path": "../log"
-    },
-    {
-      "path": "../react-hooks"
-    },
-    {
-      "path": "../redux"
-    },
-    {
-      "path": "../utils"
-    }
+    { "path": "../components" },
+    { "path": "../golden-layout" },
+    { "path": "../jsapi-bootstrap" },
+    { "path": "../log" },
+    { "path": "../react-hooks" },
+    { "path": "../redux" },
+    { "path": "../utils" }
   ]
 }

--- a/packages/embed-chart/src/App.tsx
+++ b/packages/embed-chart/src/App.tsx
@@ -85,7 +85,7 @@ function App(): JSX.Element {
 
   return (
     <div className="App">
-      {isLoaded && <Chart dh={dh} model={model} />}
+      {isLoaded && <Chart model={model} />}
       {!isLoaded && (
         <LoadingOverlay
           isLoaded={isLoaded}

--- a/packages/embed-grid/src/App.tsx
+++ b/packages/embed-grid/src/App.tsx
@@ -169,7 +169,6 @@ function App(): JSX.Element {
         <IrisGrid
           canCopy={canCopy}
           canDownloadCsv={canDownloadCsv}
-          dh={dh}
           model={model}
           inputFilters={inputFilters}
           sorts={sorts}

--- a/packages/iris-grid/src/AdvancedFilterCreator.tsx
+++ b/packages/iris-grid/src/AdvancedFilterCreator.tsx
@@ -21,12 +21,7 @@ import {
 import { Button, ContextActionUtils } from '@deephaven/components';
 import Log from '@deephaven/log';
 import { CancelablePromise, PromiseUtils } from '@deephaven/utils';
-import type {
-  Column,
-  dh as DhType,
-  FilterCondition,
-  Table,
-} from '@deephaven/jsapi-types';
+import type { Column, FilterCondition, Table } from '@deephaven/jsapi-types';
 import shortid from 'shortid';
 import AdvancedFilterCreatorFilterItem from './AdvancedFilterCreatorFilterItem';
 import AdvancedFilterCreatorSelectValue from './AdvancedFilterCreatorSelectValue';
@@ -42,7 +37,6 @@ type FilterChangeHandler = (
 ) => void;
 
 interface AdvancedFilterCreatorProps {
-  dh: DhType;
   model: IrisGridModel;
   column: Column;
   onFilterChange: (
@@ -452,14 +446,7 @@ class AdvancedFilterCreator extends PureComponent<
   }
 
   render(): JSX.Element {
-    const {
-      column,
-      dh,
-      model,
-      sortDirection,
-      formatter,
-      tableUtils,
-    } = this.props;
+    const { column, model, sortDirection, formatter, tableUtils } = this.props;
     const {
       filterItems,
       filterOperators,
@@ -468,7 +455,7 @@ class AdvancedFilterCreator extends PureComponent<
       valuesTable,
       valuesTableError,
     } = this.state;
-    const { isValuesTableAvailable } = model;
+    const { dh, isValuesTableAvailable } = model;
     const isBoolean = TableUtils.isBooleanType(column.type);
     const isDateType = TableUtils.isDateType(column.type);
     const filterTypes = this.getFilterTypes(column.type);

--- a/packages/iris-grid/src/GotoRow.tsx
+++ b/packages/iris-grid/src/GotoRow.tsx
@@ -8,7 +8,7 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import type { dh as DhType, Column } from '@deephaven/jsapi-types';
+import type { Column } from '@deephaven/jsapi-types';
 import {
   Type as FilterType,
   TypeValue as FilterTypeValue,
@@ -31,7 +31,6 @@ function isIrisGridProxyModel(
 const DEFAULT_FORMAT_STRING = '###,##0';
 
 interface GotoRowProps {
-  dh: DhType;
   gotoRow: string;
   gotoRowError: string;
   gotoValueError: string;
@@ -55,7 +54,6 @@ interface GotoRowProps {
 }
 
 function GotoRow({
-  dh,
   gotoRow,
   gotoRowError,
   gotoValueError,
@@ -88,7 +86,7 @@ function GotoRow({
 
   const res = 'Row number';
 
-  const { rowCount } = model;
+  const { dh, rowCount } = model;
 
   const handleGotoValueNumberKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
     if (e.key === 'Enter') {

--- a/packages/iris-grid/src/IrisGrid.test.tsx
+++ b/packages/iris-grid/src/IrisGrid.test.tsx
@@ -59,7 +59,7 @@ function makeComponent(
   settings = DEFAULT_SETTINGS
 ) {
   const testRenderer = TestRenderer.create(
-    <IrisGrid dh={dh} model={model} settings={settings} />,
+    <IrisGrid model={model} settings={settings} />,
     {
       createNodeMock,
     }

--- a/packages/iris-grid/src/IrisGrid.tsx
+++ b/packages/iris-grid/src/IrisGrid.tsx
@@ -252,7 +252,6 @@ export type FilterMap = Map<
 >;
 export interface IrisGridProps {
   children: React.ReactNode;
-  dh: DhType;
   advancedFilters: ReadonlyAdvancedFilterMap;
   advancedSettings: Map<AdvancedSettingsType, boolean>;
   alwaysFetchColumns: readonly ColumnName[];
@@ -677,7 +676,6 @@ export class IrisGrid extends Component<IrisGridProps, IrisGridState> {
     ];
 
     const {
-      dh,
       aggregationSettings,
       conditionalFormats,
       customColumnFormatMap,
@@ -711,6 +709,7 @@ export class IrisGrid extends Component<IrisGridProps, IrisGridState> {
     if (canCopy) {
       keyHandlers.push(new CopyKeyHandler(this));
     }
+    const { dh } = model;
     const mouseHandlers = [
       new IrisGridCellOverflowMouseHandler(this),
       new IrisGridRowTreeMouseHandler(this),
@@ -1032,23 +1031,19 @@ export class IrisGrid extends Component<IrisGridProps, IrisGridState> {
       advancedFilterOptions: AdvancedFilterOptions | undefined,
       sortDirection: SortDirection | undefined,
       formatter: Formatter
-    ) => {
-      const { dh } = this.props;
-      return (
-        <AdvancedFilterCreator
-          dh={dh}
-          model={model}
-          column={column}
-          onFilterChange={this.handleAdvancedFilterChange}
-          onSortChange={this.handleAdvancedFilterSortChange}
-          onDone={this.handleAdvancedFilterDone}
-          options={advancedFilterOptions}
-          sortDirection={sortDirection}
-          formatter={formatter}
-          tableUtils={this.tableUtils}
-        />
-      );
-    },
+    ) => (
+      <AdvancedFilterCreator
+        model={model}
+        column={column}
+        onFilterChange={this.handleAdvancedFilterChange}
+        onSortChange={this.handleAdvancedFilterSortChange}
+        onDone={this.handleAdvancedFilterDone}
+        options={advancedFilterOptions}
+        sortDirection={sortDirection}
+        formatter={formatter}
+        tableUtils={this.tableUtils}
+      />
+    ),
     { max: 50 }
   );
 
@@ -1367,7 +1362,8 @@ export class IrisGrid extends Component<IrisGridProps, IrisGridState> {
     rowIndex: GridRangeIndex,
     rawValue = false
   ): string | unknown {
-    const { dh, model } = this.props;
+    const { model } = this.props;
+    const { dh } = model;
     const modelColumn = this.getModelColumn(columnIndex);
     const modelRow = this.getModelRow(rowIndex);
     if (rawValue && modelColumn != null && modelRow != null) {
@@ -1826,7 +1822,7 @@ export class IrisGrid extends Component<IrisGridProps, IrisGridState> {
     forceUpdate = true
   ): void {
     const { customColumnFormatMap } = this.state;
-    const { dh } = this.props;
+    const { model } = this.props;
     const update = {
       customColumnFormatMap,
       ...updatedFormats,
@@ -1836,7 +1832,7 @@ export class IrisGrid extends Component<IrisGridProps, IrisGridState> {
       ...update.customColumnFormatMap.values(),
     ];
     const formatter = new Formatter(
-      dh,
+      model.dh,
       mergedColumnFormats,
       this.dateTimeFormatterOptions,
       this.decimalFormatOptions,
@@ -1861,7 +1857,6 @@ export class IrisGrid extends Component<IrisGridProps, IrisGridState> {
   initState(): void {
     const {
       applyInputFiltersOnInit,
-      dh,
       inputFilters,
       sorts,
       model,
@@ -1874,7 +1869,7 @@ export class IrisGrid extends Component<IrisGridProps, IrisGridState> {
 
     const searchColumns = selectedSearchColumns ?? [];
     const searchFilter = CrossColumnSearch.createSearchFilter(
-      dh,
+      model.dh,
       searchValue,
       searchColumns,
       model.columns,
@@ -1937,10 +1932,10 @@ export class IrisGrid extends Component<IrisGridProps, IrisGridState> {
   }
 
   updatePartition(partition: string, partitionColumn: Column): void {
-    const { dh } = this.props;
+    const { model } = this.props;
     const partitionFilter = partitionColumn
       .filter()
-      .eq(dh.FilterValue.ofString(partition));
+      .eq(model.dh.FilterValue.ofString(partition));
     const partitionFilters = [partitionFilter];
     this.setState({
       partition,
@@ -2314,9 +2309,9 @@ export class IrisGrid extends Component<IrisGridProps, IrisGridState> {
       columns: readonly Column[],
       invertSearchColumns: boolean
     ): void => {
-      const { dh } = this.props;
+      const { model } = this.props;
       const searchFilter = CrossColumnSearch.createSearchFilter(
-        dh,
+        model.dh,
         searchValue,
         selectedSearchColumns,
         columns,
@@ -2485,7 +2480,8 @@ export class IrisGrid extends Component<IrisGridProps, IrisGridState> {
   }
 
   isTableSearchAvailable(): boolean {
-    const { dh, model, canToggleSearch } = this.props;
+    const { model, canToggleSearch } = this.props;
+    const { dh } = model;
     const searchDisplayMode = model?.layoutHints?.searchDisplayMode;
 
     if (searchDisplayMode === dh.SearchDisplayMode?.SEARCH_DISPLAY_HIDE) {
@@ -3316,7 +3312,8 @@ export class IrisGrid extends Component<IrisGridProps, IrisGridState> {
       gotoValueSelectedColumnName: selectedColumnName,
       gotoValueSelectedFilter,
     } = this.state;
-    const { dh, model } = this.props;
+    const { model } = this.props;
+    const { dh } = model;
     if (!model.isSeekRowAvailable) {
       return;
     }
@@ -3861,7 +3858,6 @@ export class IrisGrid extends Component<IrisGridProps, IrisGridState> {
 
   render(): ReactElement | null {
     const {
-      dh,
       children,
       customFilters,
       getDownloadWorker,
@@ -4288,7 +4284,6 @@ export class IrisGrid extends Component<IrisGridProps, IrisGridState> {
           return (
             <ChartBuilder
               model={model}
-              dh={dh}
               onChange={this.handleChartChange}
               onSubmit={this.handleChartCreate}
               key={OptionType.CHART_BUILDER}
@@ -4322,7 +4317,7 @@ export class IrisGrid extends Component<IrisGridProps, IrisGridState> {
           assertNotNull(this.handleConditionalFormatEditorUpdate);
           return (
             <ConditionalFormatEditor
-              dh={dh}
+              dh={model.dh}
               columns={model.columns}
               rule={conditionalFormatPreview}
               onUpdate={this.handleConditionalFormatEditorUpdate}
@@ -4371,7 +4366,6 @@ export class IrisGrid extends Component<IrisGridProps, IrisGridState> {
         case OptionType.TABLE_EXPORTER:
           return (
             <TableCsvExporter
-              dh={dh}
               model={model}
               name={name}
               userColumnWidths={userColumnWidths}
@@ -4428,7 +4422,7 @@ export class IrisGrid extends Component<IrisGridProps, IrisGridState> {
             <div className="iris-grid-partition-selector-wrapper iris-grid-bar iris-grid-bar-primary">
               {partitionTable && partitionColumn && partition != null && (
                 <IrisGridPartitionSelector
-                  dh={dh}
+                  dh={model.dh}
                   table={partitionTable}
                   getFormattedString={(
                     value: unknown,
@@ -4501,7 +4495,6 @@ export class IrisGrid extends Component<IrisGridProps, IrisGridState> {
             />
             {isVisible && (
               <IrisGridModelUpdater
-                dh={dh}
                 model={model}
                 modelColumns={model.columns}
                 top={top}
@@ -4524,7 +4517,7 @@ export class IrisGrid extends Component<IrisGridProps, IrisGridState> {
                   this.grid?.state.draggingColumn?.range
                 )}
                 formatColumns={this.getCachedPreviewFormatColumns(
-                  dh,
+                  model.dh,
                   model.columns,
                   conditionalFormats,
                   conditionalFormatPreview,
@@ -4575,7 +4568,6 @@ export class IrisGrid extends Component<IrisGridProps, IrisGridState> {
               this.getLinkHoverTooltip(linkHoverTooltipProps)}
           </div>
           <GotoRow
-            dh={dh}
             model={model}
             isShown={isGotoShown}
             gotoRow={gotoRow}
@@ -4628,7 +4620,7 @@ export class IrisGrid extends Component<IrisGridProps, IrisGridState> {
             onExited={this.handleAnimationEnd}
           />
           <TableSaver
-            dh={dh}
+            dh={model.dh}
             ref={tableSaver => {
               this.tableSaver = tableSaver;
             }}

--- a/packages/iris-grid/src/IrisGridModel.ts
+++ b/packages/iris-grid/src/IrisGridModel.ts
@@ -11,6 +11,7 @@ import type {
   Column,
   ColumnStatistics,
   CustomColumn,
+  dh as DhType,
   FilterCondition,
   Format,
   LayoutHints,
@@ -65,11 +66,14 @@ abstract class IrisGridModel<
     PENDING_DATA_UPDATED: 'PENDING_DATA_UPDATED',
   } as const);
 
-  constructor() {
+  constructor(dh: DhType) {
     super();
 
+    this.dh = dh;
     this.listenerCount = 0;
   }
+
+  dh: DhType;
 
   listenerCount: number;
 

--- a/packages/iris-grid/src/IrisGridModelFactory.ts
+++ b/packages/iris-grid/src/IrisGridModelFactory.ts
@@ -15,18 +15,13 @@ class IrisGridModelFactory {
   static async makeModel(
     dh: DhType,
     table: Table | TreeTable,
-    formatter: Formatter | null = null
+    formatter = new Formatter(dh)
   ): Promise<IrisGridModel> {
     let inputTable = null;
     if (!TableUtils.isTreeTable(table) && table.hasInputTable) {
       inputTable = await table.inputTable();
     }
-    return new IrisGridProxyModel(
-      dh,
-      table,
-      formatter ?? new Formatter(dh),
-      inputTable
-    );
+    return new IrisGridProxyModel(dh, table, formatter, inputTable);
   }
 }
 

--- a/packages/iris-grid/src/IrisGridModelFactory.ts
+++ b/packages/iris-grid/src/IrisGridModelFactory.ts
@@ -15,13 +15,18 @@ class IrisGridModelFactory {
   static async makeModel(
     dh: DhType,
     table: Table | TreeTable,
-    formatter = new Formatter(dh)
+    formatter: Formatter | null = null
   ): Promise<IrisGridModel> {
     let inputTable = null;
     if (!TableUtils.isTreeTable(table) && table.hasInputTable) {
       inputTable = await table.inputTable();
     }
-    return new IrisGridProxyModel(dh, table, formatter, inputTable);
+    return new IrisGridProxyModel(
+      dh,
+      table,
+      formatter ?? new Formatter(dh),
+      inputTable
+    );
   }
 }
 

--- a/packages/iris-grid/src/IrisGridModelUpdater.tsx
+++ b/packages/iris-grid/src/IrisGridModelUpdater.tsx
@@ -4,7 +4,6 @@ import React, { useEffect, useMemo } from 'react';
 import type {
   Column,
   CustomColumn,
-  dh as DhType,
   FilterCondition,
   RollupConfig,
   Sort,
@@ -20,7 +19,6 @@ import type ColumnHeaderGroup from './ColumnHeaderGroup';
 const COLUMN_BUFFER_PAGES = 1;
 
 interface IrisGridModelUpdaterProps {
-  dh: DhType;
   model: IrisGridModel;
   modelColumns: readonly Column[];
   top: number;
@@ -50,7 +48,6 @@ interface IrisGridModelUpdaterProps {
  */
 const IrisGridModelUpdater = React.memo(
   ({
-    dh,
     model,
     modelColumns,
     top,
@@ -105,11 +102,11 @@ const IrisGridModelUpdater = React.memo(
       function updateSorts() {
         const sortsForModel = [...sorts];
         if (reverseType !== TableUtils.REVERSE_TYPE.NONE) {
-          sortsForModel.push(dh.Table.reverse());
+          sortsForModel.push(model.dh.Table.reverse());
         }
         model.sort = sortsForModel;
       },
-      [dh, model, sorts, reverseType]
+      [model, sorts, reverseType]
     );
     useEffect(
       function updateFormatter() {

--- a/packages/iris-grid/src/IrisGridProxyModel.ts
+++ b/packages/iris-grid/src/IrisGridProxyModel.ts
@@ -61,6 +61,7 @@ function makeModel(
  */
 class IrisGridProxyModel extends IrisGridModel {
   /**
+   * @param dh JSAPI instance
    * @param table Iris data table to be used in the model
    * @param formatter The formatter to use when getting formats
    * @param inputTable Iris input table associated with this table
@@ -84,7 +85,7 @@ class IrisGridProxyModel extends IrisGridModel {
     formatter = new Formatter(dh),
     inputTable: InputTable | null = null
   ) {
-    super();
+    super(dh);
 
     this.handleModelEvent = this.handleModelEvent.bind(this);
 

--- a/packages/iris-grid/src/IrisGridProxyModel.ts
+++ b/packages/iris-grid/src/IrisGridProxyModel.ts
@@ -81,14 +81,19 @@ class IrisGridProxyModel extends IrisGridModel {
   constructor(
     dh: DhType,
     table: Table | TreeTable,
-    formatter = new Formatter(dh),
+    formatter: Formatter | null = null,
     inputTable: InputTable | null = null
   ) {
     super();
 
     this.handleModelEvent = this.handleModelEvent.bind(this);
 
-    const model = makeModel(dh, table, formatter, inputTable);
+    const model = makeModel(
+      dh,
+      table,
+      formatter ?? new Formatter(dh),
+      inputTable
+    );
     this.dh = dh;
     this.originalModel = model;
     this.model = model;

--- a/packages/iris-grid/src/IrisGridProxyModel.ts
+++ b/packages/iris-grid/src/IrisGridProxyModel.ts
@@ -81,19 +81,14 @@ class IrisGridProxyModel extends IrisGridModel {
   constructor(
     dh: DhType,
     table: Table | TreeTable,
-    formatter: Formatter | null = null,
+    formatter = new Formatter(dh),
     inputTable: InputTable | null = null
   ) {
     super();
 
     this.handleModelEvent = this.handleModelEvent.bind(this);
 
-    const model = makeModel(
-      dh,
-      table,
-      formatter ?? new Formatter(dh),
-      inputTable
-    );
+    const model = makeModel(dh, table, formatter, inputTable);
     this.dh = dh;
     this.originalModel = model;
     this.model = model;

--- a/packages/iris-grid/src/IrisGridTableModel.ts
+++ b/packages/iris-grid/src/IrisGridTableModel.ts
@@ -44,10 +44,10 @@ class IrisGridTableModel extends IrisGridTableModelTemplate<Table, UIRow> {
   constructor(
     dh: DhType,
     table: Table,
-    formatter: Formatter | null = null,
+    formatter = new Formatter(dh),
     inputTable: InputTable | null = null
   ) {
-    super(dh, table, formatter ?? new Formatter(dh), inputTable);
+    super(dh, table, formatter, inputTable);
     this.customColumnList = [];
     this.formatColumnList = [];
   }

--- a/packages/iris-grid/src/IrisGridTableModel.ts
+++ b/packages/iris-grid/src/IrisGridTableModel.ts
@@ -44,10 +44,10 @@ class IrisGridTableModel extends IrisGridTableModelTemplate<Table, UIRow> {
   constructor(
     dh: DhType,
     table: Table,
-    formatter = new Formatter(dh),
+    formatter: Formatter | null = null,
     inputTable: InputTable | null = null
   ) {
-    super(dh, table, formatter, inputTable);
+    super(dh, table, formatter ?? new Formatter(dh), inputTable);
     this.customColumnList = [];
     this.formatColumnList = [];
   }

--- a/packages/iris-grid/src/IrisGridTableModel.ts
+++ b/packages/iris-grid/src/IrisGridTableModel.ts
@@ -36,6 +36,7 @@ class IrisGridTableModel extends IrisGridTableModelTemplate<Table, UIRow> {
   formatColumnList: CustomColumn[];
 
   /**
+   * @param dh JSAPI instance
    * @param table Iris data table to be used in the model
    * @param formatter The formatter to use when getting formats
    * @param inputTable Iris input table associated with this table

--- a/packages/iris-grid/src/IrisGridTableModelTemplate.ts
+++ b/packages/iris-grid/src/IrisGridTableModelTemplate.ts
@@ -203,7 +203,7 @@ class IrisGridTableModelTemplate<
   constructor(
     dh: DhType,
     table: T,
-    formatter: Formatter | null = null,
+    formatter = new Formatter(dh),
     inputTable: InputTable | null = null
   ) {
     super();
@@ -218,7 +218,7 @@ class IrisGridTableModelTemplate<
     );
 
     this.dh = dh;
-    this.irisFormatter = formatter ?? new Formatter(dh);
+    this.irisFormatter = formatter;
     this.irisGridUtils = new IrisGridUtils(dh);
     this.inputTable = inputTable;
     this.subscription = null;

--- a/packages/iris-grid/src/IrisGridTableModelTemplate.ts
+++ b/packages/iris-grid/src/IrisGridTableModelTemplate.ts
@@ -206,7 +206,7 @@ class IrisGridTableModelTemplate<
     formatter = new Formatter(dh),
     inputTable: InputTable | null = null
   ) {
-    super();
+    super(dh);
 
     this.handleTableDisconnect = this.handleTableDisconnect.bind(this);
     this.handleTableReconnect = this.handleTableReconnect.bind(this);

--- a/packages/iris-grid/src/IrisGridTableModelTemplate.ts
+++ b/packages/iris-grid/src/IrisGridTableModelTemplate.ts
@@ -203,7 +203,7 @@ class IrisGridTableModelTemplate<
   constructor(
     dh: DhType,
     table: T,
-    formatter = new Formatter(dh),
+    formatter: Formatter | null = null,
     inputTable: InputTable | null = null
   ) {
     super();
@@ -218,7 +218,7 @@ class IrisGridTableModelTemplate<
     );
 
     this.dh = dh;
-    this.irisFormatter = formatter;
+    this.irisFormatter = formatter ?? new Formatter(dh);
     this.irisGridUtils = new IrisGridUtils(dh);
     this.inputTable = inputTable;
     this.subscription = null;

--- a/packages/iris-grid/src/sidebar/ChartBuilder.test.tsx
+++ b/packages/iris-grid/src/sidebar/ChartBuilder.test.tsx
@@ -19,12 +19,7 @@ function makeChartBuilderWrapper({
   ),
 } = {}) {
   return render(
-    <ChartBuilder
-      onChange={onChange}
-      onSubmit={onSubmit}
-      model={model}
-      dh={dh}
-    />
+    <ChartBuilder onChange={onChange} onSubmit={onSubmit} model={model} />
   );
 }
 

--- a/packages/iris-grid/src/sidebar/ChartBuilder.tsx
+++ b/packages/iris-grid/src/sidebar/ChartBuilder.tsx
@@ -116,8 +116,7 @@ class ChartBuilder extends PureComponent<ChartBuilderProps, ChartBuilderState> {
     this.sendChange = this.sendChange.bind(this);
 
     const { model } = props;
-    const { dh } = model;
-    const { columns } = model;
+    const { columns, dh } = model;
 
     const type = this.getTypes()[0];
     const xAxis = ChartBuilder.getDefaultXAxis(type, columns) as string;

--- a/packages/iris-grid/src/sidebar/ChartBuilder.tsx
+++ b/packages/iris-grid/src/sidebar/ChartBuilder.tsx
@@ -41,7 +41,6 @@ export type SeriesItem = {
 };
 
 interface ChartBuilderProps {
-  dh: DhType;
   model: IrisGridModel;
   onSubmit: (obj: ChartBuilderSettings) => void;
   onChange: (obj: ChartBuilderSettings) => void;
@@ -116,7 +115,8 @@ class ChartBuilder extends PureComponent<ChartBuilderProps, ChartBuilderState> {
     this.handleXAxisChange = this.handleXAxisChange.bind(this);
     this.sendChange = this.sendChange.bind(this);
 
-    const { dh, model } = props;
+    const { model } = props;
+    const { dh } = model;
     const { columns } = model;
 
     const type = this.getTypes()[0];
@@ -139,7 +139,8 @@ class ChartBuilder extends PureComponent<ChartBuilderProps, ChartBuilderState> {
   }
 
   getTypes() {
-    const { dh } = this.props;
+    const { model } = this.props;
+    const { dh } = model;
     return [
       dh.plot.SeriesPlotStyle.LINE,
       dh.plot.SeriesPlotStyle.BAR,
@@ -155,7 +156,8 @@ class ChartBuilder extends PureComponent<ChartBuilderProps, ChartBuilderState> {
    * Just replaces underscores with spaces and capitals the first letter of each word.
    */
   getTypeName(type: SeriesPlotStyle): string | SeriesPlotStyle {
-    const { dh } = this.props;
+    const { model } = this.props;
+    const { dh } = model;
     switch (type) {
       case dh.plot.SeriesPlotStyle.LINE:
         return 'Line';
@@ -173,7 +175,8 @@ class ChartBuilder extends PureComponent<ChartBuilderProps, ChartBuilderState> {
   }
 
   getTypeIcon(type: SeriesPlotStyle): React.ReactElement | null {
-    const { dh } = this.props;
+    const { model } = this.props;
+    const { dh } = model;
     switch (type) {
       case dh.plot.SeriesPlotStyle.LINE:
         return <LineIcon />;
@@ -191,7 +194,8 @@ class ChartBuilder extends PureComponent<ChartBuilderProps, ChartBuilderState> {
   }
 
   getXAxisLabel(type: SeriesPlotStyle): string {
-    const { dh } = this.props;
+    const { model } = this.props;
+    const { dh } = model;
     switch (type) {
       case dh.plot.SeriesPlotStyle.PIE:
         return 'Labels';
@@ -203,7 +207,8 @@ class ChartBuilder extends PureComponent<ChartBuilderProps, ChartBuilderState> {
   }
 
   getSeriesLabel(type: SeriesPlotStyle): string {
-    const { dh } = this.props;
+    const { model } = this.props;
+    const { dh } = model;
     switch (type) {
       case dh.plot.SeriesPlotStyle.PIE:
         return 'Values';
@@ -233,8 +238,8 @@ class ChartBuilder extends PureComponent<ChartBuilderProps, ChartBuilderState> {
   }
 
   handleReset(): void {
-    const { dh, model } = this.props;
-    const { columns } = model;
+    const { model } = this.props;
+    const { columns, dh } = model;
 
     const type = this.getTypes()[0];
     const xAxis = ChartBuilder.getDefaultXAxis(type, columns) as string;
@@ -298,7 +303,8 @@ class ChartBuilder extends PureComponent<ChartBuilderProps, ChartBuilderState> {
     log.debug2('handleTypeSelect', type);
 
     this.setState(state => {
-      const { dh, model } = this.props;
+      const { model } = this.props;
+      const { dh } = model;
       const maxSeriesCount = ChartBuilder.getMaxSeriesCount(dh, type);
       let { seriesItems } = state;
       seriesItems = seriesItems.slice(0, maxSeriesCount);
@@ -327,8 +333,8 @@ class ChartBuilder extends PureComponent<ChartBuilderProps, ChartBuilderState> {
   }
 
   render(): JSX.Element {
-    const { dh, model } = this.props;
-    const { columns } = model;
+    const { model } = this.props;
+    const { columns, dh } = model;
     const { seriesItems, type, xAxis, isLinked } = this.state;
     const maxSeriesCount = ChartBuilder.getMaxSeriesCount(dh, type);
     const xAxisLabel = this.getXAxisLabel(type);

--- a/packages/iris-grid/src/sidebar/TableCsvExporter.tsx
+++ b/packages/iris-grid/src/sidebar/TableCsvExporter.tsx
@@ -29,7 +29,6 @@ import IrisGridUtils from '../IrisGridUtils';
 
 const log = Log.module('TableCsvExporter');
 interface TableCsvExporterProps {
-  dh: DhType;
   model: IrisGridModel;
   name: string;
   userColumnWidths: ModelSizeMap;
@@ -131,9 +130,9 @@ class TableCsvExporter extends Component<
       this
     );
 
-    const { dh, name } = props;
+    const { model, name } = props;
     this.state = {
-      fileName: `${name}-${TableCsvExporter.getDateString(dh)}.csv`,
+      fileName: `${name}-${TableCsvExporter.getDateString(model.dh)}.csv`,
 
       downloadRowOption: TableCsvExporter.DOWNLOAD_ROW_OPTIONS.ALL_ROWS,
       customizedDownloadRowOption:

--- a/packages/jsapi-utils/src/SessionUtils.ts
+++ b/packages/jsapi-utils/src/SessionUtils.ts
@@ -30,6 +30,7 @@ export interface SessionWrapper {
   connection: IdeConnection;
   config: SessionConfig;
   details?: SessionDetails;
+  dh: DhType;
 }
 
 /**
@@ -49,6 +50,7 @@ export function createConnection(
  * @returns A session and config that is ready to use
  */
 export async function createSessionWrapper(
+  dh: DhType,
   connection: IdeConnection,
   details: SessionDetails
 ): Promise<SessionWrapper> {
@@ -77,6 +79,7 @@ export async function createSessionWrapper(
     config,
     connection,
     details,
+    dh,
   };
 }
 
@@ -112,12 +115,13 @@ export async function getSessionDetails(): Promise<SessionDetails> {
 }
 
 export async function loadSessionWrapper(
+  dh: DhType,
   connection: IdeConnection,
   sessionDetails: SessionDetails
 ): Promise<SessionWrapper | undefined> {
   let sessionWrapper: SessionWrapper | undefined;
   try {
-    sessionWrapper = await createSessionWrapper(connection, sessionDetails);
+    sessionWrapper = await createSessionWrapper(dh, connection, sessionDetails);
   } catch (e) {
     // Consoles may be disabled on the server, but we should still be able to start up and open existing objects
     if (!isNoConsolesError(e)) {

--- a/packages/redux/src/reducers/api.ts
+++ b/packages/redux/src/reducers/api.ts
@@ -1,0 +1,7 @@
+/**
+ * JSAPI instance
+ */
+import { SET_API } from '../actionTypes';
+import { replaceReducer } from './common';
+
+export default replaceReducer(SET_API, null);

--- a/packages/redux/src/reducers/index.ts
+++ b/packages/redux/src/reducers/index.ts
@@ -1,3 +1,4 @@
+import api from './api';
 import activeTool from './activeTool';
 import plugins from './plugins';
 import storage from './storage';
@@ -7,6 +8,7 @@ import serverConfigValues from './serverConfigValues';
 
 const reducers = {
   activeTool,
+  api,
   plugins,
   storage,
   user,


### PR DESCRIPTION
- Remove global `dh` references in the Console package, update consumers.
- Add `SET_API` reducer.


BREAKING CHANGE:
- Components `IrisGrid`, `Chart`, `ChartBuilder`, `AdvancedFilterCreator`, `GotoRow`, `IrisGridModelUpdater`, `TableCSVExporter` get the JSAPI reference from the `model` prop. `dh` prop removed.
- `makeApi` props in `IrisGridPanel` and `ChartPanel` removed.
- Components `Console`, `ConsoleMenu`, `ConsoleStatusBar` now require the JSAPI instance in the `dh` prop.
- `ConsoleUtils`: static methods `isTableType`, `isWidgetType`, `isOpenableType`, `isFigureType`, `isPandas` require JSAPI instance passed in the first argument.
- `SessionUtils`: static methods `createSessionWrapper`, `loadSessionWrapper` require JSAPI instance passed in the first argument.
- Class `IrisGridModel` requires JSAPI instance passed in the constructor args.
- Components `DashboardLayout`, `ObjectIcon` has to be wrapped in `ApiContext.Provider` passing the JSAPI instance.