### PR TITLE
test: Fix e2e paste in chromium on mac

### DIFF
--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -136,8 +136,8 @@ export async function pasteInMonaco(
   await locator.click();
 
   const browserName = locator.page().context().browser()?.browserType().name();
-  if (browserName === 'webkit') {
-    // Webkit doesn't seem to paste w/ the keyboard shortcut in headless mode
+  if (browserName !== 'firefox') {
+    // Chromium on mac and webkit on any OS don't seem to paste w/ the keyboard shortcut
     await locator.locator('textarea').evaluate(async (element, evalText) => {
       const clipboardData = new DataTransfer();
       clipboardData.setData('text/plain', evalText);


### PR DESCRIPTION
@georgecwan was having issues w/ e2e tests running on Mac (Intel, only in headless mode). I confirmed they weren't working on my Mac (Intel) either. Specifically, `pasteInMonaco` in chromium was not working (timed out on the paste sanity check).

Tested on Mac and Linux that this adjustment works.

@georgecwan Checkout this repo (I recommend the VSCode GitHub Pull Requests and Issues plugin) and confirm e2e works for you on Mac.