### PR TITLE
chore: Add exports for plotly express docs snapshot tool

### DIFF
--- a/packages/chart/package.json
+++ b/packages/chart/package.json
@@ -18,7 +18,8 @@
   },
   "exports": {
     ".": "./dist/index.js",
-    "./*.js": "./dist/*.js"
+    "./*.js": "./dist/*.js",
+    "./*": "./dist/*.js"
   },
   "scripts": {
     "build": "cross-env NODE_ENV=production run-p build:*",

--- a/packages/chart/package.json
+++ b/packages/chart/package.json
@@ -16,6 +16,10 @@
   "engines": {
     "node": ">=16"
   },
+  "exports": {
+    ".": "./dist/index.js",
+    "./*.js": "./dist/*.js"
+  },
   "scripts": {
     "build": "cross-env NODE_ENV=production run-p build:*",
     "build:babel": "babel ./src --out-dir ./dist --extensions \".ts,.tsx,.js,.jsx\" --source-maps --root-mode upward",

--- a/packages/iris-grid/package.json
+++ b/packages/iris-grid/package.json
@@ -7,7 +7,11 @@
   "type": "module",
   "exports": {
     ".": "./dist/index.js",
-    "./*.js": "./dist/*.js"
+    "./*.js": "./dist/*.js",
+    "./*": "./dist/*.js"
+  },
+  "exportsComments": {
+    "./*": "This is used because docusaurus/webpack doesn't like the ./*.js exports"
   },
   "repository": {
     "type": "git",

--- a/packages/iris-grid/package.json
+++ b/packages/iris-grid/package.json
@@ -5,6 +5,10 @@
   "author": "Deephaven Data Labs LLC",
   "license": "Apache-2.0",
   "type": "module",
+  "exports": {
+    ".": "./dist/index.js",
+    "./*.js": "./dist/*.js"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/deephaven/web-client-ui.git",

--- a/packages/iris-grid/src/IrisGridMetricCalculator.ts
+++ b/packages/iris-grid/src/IrisGridMetricCalculator.ts
@@ -22,7 +22,7 @@ export interface IrisGridMetricState extends GridMetricState {
  * Class to calculate all the metrics for a grid.
  * Call getMetrics() with the state to get metrics
  */
-class IrisGridMetricCalculator extends GridMetricCalculator {
+export class IrisGridMetricCalculator extends GridMetricCalculator {
   getGridY(state: IrisGridMetricState): number {
     let gridY = super.getGridY(state);
     const {

--- a/packages/iris-grid/src/IrisGridRenderer.ts
+++ b/packages/iris-grid/src/IrisGridRenderer.ts
@@ -53,7 +53,7 @@ export type IrisGridRenderState = GridRenderState & {
 /**
  * Handles rendering some of the Iris specific features, such as sorting icons, sort bar display
  * */
-class IrisGridRenderer extends GridRenderer {
+export class IrisGridRenderer extends GridRenderer {
   static isFilterValid(
     advancedFilter: AdvancedFilter | undefined | null,
     quickFilter: QuickFilter | undefined | null

--- a/packages/iris-grid/src/index.ts
+++ b/packages/iris-grid/src/index.ts
@@ -22,5 +22,6 @@ export { default as IrisGridTestUtils } from './IrisGridTestUtils';
 export { default as IrisGridUtils } from './IrisGridUtils';
 export * from './IrisGridUtils';
 export * from './IrisGridMetricCalculator';
+export * from './IrisGridRenderer';
 export { default as TableViewportUpdater } from './TableViewportUpdater';
 export { default as TreeTableViewportUpdater } from './TreeTableViewportUpdater';

--- a/packages/iris-grid/src/index.ts
+++ b/packages/iris-grid/src/index.ts
@@ -21,5 +21,6 @@ export type { IrisGridThemeType } from './IrisGridTheme';
 export { default as IrisGridTestUtils } from './IrisGridTestUtils';
 export { default as IrisGridUtils } from './IrisGridUtils';
 export * from './IrisGridUtils';
+export * from './IrisGridMetricCalculator';
 export { default as TableViewportUpdater } from './TableViewportUpdater';
 export { default as TreeTableViewportUpdater } from './TreeTableViewportUpdater';


### PR DESCRIPTION
Helps clean up the docs snapshot tool imports. Lets the snapshot tool remove all imports from `@deephaven/<package>/dist/...`

There is a `./*.js` and `./*` exports because [Node has some suggestions](https://nodejs.org/api/packages.html#extensions-in-subpaths) about using extensions to allow leaner import maps and mirror the ESM requirement of full specifiers for imports. However, Docusaurus/Webpack don't like the `./*.js` export and seem to require `./*`