### PR TITLE
chore: Use correct changelog preset for lerna

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,6 +41,7 @@ Over time, forks will get out of sync with the upstream repository. To stay up t
    - Use `deephaven/web-client-ui` as the base repository.
    - Use your own fork, `<username>/web-client-ui` as the repository to push to.
 2. Fill in the information in the Pull Request:
+
    - If you know people who should be reviewers, add them as a reviewer
    - Add yourself as the Assignee
    - PR titles must follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
@@ -57,12 +58,16 @@ Over time, forks will get out of sync with the upstream repository. To stay up t
        - **chore**: Other changes that don't modify src or test files
        - **revert**: Reverts a previous commit
      - The `scope` is not required.
-   - **BREAKING CHANGE:** if your change breaks an existing API in such a way that users of the package affected will need to make some changes to migrate to the newer version, add the `BREAKING CHANGE:` footer to the PR description, detailing the breakage and any migration instructions necessary, e.g.:
+   - **BREAKING CHANGE:** if your change breaks an existing API in such a way that users of the package affected will need to make some changes to migrate to the newer version, add an exclamation mark to the `type` (e.g. `feat!`), and add the `BREAKING CHANGE:` footer to the PR description, detailing the breakage and any migration instructions necessary, e.g.:
+
    ```
+   feat!: Add 'baz' option
+
    BREAKING CHANGE: The API now takes a new parameter that must be provided.
    ```
-   - **NOTE:** Do _not_ use the `!` notation for marking a breaking change - you must use the `BREAKING CHANGE:` footer and include details of the breakage/migration.
+
    - [Link the PR](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) with any associated issues
+
 3. Submit the PR
 
 ## Deephaven Contributor License Agreement (CLA)

--- a/lerna.json
+++ b/lerna.json
@@ -5,5 +5,6 @@
     "publish": {
       "distTag": "latest"
     }
-  }
+  },
+  "changelogPreset": "conventionalcommits"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,8 @@
         "@deephaven/storage": "file:packages/storage",
         "@deephaven/stylelint-config": "file:packages/stylelint-config",
         "@deephaven/tsconfig": "file:packages/tsconfig",
-        "@deephaven/utils": "file:packages/utils"
+        "@deephaven/utils": "file:packages/utils",
+        "conventional-changelog-conventionalcommits": "^7.0.2"
       },
       "devDependencies": {
         "@babel/cli": "7.20.7",
@@ -9675,8 +9676,7 @@
     "node_modules/array-ify": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
-      "integrity": "sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==",
-      "dev": true
+      "integrity": "sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng=="
     },
     "node_modules/array-includes": {
       "version": "3.1.6",
@@ -11578,7 +11578,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/compare-func/-/compare-func-2.0.0.tgz",
       "integrity": "sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==",
-      "dev": true,
       "dependencies": {
         "array-ify": "^1.0.0",
         "dot-prop": "^5.1.0"
@@ -11703,6 +11702,17 @@
       },
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/conventional-changelog-conventionalcommits": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-7.0.2.tgz",
+      "integrity": "sha512-NKXYmMR/Hr1DevQegFB4MwfM5Vv0m4UIxKZTTYuD98lpTknaZlSRrDOG4X7wIXpGkfsYxZTghUN+Qq+T0YQI7w==",
+      "dependencies": {
+        "compare-func": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/conventional-changelog-core": {
@@ -12900,7 +12910,6 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
       "integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
-      "dev": true,
       "dependencies": {
         "is-obj": "^2.0.0"
       },
@@ -16642,7 +16651,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
       "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -36119,8 +36127,7 @@
     "array-ify": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
-      "integrity": "sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==",
-      "dev": true
+      "integrity": "sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng=="
     },
     "array-includes": {
       "version": "3.1.6",
@@ -37557,7 +37564,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/compare-func/-/compare-func-2.0.0.tgz",
       "integrity": "sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==",
-      "dev": true,
       "requires": {
         "array-ify": "^1.0.0",
         "dot-prop": "^5.1.0"
@@ -37660,6 +37666,14 @@
       "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-6.0.0.tgz",
       "integrity": "sha512-6qLgrBF4gueoC7AFVHu51nHL9pF9FRjXrH+ceVf7WmAfH3gs+gEYOkvxhjMPjZu57I4AGUGoNTY8V7Hrgf1uqg==",
       "dev": true,
+      "requires": {
+        "compare-func": "^2.0.0"
+      }
+    },
+    "conventional-changelog-conventionalcommits": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-7.0.2.tgz",
+      "integrity": "sha512-NKXYmMR/Hr1DevQegFB4MwfM5Vv0m4UIxKZTTYuD98lpTknaZlSRrDOG4X7wIXpGkfsYxZTghUN+Qq+T0YQI7w==",
       "requires": {
         "compare-func": "^2.0.0"
       }
@@ -38556,7 +38570,6 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
       "integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
-      "dev": true,
       "requires": {
         "is-obj": "^2.0.0"
       }
@@ -41160,8 +41173,7 @@
     "is-obj": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
-      "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
-      "dev": true
+      "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w=="
     },
     "is-path-inside": {
       "version": "3.0.3",

--- a/package.json
+++ b/package.json
@@ -179,6 +179,7 @@
     "@deephaven/storage": "file:packages/storage",
     "@deephaven/stylelint-config": "file:packages/stylelint-config",
     "@deephaven/tsconfig": "file:packages/tsconfig",
-    "@deephaven/utils": "file:packages/utils"
+    "@deephaven/utils": "file:packages/utils",
+    "conventional-changelog-conventionalcommits": "^7.0.2"
   }
 }


### PR DESCRIPTION
- Use the conventionalcommits preset for lerna, so we can use exclamation marks to mark breaking changes
- For some reason I can't get this working correctly, it just hangs when I try and run lerna version (`npx lerna version --no-push --conventional-commits`) to test it. So I'll just close this PR for now, but creating it as a point of reference.