### PR TITLE
build: Use automatic JSX runtime in babel

### DIFF
--- a/packages/babel-preset/index.js
+++ b/packages/babel-preset/index.js
@@ -16,7 +16,7 @@ module.exports = api => ({
         include: ['@babel/plugin-proposal-class-properties'],
       },
     ],
-    '@babel/preset-react',
+    ['@babel/preset-react', { runtime: 'automatic' }],
     ['@babel/preset-typescript', { allowDeclareFields: true }],
   ],
   plugins: [


### PR DESCRIPTION
#1450 removed an import of React which we allow w/ ESLint. Seems to be the first package outside of code-studio where we may have done that. The resulting build triggers an error b/c Babel was using the old runtime still.

The e2e tests timed out on that branch b/c of this issue, not due to the flaky tests. This is something that would have been a bug in enterprise because we consume built packages there. The build system w/ e2e did actually surface the issue since we consume built packages in the code-studio build, we just didn't catch it and merged thinking it was flaky e2e tests.

It's not a build failure, but previewing the build gives an error in the console panel before this change.