### PR TITLE
fix: Console History Not Scrolling to Bottom (DH-14062)

### DIFF
--- a/packages/console/src/Console.tsx
+++ b/packages/console/src/Console.tsx
@@ -614,7 +614,10 @@ export class Console extends PureComponent<ConsoleProps, ConsoleState> {
   scrollConsoleHistoryToBottom(force = false): void {
     const pane = this.consoleHistoryScrollPane.current;
     assertNotNull(pane);
-    if (!force && pane.scrollTop < pane.scrollHeight - pane.offsetHeight) {
+    if (
+      !force &&
+      Math.round(pane.scrollTop) < pane.scrollHeight - pane.offsetHeight
+    ) {
       return;
     }
 

--- a/packages/console/src/Console.tsx
+++ b/packages/console/src/Console.tsx
@@ -616,7 +616,7 @@ export class Console extends PureComponent<ConsoleProps, ConsoleState> {
     assertNotNull(pane);
     if (
       !force &&
-      Math.round(pane.scrollTop) < pane.scrollHeight - pane.offsetHeight
+      Math.abs(pane.scrollHeight - pane.clientHeight - pane.scrollTop) >= 1
     ) {
       return;
     }


### PR DESCRIPTION
I discovered DH-14062 independently and found that this method occasionally was prematurely returning when the view should stay stuck to the bottom of the contents.

Sometimes `pane.scrollTop` is sometimes 0.5 less than the expected value when tailing the content. This `Math.round` bumps it up. I only saw `xxxxx.0` and `xxxxx.5` values during investigation, but I did not do any further research on the origin of the value or the rounding error.

Here is a sample groovy snippet that reproduces 100% of the time:
```groovy
import io.deephaven.internal.log.LoggerFactory
log = LoggerFactory.getLogger(Object.class
log.error().append(new RuntimeException()).endl()
t = io.deephaven.engine.util.TableTools.timeTable("PT1s")
```