### PR TITLE
fix: drag to re-arrange custom columns not working (#1299)

### DIFF
--- a/packages/components/src/Button.tsx
+++ b/packages/components/src/Button.tsx
@@ -106,6 +106,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       tabIndex,
       'data-testid': dataTestId,
       'aria-label': ariaLabel,
+      ...rest
     } = props;
 
     const iconOnly = Boolean(icon && children == null);
@@ -167,6 +168,8 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
         disabled={disabled}
         tabIndex={tabIndex}
         aria-label={ariaLabelString}
+        // eslint-disable-next-line react/jsx-props-no-spreading
+        {...rest}
       >
         {icon && iconElem}
         {children}


### PR DESCRIPTION
resolves: #1282

Broken by #1013. Can't use prop spreading with our Button component,
added support for spreading.
Needs silverheels cherry-pick.