### PR TITLE
fix: Environment variable replacement in styleguide

### DIFF
--- a/packages/code-studio/src/styleguide/index.html
+++ b/packages/code-studio/src/styleguide/index.html
@@ -1,8 +1,8 @@
 <!doctype html>
 <html lang="en">
   <head>
-    <base href="#BASE_URL#" />
-    <meta name="ui-version" content="v#npm_package_version#" />
+    <base href="%BASE_URL%" />
+    <meta name="ui-version" content="v%npm_package_version%" />
     <meta charset="utf-8" />
     <meta
       name="viewport"
@@ -14,7 +14,7 @@
       homescreen on Android. See https://developers.google.com/web/fundamentals/engage-and-retain/web-app-manifest/
     -->
     <link rel="manifest" href="/manifest.json" />
-    <link rel="icon" href="#VITE_FAVICON#" />
+    <link rel="icon" href="%VITE_FAVICON%" />
     <title>Deephaven Styleguide</title>
   </head>
   <body>


### PR DESCRIPTION
Missed the styleguide in #1304. This fixes the environment variable replacement