### PR TITLE
fix: AuthPluginParent wasn't working when embedded in an iframe (#1383)

### DIFF
--- a/packages/app-utils/src/components/AuthBootstrap.tsx
+++ b/packages/app-utils/src/components/AuthBootstrap.tsx
@@ -21,8 +21,8 @@ export type AuthBootstrapProps = {
 
 /** Core auth plugins that are always loaded */
 const CORE_AUTH_PLUGINS = new Map([
-  ['@deephaven/auth-plugins.AuthPluginPsk', AuthPluginPsk],
   ['@deephaven/auth-plugins.AuthPluginParent', AuthPluginParent],
+  ['@deephaven/auth-plugins.AuthPluginPsk', AuthPluginPsk],
   ['@deephaven/auth-plugins.AuthPluginAnonymous', AuthPluginAnonymous],
 ]);
 

--- a/packages/auth-plugins/src/AuthPluginParent.tsx
+++ b/packages/auth-plugins/src/AuthPluginParent.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import type { LoginOptions } from '@deephaven/jsapi-types';
 import {
+  getWindowParent,
   LOGIN_OPTIONS_REQUEST,
   requestParentResponse,
 } from '@deephaven/jsapi-utils';
@@ -49,7 +50,7 @@ function Component({ children }: AuthPluginProps): JSX.Element {
 const AuthPluginParent: AuthPlugin = {
   Component,
   isAvailable: () =>
-    window.opener != null && getWindowAuthProvider() === 'parent',
+    getWindowParent() != null && getWindowAuthProvider() === 'parent',
 };
 
 export default AuthPluginParent;

--- a/packages/jsapi-utils/src/MessageUtils.test.ts
+++ b/packages/jsapi-utils/src/MessageUtils.test.ts
@@ -1,3 +1,4 @@
+import { TestUtils } from '@deephaven/utils';
 import {
   makeMessage,
   makeResponse,
@@ -7,76 +8,113 @@ import {
 
 it('Throws an exception if called on a window without parent', async () => {
   await expect(requestParentResponse('request')).rejects.toThrow(
-    'window.opener is null, unable to send request.'
+    'window parent is null, unable to send request.'
   );
 });
 
-describe('requestParentResponse', () => {
-  let addListenerSpy: jest.SpyInstance;
-  let removeListenerSpy: jest.SpyInstance;
-  let listenerCallback;
-  let messageId;
-  const mockPostMessage = jest.fn((data: Message<unknown>) => {
-    messageId = data.id;
-  });
+/**
+ * Set up the mock for window.parent or window.opener, and return a cleanup function.
+ * @param type Whether to mock window.parent or window.opener
+ * @param mockPostMessage The mock postMessage function to use
+ * @returns Cleanup function
+ */
+function setupWindowParentMock(
+  type: string,
+  mockPostMessage: jest.Mock
+): () => void {
+  if (type !== 'parent' && type !== 'opener') {
+    throw new Error(`Invalid type ${type}`);
+  }
+  if (type === 'parent') {
+    const windowParentSpy = jest.spyOn(window, 'parent', 'get').mockReturnValue(
+      TestUtils.createMockProxy<Window>({
+        postMessage: mockPostMessage,
+      })
+    );
+    return () => {
+      windowParentSpy.mockRestore();
+    };
+  }
+
   const originalWindowOpener = window.opener;
-  beforeEach(() => {
-    addListenerSpy = jest
-      .spyOn(window, 'addEventListener')
-      .mockImplementation((event, cb) => {
-        listenerCallback = cb;
-      });
-    removeListenerSpy = jest.spyOn(window, 'removeEventListener');
-    window.opener = { postMessage: mockPostMessage };
-  });
-  afterEach(() => {
-    addListenerSpy.mockRestore();
-    removeListenerSpy.mockRestore();
-    mockPostMessage.mockClear();
+  window.opener = { postMessage: mockPostMessage };
+  return () => {
     window.opener = originalWindowOpener;
-    messageId = undefined;
-  });
+  };
+}
 
-  it('Posts message to parent and subscribes to response', async () => {
-    requestParentResponse('request');
-    expect(mockPostMessage).toHaveBeenCalledWith(
-      expect.objectContaining(makeMessage('request', messageId)),
-      '*'
-    );
-    expect(addListenerSpy).toHaveBeenCalledWith(
-      'message',
-      expect.any(Function)
-    );
-  });
-
-  it('Resolves with the payload from the parent window response and unsubscribes', async () => {
-    const PAYLOAD = 'PAYLOAD';
-    const promise = requestParentResponse('request');
-    listenerCallback({
-      data: makeResponse(messageId, PAYLOAD),
+describe.each([['parent'], ['opener']])(
+  `requestParentResponse with %s`,
+  type => {
+    let parentCleanup: () => void;
+    let addListenerSpy: jest.SpyInstance;
+    let removeListenerSpy: jest.SpyInstance;
+    let listenerCallback;
+    let messageId;
+    const mockPostMessage = jest.fn((data: Message<unknown>) => {
+      messageId = data.id;
     });
-    const result = await promise;
-    expect(result).toBe(PAYLOAD);
-    expect(removeListenerSpy).toHaveBeenCalledWith('message', listenerCallback);
-  });
-
-  it('Ignores unrelated response, rejects on timeout', async () => {
-    jest.useFakeTimers();
-    const promise = requestParentResponse('request');
-    listenerCallback({
-      data: makeMessage('wrong-id'),
+    beforeEach(() => {
+      addListenerSpy = jest
+        .spyOn(window, 'addEventListener')
+        .mockImplementation((event, cb) => {
+          listenerCallback = cb;
+        });
+      removeListenerSpy = jest.spyOn(window, 'removeEventListener');
+      parentCleanup = setupWindowParentMock(type, mockPostMessage);
     });
-    jest.runOnlyPendingTimers();
-    await expect(promise).rejects.toThrow('Request timed out');
-    jest.useRealTimers();
-  });
+    afterEach(() => {
+      addListenerSpy.mockRestore();
+      removeListenerSpy.mockRestore();
+      mockPostMessage.mockClear();
+      parentCleanup();
+      messageId = undefined;
+    });
 
-  it('Times out if no response', async () => {
-    jest.useFakeTimers();
-    const promise = requestParentResponse('request');
-    jest.runOnlyPendingTimers();
-    expect(removeListenerSpy).toHaveBeenCalled();
-    await expect(promise).rejects.toThrow('Request timed out');
-    jest.useRealTimers();
-  });
-});
+    it('Posts message to parent and subscribes to response', async () => {
+      requestParentResponse('request');
+      expect(mockPostMessage).toHaveBeenCalledWith(
+        expect.objectContaining(makeMessage('request', messageId)),
+        '*'
+      );
+      expect(addListenerSpy).toHaveBeenCalledWith(
+        'message',
+        expect.any(Function)
+      );
+    });
+
+    it('Resolves with the payload from the parent window response and unsubscribes', async () => {
+      const PAYLOAD = 'PAYLOAD';
+      const promise = requestParentResponse('request');
+      listenerCallback({
+        data: makeResponse(messageId, PAYLOAD),
+      });
+      const result = await promise;
+      expect(result).toBe(PAYLOAD);
+      expect(removeListenerSpy).toHaveBeenCalledWith(
+        'message',
+        listenerCallback
+      );
+    });
+
+    it('Ignores unrelated response, rejects on timeout', async () => {
+      jest.useFakeTimers();
+      const promise = requestParentResponse('request');
+      listenerCallback({
+        data: makeMessage('wrong-id'),
+      });
+      jest.runOnlyPendingTimers();
+      await expect(promise).rejects.toThrow('Request timed out');
+      jest.useRealTimers();
+    });
+
+    it('Times out if no response', async () => {
+      jest.useFakeTimers();
+      const promise = requestParentResponse('request');
+      jest.runOnlyPendingTimers();
+      expect(removeListenerSpy).toHaveBeenCalled();
+      await expect(promise).rejects.toThrow('Request timed out');
+      jest.useRealTimers();
+    });
+  }
+);


### PR DESCRIPTION
- Check for window.opener _or_ window.parent when using AuthPluginParent
- Reorder plugin priority to use AuthPluginParent first if specified
- Tested using an example html page that both embeds and pops open a new tab
- Fixes #1373
- Cherry-pick of #1383 