### PR TITLE
ci: Change setup-node to read version from nvmrc

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '18.x'
+          node-version-file: '.nvmrc'
           cache: 'npm'
 
       - name: Cache node modules

--- a/.github/workflows/publish-alpha.yml
+++ b/.github/workflows/publish-alpha.yml
@@ -24,7 +24,7 @@ jobs:
           ref: ${{ github.event.inputs.ref }}
       - uses: actions/setup-node@v3
         with:
-          node-version: '18.x'
+          node-version-file: '.nvmrc'
           registry-url: 'https://registry.npmjs.org'
       - run: npm ci
       - run: npm run build

--- a/.github/workflows/publish-nightly.yml
+++ b/.github/workflows/publish-nightly.yml
@@ -35,7 +35,7 @@ jobs:
           fetch-depth: '0' # Need the history to properly select the canary version number
       - uses: actions/setup-node@v3
         with:
-          node-version: '18.x'
+          node-version-file: '.nvmrc'
           registry-url: 'https://registry.npmjs.org'
       - run: npm ci
       - run: npm run build

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: '18.x'
+          node-version-file: '.nvmrc'
           registry-url: 'https://registry.npmjs.org'
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '18.x'
+          node-version-file: '.nvmrc'
           cache: 'npm'
 
       - name: Cache jest


### PR DESCRIPTION
Small thing I noticed when working on an action file is that the setup-node action supports reading the version from a file. This means our actions should automatically stay up to date any time we change the version in `.nvmrc`