### PR TITLE
fix: drag to re-arrange custom columns not working

### DIFF
--- a/packages/components/src/Button.tsx
+++ b/packages/components/src/Button.tsx
@@ -106,6 +106,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       tabIndex,
       'data-testid': dataTestId,
       'aria-label': ariaLabel,
+      ...rest
     } = props;
 
     const iconOnly = Boolean(icon && children == null);
@@ -167,6 +168,8 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
         disabled={disabled}
         tabIndex={tabIndex}
         aria-label={ariaLabelString}
+        // eslint-disable-next-line react/jsx-props-no-spreading
+        {...rest}
       >
         {icon && iconElem}
         {children}

--- a/packages/iris-grid/src/sidebar/CustomColumnInput.tsx
+++ b/packages/iris-grid/src/sidebar/CustomColumnInput.tsx
@@ -1,8 +1,7 @@
 import React, { useCallback } from 'react';
 import classNames from 'classnames';
 import { Draggable } from 'react-beautiful-dnd';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { Button, Tooltip } from '@deephaven/components';
+import { Button } from '@deephaven/components';
 import { vsTrash, vsGripper } from '@deephaven/icons';
 import { DbNameValidator } from '@deephaven/utils';
 import InputEditor from './InputEditor';
@@ -28,6 +27,10 @@ const INPUT_TYPE = Object.freeze({
   NAME: 'name',
   FORMULA: 'formula',
 });
+
+const EMPTY_FN = () => {
+  // no-op
+};
 
 function CustomColumnInput({
   eventKey,
@@ -89,17 +92,15 @@ function CustomColumnInput({
                   tooltip="Delete custom column"
                 />
 
-                {/* // Can't use our button component with prop spreading */}
-                <button
-                  type="button"
-                  className="btn btn-link btn-link-icon px-2 btn-drag-handle"
-                  aria-label="Drag column to re-order"
+                <Button
+                  kind="ghost"
+                  className="btn-drag-handle"
+                  onClick={EMPTY_FN}
                   // eslint-disable-next-line react/jsx-props-no-spreading
                   {...provided.dragHandleProps}
-                >
-                  <Tooltip>Drag column to re-order</Tooltip>
-                  <FontAwesomeIcon icon={vsGripper} />
-                </button>
+                  icon={vsGripper}
+                  tooltip="Drag column to re-order"
+                />
               </div>
               {(!isValidName || isDuplicate) && (
                 <p className="validate-label-error text-danger mb-0 mt-2 pl-1">

--- a/packages/iris-grid/src/sidebar/CustomColumnInput.tsx
+++ b/packages/iris-grid/src/sidebar/CustomColumnInput.tsx
@@ -1,7 +1,8 @@
 import React, { useCallback } from 'react';
 import classNames from 'classnames';
 import { Draggable } from 'react-beautiful-dnd';
-import { Button } from '@deephaven/components';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { Button, Tooltip } from '@deephaven/components';
 import { vsTrash, vsGripper } from '@deephaven/icons';
 import { DbNameValidator } from '@deephaven/utils';
 import InputEditor from './InputEditor';
@@ -27,10 +28,6 @@ const INPUT_TYPE = Object.freeze({
   NAME: 'name',
   FORMULA: 'formula',
 });
-
-const EMPTY_FN = () => {
-  // no-op
-};
 
 function CustomColumnInput({
   eventKey,
@@ -92,15 +89,16 @@ function CustomColumnInput({
                   tooltip="Delete custom column"
                 />
 
-                <Button
-                  kind="ghost"
-                  className="btn-drag-handle"
-                  onClick={EMPTY_FN}
+                {/* // Can't use our button component with prop spreading */}
+                <button
+                  type="button"
+                  className="btn btn-link btn-link-icon px-2 btn-drag-handle"
                   // eslint-disable-next-line react/jsx-props-no-spreading
                   {...provided.dragHandleProps}
-                  icon={vsGripper}
-                  tooltip="Drag column to re-order"
-                />
+                >
+                  <Tooltip>Drag column to re-order</Tooltip>
+                  <FontAwesomeIcon icon={vsGripper} />
+                </button>
               </div>
               {(!isValidName || isDuplicate) && (
                 <p className="validate-label-error text-danger mb-0 mt-2 pl-1">

--- a/packages/iris-grid/src/sidebar/CustomColumnInput.tsx
+++ b/packages/iris-grid/src/sidebar/CustomColumnInput.tsx
@@ -93,6 +93,7 @@ function CustomColumnInput({
                 <button
                   type="button"
                   className="btn btn-link btn-link-icon px-2 btn-drag-handle"
+                  aria-label="Drag column to re-order"
                   // eslint-disable-next-line react/jsx-props-no-spreading
                   {...provided.dragHandleProps}
                 >


### PR DESCRIPTION
resolves: #1282

Broken by #1013. Can't use prop spreading with our Button component, added support for spreading.
Needs silverheels cherry-pick.