### PR TITLE
fix: Cannot add control from Controls menu with click

### DIFF
--- a/packages/code-studio/src/main/AppMainContainer.tsx
+++ b/packages/code-studio/src/main/AppMainContainer.tsx
@@ -379,10 +379,7 @@ export class AppMainContainer extends Component<
     this.setState({ isSettingsMenuShown: true });
   }
 
-  handleControlSelect(
-    type: string,
-    dragEvent: KeyboardEvent | null = null
-  ): void {
+  handleControlSelect(type: string, dragEvent?: KeyboardEvent): void {
     log.debug('handleControlSelect', type);
 
     switch (type) {

--- a/packages/dashboard-core-plugins/src/FilterPlugin.tsx
+++ b/packages/dashboard-core-plugins/src/FilterPlugin.tsx
@@ -176,7 +176,7 @@ export function FilterPlugin(props: FilterPluginProps): JSX.Element | null {
       id = shortid.generate(),
       focusElement = LayoutUtils.DEFAULT_FOCUS_SELECTOR,
       createNewStack = false,
-      dragEvent = null,
+      dragEvent = undefined,
     }) => {
       const config = {
         type: 'react-component' as const,

--- a/packages/dashboard/src/layout/LayoutUtils.ts
+++ b/packages/dashboard/src/layout/LayoutUtils.ts
@@ -478,7 +478,7 @@ class LayoutUtils {
       config.id = shortid.generate();
     }
 
-    if (dragEvent !== undefined) {
+    if (dragEvent != null) {
       root?.layoutManager.createDragSourceFromEvent(config, dragEvent);
       return;
     }


### PR DESCRIPTION
- We were defaulting the value to `null` instead of `undefined`
- A golden-layout refactor explicitly checked for `undefined` instead of `null`
- For some reason the type error in `FilterPlugin` and also `AppMainContainer` wasn't throwing an error when building?? Will need to investigate why not
- Loosen restriction to just be `!= null` instead of `!== undefined` as that is the intent
