### PR TITLE
fix: Upgrade Monaco to ^0.41.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ We use [Playwright](https://playwright.dev/) for end-to-end tests. We test again
 
 You should be able to pass arguments to these commands as if you were running Playwright via CLI directly. For example, to test only `table.spec.ts` you could run `npm run e2e -- ./tests/table.spec.ts`, or to test only `table.spec.ts` in Firefox, you could run `npm run e2e -- --project firefox ./tests/table.spec.ts`. See [Playwright CLI](https://playwright.dev/docs/test-cli) for more details.
 
-Snapshots are used by end-to-end tests to visually verify the output. Snapshots are both OS and broser specific. Sometimes changes are made requiring snapshots to be updated. Update snapshots locally by running `npm run e2e:update-snapshots`.
+Snapshots are used by end-to-end tests to visually verify the output. Snapshots are both OS and browser specific. Sometimes changes are made requiring snapshots to be updated. Update snapshots locally by running `npm run e2e:update-snapshots`.
 
 Once you are satisfied with the snapshots and everything is passing locally, you need to use the docker image to update snapshots for CI (unless you are running the same platform as CI (Ubuntu)). Run `npm run e2e:update-ci-snapshots` to update the CI snapshots. The snapshots will be written to your local directories. The Linux snapshots should be committed to git (non-Linux snapshots should be automatically ignored by git).
 

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,4 +1,6 @@
 import '@testing-library/jest-dom';
+import { TextDecoder, TextEncoder } from 'util';
+import { performance } from 'perf_hooks';
 import 'jest-canvas-mock';
 import './__mocks__/dh-core';
 import Log from '@deephaven/log';
@@ -28,6 +30,18 @@ Object.defineProperty(window, 'matchMedia', {
     removeEventListener: jest.fn(),
     dispatchEvent: jest.fn(),
   })),
+});
+
+Object.defineProperty(window, 'performance', {
+  value: performance,
+});
+
+Object.defineProperty(window, 'TextDecoder', {
+  value: TextDecoder,
+});
+
+Object.defineProperty(window, 'TextEncoder', {
+  value: TextEncoder,
 });
 
 Object.defineProperty(document, 'fonts', {

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -4,6 +4,7 @@ import { performance } from 'perf_hooks';
 import 'jest-canvas-mock';
 import './__mocks__/dh-core';
 import Log from '@deephaven/log';
+import { TestUtils } from '@deephaven/utils';
 
 let logLevel = parseInt(process.env.DH_LOG_LEVEL ?? '', 10);
 if (!Number.isFinite(logLevel)) {
@@ -34,6 +35,13 @@ Object.defineProperty(window, 'matchMedia', {
 
 Object.defineProperty(window, 'performance', {
   value: performance,
+  writable: true,
+});
+
+Object.defineProperty(window, 'ResizeObserver', {
+  value: function () {
+    return TestUtils.createMockProxy<ResizeObserver>();
+  },
 });
 
 Object.defineProperty(window, 'TextDecoder', {

--- a/package-lock.json
+++ b/package-lock.json
@@ -18621,9 +18621,9 @@
       }
     },
     "node_modules/monaco-editor": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.31.1.tgz",
-      "integrity": "sha512-FYPwxGZAeP6mRRyrr5XTGHD9gRXVjy7GUzF4IPChnyt3fS5WrNxIkS8DNujWf6EQy0Zlzpxw8oTVE+mWI2/D1Q=="
+      "version": "0.41.0",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.41.0.tgz",
+      "integrity": "sha512-1o4olnZJsiLmv5pwLEAmzHTE/5geLKQ07BrGxlF4Ri/AXAc2yyDGZwHjiTqD8D/ROKUZmwMA28A+yEowLNOEcA=="
     },
     "node_modules/moo-color": {
       "version": "1.0.3",
@@ -25237,7 +25237,7 @@
         "lodash.throttle": "^4.1.1",
         "memoize-one": "^5.1.1",
         "memoizee": "^0.4.15",
-        "monaco-editor": "^0.31.1",
+        "monaco-editor": "^0.41.0",
         "pouchdb-browser": "^7.2.2",
         "pouchdb-find": "^7.2.2",
         "prop-types": "^15.7.2",
@@ -25349,11 +25349,12 @@
         "lodash.throttle": "^4.1.1",
         "memoize-one": "^5.1.1",
         "memoizee": "^0.4.15",
-        "monaco-editor": "^0.31.1",
+        "monaco-editor": "^0.41.0",
         "papaparse": "5.3.2",
         "popper.js": "^1.16.1",
         "prop-types": "^15.7.2",
-        "shell-quote": "^1.7.2"
+        "shell-quote": "^1.7.2",
+        "shortid": "^2.2.16"
       },
       "devDependencies": {
         "@deephaven/jsapi-shim": "file:../jsapi-shim",
@@ -25646,7 +25647,7 @@
         "lodash.throttle": "^4.1.1",
         "memoize-one": "^5.1.1",
         "memoizee": "^0.4.15",
-        "monaco-editor": "^0.31.1",
+        "monaco-editor": "^0.41.0",
         "prop-types": "^15.7.2",
         "react-beautiful-dnd": "^13.1.0",
         "react-transition-group": "^4.4.2",
@@ -27188,7 +27189,7 @@
         "lodash.throttle": "^4.1.1",
         "memoize-one": "^5.1.1",
         "memoizee": "^0.4.15",
-        "monaco-editor": "^0.31.1",
+        "monaco-editor": "^0.41.0",
         "pouchdb-browser": "^7.2.2",
         "pouchdb-find": "^7.2.2",
         "prop-types": "^15.7.2",
@@ -27264,11 +27265,12 @@
         "lodash.throttle": "^4.1.1",
         "memoize-one": "^5.1.1",
         "memoizee": "^0.4.15",
-        "monaco-editor": "^0.31.1",
+        "monaco-editor": "^0.41.0",
         "papaparse": "5.3.2",
         "popper.js": "^1.16.1",
         "prop-types": "^15.7.2",
-        "shell-quote": "^1.7.2"
+        "shell-quote": "^1.7.2",
+        "shortid": "^2.2.16"
       }
     },
     "@deephaven/dashboard": {
@@ -27468,7 +27470,7 @@
         "lodash.throttle": "^4.1.1",
         "memoize-one": "^5.1.1",
         "memoizee": "^0.4.15",
-        "monaco-editor": "^0.31.1",
+        "monaco-editor": "^0.41.0",
         "prop-types": "^15.7.2",
         "react-beautiful-dnd": "^13.1.0",
         "react-transition-group": "^4.4.2",
@@ -39343,9 +39345,9 @@
       }
     },
     "monaco-editor": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.31.1.tgz",
-      "integrity": "sha512-FYPwxGZAeP6mRRyrr5XTGHD9gRXVjy7GUzF4IPChnyt3fS5WrNxIkS8DNujWf6EQy0Zlzpxw8oTVE+mWI2/D1Q=="
+      "version": "0.41.0",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.41.0.tgz",
+      "integrity": "sha512-1o4olnZJsiLmv5pwLEAmzHTE/5geLKQ07BrGxlF4Ri/AXAc2yyDGZwHjiTqD8D/ROKUZmwMA28A+yEowLNOEcA=="
     },
     "moo-color": {
       "version": "1.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,6 +57,7 @@
         "@deephaven/redux": "file:../redux",
         "@deephaven/stylelint-config": "file:../stylelint-config",
         "@deephaven/tsconfig": "file:../tsconfig",
+        "@deephaven/utils": "file:../utils",
         "@fortawesome/fontawesome-common-types": "^6.1.1",
         "@playwright/test": "^1.30.0",
         "@testing-library/jest-dom": "^5.16.4",

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "@deephaven/redux": "file:../redux",
     "@deephaven/stylelint-config": "file:../stylelint-config",
     "@deephaven/tsconfig": "file:../tsconfig",
+    "@deephaven/utils": "file:../utils",
     "@fortawesome/fontawesome-common-types": "^6.1.1",
     "@playwright/test": "^1.30.0",
     "@testing-library/jest-dom": "^5.16.4",

--- a/packages/code-studio/package.json
+++ b/packages/code-studio/package.json
@@ -44,7 +44,7 @@
     "lodash.throttle": "^4.1.1",
     "memoize-one": "^5.1.1",
     "memoizee": "^0.4.15",
-    "monaco-editor": "^0.31.1",
+    "monaco-editor": "^0.41.0",
     "pouchdb-browser": "^7.2.2",
     "pouchdb-find": "^7.2.2",
     "prop-types": "^15.7.2",

--- a/packages/console/package.json
+++ b/packages/console/package.json
@@ -38,11 +38,12 @@
     "lodash.throttle": "^4.1.1",
     "memoize-one": "^5.1.1",
     "memoizee": "^0.4.15",
-    "monaco-editor": "^0.31.1",
+    "monaco-editor": "^0.41.0",
     "papaparse": "5.3.2",
     "popper.js": "^1.16.1",
     "prop-types": "^15.7.2",
-    "shell-quote": "^1.7.2"
+    "shell-quote": "^1.7.2",
+    "shortid": "^2.2.16"
   },
   "peerDependencies": {
     "react": "^17.x",

--- a/packages/console/src/ConsoleInput.tsx
+++ b/packages/console/src/ConsoleInput.tsx
@@ -187,6 +187,7 @@ export class ConsoleInput extends PureComponent<
 
     const element = this.commandContainer.current;
     assertNotNull(element);
+    MonacoUtils.removeConflictingKeybindings();
     this.commandEditor = monaco.editor.create(element, commandSettings);
 
     MonacoUtils.setEOL(this.commandEditor);
@@ -283,13 +284,10 @@ export class ConsoleInput extends PureComponent<
       }
     });
 
-    // Override the Ctrl+F functionality so that the find window doesn't appear
-    this.commandEditor.addCommand(
+    // Disable the Ctrl+F functionality so that the find window doesn't appear
+    MonacoUtils.disableKeyBindings(this.commandEditor, [
       monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyF, // eslint-disable-line no-bitwise
-      () => undefined
-    );
-
-    MonacoUtils.removeConflictingKeybindings(this.commandEditor);
+    ]);
 
     MonacoUtils.registerPasteHandler(this.commandEditor);
 

--- a/packages/console/src/ConsoleInput.tsx
+++ b/packages/console/src/ConsoleInput.tsx
@@ -187,7 +187,7 @@ export class ConsoleInput extends PureComponent<
 
     const element = this.commandContainer.current;
     assertNotNull(element);
-    MonacoUtils.removeConflictingKeybindings();
+
     this.commandEditor = monaco.editor.create(element, commandSettings);
 
     MonacoUtils.setEOL(this.commandEditor);

--- a/packages/console/src/log/LogView.tsx
+++ b/packages/console/src/log/LogView.tsx
@@ -9,6 +9,7 @@ import ConsoleUtils from '../common/ConsoleUtils';
 import LogLevel from './LogLevel';
 import './LogView.scss';
 import LogLevelMenuItem from './LogLevelMenuItem';
+import { MonacoUtils } from '../monaco';
 
 interface LogViewProps {
   session: IdeSession;
@@ -226,36 +227,30 @@ class LogView extends PureComponent<LogViewProps, LogViewState> {
       wordWrap: 'on',
     });
 
-    // When find widget is open, escape key closes it.
-    // Instead, capture it and do nothing. Same for shift-escape.
-    this.editor.addCommand(monaco.KeyCode.Escape, () => undefined);
-    this.editor.addCommand(
-      // eslint-disable-next-line no-bitwise
-      monaco.KeyMod.Shift | monaco.KeyCode.Escape,
-      () => undefined
-    );
+    // Override default Monaco keybindings for `escape` and `shift-escape`
+    [
+      [monaco.KeyCode.Escape],
+      [monaco.KeyMod.Shift | monaco.KeyCode.Escape], // eslint-disable-line no-bitwise
+    ].forEach(keybindings => {
+      // Monaco default behavior is for escape key to close the find widget.
+      // Instead, capture it and do nothing. Same for shift-escape.
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      MonacoUtils.disableKeyBindings(this.editor!, keybindings);
 
-    // Restore regular escape to clear selection, when editorText has focus.
-    this.editor.addCommand(
-      monaco.KeyCode.Escape,
-      () => {
-        const position = this.editor?.getPosition();
-        assertNotNull(position);
-        this.editor?.setPosition(position);
-      },
-      'findWidgetVisible && editorTextFocus'
-    );
-
-    this.editor.addCommand(
-      // eslint-disable-next-line no-bitwise
-      monaco.KeyMod.Shift | monaco.KeyCode.Escape,
-      () => {
-        const position = this.editor?.getPosition();
-        assertNotNull(position);
-        this.editor?.setPosition(position);
-      },
-      'findWidgetVisible && editorTextFocus'
-    );
+      // Restore regular escape to clear selection, when editorText has focus.
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      this.editor!.addAction({
+        id: 'clear-selection-on-escape',
+        label: '',
+        keybindings: [monaco.KeyCode.Escape],
+        keybindingContext: 'findWidgetVisible && editorTextFocus',
+        run: () => {
+          const position = this.editor?.getPosition();
+          assertNotNull(position);
+          this.editor?.setPosition(position);
+        },
+      });
+    });
   }
 
   destroyMonaco(): void {

--- a/packages/console/src/log/LogView.tsx
+++ b/packages/console/src/log/LogView.tsx
@@ -232,14 +232,14 @@ class LogView extends PureComponent<LogViewProps, LogViewState> {
       [monaco.KeyCode.Escape],
       [monaco.KeyMod.Shift | monaco.KeyCode.Escape], // eslint-disable-line no-bitwise
     ].forEach(keybindings => {
+      assertNotNull(this.editor);
+
       // Monaco default behavior is for escape key to close the find widget.
       // Instead, capture it and do nothing. Same for shift-escape.
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      MonacoUtils.disableKeyBindings(this.editor!, keybindings);
+      MonacoUtils.disableKeyBindings(this.editor, keybindings);
 
       // Restore regular escape to clear selection, when editorText has focus.
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      this.editor!.addAction({
+      this.editor.addAction({
         id: 'clear-selection-on-escape',
         label: '',
         keybindings: [monaco.KeyCode.Escape],

--- a/packages/console/src/monaco/MonacoUtils.test.ts
+++ b/packages/console/src/monaco/MonacoUtils.test.ts
@@ -173,7 +173,7 @@ describe('disableKeyBindings', () => {
 
     keybindingsList.forEach(keybindings => {
       expect(editor.addAction).toHaveBeenCalledWith({
-        id: expect.stringMatching(/^disable-keybindings-[^-]+/),
+        id: expect.stringMatching(/^disable-keybindings-.+/),
         label: '',
         keybindings,
         run: expect.any(Function),

--- a/packages/console/src/monaco/MonacoUtils.test.ts
+++ b/packages/console/src/monaco/MonacoUtils.test.ts
@@ -1,7 +1,10 @@
 /* eslint-disable no-bitwise */
 import * as monaco from 'monaco-editor';
 import { Shortcut, KEY, MODIFIER } from '@deephaven/components';
+import { TestUtils } from '@deephaven/utils';
 import MonacoUtils from './MonacoUtils';
+
+const { createMockProxy } = TestUtils;
 
 const SINGLE_KEY_PARAMS: ConstructorParameters<typeof Shortcut>[0] = {
   id: 'Single key',
@@ -44,6 +47,11 @@ const MULTI_MOD_PARAMS: ConstructorParameters<typeof Shortcut>[0] = {
   shortcut: [MODIFIER.CTRL, MODIFIER.SHIFT, KEY.A],
   macShortcut: [MODIFIER.CMD, MODIFIER.SHIFT, KEY.B],
 };
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  expect.hasAssertions();
+});
 
 describe('Register worker', () => {
   it('Registers the getWorker function', () => {
@@ -151,6 +159,29 @@ describe('Mac shortcuts', () => {
   });
 });
 
+describe('disableKeyBindings', () => {
+  const editor = createMockProxy<monaco.editor.IStandaloneCodeEditor>();
+
+  it('should disable key bindings for the given editor', () => {
+    const keybindingsList = [
+      [1, 2, 3],
+      [4, 5, 6],
+      [7, 8, 9],
+    ];
+
+    MonacoUtils.disableKeyBindings(editor, ...keybindingsList);
+
+    keybindingsList.forEach(keybindings => {
+      expect(editor.addAction).toHaveBeenCalledWith({
+        id: expect.stringMatching(/^disable-keybindings-[^-]+/),
+        label: '',
+        keybindings,
+        run: expect.any(Function),
+      });
+    });
+  });
+});
+
 describe('provideLinks', () => {
   it('it should get a provideLinks function which should return an object with the links', () => {
     const { provideLinks } = MonacoUtils;
@@ -175,5 +206,37 @@ describe('provideLinks', () => {
     };
 
     expect(provideLinks(mockModel)).toEqual(expectedValue);
+  });
+});
+
+describe('removeConflictingKeybindings', () => {
+  beforeEach(() => {
+    jest.spyOn(monaco.editor, 'addKeybindingRules');
+    MonacoUtils.conflictingKeybindingsRemoved = false;
+  });
+
+  it('should override keybinding rules', () => {
+    MonacoUtils.removeConflictingKeybindings();
+
+    expect(monaco.editor.addKeybindingRules).toHaveBeenCalledWith([
+      {
+        keybinding: monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyD,
+        command: null,
+      },
+      {
+        keybinding: monaco.KeyMod.WinCtrl | monaco.KeyCode.KeyH,
+        command: null,
+      },
+    ]);
+  });
+
+  it('should only add keybinding rules once', () => {
+    expect(MonacoUtils.conflictingKeybindingsRemoved).toBe(false);
+
+    [1, 2].forEach(() => {
+      MonacoUtils.removeConflictingKeybindings();
+      expect(MonacoUtils.conflictingKeybindingsRemoved).toBe(true);
+      expect(monaco.editor.addKeybindingRules).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/packages/console/src/monaco/MonacoUtils.test.ts
+++ b/packages/console/src/monaco/MonacoUtils.test.ts
@@ -163,21 +163,15 @@ describe('disableKeyBindings', () => {
   const editor = createMockProxy<monaco.editor.IStandaloneCodeEditor>();
 
   it('should disable key bindings for the given editor', () => {
-    const keybindingsList = [
-      [1, 2, 3],
-      [4, 5, 6],
-      [7, 8, 9],
-    ];
+    const keybindings = [1, 2, 3];
 
-    MonacoUtils.disableKeyBindings(editor, ...keybindingsList);
+    MonacoUtils.disableKeyBindings(editor, keybindings);
 
-    keybindingsList.forEach(keybindings => {
-      expect(editor.addAction).toHaveBeenCalledWith({
-        id: expect.stringMatching(/^disable-keybindings-.+/),
-        label: '',
-        keybindings,
-        run: expect.any(Function),
-      });
+    expect(editor.addAction).toHaveBeenCalledWith({
+      id: expect.stringMatching(/^disable-keybindings-.+/),
+      label: '',
+      keybindings,
+      run: expect.any(Function),
     });
   });
 });

--- a/packages/console/src/monaco/MonacoUtils.ts
+++ b/packages/console/src/monaco/MonacoUtils.ts
@@ -341,7 +341,7 @@ class MonacoUtils {
   }
 
   // Tracks whether removeConflictingKeybindings() has been called
-  private static conflictingKeybindingsRemoved = false;
+  static conflictingKeybindingsRemoved = false;
 
   /**
    * Remove any keybindings which are used for our own shortcuts.

--- a/packages/console/src/monaco/MonacoUtils.ts
+++ b/packages/console/src/monaco/MonacoUtils.ts
@@ -363,9 +363,10 @@ class MonacoUtils {
       }
     );
 
-    // Mac has a system shortcut tied to Cmd+H, so we can't override it
+    // Cmd+H is used to focus Community console history in Windows + Linux.
+    // An alternate shortcut is used for Mac, so no need to override it
+    // (See ConsoleShortcuts.ts)
     if (!MonacoUtils.isMacPlatform()) {
-      // Console focus history in Community (see ConsoleShortcuts.ts)
       monaco.editor.addKeybindingRule({
         /* eslint-disable-next-line no-bitwise */
         keybinding: monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyH,

--- a/packages/console/src/monaco/MonacoUtils.ts
+++ b/packages/console/src/monaco/MonacoUtils.ts
@@ -340,13 +340,24 @@ class MonacoUtils {
     return platform.startsWith('Mac');
   }
 
+  // Tracks whether removeConflictingKeybindings() has been called
+  private static conflictingKeybindingsRemoved = false;
+
   /**
    * Remove any keybindings which are used for our own shortcuts.
    * This allows the key events to bubble up so a component higher up can capture
    * them. Note that this is a global configuration, so all editor instances will
-   * be impacted by this.
+   * be impacted.
    */
   static removeConflictingKeybindings(): void {
+    // This function adds the keybindings to the global registry, so we only
+    // want to do it once
+    if (MonacoUtils.conflictingKeybindingsRemoved) {
+      return;
+    }
+
+    MonacoUtils.conflictingKeybindingsRemoved = true;
+
     /* eslint-disable no-bitwise */
     monaco.editor.addKeybindingRules([
       // Restart console in Enterprise (see Shortcuts.ts)

--- a/packages/console/src/monaco/MonacoUtils.ts
+++ b/packages/console/src/monaco/MonacoUtils.ts
@@ -380,14 +380,15 @@ class MonacoUtils {
    * Note that this will swallow the events. To disable default keybindings in a
    * way that allows events to propagate upward, see `removeConflictingKeybindings`
    * @param editor Editor to disable keybindings for
-   * @param keybindings List of keybindings to disable
+   * @param keybindings List of monaco keybindings to disable. Often a bitwise
+   * combination like `monaco.KeyMod.Alt | monaco.KeyMod.KeyJ`
    */
   static disableKeyBindings(
     editor: monaco.editor.IStandaloneCodeEditor,
     keybindings: number[]
   ): void {
     editor.addAction({
-      // This shouldn't be referenced by anything so using an aritrary unique id
+      // This shouldn't be referenced by anything so using an arbitrary unique id
       id: `disable-keybindings-${shortid()}`,
       label: '', // This action won't be shown in the UI so no need for a label
       keybindings,

--- a/packages/console/src/monaco/MonacoUtils.ts
+++ b/packages/console/src/monaco/MonacoUtils.ts
@@ -363,7 +363,7 @@ class MonacoUtils {
       }
     );
 
-    // Cmd+H is used to focus Community console history in Windows + Linux.
+    // Ctrl+H is used to focus Community console history in Windows + Linux.
     // An alternate shortcut is used for Mac, so no need to override it
     // (See ConsoleShortcuts.ts)
     if (!MonacoUtils.isMacPlatform()) {
@@ -380,20 +380,18 @@ class MonacoUtils {
    * Note that this will swallow the events. To disable default keybindings in a
    * way that allows events to propagate upward, see `removeConflictingKeybindings`
    * @param editor Editor to disable keybindings for
-   * @param keybindingsList List of keybinding tuples to disable
+   * @param keybindings List of keybindings to disable
    */
   static disableKeyBindings(
     editor: monaco.editor.IStandaloneCodeEditor,
-    ...keybindingsList: number[][]
+    keybindings: number[]
   ): void {
-    keybindingsList.forEach(keybindings => {
-      editor.addAction({
-        // This shouldn't be referenced by anything so using an aritrary unique id
-        id: `disable-keybindings-${shortid()}`,
-        label: '', // This action won't be shown in the UI so no need for a label
-        keybindings,
-        run: () => undefined,
-      });
+    editor.addAction({
+      // This shouldn't be referenced by anything so using an aritrary unique id
+      id: `disable-keybindings-${shortid()}`,
+      label: '', // This action won't be shown in the UI so no need for a label
+      keybindings,
+      run: () => undefined,
     });
   }
 

--- a/packages/console/src/notebook/Editor.tsx
+++ b/packages/console/src/notebook/Editor.tsx
@@ -95,8 +95,6 @@ class Editor extends Component<EditorProps, Record<string, never>> {
     };
     assertNotNull(this.container);
 
-    MonacoUtils.removeConflictingKeybindings();
-
     this.editor = monaco.editor.create(this.container, settings);
 
     this.editor.addAction({

--- a/packages/console/src/notebook/Editor.tsx
+++ b/packages/console/src/notebook/Editor.tsx
@@ -94,7 +94,11 @@ class Editor extends Component<EditorProps, Record<string, never>> {
       ...settings,
     };
     assertNotNull(this.container);
+
+    MonacoUtils.removeConflictingKeybindings();
+
     this.editor = monaco.editor.create(this.container, settings);
+
     this.editor.addAction({
       id: 'find',
       label: 'Find',
@@ -112,7 +116,6 @@ class Editor extends Component<EditorProps, Record<string, never>> {
       },
     });
     this.editor.layout();
-    MonacoUtils.removeConflictingKeybindings(this.editor);
 
     monaco.languages.registerLinkProvider('plaintext', {
       provideLinks: MonacoUtils.provideLinks,

--- a/packages/iris-grid/package.json
+++ b/packages/iris-grid/package.json
@@ -45,7 +45,7 @@
     "lodash.throttle": "^4.1.1",
     "memoize-one": "^5.1.1",
     "memoizee": "^0.4.15",
-    "monaco-editor": "^0.31.1",
+    "monaco-editor": "^0.41.0",
     "prop-types": "^15.7.2",
     "react-beautiful-dnd": "^13.1.0",
     "react-transition-group": "^4.4.2",

--- a/packages/iris-grid/src/sidebar/CustomColumnBuilder.test.tsx
+++ b/packages/iris-grid/src/sidebar/CustomColumnBuilder.test.tsx
@@ -101,7 +101,7 @@ test('Ignores deleted formulas on save', async () => {
   // RTL/monaco aren't playing nicely and it won't edit the existing text
   // This test instead creates the new text, saves, then removes it to test the same behavior
   jest.useFakeTimers({
-    // Monaco makes a call to performance.mark(), so we need to leave it in-tact
+    // Monaco makes a call to performance.mark(), so we need to leave it intact
     doNotFake: ['performance'],
   });
   const user = userEvent.setup({ delay: null });

--- a/packages/iris-grid/src/sidebar/CustomColumnBuilder.test.tsx
+++ b/packages/iris-grid/src/sidebar/CustomColumnBuilder.test.tsx
@@ -100,7 +100,10 @@ test('Ignores deleted formulas on save', async () => {
   // There is an issue with populating the custom columns and then editing the existing column
   // RTL/monaco aren't playing nicely and it won't edit the existing text
   // This test instead creates the new text, saves, then removes it to test the same behavior
-  jest.useFakeTimers();
+  jest.useFakeTimers({
+    // Monaco makes a call to performance.mark(), so we need to leave it in-tact
+    doNotFake: ['performance'],
+  });
   const user = userEvent.setup({ delay: null });
   const model = irisGridTestUtils.makeModel();
   const mockSave = jest.fn(() =>


### PR DESCRIPTION
Fixes #1445, fixes #1191 Fixing Monaco bug by upgrading to latest ^0.41.0

Supports DH-15438

BREAKING CHANGE: Monaco will need to be upgraded to ^0.41.0 in Enterprise to ensure compatibility

**Tests Performed**

- Console Input
    - `Cmd+F` does nothing
    - Intellisense can be closed via `Esc`
- Log tab
    - `Esc` does not close find input
    - `Esc` does clear selection when focus is in the log content
- Code Editor
    - Verified that newline with leading space no longer crashes the browser tab
      ```
      a
       a
      ```
   - Wrote some Python code. Intellisense, syntax highlighting, and general typing experience seemed as expected
   - Execute full code + selected code successfully