### PR TITLE
fix: DH-14657 Disconnect handling increase debounce timeout

### DIFF
--- a/packages/code-studio/src/main/AppMainContainer.tsx
+++ b/packages/code-studio/src/main/AppMainContainer.tsx
@@ -68,6 +68,7 @@ import {
   dhShapes,
   dhPanels,
   vsDebugDisconnect,
+  dhSquareFilled,
 } from '@deephaven/icons';
 import dh from '@deephaven/jsapi-shim';
 import type {
@@ -888,10 +889,26 @@ export class AppMainContainer extends Component<
                 })}
                 onClick={this.handleSettingsMenuShow}
                 icon={
-                  <FontAwesomeIcon
-                    icon={vsGear}
-                    transform="grow-3 right-1 down-1"
-                  />
+                  <span className="fa-layers">
+                    <FontAwesomeIcon
+                      icon={vsGear}
+                      transform="grow-3 right-1 down-1"
+                    />
+                    {isDisconnected && !isAuthFailed && (
+                      <>
+                        <FontAwesomeIcon
+                          icon={dhSquareFilled}
+                          color={ThemeExport.background}
+                          transform="grow-2 right-8 down-8.5 rotate-45"
+                        />
+                        <FontAwesomeIcon
+                          icon={vsDebugDisconnect}
+                          color={ThemeExport.danger}
+                          transform="shrink-5 right-6 down-6"
+                        />
+                      </>
+                    )}
+                  </span>
                 }
                 tooltip="User Settings"
               />
@@ -954,7 +971,7 @@ export class AppMainContainer extends Component<
         />
         <DebouncedModal
           isOpen={isDisconnected && !isAuthFailed}
-          debounceMs={250}
+          debounceMs={1000}
         >
           <InfoModal
             icon={vsDebugDisconnect}

--- a/packages/code-studio/src/main/AppMainContainer.tsx
+++ b/packages/code-studio/src/main/AppMainContainer.tsx
@@ -910,7 +910,11 @@ export class AppMainContainer extends Component<
                     )}
                   </span>
                 }
-                tooltip="User Settings"
+                tooltip={
+                  isDisconnected && !isAuthFailed
+                    ? 'Server disconnected'
+                    : 'User Settings'
+                }
               />
             </div>
           </div>


### PR DESCRIPTION
DH-14657

Increases the timeout to 1s. Immediately shows the disconnect icon on the user settings icon when disconnect happens and changes the tooltip (although it will be extremely difficult for the user to trigger that tooltip since the modal will block access to it 1 second later)

Here's how to test w/ ngrok (I couldn't switch between wired and wireless on my PC b/c I need to fix some wifi drivers apparently)

```
ngrok http 10000
VITE_CORE_API_URL=https://ngrok.link/jsapi npm start
```

Then open `localhost:4000` in firefox and enable work offline from the File menu