### PR TITLE
refactor: Improve table saver to always use the correct service worker

### DIFF
--- a/packages/code-studio/public/download/serviceWorker.js
+++ b/packages/code-studio/public/download/serviceWorker.js
@@ -86,12 +86,12 @@ self.onmessage = event => {
       `service worker setting ${encodedFileName} download stream on service worker`
     );
     const rs = createReadableStream(ports[0]);
-    const downloadUrl = `${self.registration.scope}${encodedFileName}`;
+    const downloadUrl = new URL(encodedFileName, self.registration.scope);
     tableExportMap.set(downloadUrl, {
       readableStream: rs,
       port: ports[0],
       encodedFileName,
     });
-    ports[0].postMessage({ download: encodedFileName });
+    ports[0].postMessage({ download: downloadUrl });
   }
 };

--- a/packages/code-studio/public/download/serviceWorker.js
+++ b/packages/code-studio/public/download/serviceWorker.js
@@ -86,7 +86,7 @@ self.onmessage = event => {
       `service worker setting ${encodedFileName} download stream on service worker`
     );
     const rs = createReadableStream(ports[0]);
-    const downloadUrl = new URL(encodedFileName, self.registration.scope);
+    const downloadUrl = new URL(encodedFileName, self.registration.scope).href;
     tableExportMap.set(downloadUrl, {
       readableStream: rs,
       port: ports[0],

--- a/packages/code-studio/src/DownloadServiceWorkerUtils.ts
+++ b/packages/code-studio/src/DownloadServiceWorkerUtils.ts
@@ -3,9 +3,6 @@ import Log from '@deephaven/log';
 const log = Log.module('DownloadServiceWorkerUtils');
 
 class DownloadServiceWorkerUtils {
-  // The trailing slash is needed to match the scope of the service worker
-  static DOWNLOAD_PATH = new URL('./download/', document.baseURI);
-
   static SERVICE_WORKER_URL = new URL(
     `./download/serviceWorker.js`,
     document.baseURI

--- a/packages/code-studio/src/DownloadServiceWorkerUtils.ts
+++ b/packages/code-studio/src/DownloadServiceWorkerUtils.ts
@@ -3,7 +3,7 @@ import Log from '@deephaven/log';
 const log = Log.module('DownloadServiceWorkerUtils');
 
 class DownloadServiceWorkerUtils {
-  static DOWNLOAD_PATH = '/download/';
+  static DOWNLOAD_PATH = new URL('./download', document.baseURI);
 
   static registerOnLoaded(): void {
     const publicUrl = new URL(import.meta.env.BASE_URL, window.location.href);
@@ -15,22 +15,17 @@ class DownloadServiceWorkerUtils {
     }
 
     if ('serviceWorker' in navigator) {
-      window.addEventListener('load', () => {
-        const swUrl = new URL(
-          `${import.meta.env.BASE_URL ?? ''}download/serviceWorker.js`,
-          window.location.href
-        );
+      const swUrl = new URL(`./download/serviceWorker.js`, document.baseURI);
 
-        navigator.serviceWorker
-          .register(swUrl)
-          .then(reg => {
-            reg.update();
-            log.info('Registering service worker on ', swUrl, reg);
-          })
-          .catch(err => {
-            log.error('Failed to register service worker', err);
-          });
-      });
+      navigator.serviceWorker
+        .register(swUrl)
+        .then(reg => {
+          reg.update();
+          log.info('Registering service worker on ', swUrl, reg);
+        })
+        .catch(err => {
+          log.error('Failed to register service worker', err);
+        });
     } else {
       log.info('Service worker is not supported.');
     }
@@ -38,9 +33,8 @@ class DownloadServiceWorkerUtils {
 
   static async getServiceWorker(): Promise<ServiceWorker> {
     if ('serviceWorker' in navigator) {
-      const regs = await navigator.serviceWorker.getRegistrations();
-      const swReg = regs.find(reg =>
-        reg.scope.endsWith(DownloadServiceWorkerUtils.DOWNLOAD_PATH)
+      const swReg = await navigator.serviceWorker.getRegistration(
+        this.DOWNLOAD_PATH
       );
       if (swReg && swReg.active) {
         log.info('Download service worker is active.');


### PR DESCRIPTION
Fixes #766 

BREAKING CHANGE: `TableSaver` now expects the service worker to send it a complete URL for download instead of just a file name. DHE will need to adjust its `serviceWorker.js` to incorporate the same changes from this PR.