### PR TITLE
feat: Expose containerRef from ChartPanel

### DIFF
--- a/packages/dashboard-core-plugins/src/panels/ChartPanel.tsx
+++ b/packages/dashboard-core-plugins/src/panels/ChartPanel.tsx
@@ -135,6 +135,8 @@ export interface ChartPanelProps extends DashboardPanelProps {
     secondParam: undefined
   ) => void;
   Plotly?: typeof PlotlyType;
+  /** The panel container div */
+  containerRef?: RefObject<HTMLDivElement>;
 
   panelState: GLChartPanelState;
   settings: Partial<WorkspaceSettings>;
@@ -184,6 +186,7 @@ export class ChartPanel extends Component<ChartPanelProps, ChartPanelState> {
     sourcePanel: null,
     panelState: null,
     settings: {},
+    containerRef: null,
   };
 
   static displayName = 'ChartPanel';
@@ -219,7 +222,7 @@ export class ChartPanel extends Component<ChartPanelProps, ChartPanelState> {
     );
     this.handleClearAllFilters = this.handleClearAllFilters.bind(this);
 
-    this.panelContainer = React.createRef();
+    this.panelContainer = props.containerRef ?? React.createRef();
     this.chart = React.createRef();
     this.pending = new Pending();
 


### PR DESCRIPTION
This is needed so the plotly-express plugin can attach event handlers to the chart container to pause re-renders when the user is manipulating the view on a 3d plot