### PR TITLE
fix: Zip CSV uploads not working

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -70,7 +70,6 @@
         "@types/eslint": "^8.4.10",
         "@types/jest": "^29.2.5",
         "@types/jquery": "^3.5.14",
-        "@types/jszip": "3.1.7",
         "@types/lodash": "^4.14.182",
         "@types/lodash.clamp": "^4.0.6",
         "@types/lodash.debounce": "^4.0.6",
@@ -5632,14 +5631,6 @@
     "node_modules/@types/json5": {
       "version": "0.0.29",
       "license": "MIT"
-    },
-    "node_modules/@types/jszip": {
-      "version": "3.1.7",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
     },
     "node_modules/@types/lodash": {
       "version": "4.14.182",
@@ -16487,13 +16478,14 @@
       }
     },
     "node_modules/jszip": {
-      "version": "3.2.2",
-      "license": "(MIT OR GPL-3.0)",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
       "dependencies": {
         "lie": "~3.3.0",
         "pako": "~1.0.2",
         "readable-stream": "~2.3.6",
-        "set-immediate-shim": "~1.0.1"
+        "setimmediate": "^1.0.5"
       }
     },
     "node_modules/karma": {
@@ -22034,12 +22026,10 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/set-immediate-shim": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
@@ -25233,7 +25223,7 @@
         "@fortawesome/react-fontawesome": "^0.2.0",
         "classnames": "^2.3.1",
         "event-target-shim": "^6.0.2",
-        "jszip": "3.2.2",
+        "jszip": "3.10.1",
         "lodash.debounce": "^4.0.8",
         "lodash.throttle": "^4.1.1",
         "memoize-one": "^5.1.1",
@@ -27185,7 +27175,7 @@
         "autoprefixer": "^10.4.8",
         "classnames": "^2.3.1",
         "event-target-shim": "^6.0.2",
-        "jszip": "3.2.2",
+        "jszip": "3.10.1",
         "lodash.debounce": "^4.0.8",
         "lodash.throttle": "^4.1.1",
         "memoize-one": "^5.1.1",
@@ -30077,13 +30067,6 @@
     },
     "@types/json5": {
       "version": "0.0.29"
-    },
-    "@types/jszip": {
-      "version": "3.1.7",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
     },
     "@types/lodash": {
       "version": "4.14.182",
@@ -37789,12 +37772,14 @@
       }
     },
     "jszip": {
-      "version": "3.2.2",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
       "requires": {
         "lie": "~3.3.0",
         "pako": "~1.0.2",
         "readable-stream": "~2.3.6",
-        "set-immediate-shim": "~1.0.1"
+        "setimmediate": "^1.0.5"
       }
     },
     "karma": {
@@ -41783,8 +41768,10 @@
       "version": "2.0.0",
       "dev": true
     },
-    "set-immediate-shim": {
-      "version": "1.0.1"
+    "setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="
     },
     "setprototypeof": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,6 @@
     "@types/eslint": "^8.4.10",
     "@types/jest": "^29.2.5",
     "@types/jquery": "^3.5.14",
-    "@types/jszip": "3.1.7",
     "@types/lodash": "^4.14.182",
     "@types/lodash.clamp": "^4.0.6",
     "@types/lodash.debounce": "^4.0.6",

--- a/packages/code-studio/package.json
+++ b/packages/code-studio/package.json
@@ -39,7 +39,7 @@
     "@fortawesome/react-fontawesome": "^0.2.0",
     "classnames": "^2.3.1",
     "event-target-shim": "^6.0.2",
-    "jszip": "3.2.2",
+    "jszip": "3.10.1",
     "lodash.debounce": "^4.0.8",
     "lodash.throttle": "^4.1.1",
     "memoize-one": "^5.1.1",
@@ -57,10 +57,6 @@
     "redux": "^4.2.0",
     "redux-thunk": "^2.4.1",
     "shortid": "^2.2.16"
-  },
-  "dependenciesComments": {
-    "@types/jszip": "3.1.7 is the closest to 3.2.2 available. JSZip adds official typings in 3.4.0, so remove if going past JSZip 3.4.0",
-    "jszip": "Pinned to 3.2.2 b/c 3.3.0+ breaks nodestream usage. Not fixed as of 3.5.0. https://github.com/Stuk/jszip/issues/663"
   },
   "homepage": ".",
   "main": "build/index.html",

--- a/packages/console/src/csv/CsvInputBar.tsx
+++ b/packages/console/src/csv/CsvInputBar.tsx
@@ -178,7 +178,7 @@ class CsvInputBar extends Component<CsvInputBarProps, CsvInputBarState> {
     }
   }
 
-  handleFile(file: Blob | JSZipObject, isZip = false): void {
+  handleFile(file: File | Blob | JSZipObject, isZip = false): void {
     log.info(
       `Starting CSV parser for ${
         file instanceof File ? file.name : 'pasted values'

--- a/packages/console/src/csv/CsvTypeParser.ts
+++ b/packages/console/src/csv/CsvTypeParser.ts
@@ -1,4 +1,4 @@
-import type { JSZipObject, JSZipStreamHelper } from 'jszip';
+import type { JSZipObject } from 'jszip';
 import { assertNotNull } from '@deephaven/utils';
 import Papa, { Parser, ParseResult, ParseLocalConfig } from 'papaparse';
 // Intentionally using isNaN rather than Number.isNaN

--- a/packages/console/src/csv/CsvTypeParser.ts
+++ b/packages/console/src/csv/CsvTypeParser.ts
@@ -157,7 +157,7 @@ class CsvTypeParser {
   }
 
   constructor(
-    onFileCompleted: (types: string[]) => void,
+    onFileCompleted: (types: string[], rowCount: number) => void,
     file: File | Blob | JSZipObject,
     readHeaders: boolean,
     parentConfig: ParseLocalConfig<unknown, Blob | NodeJS.ReadableStream>,
@@ -176,6 +176,7 @@ class CsvTypeParser {
     this.onError = onError;
     this.chunks = 0;
     this.totalChunks = totalChunks;
+    this.rowCount = 0;
     this.isZip = isZip;
     this.shouldTrim = shouldTrim;
     this.zipProgress = 0;
@@ -193,7 +194,7 @@ class CsvTypeParser {
     };
   }
 
-  onFileCompleted: (types: string[]) => void;
+  onFileCompleted: (types: string[], rowCount: number) => void;
 
   file: File | Blob | JSZipObject;
 
@@ -210,6 +211,8 @@ class CsvTypeParser {
   chunks: number;
 
   totalChunks: number;
+
+  rowCount: number;
 
   isZip: boolean;
 
@@ -246,6 +249,8 @@ class CsvTypeParser {
         data = data.slice(1);
       }
     }
+
+    this.rowCount += data.length;
 
     assertNotNull(this.types);
 
@@ -296,7 +301,8 @@ class CsvTypeParser {
           type === UNKNOWN || type === NewTableColumnTypes.LOCAL_TIME
             ? NewTableColumnTypes.STRING
             : type
-        )
+        ),
+        this.rowCount
       );
     }
   }

--- a/packages/console/src/csv/ZipStreamHelper.ts
+++ b/packages/console/src/csv/ZipStreamHelper.ts
@@ -1,5 +1,10 @@
 import type { JSZipObject, OnUpdateCallback, JSZipStreamHelper } from 'jszip';
 
+/**
+ * This is used to help papaparse understand our stream.
+ * It uses these fields for feature detection, but never actually calls read()
+ * https://github.com/mholt/PapaParse/blob/master/papaparse.js#L244
+ */
 interface ZipStreamHelper extends JSZipStreamHelper<string> {
   readable: boolean;
   read(): void;
@@ -14,6 +19,7 @@ export default function makeZipStreamHelper(
     zipObj as JSZipObject & {
       // The type could be anything except nodebuffer from https://stuk.github.io/jszip/documentation/api_zipobject/internal_stream.html
       // We only need it as a string though
+      // JSZip types don't include this method for some reason
       internalStream(type: 'string'): JSZipStreamHelper<string>;
     }
   ).internalStream('string') as ZipStreamHelper;

--- a/packages/console/src/csv/ZipStreamHelper.ts
+++ b/packages/console/src/csv/ZipStreamHelper.ts
@@ -1,0 +1,27 @@
+import type { JSZipObject, OnUpdateCallback, JSZipStreamHelper } from 'jszip';
+
+interface ZipStreamHelper extends JSZipStreamHelper<string> {
+  readable: boolean;
+  read(): void;
+  removeListener(): void;
+}
+
+export default function makeZipStreamHelper(
+  zipObj: JSZipObject,
+  onUpdate: OnUpdateCallback
+) {
+  const helper: ZipStreamHelper = (
+    zipObj as JSZipObject & {
+      // The type could be anything except nodebuffer from https://stuk.github.io/jszip/documentation/api_zipobject/internal_stream.html
+      // We only need it as a string though
+      internalStream(type: 'string'): JSZipStreamHelper<string>;
+    }
+  ).internalStream('string') as ZipStreamHelper;
+
+  helper.readable = true;
+  helper.read = () => false;
+  helper.removeListener = () => false;
+  helper.on('data', (_, metadata) => onUpdate(metadata));
+
+  return helper;
+}


### PR DESCRIPTION
Fixes #1080. Fixes #1416 

Updates jszip and uses the internal stream helper instead of nodestream which we would need a polyfill for. The progress on zip uploads is a bit odd since we use the unzip progress. It seems papaparse loads more from the stream while processing/before processing and can finish reading the zip before it's done processing chunks.

Also, uploading the tables seems to be a blocking operation. Not sure if that's an easy fix, but after the 50% mark on uploading a large zip, there are some blocks on the main thread (marching ants freezes as an indicator).

There is a ~2GB limit for JSZip it seems https://github.com/Stuk/jszip/issues/777