### PR TITLE
fix: webpack dynamic import

### DIFF
--- a/packages/jsapi-bootstrap/src/ApiBootstrap.tsx
+++ b/packages/jsapi-bootstrap/src/ApiBootstrap.tsx
@@ -40,7 +40,9 @@ export function ApiBootstrap({
   useEffect(() => {
     async function loadApi() {
       try {
-        const dh: DhType = (await import(/* @vite-ignore */ apiUrl)).default;
+        const dh: DhType = (
+          await import(/* @vite-ignore */ /* webpackIgnore: true */ apiUrl)
+        ).default;
         log.info('API bootstrapped from', apiUrl);
         setApi(dh);
         if (setGlobally) {

--- a/packages/jsapi-bootstrap/src/ApiBootstrap.tsx
+++ b/packages/jsapi-bootstrap/src/ApiBootstrap.tsx
@@ -40,9 +40,11 @@ export function ApiBootstrap({
   useEffect(() => {
     async function loadApi() {
       try {
-        const dh: DhType = (
-          await import(/* @vite-ignore */ /* webpackIgnore: true */ apiUrl)
-        ).default;
+        const dh: DhType =
+          // Ignore the warning about dynamic import in both Vite and Webpack.
+          // We use Vite, but some clients may use Webpack.
+          (await import(/* @vite-ignore */ /* webpackIgnore: true */ apiUrl))
+            .default;
         log.info('API bootstrapped from', apiUrl);
         setApi(dh);
         if (setGlobally) {

--- a/packages/jsapi-bootstrap/src/ApiBootstrap.tsx
+++ b/packages/jsapi-bootstrap/src/ApiBootstrap.tsx
@@ -40,9 +40,7 @@ export function ApiBootstrap({
   useEffect(() => {
     async function loadApi() {
       try {
-        // Using a string template around `apiUrl` to avoid a warning with webpack: https://stackoverflow.com/a/73359606
-        const dh: DhType = (await import(/* @vite-ignore */ `${apiUrl}`))
-          .default;
+        const dh: DhType = (await import(/* @vite-ignore */ apiUrl)).default;
         log.info('API bootstrapped from', apiUrl);
         setApi(dh);
         if (setGlobally) {


### PR DESCRIPTION
- Use webpackIgnore to disable url resolving: https://webpack.js.org/loaders/css-loader/#disable-url-resolving-using-the--webpackignore-true--comment
- Tested with https://github.com/deephaven-examples/deephaven-react-app-enterprise/tree/cra-light-dashboard. No warning was emitted from the webpack build step.
- Tested `npm start` still loaded correctly