### PR TITLE
test: Add firefox support for playwright pasteInMonaco

### DIFF
--- a/tests/console.spec.ts
+++ b/tests/console.spec.ts
@@ -17,15 +17,6 @@ test.afterAll(async () => {
 });
 
 test.describe('console input tests', () => {
-  test.beforeEach(async () => {
-    // Find the console input
-    const consoleInput = page.locator('.console-input');
-
-    // Monaco editor doesn't have a native input, so need to just click into it and type on the page
-    // https://github.com/microsoft/playwright/issues/14126
-    await consoleInput.click();
-  });
-
   test('print commands get logged', async () => {
     const message = `Hello ${shortid()}!`;
     const command = `print("${message}")`;

--- a/tests/notebook.spec.ts
+++ b/tests/notebook.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test';
-import { pasteInMonaco } from './utils';
 import shortid from 'shortid';
+import { pasteInMonaco } from './utils';
 
 test('test creating a file, saving it, closing it, re-opening it, running it, then deleting it', async ({
   page,

--- a/tests/table-operations.spec.ts
+++ b/tests/table-operations.spec.ts
@@ -109,7 +109,6 @@ test.beforeEach(async ({ page }) => {
   await page.goto('');
 
   const consoleInput = page.locator('.console-input');
-  await consoleInput.click();
 
   const command = makeTableCommand(undefined, TableTypes.AllTypes);
 
@@ -516,7 +515,6 @@ test('advanced settings', async ({ page }) => {
 
   await test.step('create 2nd table', async () => {
     const consoleInput = page.locator('.console-input');
-    await consoleInput.click();
 
     const command = makeTableCommand(table2Name, TableTypes.AllTypes);
 

--- a/tests/table.spec.ts
+++ b/tests/table.spec.ts
@@ -1,12 +1,11 @@
 import { test, expect, Page } from '@playwright/test';
-import { makeTableCommand, pasteInMonaco, TableTypes } from './utils';
+import { makeTableCommand, pasteInMonaco } from './utils';
 
 // Run tests serially since they all use the same table
 test.describe.configure({ mode: 'serial' });
 
 async function openSimpleTable(page: Page) {
   const consoleInput = page.locator('.console-input');
-  await consoleInput.click();
 
   const command = makeTableCommand();
 
@@ -42,7 +41,6 @@ test('can open a simple table', async ({ page }) => {
 test('can open a table with column header groups', async ({ page }) => {
   await page.goto('');
   const consoleInput = page.locator('.console-input');
-  await consoleInput.click();
 
   const command = `${makeTableCommand('column_header_group')}
 column_groups = [{ 'name': 'YandZ', 'children': ['y', 'z'] }, { 'name': 'All', 'children': ['x', 'YandZ'], 'color': 'white' }]
@@ -71,7 +69,6 @@ test('can open a table with column header groups and hidden columns', async ({
 }) => {
   await page.goto('');
   const consoleInput = page.locator('.console-input');
-  await consoleInput.click();
 
   const command = `${makeTableCommand('column_header_group')}
 column_groups = [{ 'name': 'YandZ', 'children': ['y', 'z'] }, { 'name': 'All', 'children': ['x', 'YandZ'], 'color': 'white' }]


### PR DESCRIPTION
Doesn't seem to be a single solution that works in all 3 browsers in headless mode, but between 2 solutions we can cover pasting in all 3 browsers