### PR TITLE
fix: legal notices dismisses on click anywhere

### DIFF
--- a/packages/code-studio/src/settings/LegalNotice.tsx
+++ b/packages/code-studio/src/settings/LegalNotice.tsx
@@ -9,8 +9,10 @@ function LegalNotice(): ReactElement {
   };
 
   return (
-    <Button kind="ghost" onClick={toggle} icon={vsLaw}>
-      Legal Notices
+    <>
+      <Button kind="ghost" onClick={toggle} icon={vsLaw}>
+        Legal Notices
+      </Button>
       <Modal isOpen={modal} toggle={toggle} className="theme-bg-light">
         <ModalHeader toggle={toggle}>Legal Notice</ModalHeader>
         <ModalBody>
@@ -35,7 +37,7 @@ function LegalNotice(): ReactElement {
           </p>
         </ModalBody>
       </Modal>
-    </Button>
+    </>
   );
 }
 


### PR DESCRIPTION
Modal shouldn't be nested inside the button, messes up click handling and makes the modal dismiss on a click anywhere.