### PR TITLE
fix: Plugin peer dependencies do not get versions from lerna

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28650,13 +28650,13 @@
       "name": "@deephaven/plugin",
       "version": "0.48.0",
       "license": "Apache-2.0",
-      "engines": {
-        "node": ">=16"
-      },
-      "peerDependencies": {
+      "dependencies": {
         "@deephaven/components": "file:../components",
         "@deephaven/iris-grid": "file:../iris-grid",
         "@deephaven/jsapi-types": "file:../jsapi-types"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "packages/plugin-utils": {
@@ -30493,7 +30493,11 @@
     },
     "@deephaven/plugin": {
       "version": "file:packages/plugin",
-      "requires": {}
+      "requires": {
+        "@deephaven/components": "file:../components",
+        "@deephaven/iris-grid": "file:../iris-grid",
+        "@deephaven/jsapi-types": "file:../jsapi-types"
+      }
     },
     "@deephaven/pouch-storage": {
       "version": "file:packages/pouch-storage",

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -21,7 +21,7 @@
     "build": "cross-env NODE_ENV=production run-p build:*",
     "build:babel": "babel ./src --out-dir ./dist --extensions \".ts,.tsx,.js,.jsx\" --source-maps --root-mode upward"
   },
-  "peerDependencies": {
+  "dependencies": {
     "@deephaven/components": "file:../components",
     "@deephaven/iris-grid": "file:../iris-grid",
     "@deephaven/jsapi-types": "file:../jsapi-types"


### PR DESCRIPTION
Apparently lerna doesn't treat `file` items in peer dependencies the same as it does for regular or dev dependencies. They don't get replaced and make the peer dependency unfindable.

Compare these 2. In peer dependencies for plugin it lists `file:../dashboard` instead of an actual version. But for regular dependencies in components, they get a version.

https://unpkg.com/@deephaven/plugin@0.48.0/package.json
https://unpkg.com/@deephaven/components@0.48.0/package.json