### PR TITLE
fix: Prompt for resetting layout

### DIFF
--- a/packages/dashboard-core-plugins/src/panels/NotebookPanel.test.tsx
+++ b/packages/dashboard-core-plugins/src/panels/NotebookPanel.test.tsx
@@ -1,0 +1,41 @@
+import NotebookPanel from './NotebookPanel';
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+  jest.clearAllMocks();
+  expect.hasAssertions();
+});
+
+describe('unsavedNotebookCount', () => {
+  function mockPanel(...classNames: string[]): HTMLDivElement {
+    const el = document.createElement('div');
+    el.className = classNames.join(' ');
+    return el;
+  }
+
+  const panel = {
+    random: mockPanel('some-random-class'),
+    saved: mockPanel(NotebookPanel.UNSAVED_INDICATOR_CLASS_NAME),
+    statusOnly: mockPanel(NotebookPanel.UNSAVED_STATUS_CLASS_NAME),
+    unsaved: mockPanel(
+      NotebookPanel.UNSAVED_INDICATOR_CLASS_NAME,
+      NotebookPanel.UNSAVED_STATUS_CLASS_NAME
+    ),
+  };
+
+  it.each([
+    [[], 0],
+    [[panel.random], 0],
+    [[panel.saved], 0],
+    [[panel.statusOnly], 0],
+    [[panel.unsaved], 1],
+    [[panel.unsaved, panel.unsaved], 2],
+    [[panel.unsaved, panel.unsaved, panel.saved], 2],
+  ] as const)(
+    'should return the count of unsaved notebooks: %s, %s',
+    (panels, expectedCount) => {
+      panels.forEach(p => document.body.appendChild(p.cloneNode()));
+      expect(NotebookPanel.unsavedNotebookCount()).toBe(expectedCount);
+    }
+  );
+});

--- a/packages/dashboard-core-plugins/src/panels/NotebookPanel.tsx
+++ b/packages/dashboard-core-plugins/src/panels/NotebookPanel.tsx
@@ -126,11 +126,24 @@ class NotebookPanel extends Component<NotebookPanelProps, NotebookPanelState> {
 
   static DEFAULT_NAME = 'Untitled';
 
+  static UNSAVED_INDICATOR_CLASS_NAME = 'editor-unsaved-indicator';
+
+  static UNSAVED_STATUS_CLASS_NAME = 'is-unsaved';
+
   static handleError(error: unknown): void {
     if (PromiseUtils.isCanceled(error)) {
       return;
     }
     log.error(error);
+  }
+
+  /**
+   * Returns number of unsaved notebooks.
+   */
+  static unsavedNotebookCount(): number {
+    return document.querySelectorAll(
+      `.${NotebookPanel.UNSAVED_INDICATOR_CLASS_NAME}.${NotebookPanel.UNSAVED_STATUS_CLASS_NAME}`
+    ).length;
   }
 
   static defaultProps = {
@@ -1185,9 +1198,13 @@ class NotebookPanel extends Component<NotebookPanelProps, NotebookPanelState> {
         {portal != null &&
           ReactDOM.createPortal(
             <span
-              className={classNames('editor-unsaved-indicator', {
-                'is-unsaved': changeCount !== savedChangeCount,
-              })}
+              className={classNames(
+                NotebookPanel.UNSAVED_INDICATOR_CLASS_NAME,
+                {
+                  [NotebookPanel.UNSAVED_STATUS_CLASS_NAME]:
+                    changeCount !== savedChangeCount,
+                }
+              )}
             />,
             portal // tab.element is jquery element, we want a dom element
           )}

--- a/tests/golden-layout.spec.ts
+++ b/tests/golden-layout.spec.ts
@@ -26,9 +26,37 @@ test.describe('tests golden-layout operations', () => {
   });
 
   test.afterAll(async () => {
-    //  reset layout
-    await page.getByTestId('app-main-panels-button').click();
-    await page.getByLabel('Reset Layout').click();
+    /**
+     * Open panels menu, reset layout, confirm or cancel "Reset Layout" prompt
+     */
+    async function resetLayout(confirm: boolean) {
+      await page.getByTestId('app-main-panels-button').click();
+      await page.getByLabel('Reset Layout').click();
+
+      if (confirm) {
+        await page
+          .locator('.modal .btn-danger')
+          .filter({ hasText: 'Reset' })
+          .click();
+      } else {
+        await page
+          .locator('[data-dismiss=modal]')
+          .filter({ hasText: 'Cancel' })
+          .click();
+      }
+
+      await expect(page.locator('.modal')).toHaveCount(0);
+    }
+
+    // Reset layout cancelled by user
+    await resetLayout(false);
+
+    await expect(
+      page.locator('.lm_tab').filter({ has: page.getByText('test-a') })
+    ).toHaveCount(1);
+
+    // Reset layout confirmed by user
+    await resetLayout(true);
 
     await expect(
       page.locator('.lm_tab').filter({ has: page.getByText('test-a') })


### PR DESCRIPTION
User is not prompted to confirm when using the "reset layout" feature.
- With unsaved notebook changes, prompt title will be "Reset layout and discard unsaved changes"
- With open notebooks that are saved or no open notebooks, prompt title will be "Reset Layout"
- If user clicks "Reset", layout will be reset. Unsaved notebook changes will be lost
- If user clicks "Cancel", layout will not be reset and notebooks remain open

fixes #1250