### PR TITLE
fix: Table overflow button has lower priority than grid tokens

### DIFF
--- a/packages/grid/src/Grid.tsx
+++ b/packages/grid/src/Grid.tsx
@@ -383,7 +383,7 @@ class Grid extends PureComponent<GridProps, GridState> {
       new GridHorizontalScrollBarMouseHandler(600),
       new GridScrollBarCornerMouseHandler(700),
       new GridRowTreeMouseHandler(800),
-      new GridTokenMouseHandler(825),
+      new GridTokenMouseHandler(875),
       new GridSelectionMouseHandler(900),
     ];
 


### PR DESCRIPTION
* The mouse handler for the table "view full contents" button was called after the mousehandler for cell tokens. This caused links inside the cell to open if the cell overflow button overlapped with a link inside the cell underneath it.
* Priority for GridTokenMouseHandler changed to be after the CellOverflowMouseHandler.

* Fixes #1480 