### PR TITLE
fix: Render tables partitioned by non-string columns

### DIFF
--- a/packages/iris-grid/src/IrisGrid.tsx
+++ b/packages/iris-grid/src/IrisGrid.tsx
@@ -1921,38 +1921,27 @@ export class IrisGrid extends Component<IrisGridProps, IrisGridState> {
   }
 
   updatePartition(partition: string, partitionColumn: Column): void {
-    if (partitionColumn.type === 'char' && partition === '') {
+    if (TableUtils.isCharType(partitionColumn.type) && partition === '') {
       return;
     }
 
     const { model } = this.props;
 
-    let partitionFilterValue;
-    if (
-      partitionColumn.type === 'java.lang.String' ||
-      partitionColumn.type === 'char'
-    ) {
-      partitionFilterValue = model.dh.FilterValue.ofString(
-        model.displayString(
+    const partitionText = TableUtils.isCharType(partitionColumn.type)
+      ? model.displayString(
           partition,
           partitionColumn.type,
           partitionColumn.name
         )
-      );
-    } else if (
-      partitionColumn.type === 'java.lang.Boolean' ||
-      partitionColumn.type === 'boolean'
-    ) {
-      partitionFilterValue = model.dh.FilterValue.ofBoolean(
-        typeof partition === 'string'
-          ? TableUtils.makeBooleanValue(partition)
-          : partition
-      );
-    } else {
-      partitionFilterValue = model.dh.FilterValue.ofNumber(partition);
-    }
+      : partition;
+    const partitionFilter = this.tableUtils.makeQuickFilterFromComponent(
+      partitionColumn,
+      partitionText
+    );
 
-    const partitionFilter = partitionColumn.filter().eq(partitionFilterValue);
+    if (partitionFilter === null) {
+      return;
+    }
 
     const partitionFilters = [partitionFilter];
     this.setState({

--- a/packages/iris-grid/src/IrisGrid.tsx
+++ b/packages/iris-grid/src/IrisGrid.tsx
@@ -1938,7 +1938,6 @@ export class IrisGrid extends Component<IrisGridProps, IrisGridState> {
       partitionColumn,
       partitionText
     );
-
     if (partitionFilter === null) {
       return;
     }

--- a/packages/iris-grid/src/IrisGrid.tsx
+++ b/packages/iris-grid/src/IrisGrid.tsx
@@ -1921,10 +1921,25 @@ export class IrisGrid extends Component<IrisGridProps, IrisGridState> {
   }
 
   updatePartition(partition: string, partitionColumn: Column): void {
+    if (partitionColumn.type === 'char' && partition === '') {
+      return;
+    }
+
     const { model } = this.props;
     const partitionFilter = partitionColumn
       .filter()
-      .eq(model.dh.FilterValue.ofString(partition));
+      .eq(
+        partitionColumn.type === 'java.lang.String' ||
+          partitionColumn.type === 'char'
+          ? model.dh.FilterValue.ofString(
+              model.displayString(
+                partition,
+                partitionColumn.type,
+                partitionColumn.name
+              )
+            )
+          : model.dh.FilterValue.ofNumber(partition)
+      );
     const partitionFilters = [partitionFilter];
     this.setState({
       partition,
@@ -4424,7 +4439,7 @@ export class IrisGrid extends Component<IrisGridProps, IrisGridState> {
                     type: string,
                     stringName: string
                   ) => model.displayString(value, type, stringName)}
-                  columnName={partitionColumn.name}
+                  column={partitionColumn}
                   partition={partition}
                   onChange={this.handlePartitionChange}
                   onFetchAll={this.handlePartitionFetchAll}

--- a/packages/iris-grid/src/IrisGrid.tsx
+++ b/packages/iris-grid/src/IrisGrid.tsx
@@ -1943,7 +1943,11 @@ export class IrisGrid extends Component<IrisGridProps, IrisGridState> {
       partitionColumn.type === 'java.lang.Boolean' ||
       partitionColumn.type === 'boolean'
     ) {
-      partitionFilterValue = model.dh.FilterValue.ofBoolean(partition);
+      partitionFilterValue = model.dh.FilterValue.ofBoolean(
+        typeof partition === 'string'
+          ? TableUtils.makeBooleanValue(partition)
+          : partition
+      );
     } else {
       partitionFilterValue = model.dh.FilterValue.ofNumber(partition);
     }

--- a/packages/iris-grid/src/IrisGrid.tsx
+++ b/packages/iris-grid/src/IrisGrid.tsx
@@ -1926,20 +1926,30 @@ export class IrisGrid extends Component<IrisGridProps, IrisGridState> {
     }
 
     const { model } = this.props;
-    const partitionFilter = partitionColumn
-      .filter()
-      .eq(
-        partitionColumn.type === 'java.lang.String' ||
-          partitionColumn.type === 'char'
-          ? model.dh.FilterValue.ofString(
-              model.displayString(
-                partition,
-                partitionColumn.type,
-                partitionColumn.name
-              )
-            )
-          : model.dh.FilterValue.ofNumber(partition)
+
+    let partitionFilterValue;
+    if (
+      partitionColumn.type === 'java.lang.String' ||
+      partitionColumn.type === 'char'
+    ) {
+      partitionFilterValue = model.dh.FilterValue.ofString(
+        model.displayString(
+          partition,
+          partitionColumn.type,
+          partitionColumn.name
+        )
       );
+    } else if (
+      partitionColumn.type === 'java.lang.Boolean' ||
+      partitionColumn.type === 'boolean'
+    ) {
+      partitionFilterValue = model.dh.FilterValue.ofBoolean(partition);
+    } else {
+      partitionFilterValue = model.dh.FilterValue.ofNumber(partition);
+    }
+
+    const partitionFilter = partitionColumn.filter().eq(partitionFilterValue);
+
     const partitionFilters = [partitionFilter];
     this.setState({
       partition,

--- a/packages/iris-grid/src/IrisGridPartitionSelector.test.tsx
+++ b/packages/iris-grid/src/IrisGridPartitionSelector.test.tsx
@@ -14,7 +14,7 @@ function makeIrisGridPartitionSelector(
     <IrisGridPartitionSelector
       dh={dh}
       table={table}
-      columnName="0"
+      column={new IrisGridTestUtils(dh).makeColumn()}
       getFormattedString={getFormattedString}
       onChange={onChange}
       onDone={onDone}

--- a/packages/iris-grid/src/IrisGridPartitionSelector.tsx
+++ b/packages/iris-grid/src/IrisGridPartitionSelector.tsx
@@ -97,13 +97,6 @@ class IrisGridPartitionSelector<T> extends Component<
         column.type === 'char' && partition.length > 0
           ? partition.charCodeAt(0).toString()
           : partition,
-
-      // partition:
-      //   column.type === 'char'
-      //     ? partition.length > 0
-      //       ? partition.charCodeAt(0).toString()
-      //       : prevState.partition
-      //     : partition,
     });
 
     this.debounceUpdate();

--- a/packages/iris-grid/src/IrisGridPartitionSelector.tsx
+++ b/packages/iris-grid/src/IrisGridPartitionSelector.tsx
@@ -185,7 +185,6 @@ class IrisGridPartitionSelector<T> extends Component<
           <input
             type="text"
             value={
-              // IrisGridUtils.convertValueToText(partition, column.type)
               column.type === 'char' && partition.toString().length > 0
                 ? String.fromCharCode(parseInt(partition, 10))
                 : IrisGridUtils.convertValueToText(partition, column.type)

--- a/packages/iris-grid/src/IrisGridPartitionSelector.tsx
+++ b/packages/iris-grid/src/IrisGridPartitionSelector.tsx
@@ -7,6 +7,7 @@ import debounce from 'lodash.debounce';
 import type { Column, dh as DhType, Table } from '@deephaven/jsapi-types';
 import PartitionSelectorSearch from './PartitionSelectorSearch';
 import './IrisGridPartitionSelector.scss';
+import IrisGridUtils from './IrisGridUtils';
 
 const log = Log.module('IrisGridPartitionSelector');
 
@@ -184,9 +185,10 @@ class IrisGridPartitionSelector<T> extends Component<
           <input
             type="text"
             value={
+              // IrisGridUtils.convertValueToText(partition, column.type)
               column.type === 'char' && partition.toString().length > 0
                 ? String.fromCharCode(parseInt(partition, 10))
-                : partition
+                : IrisGridUtils.convertValueToText(partition, column.type)
             }
             onChange={this.handlePartitionChange}
             className="form-control input-partition"

--- a/packages/iris-grid/src/IrisGridPartitionSelector.tsx
+++ b/packages/iris-grid/src/IrisGridPartitionSelector.tsx
@@ -5,6 +5,7 @@ import { vsTriangleDown, vsClose } from '@deephaven/icons';
 import Log from '@deephaven/log';
 import debounce from 'lodash.debounce';
 import type { Column, dh as DhType, Table } from '@deephaven/jsapi-types';
+import { TableUtils } from '@deephaven/jsapi-utils';
 import PartitionSelectorSearch from './PartitionSelectorSearch';
 import './IrisGridPartitionSelector.scss';
 import IrisGridUtils from './IrisGridUtils';
@@ -95,7 +96,7 @@ class IrisGridPartitionSelector<T> extends Component<
 
     this.setState({
       partition:
-        column.type === 'char' && partition.length > 0
+        TableUtils.isCharType(column.type) && partition.length > 0
           ? partition.charCodeAt(0).toString()
           : partition,
     });
@@ -185,7 +186,8 @@ class IrisGridPartitionSelector<T> extends Component<
           <input
             type="text"
             value={
-              column.type === 'char' && partition.toString().length > 0
+              TableUtils.isCharType(column.type) &&
+              partition.toString().length > 0
                 ? String.fromCharCode(parseInt(partition, 10))
                 : IrisGridUtils.convertValueToText(partition, column.type)
             }

--- a/packages/iris-grid/src/PartitionSelectorSearch.tsx
+++ b/packages/iris-grid/src/PartitionSelectorSearch.tsx
@@ -75,7 +75,6 @@ class PartitionSelectorSearch<T> extends Component<
     super(props);
 
     this.handleFilterChange = this.handleFilterChange.bind(this);
-    this.handleInputFocus = this.handleInputFocus.bind(this);
     this.handleKeyDown = this.handleKeyDown.bind(this);
     this.handleListKeydown = this.handleListKeydown.bind(this);
     this.handleSelect = this.handleSelect.bind(this);
@@ -185,12 +184,6 @@ class PartitionSelectorSearch<T> extends Component<
     const { table } = this.props;
     const itemCount = table.size;
     this.setState({ itemCount, isLoading: true });
-  }
-
-  handleInputFocus(): void {
-    if (this.itemList) {
-      this.itemList.focusItem(0);
-    }
   }
 
   handleSelect(itemIndex: ModelIndex): void {
@@ -333,7 +326,6 @@ class PartitionSelectorSearch<T> extends Component<
             value={text}
             placeholder="Available Partitions"
             onChange={this.handleTextChange}
-            onFocus={this.handleInputFocus}
             onKeyDown={this.handleKeyDown}
             className="form-control input-partition"
           />

--- a/packages/iris-grid/src/PartitionSelectorSearch.tsx
+++ b/packages/iris-grid/src/PartitionSelectorSearch.tsx
@@ -287,6 +287,13 @@ class PartitionSelectorSearch<T> extends Component<
     const filters = [];
     if (filterText.length > 0) {
       const column = table.columns[0];
+      if (
+        column.type !== 'java.lang.String' &&
+        column.type !== 'char' &&
+        Number.isNaN(Number(filterText))
+      ) {
+        return;
+      }
       const filter = this.tableUtils.makeQuickFilterFromComponent(
         column,
         column.type === 'java.lang.String' ? `~${filterText}` : filterText

--- a/packages/iris-grid/src/PartitionSelectorSearch.tsx
+++ b/packages/iris-grid/src/PartitionSelectorSearch.tsx
@@ -297,9 +297,12 @@ class PartitionSelectorSearch<T> extends Component<
           column,
           column.type === 'java.lang.String' ? `~${filterText}` : filterText
         );
-        if (filter) {
-          filters.push(filter);
+        if (!filter) {
+          throw new Error(
+            'Unable to create column filter for partition selector'
+          );
         }
+        filters.push(filter);
       }
     }
 

--- a/packages/iris-grid/src/PartitionSelectorSearch.tsx
+++ b/packages/iris-grid/src/PartitionSelectorSearch.tsx
@@ -288,18 +288,18 @@ class PartitionSelectorSearch<T> extends Component<
     if (filterText.length > 0) {
       const column = table.columns[0];
       if (
-        column.type !== 'java.lang.String' &&
-        column.type !== 'char' &&
-        Number.isNaN(Number(filterText))
+        column.type === 'java.lang.String' ||
+        column.type === 'char' ||
+        column.type === 'java.lang.Boolean' ||
+        !Number.isNaN(Number(filterText))
       ) {
-        return;
-      }
-      const filter = this.tableUtils.makeQuickFilterFromComponent(
-        column,
-        column.type === 'java.lang.String' ? `~${filterText}` : filterText
-      );
-      if (filter !== null) {
-        filters.push(filter);
+        const filter = this.tableUtils.makeQuickFilterFromComponent(
+          column,
+          column.type === 'java.lang.String' ? `~${filterText}` : filterText
+        );
+        if (filter) {
+          filters.push(filter);
+        }
       }
     }
 


### PR DESCRIPTION
* Partitioned tables were unable to be rendered if the partitioned column type is not `java.lang.String`
* Grid can now render string, numerical, and character columns
* Fixes partitioning columns filter dropdown to correctly display `char` types instead of their ASCII values
* The partition search bar function is now able to search for numbers
* Removes the handleFocus function for `PartitionSelectorSearch` since it made it impossible for the user to edit the search bar after deselecting it
* Fixes #1441