### PR TITLE
fix: makeApiContextWrapper and createMockProxy

### DIFF
--- a/packages/jsapi-components/src/HookTestUtils.tsx
+++ b/packages/jsapi-components/src/HookTestUtils.tsx
@@ -1,18 +1,11 @@
-import React, { forwardRef, ReactNode } from 'react';
+import React, { ReactNode } from 'react';
 import { ApiContext } from '@deephaven/jsapi-bootstrap';
 import type { dh as DhType } from '@deephaven/jsapi-types';
 
-export function makeApiContextWrapper<TProps, TRef = unknown>(dh: DhType) {
-  return forwardRef<TRef, TProps>(function ApiContextWrapper(
-    {
-      children,
-    }: {
-      children?: ReactNode;
-    },
-    _ref
-  ) {
+export function makeApiContextWrapper(dh: DhType) {
+  return function ApiContextWrapper({ children }: { children?: ReactNode }) {
     return <ApiContext.Provider value={dh}>{children}</ApiContext.Provider>;
-  });
+  };
 }
 
 export default {

--- a/packages/jsapi-components/src/HookTestUtils.tsx
+++ b/packages/jsapi-components/src/HookTestUtils.tsx
@@ -2,8 +2,8 @@ import React, { forwardRef, ReactNode } from 'react';
 import { ApiContext } from '@deephaven/jsapi-bootstrap';
 import type { dh as DhType } from '@deephaven/jsapi-types';
 
-export function makeApiContextWrapper(dh: DhType) {
-  return forwardRef(function ApiContextWrapper(
+export function makeApiContextWrapper<TProps, TRef = unknown>(dh: DhType) {
+  return forwardRef<TRef, TProps>(function ApiContextWrapper(
     {
       children,
     }: {

--- a/packages/jsapi-components/src/HookTestUtils.tsx
+++ b/packages/jsapi-components/src/HookTestUtils.tsx
@@ -1,11 +1,18 @@
-import React, { ReactNode } from 'react';
+import React, { forwardRef, ReactNode } from 'react';
 import { ApiContext } from '@deephaven/jsapi-bootstrap';
 import type { dh as DhType } from '@deephaven/jsapi-types';
 
 export function makeApiContextWrapper(dh: DhType) {
-  return function ApiContextWrapper({ children }: { children?: ReactNode }) {
+  return forwardRef(function ApiContextWrapper(
+    {
+      children,
+    }: {
+      children?: ReactNode;
+    },
+    _ref
+  ) {
     return <ApiContext.Provider value={dh}>{children}</ApiContext.Provider>;
-  };
+  });
 }
 
 export default {

--- a/packages/utils/src/MockProxy.test.ts
+++ b/packages/utils/src/MockProxy.test.ts
@@ -1,0 +1,86 @@
+import createMockProxy, { MockProxySymbol } from './MockProxy';
+
+describe('createMockProxy', () => {
+  it('should proxy property access as jest.fn() unless explicitly set', () => {
+    const mock = createMockProxy<Record<string, unknown>>({
+      name: 'mock.name',
+    });
+
+    expect(mock.name).toEqual('mock.name');
+    expect(mock.propA).toBeInstanceOf(jest.fn().constructor);
+    expect(mock.propB).toBeInstanceOf(jest.fn().constructor);
+  });
+
+  it('should not interfere with `await` by not proxying `then` property', async () => {
+    const mock = createMockProxy<Record<string, unknown>>({});
+    expect(mock.then).toBeUndefined();
+
+    const result = await mock;
+
+    expect(result).toBe(mock);
+  });
+
+  it('should only show `in` for explicit properties', () => {
+    const mock = createMockProxy<Record<string, unknown>>({
+      name: 'mock.name',
+      age: 42,
+    });
+
+    expect('name' in mock).toBeTruthy();
+    expect('age' in mock).toBeTruthy();
+    expect('blah' in mock).toBeFalsy();
+  });
+
+  it.each([
+    Symbol.iterator,
+    'then',
+    'asymmetricMatch',
+    'hasAttribute',
+    'nodeType',
+    'tagName',
+    'toJSON',
+  ])('should return undefined for default props', prop => {
+    const mock = createMockProxy();
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((mock as any)[prop]).toBeUndefined();
+  });
+
+  it('should return custom Symbol.toStringTag', () => {
+    const mock = createMockProxy();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((mock as any)[Symbol.toStringTag]).toEqual('Mock Proxy');
+  });
+
+  it('should return internal storage by name', () => {
+    const overrides = {
+      name: 'mock.name',
+      age: 42,
+    };
+
+    const mock = createMockProxy<{
+      name: string;
+      age: number;
+      testMethod: () => void;
+    }>(overrides);
+
+    mock.testMethod();
+
+    expect(mock[MockProxySymbol.defaultProps]).toEqual({
+      then: undefined,
+      asymmetricMatch: undefined,
+      hasAttribute: undefined,
+      nodeType: undefined,
+      tagName: undefined,
+      toJSON: undefined,
+      [Symbol.iterator]: undefined,
+    });
+
+    expect(mock[MockProxySymbol.overrides]).toEqual(overrides);
+
+    expect(mock[MockProxySymbol.proxies]).toEqual({
+      testMethod: expect.any(Function),
+    });
+    expect(mock.testMethod).toBeInstanceOf(jest.fn().constructor);
+  });
+});

--- a/packages/utils/src/MockProxy.test.ts
+++ b/packages/utils/src/MockProxy.test.ts
@@ -37,6 +37,7 @@ describe('createMockProxy', () => {
     'asymmetricMatch',
     'hasAttribute',
     'nodeType',
+    'ref',
     'tagName',
     'toJSON',
   ])('should return undefined for default props', prop => {
@@ -71,6 +72,7 @@ describe('createMockProxy', () => {
       asymmetricMatch: undefined,
       hasAttribute: undefined,
       nodeType: undefined,
+      ref: undefined,
       tagName: undefined,
       toJSON: undefined,
       [Symbol.iterator]: undefined,

--- a/packages/utils/src/MockProxy.ts
+++ b/packages/utils/src/MockProxy.ts
@@ -1,0 +1,95 @@
+const defaultPropsSymbol: unique symbol = Symbol('mockProxyDefaultProps');
+const overridesSymbol: unique symbol = Symbol('mockProxyOverrides');
+const proxiesSymbol: unique symbol = Symbol('mockProxyProxies');
+
+export const MockProxySymbol = {
+  defaultProps: defaultPropsSymbol,
+  overrides: overridesSymbol,
+  proxies: proxiesSymbol,
+} as const;
+
+// Set default values on certain properties so they don't get automatically
+// proxied as jest.fn() instances.
+const mockProxyDefaultProps = {
+  // `Symbol.iterator` - returning a jest.fn() throws a TypeError
+  // `then` - avoid issues with `await` treating object as "thenable"
+  [Symbol.iterator]: undefined,
+  then: undefined,
+  // Jest makes calls to `asymmetricMatch`, `hasAttribute`, `nodeType`
+  // `tagName`, and `toJSON`
+  asymmetricMatch: undefined,
+  hasAttribute: undefined,
+  nodeType: undefined,
+  tagName: undefined,
+  toJSON: undefined,
+};
+
+/**
+ * The proxy target contains state + configuration for the proxy
+ */
+export interface MockProxyTarget<T> {
+  [MockProxySymbol.defaultProps]: typeof mockProxyDefaultProps;
+  [MockProxySymbol.overrides]: Partial<T>;
+  [MockProxySymbol.proxies]: Record<keyof T, jest.Mock>;
+}
+
+/**
+ * Creates a mock object for a type `T` using a Proxy object. Each prop can
+ * optionally be set via the constructor. Any prop that is not set will be set
+ * to a jest.fn() instance on first access with the exeption of "then" which
+ * will not be automatically proxied.
+ * @param overrides Optional props to explicitly set on the Proxy.
+ * @returns
+ */
+export default function createMockProxy<T>(
+  overrides: Partial<T> = {}
+): T & MockProxyTarget<T> {
+  const targetDef: MockProxyTarget<T> = {
+    [MockProxySymbol.defaultProps]: mockProxyDefaultProps,
+    [MockProxySymbol.overrides]: overrides,
+    [MockProxySymbol.proxies]: {} as Record<keyof T, jest.Mock>,
+  };
+
+  return new Proxy(targetDef, {
+    get(target, name) {
+      if (name === Symbol.toStringTag) {
+        return 'Mock Proxy';
+      }
+
+      // Reserved attributes for the proxy
+      if (
+        MockProxySymbol.defaultProps === name ||
+        MockProxySymbol.overrides === name ||
+        MockProxySymbol.proxies === name
+      ) {
+        return target[name as keyof typeof target];
+      }
+
+      // Properties that have been explicitly overriden
+      if (name in target[MockProxySymbol.overrides]) {
+        return target[MockProxySymbol.overrides][name as keyof Partial<T>];
+      }
+
+      // Properties that have defaults set
+      if (name in target[MockProxySymbol.defaultProps]) {
+        return target[MockProxySymbol.defaultProps][
+          name as keyof typeof mockProxyDefaultProps
+        ];
+      }
+
+      // Any other property access will create and cache a jest.fn() instance
+      if (target[MockProxySymbol.proxies][name as keyof T] == null) {
+        // eslint-disable-next-line no-param-reassign
+        target[MockProxySymbol.proxies][name as keyof T] = jest
+          .fn()
+          .mockName(String(name));
+      }
+
+      return target[MockProxySymbol.proxies][name as keyof T];
+    },
+    // Only consider explicitly defined props as "in" the proxy
+    has(target, name) {
+      return name in target[MockProxySymbol.overrides];
+    },
+  }) as T & typeof targetDef;
+}

--- a/packages/utils/src/MockProxy.ts
+++ b/packages/utils/src/MockProxy.ts
@@ -16,8 +16,9 @@ const mockProxyDefaultProps = {
   [Symbol.iterator]: undefined,
   then: undefined,
   // Jest makes calls to `asymmetricMatch`, `hasAttribute`, `nodeType`
-  // `tagName`, and `toJSON`
+  // `tagName`, and `toJSON`. react-test-renderer checks `ref`
   asymmetricMatch: undefined,
+  ref: undefined,
   hasAttribute: undefined,
   nodeType: undefined,
   tagName: undefined,

--- a/packages/utils/src/TestUtils.test.tsx
+++ b/packages/utils/src/TestUtils.test.tsx
@@ -3,6 +3,7 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import TestUtils from './TestUtils';
+import createMockProxy from './MockProxy';
 
 beforeEach(() => {
   jest.clearAllMocks();
@@ -150,90 +151,7 @@ describe('click', () => {
 });
 
 describe('createMockProxy', () => {
-  it('should proxy property access as jest.fn() unless explicitly set', () => {
-    const mock = TestUtils.createMockProxy<Record<string, unknown>>({
-      name: 'mock.name',
-    });
-
-    expect(mock.name).toEqual('mock.name');
-    expect(mock.propA).toBeInstanceOf(jest.fn().constructor);
-    expect(mock.propB).toBeInstanceOf(jest.fn().constructor);
-  });
-
-  it('should not interfere with `await` by not proxying `then` property', async () => {
-    const mock = TestUtils.createMockProxy<Record<string, unknown>>({});
-    expect(mock.then).toBeUndefined();
-
-    const result = await mock;
-
-    expect(result).toBe(mock);
-  });
-
-  it('should only show `in` for explicit properties', () => {
-    const mock = TestUtils.createMockProxy<Record<string, unknown>>({
-      name: 'mock.name',
-      age: 42,
-    });
-
-    expect('name' in mock).toBeTruthy();
-    expect('age' in mock).toBeTruthy();
-    expect('blah' in mock).toBeFalsy();
-  });
-
-  it.each([
-    Symbol.iterator,
-    'then',
-    'asymmetricMatch',
-    'hasAttribute',
-    'nodeType',
-    'tagName',
-    'toJSON',
-  ])('should return undefined for default props', prop => {
-    const mock = TestUtils.createMockProxy();
-
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    expect((mock as any)[prop]).toBeUndefined();
-  });
-
-  it('should return custom Symbol.toStringTag', () => {
-    const mock = TestUtils.createMockProxy();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    expect((mock as any)[Symbol.toStringTag]).toEqual('Mock Proxy');
-  });
-
-  it('should return internal storage by name', () => {
-    const overrides = {
-      name: 'mock.name',
-      age: 42,
-    };
-
-    const mock = TestUtils.createMockProxy<{
-      name: string;
-      age: number;
-      testMethod: () => void;
-    }>(overrides);
-
-    mock.testMethod();
-
-    /* eslint-disable @typescript-eslint/no-explicit-any, no-underscore-dangle */
-    expect((mock as any).__mockProxyDefaultProps).toEqual({
-      then: undefined,
-      asymmetricMatch: undefined,
-      hasAttribute: undefined,
-      nodeType: undefined,
-      tagName: undefined,
-      toJSON: undefined,
-      [Symbol.iterator]: undefined,
-    });
-
-    expect((mock as any).__mockProxyOverrides).toEqual(overrides);
-
-    expect((mock as any).__mockProxyProxies).toEqual({
-      testMethod: expect.any(Function),
-    });
-    expect(mock.testMethod).toBeInstanceOf(jest.fn().constructor);
-    /* eslint-enable @typescript-eslint/no-explicit-any, no-underscore-dangle */
-  });
+  expect(TestUtils.createMockProxy).toBe(createMockProxy);
 });
 
 describe('extractCallArgs', () => {

--- a/packages/utils/src/TestUtils.test.tsx
+++ b/packages/utils/src/TestUtils.test.tsx
@@ -179,6 +179,61 @@ describe('createMockProxy', () => {
     expect('age' in mock).toBeTruthy();
     expect('blah' in mock).toBeFalsy();
   });
+
+  it.each([
+    Symbol.iterator,
+    'then',
+    'asymmetricMatch',
+    'hasAttribute',
+    'nodeType',
+    'tagName',
+    'toJSON',
+  ])('should return undefined for default props', prop => {
+    const mock = TestUtils.createMockProxy();
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((mock as any)[prop]).toBeUndefined();
+  });
+
+  it('should return custom Symbol.toStringTag', () => {
+    const mock = TestUtils.createMockProxy();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((mock as any)[Symbol.toStringTag]).toEqual('Mock Proxy');
+  });
+
+  it('should return internal storage by name', () => {
+    const overrides = {
+      name: 'mock.nam',
+      age: 42,
+    };
+
+    const mock = TestUtils.createMockProxy<{
+      name: string;
+      age: number;
+      testMethod: () => void;
+    }>(overrides);
+
+    mock.testMethod();
+
+    /* eslint-disable @typescript-eslint/no-explicit-any, no-underscore-dangle */
+    expect((mock as any).__mockProxyDefaultProps).toEqual({
+      then: undefined,
+      asymmetricMatch: undefined,
+      hasAttribute: undefined,
+      nodeType: undefined,
+      tagName: undefined,
+      toJSON: undefined,
+      [Symbol.iterator]: undefined,
+    });
+
+    expect((mock as any).__mockProxyOverrides).toEqual(overrides);
+
+    expect((mock as any).__mockProxyProxies).toEqual({
+      testMethod: expect.any(Function),
+    });
+    expect(mock.testMethod).toBeInstanceOf(jest.fn().constructor);
+    /* eslint-enable @typescript-eslint/no-explicit-any, no-underscore-dangle */
+  });
 });
 
 describe('extractCallArgs', () => {

--- a/packages/utils/src/TestUtils.test.tsx
+++ b/packages/utils/src/TestUtils.test.tsx
@@ -203,7 +203,7 @@ describe('createMockProxy', () => {
 
   it('should return internal storage by name', () => {
     const overrides = {
-      name: 'mock.nam',
+      name: 'mock.name',
       age: 42,
     };
 

--- a/packages/utils/src/TestUtils.ts
+++ b/packages/utils/src/TestUtils.ts
@@ -1,4 +1,5 @@
 import type userEvent from '@testing-library/user-event';
+import createMockProxy from './MockProxy';
 
 interface MockContext {
   arc: jest.Mock<void>;
@@ -180,71 +181,8 @@ class TestUtils {
    * to a jest.fn() instance on first access with the exeption of "then" which
    * will not be automatically proxied.
    * @param overrides Optional props to explicitly set on the Proxy.
-   * @returns
    */
-  static createMockProxy<T>(overrides: Partial<T> = {}): T {
-    /* eslint-disable no-underscore-dangle */
-    return new Proxy(
-      {
-        // Set default values on certain properties so they don't get automatically
-        // proxied as jest.fn() instances.
-        __mockProxyDefaultProps: {
-          // `Symbol.iterator` - returning a jest.fn() throws a TypeError
-          // `then` - avoid issues with `await` treating object as "thenable"
-          [Symbol.iterator]: undefined,
-          then: undefined,
-          // Jest makes calls to `asymmetricMatch`, `hasAttribute`, `nodeType`
-          // `tagName`, and `toJSON`
-          asymmetricMatch: undefined,
-          hasAttribute: undefined,
-          nodeType: undefined,
-          tagName: undefined,
-          toJSON: undefined,
-        },
-        __mockProxyOverrides: overrides,
-        __mockProxyProxies: {} as Record<keyof T, jest.Mock>,
-      },
-      {
-        get(target, name) {
-          if (name === Symbol.toStringTag) {
-            return 'Mock Proxy';
-          }
-
-          // Reserved attributes for the proxy
-          if (String(name).startsWith('__mockProxy')) {
-            return target[name as keyof typeof target];
-          }
-
-          // Properties that have been explicitly overriden
-          if (name in target.__mockProxyOverrides) {
-            return target.__mockProxyOverrides[name as keyof T];
-          }
-
-          // Properties that have defaults set
-          if (name in target.__mockProxyDefaultProps) {
-            return target.__mockProxyDefaultProps[
-              name as keyof typeof target.__mockProxyDefaultProps
-            ];
-          }
-
-          // Any other property access will create and cache a jest.fn() instance
-          if (target.__mockProxyProxies[name as keyof T] == null) {
-            // eslint-disable-next-line no-param-reassign
-            target.__mockProxyProxies[name as keyof T] = jest
-              .fn()
-              .mockName(String(name));
-          }
-
-          return target.__mockProxyProxies[name as keyof T];
-        },
-        // Only consider explicitly defined props as "in" the proxy
-        has(target, name) {
-          return name in target.__mockProxyOverrides;
-        },
-      }
-    ) as T;
-    /* eslint-enable no-underscore-dangle */
-  }
+  static createMockProxy = createMockProxy;
 
   /**
    * Attempt to extract the args for the nth call to a given function. This will


### PR DESCRIPTION
- makeApiContextWrapper - wrapped in forwardRef to remove console.errr
- createMockProxy - now prints object properties instead of `undefined` in jest matchers. Proxied mock methods now include a mockName() call to give clearer output

fixes #1311