### PR TITLE
fix: DH-14972 Remove setSearch debounce in CommandHistoryViewportUpdater

### DIFF
--- a/packages/console/src/command-history/CommandHistoryViewportUpdater.tsx
+++ b/packages/console/src/command-history/CommandHistoryViewportUpdater.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useMemo } from 'react';
-import debounce from 'lodash.debounce';
 import throttle from 'lodash.throttle';
 import {
   StorageTableViewport,
@@ -22,8 +21,6 @@ export type CommandHistoryViewportUpdaterProps = {
   onUpdate: ViewportUpdateCallback<CommandHistoryStorageItem>;
 };
 
-const SET_SEARCH_DEBOUNCE_MS = 150;
-
 const UPDATE_DELAY = 150;
 
 const ROW_BUFFER_PAGES = 3;
@@ -39,14 +36,6 @@ function CommandHistoryViewportUpdater({
   isReversed = false,
   onUpdate,
 }: CommandHistoryViewportUpdaterProps): null {
-  const debounceSetSearch = useMemo(
-    () =>
-      debounce((searchText?: string) => {
-        table.setSearch(searchText ?? '');
-      }, SET_SEARCH_DEBOUNCE_MS),
-    [table]
-  );
-
   const throttledUpdateViewport = useMemo(
     () =>
       throttle((viewport: StorageTableViewport) => {
@@ -87,9 +76,9 @@ function CommandHistoryViewportUpdater({
 
   useEffect(
     function setSearchText() {
-      debounceSetSearch(search);
+      table.setSearch(search ?? '');
     },
-    [debounceSetSearch, search]
+    [table, search]
   );
   useEffect(
     function updateViewport() {


### PR DESCRIPTION
There was an issue with Enterprise command history, where `applyFilters` method was called on the history table after `setViewport`, because of the `setSearch` debounce.

Fixed by moving the debounce to the parent component.