### PR TITLE
fix: Adjusted Monaco "white" colors

### DIFF
--- a/packages/components/src/theme/theme-dark/theme-dark-semantic-editor.css
+++ b/packages/components/src/theme/theme-dark/theme-dark-semantic-editor.css
@@ -58,6 +58,7 @@
   --dh-color-editor-suggest-selected-bg: var(--dh-color-highlight-selected);
   --dh-color-editor-suggest-selected-fg: var(--dh-color-white);
   --dh-color-editor-suggest-highlight-fg: var(--dh-color-accent-700);
+  --dh-color-editor-suggest-focus-highlight-fg: var(--dh-color-accent-700);
   --dh-color-editor-suggest-hover-bg: var(--dh-color-highlight-hover);
 
   /* Links */

--- a/packages/components/src/theme/theme-dark/theme-dark-semantic-editor.css
+++ b/packages/components/src/theme/theme-dark/theme-dark-semantic-editor.css
@@ -54,8 +54,9 @@
   /* Suggest */
   --dh-color-editor-suggest-bg: var(--dh-color-gray-200);
   --dh-color-editor-suggest-border: var(--dh-color-gray-400);
-  --dh-color-editor-suggest-fg: var(--dh-color-gray-100);
+  --dh-color-editor-suggest-fg: var(--dh-color-white);
   --dh-color-editor-suggest-selected-bg: var(--dh-color-highlight-selected);
+  --dh-color-editor-suggest-selected-fg: var(--dh-color-white);
   --dh-color-editor-suggest-highlight-fg: var(--dh-color-accent-700);
   --dh-color-editor-suggest-hover-bg: var(--dh-color-highlight-hover);
 

--- a/packages/console/src/monaco/MonacoTheme.module.scss
+++ b/packages/console/src/monaco/MonacoTheme.module.scss
@@ -66,6 +66,9 @@
   editor-suggest-widget-selected-background: var(
     --dh-color-editor-suggest-selected-bg
   );
+  editor-suggest-widget-selected-foreground: var(
+    --dh-color-editor-suggest-selected-fg
+  );
   editor-suggest-widget-highlightForeground: var(
     --dh-color-editor-suggest-highlight-fg
   );

--- a/packages/console/src/monaco/MonacoTheme.module.scss
+++ b/packages/console/src/monaco/MonacoTheme.module.scss
@@ -72,6 +72,9 @@
   editor-suggest-widget-highlightForeground: var(
     --dh-color-editor-suggest-highlight-fg
   );
+  editor-suggest-widget-focus-highlight-foreground: var(
+    --dh-color-editor-suggest-focus-highlight-fg
+  );
   list-hover-background: var(--dh-color-editor-suggest-hover-bg);
 
   // links

--- a/packages/console/src/monaco/MonacoUtils.ts
+++ b/packages/console/src/monaco/MonacoUtils.ts
@@ -134,6 +134,8 @@ class MonacoUtils {
         MonacoTheme['editor-suggest-widget-selected-foreground'],
       'editorSuggestWidget.highlightForeground':
         MonacoTheme['editor-suggest-widget-highlightForeground'],
+      'editorSuggestWidget.focusHighlightForeground':
+        MonacoTheme['editor-suggest-widget-focus-highlight-foreground'],
       'list.hoverBackground': MonacoTheme['list-hover-background'],
       'dropdown.background': MonacoTheme['context-menu-background'],
       'dropdown.foreground': MonacoTheme['context-menu-foreground'],

--- a/packages/console/src/monaco/MonacoUtils.ts
+++ b/packages/console/src/monaco/MonacoUtils.ts
@@ -130,6 +130,8 @@ class MonacoUtils {
         MonacoTheme['editor-suggest-widget-foreground'],
       'editorSuggestWidget.selectedBackground':
         MonacoTheme['editor-suggest-widget-selected-background'],
+      'editorSuggestWidget.selectedForeground':
+        MonacoTheme['editor-suggest-widget-selected-foreground'],
       'editorSuggestWidget.highlightForeground':
         MonacoTheme['editor-suggest-widget-highlightForeground'],
       'list.hoverBackground': MonacoTheme['list-hover-background'],


### PR DESCRIPTION
This fixes some Monaco suggestion colors

<img width="486" alt="image" src="https://github.com/deephaven/web-client-ui/assets/1900643/8e550d37-5da5-4e9f-a5c4-1ea95a2e5c0b">

fixes #1592