### PR TITLE
build: Use Vite HTML env variable replacement

### DIFF
--- a/packages/code-studio/index.html
+++ b/packages/code-studio/index.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <base href="#BASE_URL#" />
-    <meta name="ui-version" content="v#npm_package_version#" />
+    <base href="%BASE_URL%" />
+    <meta name="ui-version" content="v%npm_package_version%" />
     <meta charset="utf-8" />
     <meta
       name="viewport"
@@ -14,7 +14,7 @@
       homescreen on Android. See https://developers.google.com/web/fundamentals/engage-and-retain/web-app-manifest/
     -->
     <link rel="manifest" href="/manifest.json" />
-    <link rel="icon" href="#VITE_FAVICON#" />
+    <link rel="icon" href="%VITE_FAVICON%" />
     <title>Deephaven</title>
   </head>
   <body>

--- a/packages/code-studio/vite.config.ts
+++ b/packages/code-studio/vite.config.ts
@@ -8,17 +8,6 @@ import path from 'path';
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), '');
 
-  // https://github.com/vitejs/vite/issues/3105#issuecomment-939703781
-  const htmlPlugin = () => ({
-    name: 'html-transform',
-    transformIndexHtml: {
-      enforce: 'pre' as const,
-      transform(html: string) {
-        return html.replace(/#(.*?)#/g, (_, p1) => env[p1]);
-      },
-    },
-  });
-
   const packagesDir = path.resolve(__dirname, '..');
 
   let port = Number.parseInt(env.PORT, 10);
@@ -148,6 +137,6 @@ export default defineConfig(({ mode }) => {
     css: {
       devSourcemap: true,
     },
-    plugins: [htmlPlugin(), react()],
+    plugins: [react()],
   };
 });

--- a/packages/embed-chart/index.html
+++ b/packages/embed-chart/index.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <base href="#BASE_URL#" />
-    <meta name="ui-version" content="v#npm_package_version#" />
+    <base href="%BASE_URL%" />
+    <meta name="ui-version" content="v%npm_package_version%" />
     <meta charset="utf-8" />
     <meta
       name="viewport"
@@ -15,7 +15,7 @@
     -->
     <link rel="manifest" href="/manifest.json" />
 
-    <link rel="icon" href="#VITE_FAVICON#" />
+    <link rel="icon" href="%VITE_FAVICON%" />
     <title>Deephaven Embedded Chart</title>
   </head>
   <body>

--- a/packages/embed-chart/vite.config.ts
+++ b/packages/embed-chart/vite.config.ts
@@ -7,14 +7,6 @@ import path from 'path';
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), '');
 
-  // https://github.com/vitejs/vite/issues/3105#issuecomment-939703781
-  const htmlPlugin = () => ({
-    name: 'html-transform',
-    transformIndexHtml(html: string) {
-      return html.replace(/#(.*?)#/g, (_, p1) => env[p1]);
-    },
-  });
-
   const packagesDir = path.resolve(__dirname, '..');
 
   let port = Number.parseInt(env.PORT, 10);
@@ -22,6 +14,7 @@ export default defineConfig(({ mode }) => {
     port = 4020;
   }
 
+  const baseURL = new URL(env.BASE_URL, `http://localhost:${port}/`);
   // These are paths which should be proxied to the core server
   // https://vitejs.dev/config/server-options.html#server-proxy
   const proxy = {
@@ -42,11 +35,9 @@ export default defineConfig(({ mode }) => {
   // Vite does not have a "any unknown fallback to proxy" like CRA
   // It is possible to add one with a custom middleware though if this list grows
   if (env.VITE_PROXY_URL) {
-    [
-      path.resolve(env.BASE_URL, env.VITE_CORE_API_URL),
-      path.resolve(env.BASE_URL, env.VITE_MODULE_PLUGINS_URL),
-    ].forEach(p => {
-      proxy[p] = {
+    [env.VITE_CORE_API_URL, env.VITE_MODULE_PLUGINS_URL].forEach(p => {
+      const route = new URL(p, baseURL).pathname;
+      proxy[route] = {
         target: env.VITE_PROXY_URL,
         changeOrigin: true,
       };
@@ -116,6 +107,6 @@ export default defineConfig(({ mode }) => {
         },
       },
     },
-    plugins: [htmlPlugin(), react()],
+    plugins: [react()],
   };
 });

--- a/packages/embed-grid/index.html
+++ b/packages/embed-grid/index.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <base href="#BASE_URL#" />
-    <meta name="ui-version" content="v#npm_package_version#" />
+    <base href="%BASE_URL%" />
+    <meta name="ui-version" content="v%npm_package_version%" />
     <meta charset="utf-8" />
     <meta
       name="viewport"
@@ -15,7 +15,7 @@
     -->
     <link rel="manifest" href="/manifest.json" />
 
-    <link rel="icon" href="#VITE_FAVICON#" />
+    <link rel="icon" href="%VITE_FAVICON%" />
     <title>Deephaven Embedded Grid</title>
   </head>
   <body>


### PR DESCRIPTION
Fixes #1161 

Also fixed an embed-grid/embed-chart Vite proxy server issue in preview mode

Tested by running `npm start` and looking at those tags in the head which should be replaced (base, npm version, favicon). Then ran `npm run build` and `npm run preview` and checked the tags in the built version