### PR TITLE
fix: AuthPluginParent wasn't working when embedded in an iframe

### DIFF
--- a/packages/app-utils/src/components/AuthBootstrap.tsx
+++ b/packages/app-utils/src/components/AuthBootstrap.tsx
@@ -21,8 +21,8 @@ export type AuthBootstrapProps = {
 
 /** Core auth plugins that are always loaded */
 const CORE_AUTH_PLUGINS = new Map([
-  ['@deephaven/auth-plugins.AuthPluginPsk', AuthPluginPsk],
   ['@deephaven/auth-plugins.AuthPluginParent', AuthPluginParent],
+  ['@deephaven/auth-plugins.AuthPluginPsk', AuthPluginPsk],
   ['@deephaven/auth-plugins.AuthPluginAnonymous', AuthPluginAnonymous],
 ]);
 

--- a/packages/auth-plugins/src/AuthPluginParent.tsx
+++ b/packages/auth-plugins/src/AuthPluginParent.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import type { LoginOptions } from '@deephaven/jsapi-types';
 import {
+  getWindowParent,
   LOGIN_OPTIONS_REQUEST,
   requestParentResponse,
 } from '@deephaven/jsapi-utils';
@@ -49,7 +50,7 @@ function Component({ children }: AuthPluginProps): JSX.Element {
 const AuthPluginParent: AuthPlugin = {
   Component,
   isAvailable: () =>
-    window.opener != null && getWindowAuthProvider() === 'parent',
+    getWindowParent() != null && getWindowAuthProvider() === 'parent',
 };
 
 export default AuthPluginParent;

--- a/packages/jsapi-utils/src/MessageUtils.test.ts
+++ b/packages/jsapi-utils/src/MessageUtils.test.ts
@@ -1,3 +1,4 @@
+import { TestUtils } from '@deephaven/utils';
 import {
   makeMessage,
   makeResponse,
@@ -7,11 +8,11 @@ import {
 
 it('Throws an exception if called on a window without parent', async () => {
   await expect(requestParentResponse('request')).rejects.toThrow(
-    'window.opener is null, unable to send request.'
+    'window parent is null, unable to send request.'
   );
 });
 
-describe('requestParentResponse', () => {
+describe('requestParentResponse with opener', () => {
   let addListenerSpy: jest.SpyInstance;
   let removeListenerSpy: jest.SpyInstance;
   let listenerCallback;
@@ -34,6 +35,81 @@ describe('requestParentResponse', () => {
     removeListenerSpy.mockRestore();
     mockPostMessage.mockClear();
     window.opener = originalWindowOpener;
+    messageId = undefined;
+  });
+
+  it('Posts message to parent and subscribes to response', async () => {
+    requestParentResponse('request');
+    expect(mockPostMessage).toHaveBeenCalledWith(
+      expect.objectContaining(makeMessage('request', messageId)),
+      '*'
+    );
+    expect(addListenerSpy).toHaveBeenCalledWith(
+      'message',
+      expect.any(Function)
+    );
+  });
+
+  it('Resolves with the payload from the parent window response and unsubscribes', async () => {
+    const PAYLOAD = 'PAYLOAD';
+    const promise = requestParentResponse('request');
+    listenerCallback({
+      data: makeResponse(messageId, PAYLOAD),
+    });
+    const result = await promise;
+    expect(result).toBe(PAYLOAD);
+    expect(removeListenerSpy).toHaveBeenCalledWith('message', listenerCallback);
+  });
+
+  it('Ignores unrelated response, rejects on timeout', async () => {
+    jest.useFakeTimers();
+    const promise = requestParentResponse('request');
+    listenerCallback({
+      data: makeMessage('wrong-id'),
+    });
+    jest.runOnlyPendingTimers();
+    await expect(promise).rejects.toThrow('Request timed out');
+    jest.useRealTimers();
+  });
+
+  it('Times out if no response', async () => {
+    jest.useFakeTimers();
+    const promise = requestParentResponse('request');
+    jest.runOnlyPendingTimers();
+    expect(removeListenerSpy).toHaveBeenCalled();
+    await expect(promise).rejects.toThrow('Request timed out');
+    jest.useRealTimers();
+  });
+});
+
+describe('requestParentResponse with parent', () => {
+  let addListenerSpy: jest.SpyInstance;
+  let removeListenerSpy: jest.SpyInstance;
+  let windowParentSpy: jest.SpyInstance;
+  let listenerCallback;
+  let messageId;
+  const mockPostMessage = jest.fn((data: Message<unknown>) => {
+    messageId = data.id;
+  });
+  beforeEach(() => {
+    addListenerSpy = jest
+      .spyOn(window, 'addEventListener')
+      .mockImplementation((event, cb) => {
+        listenerCallback = cb;
+      });
+    removeListenerSpy = jest.spyOn(window, 'removeEventListener');
+    windowParentSpy = jest.spyOn(window, 'parent', 'get').mockReturnValue(
+      TestUtils.createMockProxy<Window>({
+        postMessage: mockPostMessage,
+      })
+    );
+  });
+
+  afterEach(() => {
+    addListenerSpy.mockRestore();
+    removeListenerSpy.mockRestore();
+    windowParentSpy.mockRestore();
+    mockPostMessage.mockClear();
     messageId = undefined;
   });
 

--- a/packages/jsapi-utils/src/MessageUtils.test.ts
+++ b/packages/jsapi-utils/src/MessageUtils.test.ts
@@ -12,147 +12,109 @@ it('Throws an exception if called on a window without parent', async () => {
   );
 });
 
-describe('requestParentResponse with opener', () => {
-  let addListenerSpy: jest.SpyInstance;
-  let removeListenerSpy: jest.SpyInstance;
-  let listenerCallback;
-  let messageId;
-  const mockPostMessage = jest.fn((data: Message<unknown>) => {
-    messageId = data.id;
-  });
-  const originalWindowOpener = window.opener;
-  beforeEach(() => {
-    addListenerSpy = jest
-      .spyOn(window, 'addEventListener')
-      .mockImplementation((event, cb) => {
-        listenerCallback = cb;
-      });
-    removeListenerSpy = jest.spyOn(window, 'removeEventListener');
-    window.opener = { postMessage: mockPostMessage };
-  });
-  afterEach(() => {
-    addListenerSpy.mockRestore();
-    removeListenerSpy.mockRestore();
-    mockPostMessage.mockClear();
-    window.opener = originalWindowOpener;
-    messageId = undefined;
-  });
-
-  it('Posts message to parent and subscribes to response', async () => {
-    requestParentResponse('request');
-    expect(mockPostMessage).toHaveBeenCalledWith(
-      expect.objectContaining(makeMessage('request', messageId)),
-      '*'
-    );
-    expect(addListenerSpy).toHaveBeenCalledWith(
-      'message',
-      expect.any(Function)
-    );
-  });
-
-  it('Resolves with the payload from the parent window response and unsubscribes', async () => {
-    const PAYLOAD = 'PAYLOAD';
-    const promise = requestParentResponse('request');
-    listenerCallback({
-      data: makeResponse(messageId, PAYLOAD),
-    });
-    const result = await promise;
-    expect(result).toBe(PAYLOAD);
-    expect(removeListenerSpy).toHaveBeenCalledWith('message', listenerCallback);
-  });
-
-  it('Ignores unrelated response, rejects on timeout', async () => {
-    jest.useFakeTimers();
-    const promise = requestParentResponse('request');
-    listenerCallback({
-      data: makeMessage('wrong-id'),
-    });
-    jest.runOnlyPendingTimers();
-    await expect(promise).rejects.toThrow('Request timed out');
-    jest.useRealTimers();
-  });
-
-  it('Times out if no response', async () => {
-    jest.useFakeTimers();
-    const promise = requestParentResponse('request');
-    jest.runOnlyPendingTimers();
-    expect(removeListenerSpy).toHaveBeenCalled();
-    await expect(promise).rejects.toThrow('Request timed out');
-    jest.useRealTimers();
-  });
-});
-
-describe('requestParentResponse with parent', () => {
-  let addListenerSpy: jest.SpyInstance;
-  let removeListenerSpy: jest.SpyInstance;
-  let windowParentSpy: jest.SpyInstance;
-  let listenerCallback;
-  let messageId;
-  const mockPostMessage = jest.fn((data: Message<unknown>) => {
-    messageId = data.id;
-  });
-  beforeEach(() => {
-    addListenerSpy = jest
-      .spyOn(window, 'addEventListener')
-      .mockImplementation((event, cb) => {
-        listenerCallback = cb;
-      });
-    removeListenerSpy = jest.spyOn(window, 'removeEventListener');
-    windowParentSpy = jest.spyOn(window, 'parent', 'get').mockReturnValue(
+/**
+ * Set up the mock for window.parent or window.opener, and return a cleanup function.
+ * @param type Whether to mock window.parent or window.opener
+ * @param mockPostMessage The mock postMessage function to use
+ * @returns Cleanup function
+ */
+function setupWindowParentMock(
+  type: string,
+  mockPostMessage: jest.Mock
+): () => void {
+  if (type !== 'parent' && type !== 'opener') {
+    throw new Error(`Invalid type ${type}`);
+  }
+  if (type === 'parent') {
+    const windowParentSpy = jest.spyOn(window, 'parent', 'get').mockReturnValue(
       TestUtils.createMockProxy<Window>({
         postMessage: mockPostMessage,
       })
     );
-  });
+    return () => {
+      windowParentSpy.mockRestore();
+    };
+  }
 
-  afterEach(() => {
-    addListenerSpy.mockRestore();
-    removeListenerSpy.mockRestore();
-    windowParentSpy.mockRestore();
-    mockPostMessage.mockClear();
-    messageId = undefined;
-  });
+  const originalWindowOpener = window.opener;
+  window.opener = { postMessage: mockPostMessage };
+  return () => {
+    window.opener = originalWindowOpener;
+  };
+}
 
-  it('Posts message to parent and subscribes to response', async () => {
-    requestParentResponse('request');
-    expect(mockPostMessage).toHaveBeenCalledWith(
-      expect.objectContaining(makeMessage('request', messageId)),
-      '*'
-    );
-    expect(addListenerSpy).toHaveBeenCalledWith(
-      'message',
-      expect.any(Function)
-    );
-  });
-
-  it('Resolves with the payload from the parent window response and unsubscribes', async () => {
-    const PAYLOAD = 'PAYLOAD';
-    const promise = requestParentResponse('request');
-    listenerCallback({
-      data: makeResponse(messageId, PAYLOAD),
+describe.each([['parent'], ['opener']])(
+  `requestParentResponse with %s`,
+  type => {
+    let parentCleanup: () => void;
+    let addListenerSpy: jest.SpyInstance;
+    let removeListenerSpy: jest.SpyInstance;
+    let listenerCallback;
+    let messageId;
+    const mockPostMessage = jest.fn((data: Message<unknown>) => {
+      messageId = data.id;
     });
-    const result = await promise;
-    expect(result).toBe(PAYLOAD);
-    expect(removeListenerSpy).toHaveBeenCalledWith('message', listenerCallback);
-  });
-
-  it('Ignores unrelated response, rejects on timeout', async () => {
-    jest.useFakeTimers();
-    const promise = requestParentResponse('request');
-    listenerCallback({
-      data: makeMessage('wrong-id'),
+    beforeEach(() => {
+      addListenerSpy = jest
+        .spyOn(window, 'addEventListener')
+        .mockImplementation((event, cb) => {
+          listenerCallback = cb;
+        });
+      removeListenerSpy = jest.spyOn(window, 'removeEventListener');
+      parentCleanup = setupWindowParentMock(type, mockPostMessage);
     });
-    jest.runOnlyPendingTimers();
-    await expect(promise).rejects.toThrow('Request timed out');
-    jest.useRealTimers();
-  });
+    afterEach(() => {
+      addListenerSpy.mockRestore();
+      removeListenerSpy.mockRestore();
+      mockPostMessage.mockClear();
+      parentCleanup();
+      messageId = undefined;
+    });
 
-  it('Times out if no response', async () => {
-    jest.useFakeTimers();
-    const promise = requestParentResponse('request');
-    jest.runOnlyPendingTimers();
-    expect(removeListenerSpy).toHaveBeenCalled();
-    await expect(promise).rejects.toThrow('Request timed out');
-    jest.useRealTimers();
-  });
-});
+    it('Posts message to parent and subscribes to response', async () => {
+      requestParentResponse('request');
+      expect(mockPostMessage).toHaveBeenCalledWith(
+        expect.objectContaining(makeMessage('request', messageId)),
+        '*'
+      );
+      expect(addListenerSpy).toHaveBeenCalledWith(
+        'message',
+        expect.any(Function)
+      );
+    });
+
+    it('Resolves with the payload from the parent window response and unsubscribes', async () => {
+      const PAYLOAD = 'PAYLOAD';
+      const promise = requestParentResponse('request');
+      listenerCallback({
+        data: makeResponse(messageId, PAYLOAD),
+      });
+      const result = await promise;
+      expect(result).toBe(PAYLOAD);
+      expect(removeListenerSpy).toHaveBeenCalledWith(
+        'message',
+        listenerCallback
+      );
+    });
+
+    it('Ignores unrelated response, rejects on timeout', async () => {
+      jest.useFakeTimers();
+      const promise = requestParentResponse('request');
+      listenerCallback({
+        data: makeMessage('wrong-id'),
+      });
+      jest.runOnlyPendingTimers();
+      await expect(promise).rejects.toThrow('Request timed out');
+      jest.useRealTimers();
+    });
+
+    it('Times out if no response', async () => {
+      jest.useFakeTimers();
+      const promise = requestParentResponse('request');
+      jest.runOnlyPendingTimers();
+      expect(removeListenerSpy).toHaveBeenCalled();
+      await expect(promise).rejects.toThrow('Request timed out');
+      jest.useRealTimers();
+    });
+  }
+);


### PR DESCRIPTION
- Check for window.opener _or_ window.parent when using AuthPluginParent
- Reorder plugin priority to use AuthPluginParent first if specified
- Tested using an example html page that both embeds and pops open a new tab
- Fixes #1373 

To test:
1. Start up deephaven-core with PSK set to `hello`: `./gradlew server-jetty-app:run -Ppsk=hello`
2. Start up Web UI: `npm start`
3. Create a table named `t` in the Web UI at https://localhost:4000:
```
from deephaven import empty_table
t = empty_table(50).update(["x=i%5", "y=(i*i)%5"])
```
4. Open the HTML file in the provided zip.
[iframe-auth-provider-local.zip](https://github.com/deephaven/web-client-ui/files/11820375/iframe-auth-provider-local.zip)
5. Ensure the table appears correctly in the iframe. Click the "Open in new tab" link, and ensure the table opens there correctly as well.

Also tested that going to localhost:4010/?name=t&authProvider=parent directly did not try and use the parent plugin, because it wasn't opened by another window.