### PR TITLE
feat: Add support for Category plots with error bars

### DIFF
--- a/packages/chart/src/ChartUtils.ts
+++ b/packages/chart/src/ChartUtils.ts
@@ -196,7 +196,8 @@ class ChartUtils {
   static getPlotlyErrorBars(
     x: number[],
     xLow: number[],
-    xHigh: number[]
+    xHigh: number[],
+    theme = ChartTheme
   ): ErrorBar {
     const array = xHigh.map((value, i) => value - x[i]);
     const arrayminus = xLow.map((value, i) => x[i] - value);
@@ -205,6 +206,7 @@ class ChartUtils {
       symmetric: false,
       array,
       arrayminus,
+      color: theme.error_band_line_color,
     };
   }
 

--- a/packages/chart/src/FigureChartModel.ts
+++ b/packages/chart/src/FigureChartModel.ts
@@ -678,7 +678,11 @@ class FigureChartModel extends ChartModel {
         }
         seriesData.width = width;
       }
-    } else if (plotStyle === dh.plot.SeriesPlotStyle.LINE) {
+    } else if (
+      plotStyle === dh.plot.SeriesPlotStyle.LINE ||
+      plotStyle === dh.plot.SeriesPlotStyle.ERROR_BAR ||
+      plotStyle === dh.plot.SeriesPlotStyle.BAR
+    ) {
       const { x, xLow, xHigh, y, yLow, yHigh } = seriesData;
       if (xLow && xHigh && xLow !== x) {
         seriesData.error_x = ChartUtils.getPlotlyErrorBars(


### PR DESCRIPTION
- Wasn't adding the error bars in this case
- Needed for https://github.com/deephaven/deephaven-core/issues/2156 to work
- Needs https://github.com/deephaven/deephaven-core/pull/4202
- Tested with the snippet in the ticket to create the plot:
```
from deephaven.plot.figure import Figure
from deephaven.plot import PlotStyle
from deephaven import new_table
from deephaven.column import int_col, string_col

source = new_table([
    string_col("Categories", ["A", "B", "C"]),
    int_col("Categories2", [1, 2, 3]),
    int_col("Values", [9, 10, 11]),
    int_col("LowerError", [8, 9, 10]),
    int_col("UpperError", [10, 11, 12])
])

v2_plot = Figure().plot_cat(series_name="Categories Plot v2", t=source, category="Categories2", y="Values", y_low="LowerError", y_high="UpperError").show()
```
- Also tested OHLC and existing Bar plots from the core/docs examples to ensure they looked the same
