### PR TITLE
fix: Formatting Rule Doesn't use default set by user

### DIFF
--- a/packages/code-studio/src/settings/ColumnSpecificSectionContent.test.tsx
+++ b/packages/code-studio/src/settings/ColumnSpecificSectionContent.test.tsx
@@ -138,7 +138,10 @@ it('displays an error when the formatting rule is empty', async () => {
   expect(screen.getByDisplayValue('test')).toBeInTheDocument();
 
   await user.selectOptions(screen.getByLabelText('Column Type'), 'Decimal');
-  await user.type(screen.getByLabelText('Formatting Rule'), ' {backspace}');
+  await user.type(
+    screen.getByLabelText('Formatting Rule'),
+    ' {Control>}A{/Control}{backspace}'
+  );
   expect(screen.queryByText(/Empty formatting rule\./)).toBeInTheDocument();
 });
 
@@ -215,7 +218,7 @@ it('should change the input value when column type is Integer', async () => {
   await user.selectOptions(screen.getByLabelText('Column Type'), 'Integer');
   await user.type(
     screen.getByLabelText('Formatting Rule'),
-    `{selectall}${newFormat}`
+    `{Control>}A{/Control}${newFormat}`
   );
 
   expect(screen.getByDisplayValue(newFormat)).toBeInTheDocument();

--- a/packages/code-studio/src/settings/ColumnSpecificSectionContent.tsx
+++ b/packages/code-studio/src/settings/ColumnSpecificSectionContent.tsx
@@ -212,7 +212,7 @@ export class ColumnSpecificSectionContent extends PureComponent<
         let resetKeys = {};
         if (key === 'columnType') {
           resetKeys = {
-            format: '',
+            format: this.makeDefaultFormatterItemByType(value as string),
           };
         }
         const newEntry = {
@@ -431,11 +431,6 @@ export class ColumnSpecificSectionContent extends PureComponent<
       this.handleFormatRuleChange(i, 'isNewRule', false);
     const onTypeChange = (e: ChangeEvent<HTMLSelectElement>): void => {
       this.handleFormatRuleChange(i, 'columnType', e.target.value);
-      this.handleFormatRuleChange(
-        i,
-        'format',
-        this.makeDefaultFormatterItemByType(e.target.value)
-      );
     };
     const ruleError = this.getRuleError(rule);
 

--- a/packages/code-studio/src/settings/ColumnSpecificSectionContent.tsx
+++ b/packages/code-studio/src/settings/ColumnSpecificSectionContent.tsx
@@ -71,9 +71,6 @@ interface ColumnSpecificSectionContentState {
   showTimeZone: boolean;
   showTSeparator: boolean;
   timeZone: string;
-  defaultDateTimeFormat: string;
-  defaultDecimalFormatOptions: FormatOption;
-  defaultIntegerFormatOptions: FormatOption;
   truncateNumbersWithPound: boolean;
   timestampAtMenuOpen: Date;
 }
@@ -116,9 +113,6 @@ export class ColumnSpecificSectionContent extends PureComponent<
 
     const {
       formatter,
-      defaultDateTimeFormat,
-      defaultDecimalFormatOptions,
-      defaultIntegerFormatOptions,
       showTimeZone,
       showTSeparator,
       timeZone,
@@ -141,9 +135,6 @@ export class ColumnSpecificSectionContent extends PureComponent<
       showTimeZone,
       showTSeparator,
       timeZone,
-      defaultDateTimeFormat,
-      defaultDecimalFormatOptions,
-      defaultIntegerFormatOptions,
       truncateNumbersWithPound,
       timestampAtMenuOpen: new Date(),
     };
@@ -284,14 +275,18 @@ export class ColumnSpecificSectionContent extends PureComponent<
   commitChanges(): void {
     const {
       formatSettings,
-      defaultDateTimeFormat,
       showTimeZone,
       showTSeparator,
       timeZone,
-      defaultDecimalFormatOptions,
-      defaultIntegerFormatOptions,
       truncateNumbersWithPound,
     } = this.state;
+
+    const {
+      defaultDateTimeFormat,
+      defaultDecimalFormatOptions,
+      defaultIntegerFormatOptions,
+    } = this.props;
+
     const { dh } = this.props;
 
     const formatter =
@@ -511,6 +506,7 @@ export class ColumnSpecificSectionContent extends PureComponent<
     isInvalid: boolean
   ): ReactElement {
     const { showTimeZone, showTSeparator, timeZone } = this.state;
+
     const value = format.formatString ?? '';
     return (
       <select
@@ -544,6 +540,8 @@ export class ColumnSpecificSectionContent extends PureComponent<
     format: Partial<TableColumnFormat>,
     isInvalid: boolean
   ): ReactElement {
+    const { defaultIntegerFormatOptions } = this.props;
+    const { defaultFormatString } = defaultIntegerFormatOptions;
     const value = format.formatString ?? '';
     return (
       <input
@@ -552,7 +550,22 @@ export class ColumnSpecificSectionContent extends PureComponent<
         })}
         data-lpignore
         id={formatId}
-        placeholder={IntegerColumnFormatter.DEFAULT_FORMAT_STRING}
+        placeholder={
+          defaultFormatString ?? IntegerColumnFormatter.DEFAULT_FORMAT_STRING
+        }
+        onKeyDown={e => {
+          if (e.key === 'Enter' && value === '') {
+            e.preventDefault();
+            const selectedFormat = IntegerColumnFormatter.makeFormat(
+              '',
+              defaultFormatString ??
+                IntegerColumnFormatter.DEFAULT_FORMAT_STRING,
+              IntegerColumnFormatter.TYPE_GLOBAL,
+              undefined
+            );
+            this.handleFormatRuleChange(i, 'format', selectedFormat);
+          }
+        }}
         type="text"
         value={value}
         onChange={e => {
@@ -574,6 +587,9 @@ export class ColumnSpecificSectionContent extends PureComponent<
     format: Partial<TableColumnFormat>,
     isInvalid: boolean
   ): ReactElement {
+    const { defaultDecimalFormatOptions } = this.props;
+    const { defaultFormatString } = defaultDecimalFormatOptions;
+
     const value = format.formatString ?? '';
     return (
       <input
@@ -582,7 +598,22 @@ export class ColumnSpecificSectionContent extends PureComponent<
         })}
         data-lpignore
         id={formatId}
-        placeholder={DecimalColumnFormatter.DEFAULT_FORMAT_STRING}
+        placeholder={
+          defaultFormatString ?? DecimalColumnFormatter.DEFAULT_FORMAT_STRING
+        }
+        onKeyDown={e => {
+          if (e.key === 'Enter' && value === '') {
+            e.preventDefault();
+            const selectedFormat = DecimalColumnFormatter.makeFormat(
+              '',
+              defaultFormatString ??
+                DecimalColumnFormatter.DEFAULT_FORMAT_STRING,
+              DecimalColumnFormatter.TYPE_GLOBAL,
+              undefined
+            );
+            this.handleFormatRuleChange(i, 'format', selectedFormat);
+          }
+        }}
         type="text"
         value={value}
         onChange={e => {

--- a/packages/code-studio/src/settings/ColumnSpecificSectionContent.tsx
+++ b/packages/code-studio/src/settings/ColumnSpecificSectionContent.tsx
@@ -388,8 +388,8 @@ export class ColumnSpecificSectionContent extends PureComponent<
   makeDefaultFormatterItemByType(
     columnType: string
   ): TableColumnFormat | string {
-    switch (columnType) {
-      case 'int': {
+    switch (TableUtils.getNormalizedType(columnType)) {
+      case TableUtils.dataType.INT: {
         const { defaultIntegerFormatOptions } = this.props;
         const { defaultFormatString: defaultIntegerFormatString } =
           defaultIntegerFormatOptions;
@@ -402,7 +402,7 @@ export class ColumnSpecificSectionContent extends PureComponent<
         );
       }
 
-      case 'decimal': {
+      case TableUtils.dataType.DECIMAL: {
         const { defaultDecimalFormatOptions } = this.props;
         const { defaultFormatString: defaultDecimalFormatString } =
           defaultDecimalFormatOptions;

--- a/packages/code-studio/src/settings/ColumnSpecificSectionContent.tsx
+++ b/packages/code-studio/src/settings/ColumnSpecificSectionContent.tsx
@@ -385,6 +385,41 @@ export class ColumnSpecificSectionContent extends PureComponent<
     return error;
   }
 
+  makeDefaultFormatterItemByType(
+    columnType: string
+  ): TableColumnFormat | string {
+    switch (columnType) {
+      case 'int': {
+        const { defaultIntegerFormatOptions } = this.props;
+        const { defaultFormatString: defaultIntegerFormatString } =
+          defaultIntegerFormatOptions;
+        return IntegerColumnFormatter.makeFormat(
+          '',
+          defaultIntegerFormatString ??
+            IntegerColumnFormatter.DEFAULT_FORMAT_STRING,
+          IntegerColumnFormatter.TYPE_GLOBAL,
+          undefined
+        );
+      }
+
+      case 'decimal': {
+        const { defaultDecimalFormatOptions } = this.props;
+        const { defaultFormatString: defaultDecimalFormatString } =
+          defaultDecimalFormatOptions;
+        return DecimalColumnFormatter.makeFormat(
+          '',
+          defaultDecimalFormatString ??
+            DecimalColumnFormatter.DEFAULT_FORMAT_STRING,
+          DecimalColumnFormatter.TYPE_GLOBAL,
+          undefined
+        );
+      }
+      default: {
+        return '';
+      }
+    }
+  }
+
   renderFormatRule(i: number, rule: FormatterItem): ReactElement {
     const columnNameId = `input-${i}-columnName`;
     const columnTypeId = `input-${i}-columnType`;
@@ -394,8 +429,14 @@ export class ColumnSpecificSectionContent extends PureComponent<
       this.handleFormatRuleChange(i, 'columnName', e.target.value);
     const onNameBlur = (): void =>
       this.handleFormatRuleChange(i, 'isNewRule', false);
-    const onTypeChange = (e: ChangeEvent<HTMLSelectElement>): void =>
+    const onTypeChange = (e: ChangeEvent<HTMLSelectElement>): void => {
       this.handleFormatRuleChange(i, 'columnType', e.target.value);
+      this.handleFormatRuleChange(
+        i,
+        'format',
+        this.makeDefaultFormatterItemByType(e.target.value)
+      );
+    };
     const ruleError = this.getRuleError(rule);
 
     return (
@@ -553,19 +594,6 @@ export class ColumnSpecificSectionContent extends PureComponent<
         placeholder={
           defaultFormatString ?? IntegerColumnFormatter.DEFAULT_FORMAT_STRING
         }
-        onKeyDown={e => {
-          if (e.key === 'Enter' && value === '') {
-            e.preventDefault();
-            const selectedFormat = IntegerColumnFormatter.makeFormat(
-              '',
-              defaultFormatString ??
-                IntegerColumnFormatter.DEFAULT_FORMAT_STRING,
-              IntegerColumnFormatter.TYPE_GLOBAL,
-              undefined
-            );
-            this.handleFormatRuleChange(i, 'format', selectedFormat);
-          }
-        }}
         type="text"
         value={value}
         onChange={e => {
@@ -601,19 +629,6 @@ export class ColumnSpecificSectionContent extends PureComponent<
         placeholder={
           defaultFormatString ?? DecimalColumnFormatter.DEFAULT_FORMAT_STRING
         }
-        onKeyDown={e => {
-          if (e.key === 'Enter' && value === '') {
-            e.preventDefault();
-            const selectedFormat = DecimalColumnFormatter.makeFormat(
-              '',
-              defaultFormatString ??
-                DecimalColumnFormatter.DEFAULT_FORMAT_STRING,
-              DecimalColumnFormatter.TYPE_GLOBAL,
-              undefined
-            );
-            this.handleFormatRuleChange(i, 'format', selectedFormat);
-          }
-        }}
         type="text"
         value={value}
         onChange={e => {

--- a/packages/code-studio/src/settings/ColumnSpecificSectionContent.tsx
+++ b/packages/code-studio/src/settings/ColumnSpecificSectionContent.tsx
@@ -429,9 +429,9 @@ export class ColumnSpecificSectionContent extends PureComponent<
       this.handleFormatRuleChange(i, 'columnName', e.target.value);
     const onNameBlur = (): void =>
       this.handleFormatRuleChange(i, 'isNewRule', false);
-    const onTypeChange = (e: ChangeEvent<HTMLSelectElement>): void => {
+    const onTypeChange = (e: ChangeEvent<HTMLSelectElement>): void =>
       this.handleFormatRuleChange(i, 'columnType', e.target.value);
-    };
+
     const ruleError = this.getRuleError(rule);
 
     return (

--- a/packages/code-studio/src/settings/FormattingSectionContent.tsx
+++ b/packages/code-studio/src/settings/FormattingSectionContent.tsx
@@ -617,7 +617,7 @@ export class FormattingSectionContent extends PureComponent<
                 checked={truncateNumbersWithPound ?? null}
                 onChange={this.handleTruncateNumbersWithPoundChange}
               >
-                Truncate numbers with #
+                Show truncated numbers as ###
               </Checkbox>
             </div>
           </div>

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -14,7 +14,12 @@ module.exports = {
     'react-refresh',
   ],
   rules: {
-    'prettier/prettier': ['error'],
+    'prettier/prettier': [
+      'error',
+      {
+        endOfLine: 'auto',
+      },
+    ],
     'react/forbid-prop-types': 'off',
     'react/jsx-curly-newline': 'off',
     'react/jsx-uses-react': 'error',

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -14,12 +14,7 @@ module.exports = {
     'react-refresh',
   ],
   rules: {
-    'prettier/prettier': [
-      'error',
-      {
-        endOfLine: 'auto',
-      },
-    ],
+    'prettier/prettier': ['error'],
     'react/forbid-prop-types': 'off',
     'react/jsx-curly-newline': 'off',
     'react/jsx-uses-react': 'error',


### PR DESCRIPTION
* Default Formatting Rule should change depending on the defaults set by the user
* Changing columnType should fill the input with the default string
~~* Pressing `enter` on empty formatting string input fields should fill the input with the default string~~
~~* Updated eslint config to handle lines ending in CRLF correctly~~