### PR TITLE
fix: panels menu should only open downwards

### DIFF
--- a/packages/code-studio/src/main/AppMainContainer.tsx
+++ b/packages/code-studio/src/main/AppMainContainer.tsx
@@ -867,6 +867,9 @@ export class AppMainContainer extends Component<
                     isShown={isPanelsMenuShown}
                     className="panels-menu-popper"
                     onExited={this.handleWidgetsMenuClose}
+                    options={{
+                      placement: 'bottom',
+                    }}
                     closeOnBlur
                     interactive
                   >


### PR DESCRIPTION
Noticed it would shift left sometimes if window is really short. Only allow it to open downwards.