### PR TITLE
feat: Dynamic theme selection

### DIFF
--- a/packages/code-studio/index.html
+++ b/packages/code-studio/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <base href="%BASE_URL%" />
@@ -16,6 +16,8 @@
     <link rel="manifest" href="/manifest.json" />
     <link rel="icon" href="%VITE_FAVICON%" />
     <title>Deephaven</title>
+    <link rel="stylesheet" href="/default_theme.css" />
+    <link rel="stylesheet" href="/custom_theme.css" />
   </head>
   <body>
     <noscript> You need to enable JavaScript to run this app. </noscript>

--- a/packages/code-studio/public/custom_theme.css
+++ b/packages/code-studio/public/custom_theme.css
@@ -1,3 +1,9 @@
+/**
+ * Example of 3 custom themes. 
+ * Note the optional `--dh-base-theme` variable that specifies the base default 
+ * theme to inherit from. If not provided, defaults to `default-dark`.
+ */
+
 .dh-theme-custom-aaa {
   --dh-base-theme: default-dark;
 

--- a/packages/code-studio/public/custom_theme.css
+++ b/packages/code-studio/public/custom_theme.css
@@ -1,0 +1,19 @@
+.dh-theme-custom-aaa {
+  --dh-base-theme: default-dark;
+
+  /* Semantic */
+  --dh-semantic-background-color: rgb(29, 11, 146);
+  --dh-semantic-foreground-color: rgb(126, 7, 7);
+}
+
+.dh-theme-custom-bbb {
+  --dh-base-theme: default-light;
+
+  /* Semantic */
+  --dh-semantic-foreground-color: #d5ea1e;
+}
+
+.dh-theme-custom-ccc {
+  --dh-color-gray-50: orange;
+  --dh-semantic-grid-background-color: var(--dh-colorseafoam-900);
+}

--- a/packages/code-studio/public/default_theme.css
+++ b/packages/code-studio/public/default_theme.css
@@ -1,3 +1,7 @@
+/**
+ * Default dark and light themes.
+ */
+
 .dh-theme-default-dark {
   /* Grays */
   --dh-color-gray-900: #fcfcfa;

--- a/packages/code-studio/public/default_theme.css
+++ b/packages/code-studio/public/default_theme.css
@@ -1,0 +1,75 @@
+.dh-theme-default-dark {
+  /* Grays */
+  --dh-color-gray-900: #fcfcfa;
+  --dh-color-gray-800: #f0f0ee;
+  --dh-color-gray-700: #c0bfbf;
+  --dh-color-gray-600: #929192;
+  --dh-color-gray-500: #5b5a5c;
+  --dh-color-gray-400: #403e41;
+  --dh-color-gray-300: #373438;
+  --dh-color-gray-200: #322f33;
+  --dh-color-gray-100: #2d2a2e;
+  --dh-color-gray-75: #211f22;
+  --dh-color-gray-50: #1a171a;
+  --dh-color-black: var(--dh-color-gray-50);
+  --dh-color-white: var(--dh-color-gray-800);
+
+  /* Seafoam */
+  --dh-colorseafoam-100: #1f2925;
+  --dh-colorseafoam-200: #263630;
+  --dh-colorseafoam-300: #2f463e;
+  --dh-colorseafoam-400: #37574b;
+  --dh-colorseafoam-500: #3e6959;
+  --dh-colorseafoam-600: #447b68;
+  --dh-colorseafoam-700: #488f78;
+  --dh-colorseafoam-800: #4ca387;
+  --dh-colorseafoam-900: #4fb797;
+  --dh-colorseafoam-1000: #54cba6;
+  --dh-colorseafoam-1100: #5edeb7;
+  --dh-colorseafoam-1200: #78edc7;
+  --dh-colorseafoam-1300: #9ef8d7;
+  --dh-colorseafoam-1400: #cbfce8;
+
+  /* Semantic */
+  --dh-semantic-background-color: var(--dh-color-black);
+  --dh-semantic-foreground-color: var(--dh-color-white);
+  --dh-semantic-grid-background-color: var(--dh-semantic-background-color);
+}
+
+.dh-theme-default-light {
+  /* Grays */
+  --dh-color-gray-900: #fcfcfa;
+  --dh-color-gray-800: #f0f0ee;
+  --dh-color-gray-700: #c0bfbf;
+  --dh-color-gray-600: #929192;
+  --dh-color-gray-500: #5b5a5c;
+  --dh-color-gray-400: #403e41;
+  --dh-color-gray-300: #373438;
+  --dh-color-gray-200: #322f33;
+  --dh-color-gray-100: #2d2a2e;
+  --dh-color-gray-75: #211f22;
+  --dh-color-gray-50: #1a171a;
+  --dh-color-black: var(--dh-color-gray-50);
+  --dh-color-white: var(--dh-color-gray-800);
+
+  /* Seafoam */
+  --dh-colorseafoam-100: #1f2925;
+  --dh-colorseafoam-200: #263630;
+  --dh-colorseafoam-300: #2f463e;
+  --dh-colorseafoam-400: #37574b;
+  --dh-colorseafoam-500: #3e6959;
+  --dh-colorseafoam-600: #447b68;
+  --dh-colorseafoam-700: #488f78;
+  --dh-colorseafoam-800: #4ca387;
+  --dh-colorseafoam-900: #4fb797;
+  --dh-colorseafoam-1000: #54cba6;
+  --dh-colorseafoam-1100: #5edeb7;
+  --dh-colorseafoam-1200: #78edc7;
+  --dh-colorseafoam-1300: #9ef8d7;
+  --dh-colorseafoam-1400: #cbfce8;
+
+  /* Semantic */
+  --dh-semantic-background-color: var(--dh-color-white);
+  --dh-semantic-foreground-color: var(--dh-color-black);
+  --dh-semantic-grid-background-color: var(--dh-semantic-background-color);
+}

--- a/packages/code-studio/src/index.tsx
+++ b/packages/code-studio/src/index.tsx
@@ -1,11 +1,13 @@
 import React, { Suspense } from 'react';
 import ReactDOM from 'react-dom';
 import '@deephaven/components/scss/BaseStyleSheet.scss';
-import { LoadingOverlay } from '@deephaven/components';
+import { initializeTheme, LoadingOverlay } from '@deephaven/components';
 import { ApiBootstrap } from '@deephaven/jsapi-bootstrap';
 import logInit from './log/LogInit';
 
 logInit();
+
+initializeTheme();
 
 // Lazy load components for code splitting and also to avoid importing the jsapi-shim before API is bootstrapped.
 // eslint-disable-next-line react-refresh/only-export-components

--- a/packages/components/scss/BaseStyleSheet.scss
+++ b/packages/components/scss/BaseStyleSheet.scss
@@ -18,10 +18,14 @@ html {
   vertical-align: -3px;
 }
 
+// Testing Sass variables
+$bg: var(--dh-semantic-background-color);
+$fg: var(--dh-semantic-foreground-color);
+
 body {
   min-height: 100%;
-  background-color: $background;
-  color: $foreground;
+  background-color: $bg;
+  color: $fg;
   margin: 0;
   padding: 0;
   overscroll-behavior: none;
@@ -255,7 +259,9 @@ span.btn-disabled-wrapper {
     border-radius: 2px;
     margin-bottom: 2px;
     filter: saturate(0%);
-    transition: filter 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+    transition:
+      filter 0.15s ease-in-out,
+      box-shadow 0.15s ease-in-out;
     pointer-events: none;
   }
 
@@ -712,7 +718,8 @@ input[type='number']::-webkit-inner-spin-button {
 
     .monaco-checkbox:focus {
       border: none !important;
-      box-shadow: $input-btn-focus-box-shadow,
+      box-shadow:
+        $input-btn-focus-box-shadow,
         0 0 0 1px $input-focus-border-color; //can't use regular border due to position of checkbox
     }
   }
@@ -746,7 +753,9 @@ input[type='number']::-webkit-inner-spin-button {
       linear-gradient(0deg, $input-bg, $input-bg);
     background-size: $custom-select-bg-size, cover;
     background-repeat: no-repeat;
-    background-position: bottom 50% right $custom-select-padding-x, center;
+    background-position:
+      bottom 50% right $custom-select-padding-x,
+      center;
     //make the dotted duplicate focus line on firefox go away
     &:-moz-focusring {
       color: rgba(0, 0, 0, 0%);
@@ -835,11 +844,18 @@ input[type='number']::-webkit-inner-spin-button {
 /// used by marching ants animation
 @keyframes march {
   from {
-    background-position: 0 top, 0 bottom, left 0, right 0;
+    background-position:
+      0 top,
+      0 bottom,
+      left 0,
+      right 0;
   }
 
   to {
-    background-position: $ant-size top, $ant-size bottom, left $ant-size,
+    background-position:
+      $ant-size top,
+      $ant-size bottom,
+      left $ant-size,
       right $ant-size;
   }
 }

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -50,6 +50,7 @@ export { default as SocketedButton } from './SocketedButton';
 export * from './SpectrumUtils';
 export * from './TableViewEmptyState';
 export * from './TextWithTooltip';
+export * from './theme';
 export { default as ThemeExport } from './ThemeExport';
 export { default as TimeInput } from './TimeInput';
 export { default as TimeSlider } from './TimeSlider';

--- a/packages/components/src/theme/ThemeUtils.test.ts
+++ b/packages/components/src/theme/ThemeUtils.test.ts
@@ -1,0 +1,126 @@
+import { TestUtils } from '@deephaven/utils';
+import {
+  replaceCssVariables,
+  selectTheme,
+  ThemeVariables,
+  THEME_LOCAL_STORAGE_KEY,
+} from './ThemeUtils';
+
+const { createMockProxy } = TestUtils;
+
+// const cssCustomProperties = {
+//   // Colors
+//   '--dh-color-gray-900': '#fcfcfa',
+//   '--dh-color-gray-800': '#f0f0ee',
+//   '--dh-color-gray-700': '#c0bfbf',
+//   '--dh-color-gray-600': '#929192',
+//   '--dh-color-gray-500': '#5b5a5c',
+//   '--dh-color-gray-400': '#403e41',
+//   '--dh-color-gray-300': '#373438',
+//   '--dh-color-gray-200': '#322f33',
+//   '--dh-color-gray-100': '#2d2a2e',
+//   '--dh-color-gray-75': '#211f22',
+//   '--dh-color-gray-50': '#1a171a',
+//   '--dh-color-black': 'var(--dh-color-gray-50)',
+//   '--dh-color-white': 'var(--dh-color-gray-800)',
+//   // Semantic
+//   '--dh-semantic-background-color': 'var(--dh-color-black)',
+//   '--dh-semantic-foreground-color': 'var(--dh-color-white)',
+// };
+
+const mockGetPropertyValue = jest.fn();
+
+beforeEach(() => {
+  document.body.className = '';
+  jest.clearAllMocks();
+  expect.hasAssertions();
+
+  jest.spyOn(window, 'getComputedStyle').mockImplementation(() =>
+    createMockProxy<CSSStyleDeclaration>({
+      getPropertyValue: mockGetPropertyValue,
+    })
+  );
+});
+
+describe('replaceCssVariables', () => {
+  beforeEach(() => {
+    mockGetPropertyValue.mockImplementation(name => `replaced${name}`);
+  });
+
+  it.each([null, document.body, document.createElement('div')])(
+    'should replace css variables: %s',
+    targetEl => {
+      const given: ThemeVariables = {
+        aaa: 'var(--dh-color-gray-900)',
+        bbb: 'var(--dh-color-black)',
+        ccc: '4px var(--dh-color-black)',
+        ddd: 'var(--dh-color-gray-900) var(--dh-color-black) 9px solid',
+      };
+
+      const expected: ThemeVariables = {
+        aaa: 'replaced--dh-color-gray-900',
+        bbb: 'replaced--dh-color-black',
+        ccc: '4px replaced--dh-color-black',
+        ddd: 'replaced--dh-color-gray-900 replaced--dh-color-black 9px solid',
+      };
+
+      const actual = replaceCssVariables(targetEl, given);
+
+      expect(getComputedStyle).toHaveBeenCalledWith(targetEl ?? document.body);
+      expect(actual).toEqual(expected);
+    }
+  );
+});
+
+describe('selectTheme', () => {
+  it.each(['', 'default-dark', 'custom-aaa'])(
+    'should set the theme key in local storage: %s',
+    themeKey => {
+      selectTheme(themeKey);
+
+      if (themeKey === '') {
+        expect(localStorage.getItem(THEME_LOCAL_STORAGE_KEY)).toBeNull();
+      } else {
+        expect(localStorage.getItem(THEME_LOCAL_STORAGE_KEY)).toEqual(themeKey);
+      }
+    }
+  );
+
+  it('should throw an error for invalid theme keys', () => {
+    const themeKey = 'not-key';
+
+    expect(() => selectTheme(themeKey)).toThrow(
+      `Invalid theme key: ${themeKey}`
+    );
+  });
+
+  it.each([
+    ['', 'dh-theme-default-dark'],
+    ['default-dark', 'dh-theme-default-dark'],
+    ['default-light', 'dh-theme-default-light'],
+  ])(
+    'should set default theme css classes on body: %s, %s',
+    (themeKey, expectedClassName) => {
+      selectTheme(themeKey);
+
+      expect(mockGetPropertyValue).not.toHaveBeenCalled();
+      expect(document.body.className).toEqual(expectedClassName);
+    }
+  );
+
+  it.each([
+    ['custom-aaa', '', 'dh-theme-custom-aaa dh-theme-default-dark'],
+    ['custom-aaa', 'base-theme', 'dh-theme-custom-aaa dh-theme-base-theme'],
+  ])(
+    'should set default + custom theme classes on body: %s, %s, %s',
+    (themeKey, baseThemeKey, expectedClassName) => {
+      mockGetPropertyValue.mockImplementation(name =>
+        name === '--dh-base-theme' ? baseThemeKey : 'unexpected'
+      );
+
+      selectTheme(themeKey);
+
+      expect(document.body.className).toEqual(expectedClassName);
+    }
+  );
+});

--- a/packages/components/src/theme/ThemeUtils.ts
+++ b/packages/components/src/theme/ThemeUtils.ts
@@ -1,0 +1,89 @@
+export type ThemeVariables = Record<string, string | boolean | number | null>;
+
+export const THEME_LOCAL_STORAGE_KEY = 'deephaven.themeKey';
+const CSS_PROPERTY_NAME_REGEX = /var\((--.+?)\)/g;
+const THEME_KEY_REGEX = /^(custom|default)/;
+const THEME_CSS_CLASS_NAME_REGEX = /dh-theme-(custom|default)-[^ ]+/g;
+
+/**
+ * Get css class name for theme key.
+ * @param themeKey Theme key
+ */
+export function getThemeClassName(themeKey: string): string {
+  return `dh-theme-${themeKey}`;
+}
+
+/**
+ * Initialize theme from any previously selected theme key.
+ */
+export function initializeTheme(): void {
+  selectTheme(localStorage.getItem(THEME_LOCAL_STORAGE_KEY) ?? '');
+}
+
+/**
+ * Set the currently selected theme. This will store the given theme key in
+ * localStorage and update css classes on the body element for the selected
+ * theme. The body will have at least a `dh-theme-default-xxx` class and may
+ * have a `dh-custom-
+ * @param themeKey
+ */
+export function selectTheme(themeKey: string): void {
+  if (themeKey !== '' && THEME_KEY_REGEX.test(themeKey) === false) {
+    throw new Error(`Invalid theme key: ${themeKey}`);
+  }
+
+  if (themeKey === '') {
+    localStorage.removeItem(THEME_LOCAL_STORAGE_KEY);
+  } else {
+    localStorage.setItem(THEME_LOCAL_STORAGE_KEY, themeKey);
+  }
+
+  // Clear existing theme classes
+  document.body.className = document.body.className.replace(
+    THEME_CSS_CLASS_NAME_REGEX,
+    ''
+  );
+
+  if (themeKey === '') {
+    document.body.classList.add(getThemeClassName('default-dark'));
+    return;
+  }
+
+  // May be default or custom theme
+  document.body.classList.add(getThemeClassName(themeKey));
+
+  // By default, custom themes are based on the `deafult-dark` theme, but they
+  // can optionally specify a different base theme via the `--dh-base-theme`
+  // css variable.
+  if (themeKey?.startsWith('custom-') === true) {
+    const baseThemeKey =
+      getComputedStyle(document.body).getPropertyValue('--dh-base-theme') ||
+      'default-dark';
+
+    document.body.classList.add(getThemeClassName(baseThemeKey));
+  }
+}
+
+/**
+ * Replace custom CSS property values in an object with computed values.
+ * @param targetElement Element to use to compute CSS property values
+ * @param variables Theme variables object to replace values in
+ */
+export function replaceCssVariables(
+  targetElement: HTMLElement | null,
+  variables: ThemeVariables
+): ThemeVariables {
+  return Object.entries(variables).reduce((result, [key, value]) => {
+    // eslint-disable-next-line no-param-reassign
+    result[key] =
+      typeof value === 'string'
+        ? value.replace(CSS_PROPERTY_NAME_REGEX, (_match, propertyName) =>
+            getComputedStyle(targetElement ?? document.body).getPropertyValue(
+              propertyName
+            )
+          )
+        : value;
+
+    return result;
+  }, {} as ThemeVariables);
+}

--- a/packages/components/src/theme/index.ts
+++ b/packages/components/src/theme/index.ts
@@ -1,0 +1,1 @@
+export * from './ThemeUtils';

--- a/packages/golden-layout/scss/goldenlayout-dark-theme.scss
+++ b/packages/golden-layout/scss/goldenlayout-dark-theme.scss
@@ -69,7 +69,7 @@ body:not(.lm_dragging) .lm_header .lm_tab .lm_close_tab:hover {
 
 // Single Pane content (area in which final dragged content is contained)
 .lm_content {
-  background: $content-bg;
+  background: var(--dh-semantic-background-color);
   overflow: visible;
 }
 
@@ -156,14 +156,16 @@ body:not(.lm_dragging) .lm_header .lm_tab .lm_close_tab:hover {
     align-items: center;
     font-family: $font-family-sans-serif;
     background-color: $lm-tab-background;
-    color: $lm-tab-color;
+    color: var(--dh-semantic-foreground-color);
     height: $tab-height;
     font-size: $tab-font-size;
     min-width: 5rem;
     margin: 0;
     padding: 0 $spacer-1 0 $spacer-2;
     box-shadow: inset -1px -1px 0 0 $background; // acting as bottom and right border
-    transition: color $transition, background-color $transition;
+    transition:
+      color $transition,
+      background-color $transition;
     max-width: 12rem;
     white-space: nowrap;
     overflow: hidden;
@@ -224,7 +226,9 @@ body:not(.lm_dragging) .lm_header .lm_tab .lm_close_tab:hover {
   box-shadow: inset -1px 0 0 0 $background; // act as right border only when active
   // also kills the default shadow, doesn't work well with our design
   &.lm_focusin {
-    box-shadow: inset 0 1px $primary, inset -1px 0 0 0 $background; // top focus indicator, right border
+    box-shadow:
+      inset 0 1px $primary,
+      inset -1px 0 0 0 $background; // top focus indicator, right border
   }
 }
 

--- a/packages/iris-grid/src/IrisGrid.tsx
+++ b/packages/iris-grid/src/IrisGrid.tsx
@@ -25,6 +25,7 @@ import {
   ReferenceObject,
   Button,
   ContextActionUtils,
+  replaceCssVariables,
   ResolvableContextAction,
 } from '@deephaven/components';
 import {
@@ -1330,16 +1331,18 @@ export class IrisGrid extends Component<IrisGridProps, IrisGridState> {
 
   getCachedTheme = memoize(
     (
+      targetElement: HTMLElement | null,
       theme: GridThemeType,
       isEditable: boolean,
       floatingRowCount: number
-    ): Partial<IrisGridThemeType> => ({
-      ...IrisGridTheme,
-      ...theme,
-      autoSelectRow: !isEditable,
-      // We only show the row footers when we have floating rows for aggregations
-      rowFooterWidth: floatingRowCount > 0 ? theme.rowFooterWidth : 0,
-    }),
+    ): Partial<IrisGridThemeType> =>
+      replaceCssVariables(targetElement, {
+        ...IrisGridTheme,
+        ...theme,
+        autoSelectRow: !isEditable,
+        // We only show the row footers when we have floating rows for aggregations
+        rowFooterWidth: floatingRowCount > 0 ? theme.rowFooterWidth : 0,
+      }),
     { max: 1 }
   );
 
@@ -1399,6 +1402,7 @@ export class IrisGrid extends Component<IrisGridProps, IrisGridState> {
   getTheme(): Partial<IrisGridThemeType> {
     const { model, theme } = this.props;
     return this.getCachedTheme(
+      this.gridWrapper,
       theme,
       (isEditableGridModel(model) && model.isEditable) ?? false,
       model.floatingTopRowCount + model.floatingBottomRowCount

--- a/packages/iris-grid/src/IrisGridTheme.ts
+++ b/packages/iris-grid/src/IrisGridTheme.ts
@@ -40,7 +40,7 @@ export type IrisGridThemeType = GridThemeType & {
 };
 
 const theme: Partial<IrisGridThemeType> = Object.freeze({
-  backgroundColor: IrisGridTheme['grid-bg'],
+  backgroundColor: 'var(--dh-semantic-grid-background-color)',
   white: IrisGridTheme.white,
   black: IrisGridTheme.black,
   font: IrisGridTheme.font,


### PR DESCRIPTION
Draft PR showing dynamic theme selection.

- Theme key for selected theme is stored in local storage
- Loads default + custom theme files from public folder (default_theme.css & custom_theme.css respectively)
- Custom theme files can specify `--dh-base-theme` to inherit from a default theme
- Loader assigns appropriate css class for default + custom theme to body element
- IrisGrid themes replace any css variable references via getComputedStyles + getPropertyValue

This includes a few minimal changes to `BaseStyleSheet.scss`, `goldenlayout-dark-theme.scss`, and `IrisGridTheme.ts` to prove they can consume the theme variables.

NOTES: 
- We will need to determine custom themes dynamically likely from a manifest. This is not implemented yet
- This does not yet include an example of Spectrum theming, but we should just be able to map their custom css props to our `dh-xxxx` ones.

To see it work, you can set the theme key in local storage in the console and then refresh the page. You should see different css classes get attached to the body based on the theme key:

```js
localStorage.setItem('deephaven.themeKey', '') // should load default dark theme

localStorage.setItem('deephaven.themeKey', 'custom-aaa') // should load custom-aaa + default-dark theme

localStorage.setItem('deephaven.themeKey', 'custom-bbb') // should load custom-bbb + default-light theme

localStorage.setItem('deephaven.themeKey', 'custom-ccc') // should load custom-ccc + default-dark theme
```

#1504