### PR TITLE
build: Remove broken nx cache clean script

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "clean:cache": "run-s clean:cache:*",
     "clean:cache:eslint": "rimraf .eslintcache",
     "clean:cache:jest": "jest --clearCache",
-    "clean:cache:nx": "nx clear-cache",
     "clean:cache:vite": "rimraf **/node_modules/.vite",
     "clean:modules": "lerna clean --yes",
     "clean:types": "tsc --build --clean",


### PR DESCRIPTION
`npm run clean` was broken b/c I added a `clean:cache:nx` but then removed `nx` since it doesn't play nicely w/ env variables.