### PR TITLE
fix: Heap usage should tick immediately when dependencies change

### DIFF
--- a/packages/react-hooks/src/useAsyncInterval.ts
+++ b/packages/react-hooks/src/useAsyncInterval.ts
@@ -57,10 +57,8 @@ export function useAsyncInterval(
 
     elapsedSinceLastTick += Date.now() - trackingStartedRef.current;
 
-    // Calculate any elapsed time beyond the target interval. Note that
-    // elapsedSinceLastTick should always be >= targetIntervalMs, so overage
-    // should always be >= 0.
-    const overage = elapsedSinceLastTick - targetIntervalMs;
+    // Calculate any elapsed time beyond the target interval.
+    const overage = Math.max(0, elapsedSinceLastTick - targetIntervalMs);
 
     const nextTickInterval = Math.max(0, targetIntervalMs - overage);
 


### PR DESCRIPTION
fixes #1464 - Heap usage checks now run immediately whenever useEffect dependencies change.
