### PR TITLE
ci: Add workflow to automatically run npm audit fix weekly

### DIFF
--- a/.github/workflows/audit-fix.yml
+++ b/.github/workflows/audit-fix.yml
@@ -16,6 +16,8 @@ jobs:
           node-version-file: '.nvmrc'
           registry-url: 'https://registry.npmjs.org'
       - name: Run npm audit fix
+        # There may be some packages that can't be updated automatically. We don't want that to error out this step.
+        continue-on-error: true
         run: npm audit fix
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v5

--- a/.github/workflows/audit-fix.yml
+++ b/.github/workflows/audit-fix.yml
@@ -1,4 +1,4 @@
-# This workflow will automatically run `npm audit fix` every Thursday morning and open a PR if there are changes
+# Automatically run `npm audit fix` every Thursday morning and open a PR if there are changes
 name: Audit fix
 on:
   schedule:

--- a/.github/workflows/audit-fix.yml
+++ b/.github/workflows/audit-fix.yml
@@ -1,0 +1,26 @@
+# This workflow will automatically run `npm audit fix` every Thursday morning and open a PR if there are changes
+name: Audit fix
+on:
+  schedule:
+    - cron: '0 6 * * 4'
+jobs:
+  audit_fix:
+    runs-on: ubuntu-22.04
+    name: Run npm audit fix
+    steps:
+      - name: Checkout latest
+        uses: actions/checkout@v3
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
+          registry-url: 'https://registry.npmjs.org'
+      - name: Run npm audit fix
+        run: npm audit fix
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v5
+        with:
+          base: main
+          title: npm audit fix
+          branch: deephaven-bot/npm-audit-fix
+          delete-branch: true

--- a/.github/workflows/audit-fix.yml
+++ b/.github/workflows/audit-fix.yml
@@ -23,6 +23,6 @@ jobs:
         uses: peter-evans/create-pull-request@v5
         with:
           base: main
-          title: npm audit fix
+          title: 'fix: npm audit fix'
           branch: deephaven-bot/npm-audit-fix
           delete-branch: true

--- a/.github/workflows/audit-fix.yml
+++ b/.github/workflows/audit-fix.yml
@@ -23,6 +23,6 @@ jobs:
         uses: peter-evans/create-pull-request@v5
         with:
           base: main
-          title: 'fix: npm audit fix'
+          title: 'chore: npm audit fix'
           branch: deephaven-bot/npm-audit-fix
           delete-branch: true


### PR DESCRIPTION
- Scheduled to run every Thursday morning at 6am UTC (2am ET)
- Opens a PR automatically
- PR still needs to be reviewed/approved