### PR TITLE
feat: add sort-slash icon

### DIFF
--- a/packages/icons/src/icons/sort-slash.svg
+++ b/packages/icons/src/icons/sort-slash.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 27.6.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 16 16" style="enable-background:new 0 0 16 16;" xml:space="preserve">
+<path d="M4,7L3.6,6.2l4-3.7h0.8L10,3.9L6.9,7H4z M4.9,9H4L3.6,9.8L3.9,10L4.9,9z M11.1,7H12l0.4-0.8L12.2,6L11.1,7z M9.1,9l-3.1,3.1
+	l1.5,1.4h0.8l4-3.7L12,9H9.1z M1.3,15.4L15.4,1.3l-0.7-0.7L0.6,14.7L1.3,15.4z"/>
+</svg>


### PR DESCRIPTION
Adds `dhSortSlash` icon needed by #1380

![image](https://github.com/deephaven/web-client-ui/assets/1576283/b56d4003-81c2-4c11-a36c-ceac5fa19bb1)