### PR TITLE
fix: Right clicking with a custom context menu open should open another context menu

### DIFF
--- a/packages/components/src/context-actions/ContextMenuRoot.tsx
+++ b/packages/components/src/context-actions/ContextMenuRoot.tsx
@@ -67,6 +67,7 @@ class ContextMenuRoot extends Component<
     const left = e.clientX - parentRect.left;
     const { actions } = this.state;
 
+    // Context menu is open and user clicked on the context-root blocking layer
     // Mac and Linux appear to trigger contextmenu events on mousedown vs. mouseup on Windows
     // Mouseup on Windows triggers blur before contextmenu which effectively does what this path does
     if (actions != null && e.target === this.container.current) {
@@ -93,10 +94,7 @@ class ContextMenuRoot extends Component<
       return;
     }
 
-    if (
-      !ContextActionUtils.isContextActionEvent(e) ||
-      e.contextActions.length === 0
-    ) {
+    if (!ContextActionUtils.isContextActionEvent(e)) {
       // Open native menu if no custom context actions
       return;
     }
@@ -107,6 +105,11 @@ class ContextMenuRoot extends Component<
     }
 
     const contextActions = ContextActionUtils.getMenuItems(e.contextActions);
+
+    if (contextActions.length === 0) {
+      // No actions after filtering. Use native menu
+      return;
+    }
 
     // new clicks, set actions
     e.preventDefault();

--- a/tests/context-menu.spec.ts
+++ b/tests/context-menu.spec.ts
@@ -1,0 +1,15 @@
+import { test, expect } from '@playwright/test';
+
+test('open custom context menu with another custom context menu open', async ({
+  page,
+}) => {
+  await page.goto('');
+
+  await page.getByText('Console').click({ button: 'right' });
+  await expect(page.getByText('Close', { exact: true })).toHaveCount(1);
+
+  await page
+    .getByText('Command History')
+    .click({ button: 'right', force: true });
+  await expect(page.getByText('Close', { exact: true })).toHaveCount(1);
+});


### PR DESCRIPTION
Fixes #1525 

This was bothering me while working on element plugins which should have a panel w/ the custom context menu enabled. Tested on Chrome/Firefox on Linux