### PR TITLE
chore: Disabled react/react-in-jsx-scope

### DIFF
--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -20,6 +20,7 @@ module.exports = {
     'react/jsx-uses-react': 'error',
     'react/jsx-uses-vars': 'error',
     'react/jsx-filename-extension': [1, { extensions: ['.jsx', '.tsx'] }],
+    'react/react-in-jsx-scope': 'off',
     'react/sort-comp': [
       2,
       {


### PR DESCRIPTION
While migrating Enterprise to use our Community eslint rules, there seemed to be only 1 additional rule used by Enterprise:
```json
"react/react-in-jsx-scope": "off"
```
I added it to the Community config.
resolves #1429