### PR TITLE
Forbid @deephaven modules from self importing

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,3 +1,7 @@
+const buildPackageManifest = require('./packageManifest');
+
+const { packageNames, packageManifest } = buildPackageManifest();
+
 module.exports = {
   root: true,
   extends: ['@deephaven/eslint-config'],
@@ -10,5 +14,18 @@ module.exports = {
         tsconfigRootDir: __dirname,
       },
     },
+    // For each @deephaven package, forbid importing from itself
+    ...packageNames.map(packageName => ({
+      files: [`packages/${packageManifest.get(packageName)}/**/*.@(ts|tsx)`],
+      rules: {
+        'no-restricted-imports': [
+          'error',
+          {
+            name: packageName,
+            message: 'Forbid importing from owning @deephaven package.',
+          },
+        ],
+      },
+    })),
   ],
 };

--- a/packageManifest.js
+++ b/packageManifest.js
@@ -1,0 +1,31 @@
+const fs = require('fs');
+const path = require('path');
+
+function buildPackageManifest() {
+  const packageDirNames = fs
+    .readdirSync(path.join(__dirname, 'packages'), { withFileTypes: true })
+    .filter(ent => ent.isDirectory())
+    .map(({ name }) => name);
+
+  // Map of package name to directory name
+  const packageManifest = new Map();
+
+  packageDirNames.forEach(dirName => {
+    // eslint-disable-next-line import/no-dynamic-require, global-require
+    const packageName = require(path.join(
+      __dirname,
+      'packages',
+      dirName,
+      'package.json'
+    )).name;
+
+    packageManifest.set(packageName, dirName);
+  });
+
+  return {
+    packageNames: [...packageManifest.keys()],
+    packageManifest,
+  };
+}
+
+module.exports = buildPackageManifest;

--- a/packages/jsapi-utils/src/SessionUtils.ts
+++ b/packages/jsapi-utils/src/SessionUtils.ts
@@ -5,12 +5,9 @@ import type {
   IdeConnection,
   IdeSession,
 } from '@deephaven/jsapi-types';
-import {
-  requestParentResponse,
-  SESSION_DETAILS_REQUEST,
-} from '@deephaven/jsapi-utils';
 import Log from '@deephaven/log';
 import shortid from 'shortid';
+import { requestParentResponse, SESSION_DETAILS_REQUEST } from './MessageUtils';
 import NoConsolesError, { isNoConsolesError } from './NoConsolesError';
 
 const log = Log.module('SessionUtils');


### PR DESCRIPTION
- Eslint rules to forbid importing from @deephaven package owning the module
- Fixed offending SessionUtils

I tested this by running npm run test:lint. It showed expected linting error before fixing SessionUtils. Fixing SessionUtils made error go away. Also tested in vscode. Error shows up in the editor as expected.

fixes #1497