### PR TITLE
feat: Convert DashboardPlugins to WidgetPlugins

### DIFF
--- a/packages/dashboard-core-plugins/src/ChartPlugin.tsx
+++ b/packages/dashboard-core-plugins/src/ChartPlugin.tsx
@@ -91,7 +91,7 @@ export const ChartPlugin = forwardRef(
 
     const hydratedProps = useMemo(
       () => ({
-        ...props,
+        ...(props as unknown as ChartPanelProps),
         metadata: props.metadata as ChartPanelMetadata,
         localDashboardId: props.localDashboardId,
         makeModel: () => {
@@ -103,7 +103,12 @@ export const ChartPlugin = forwardRef(
             throw new Error('Metadata is required for chart panel');
           }
 
-          return createChartModel(dh, connection, metadata, panelState);
+          return createChartModel(
+            dh,
+            connection,
+            metadata as ChartPanelMetadata,
+            panelState
+          );
         },
       }),
       [dh, connection, props]

--- a/packages/dashboard-core-plugins/src/ChartPluginConfig.ts
+++ b/packages/dashboard-core-plugins/src/ChartPluginConfig.ts
@@ -1,10 +1,15 @@
-import { PluginType, DashboardPlugin } from '@deephaven/plugin';
+import { PluginType, type WidgetPlugin } from '@deephaven/plugin';
+import { vsGraph } from '@deephaven/icons';
 import ChartPlugin from './ChartPlugin';
 
-const ChartPluginConfig: DashboardPlugin = {
-  name: 'ChartPlugin',
-  type: PluginType.DASHBOARD_PLUGIN,
+const ChartPluginConfig: WidgetPlugin = {
+  name: 'ChartPanel',
+  title: 'Chart',
+  type: PluginType.WIDGET_PLUGIN,
   component: ChartPlugin,
+  panelComponent: ChartPlugin,
+  supportedTypes: 'Figure',
+  icon: vsGraph,
 };
 
 export default ChartPluginConfig;

--- a/packages/dashboard-core-plugins/src/GridPluginConfig.ts
+++ b/packages/dashboard-core-plugins/src/GridPluginConfig.ts
@@ -1,10 +1,15 @@
-import { PluginType, DashboardPlugin } from '@deephaven/plugin';
+import { PluginType, type WidgetPlugin } from '@deephaven/plugin';
+import { dhTable } from '@deephaven/icons';
 import GridPlugin from './GridPlugin';
 
-const GridPluginConfig: DashboardPlugin = {
-  name: 'GridPlugin',
-  type: PluginType.DASHBOARD_PLUGIN,
+const GridPluginConfig: WidgetPlugin = {
+  name: 'IrisGridPanel',
+  title: 'Table',
+  type: PluginType.WIDGET_PLUGIN,
   component: GridPlugin,
+  panelComponent: GridPlugin,
+  supportedTypes: ['Table', 'TreeTable', 'HierarchicalTable'],
+  icon: dhTable,
 };
 
 export default GridPluginConfig;

--- a/packages/dashboard-core-plugins/src/PandasPluginConfig.ts
+++ b/packages/dashboard-core-plugins/src/PandasPluginConfig.ts
@@ -3,7 +3,7 @@ import { dhPandas } from '@deephaven/icons';
 import PandasPlugin from './PandasPlugin';
 
 const PandasPluginConfig: WidgetPlugin = {
-  name: 'PandasPlugin',
+  name: 'PandasPanel',
   title: 'Pandas',
   type: PluginType.WIDGET_PLUGIN,
   // TODO: #1573 Replace with actual base component and not just the panel plugin

--- a/packages/dashboard-core-plugins/src/WidgetLoaderPlugin.tsx
+++ b/packages/dashboard-core-plugins/src/WidgetLoaderPlugin.tsx
@@ -72,7 +72,6 @@ export function WrapWidgetPlugin(
             {...props}
           />
         )}
-        )
       </WidgetPanel>
     );
   }

--- a/packages/dashboard-core-plugins/src/index.test.tsx
+++ b/packages/dashboard-core-plugins/src/index.test.tsx
@@ -9,10 +9,8 @@ import { type IdeConnection } from '@deephaven/jsapi-types';
 import { ConnectionContext } from '@deephaven/jsapi-components';
 import { PluginsContext } from '@deephaven/plugin';
 import {
-  ChartPlugin,
   ConsolePlugin,
   FilterPlugin,
-  GridPlugin,
   LinkerPlugin,
   MarkdownPlugin,
   WidgetLoaderPlugin,
@@ -36,8 +34,6 @@ it('handles mounting and unmount core plugins properly', () => {
           <Provider store={store}>
             <Dashboard>
               <FilterPlugin />
-              <GridPlugin hydrate={() => undefined} />
-              <ChartPlugin hydrate={() => undefined} />
               <ConsolePlugin />
               <LinkerPlugin />
               <MarkdownPlugin />

--- a/packages/dashboard-core-plugins/src/panels/IrisGridPanel.tsx
+++ b/packages/dashboard-core-plugins/src/panels/IrisGridPanel.tsx
@@ -133,7 +133,7 @@ type LoadedPanelState = PanelState & {
     >;
 };
 
-export interface IrisGridPanelOwnProps extends DashboardPanelProps {
+export interface OwnProps extends DashboardPanelProps {
   children?: ReactNode;
   panelState: LoadedPanelState | null;
   makeModel: () => IrisGridModel | Promise<IrisGridModel>;
@@ -225,7 +225,7 @@ function getTableNameFromMetadata(metadata: PanelMetadata | undefined): string {
   throw new Error(`Unable to determine table name from metadata: ${metadata}`);
 }
 
-export type IrisGridPanelProps = IrisGridPanelOwnProps & StateProps;
+export type IrisGridPanelProps = OwnProps & StateProps;
 
 export class IrisGridPanel extends PureComponent<
   IrisGridPanelProps,
@@ -1372,7 +1372,7 @@ export class IrisGridPanel extends PureComponent<
 
 const mapStateToProps = (
   state: RootState,
-  { localDashboardId = DEFAULT_DASHBOARD_ID }: IrisGridPanelOwnProps
+  { localDashboardId = DEFAULT_DASHBOARD_ID }: OwnProps
 ): StateProps => ({
   inputFilters: getInputFiltersForDashboard(state, localDashboardId),
   links: getLinksForDashboard(state, localDashboardId),

--- a/packages/dashboard-core-plugins/src/panels/IrisGridPanel.tsx
+++ b/packages/dashboard-core-plugins/src/panels/IrisGridPanel.tsx
@@ -133,7 +133,7 @@ type LoadedPanelState = PanelState & {
     >;
 };
 
-export interface IrisGridPanelProps extends DashboardPanelProps {
+export interface IrisGridPanelOwnProps extends DashboardPanelProps {
   children?: ReactNode;
   panelState: LoadedPanelState | null;
   makeModel: () => IrisGridModel | Promise<IrisGridModel>;
@@ -150,7 +150,7 @@ export interface IrisGridPanelProps extends DashboardPanelProps {
   theme?: IrisGridThemeType;
 }
 
-interface PropsFromRedux {
+interface StateProps {
   inputFilters: InputFilter[];
   links: Link[];
   columnSelectionValidator?: (
@@ -225,10 +225,10 @@ function getTableNameFromMetadata(metadata: PanelMetadata | undefined): string {
   throw new Error(`Unable to determine table name from metadata: ${metadata}`);
 }
 
-type IrisGridPanelPropsWithRedux = IrisGridPanelProps & PropsFromRedux;
+export type IrisGridPanelProps = IrisGridPanelOwnProps & StateProps;
 
 export class IrisGridPanel extends PureComponent<
-  IrisGridPanelPropsWithRedux,
+  IrisGridPanelProps,
   IrisGridPanelState
 > {
   static defaultProps = {
@@ -240,7 +240,7 @@ export class IrisGridPanel extends PureComponent<
 
   static COMPONENT = 'IrisGridPanel';
 
-  constructor(props: IrisGridPanelPropsWithRedux) {
+  constructor(props: IrisGridPanelProps) {
     super(props);
 
     this.handleAdvancedSettingsChange =
@@ -1372,8 +1372,8 @@ export class IrisGridPanel extends PureComponent<
 
 const mapStateToProps = (
   state: RootState,
-  { localDashboardId = DEFAULT_DASHBOARD_ID }: { localDashboardId?: string }
-) => ({
+  { localDashboardId = DEFAULT_DASHBOARD_ID }: IrisGridPanelOwnProps
+): StateProps => ({
   inputFilters: getInputFiltersForDashboard(state, localDashboardId),
   links: getLinksForDashboard(state, localDashboardId),
   columnSelectionValidator: getColumnSelectionValidatorForDashboard(

--- a/packages/dashboard-core-plugins/src/panels/PandasPanel.tsx
+++ b/packages/dashboard-core-plugins/src/panels/PandasPanel.tsx
@@ -5,13 +5,13 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { dhRefresh } from '@deephaven/icons';
 import { Button } from '@deephaven/components';
 import ConnectedIrisGridPanel, {
-  IrisGridPanel,
-  IrisGridPanelProps,
-  PanelState,
+  type IrisGridPanel,
+  type IrisGridPanelOwnProps,
+  type PanelState,
 } from './IrisGridPanel';
 import './PandasPanel.scss';
 
-export interface PandasPanelProps extends IrisGridPanelProps {
+export interface PandasPanelProps extends IrisGridPanelOwnProps {
   panelState: PanelState | null;
 }
 

--- a/packages/dashboard-core-plugins/src/panels/PandasPanel.tsx
+++ b/packages/dashboard-core-plugins/src/panels/PandasPanel.tsx
@@ -6,7 +6,7 @@ import { dhRefresh } from '@deephaven/icons';
 import { Button } from '@deephaven/components';
 import ConnectedIrisGridPanel, {
   type IrisGridPanel,
-  type IrisGridPanelOwnProps,
+  type OwnProps as IrisGridPanelOwnProps,
   type PanelState,
 } from './IrisGridPanel';
 import './PandasPanel.scss';

--- a/packages/dashboard-core-plugins/src/panels/Panel.tsx
+++ b/packages/dashboard-core-plugins/src/panels/Panel.tsx
@@ -125,7 +125,7 @@ class Panel extends PureComponent<PanelProps, PanelState> {
     this.state = {
       title: LayoutUtils.getTitleFromContainer(glContainer),
       showRenameDialog: false,
-      isWithinPanel: false,
+      isWithinPanel: true,
     };
   }
 

--- a/packages/dashboard-core-plugins/src/panels/Panel.tsx
+++ b/packages/dashboard-core-plugins/src/panels/Panel.tsx
@@ -66,6 +66,7 @@ interface PanelProps {
 interface PanelState {
   title?: string | null;
   showRenameDialog: boolean;
+  isWithinPanel: boolean;
 }
 /**
  * Generic panel component that emits mount/unmount/focus events.
@@ -118,10 +119,13 @@ class Panel extends PureComponent<PanelProps, PanelState> {
     this.handleTabClicked = this.handleTabClicked.bind(this);
     this.handleTab = this.handleTab.bind(this);
 
+    this.ref = React.createRef<HTMLDivElement>();
+
     const { glContainer } = this.props;
     this.state = {
       title: LayoutUtils.getTitleFromContainer(glContainer),
       showRenameDialog: false,
+      isWithinPanel: false,
     };
   }
 
@@ -151,6 +155,11 @@ class Panel extends PureComponent<PanelProps, PanelState> {
     if (prevProps.componentPanel == null && componentPanel != null) {
       glEventHub.emit(PanelEvent.MOUNT, componentPanel);
     }
+
+    this.setState({
+      isWithinPanel:
+        this.ref.current?.parentElement?.closest('.iris-panel') != null,
+    });
   }
 
   componentWillUnmount(): void {
@@ -175,6 +184,8 @@ class Panel extends PureComponent<PanelProps, PanelState> {
       glEventHub.emit(PanelEvent.UNMOUNT, componentPanel);
     }
   }
+
+  ref: React.RefObject<HTMLDivElement>;
 
   handleTab(tab: Tab): void {
     if (tab != null) {
@@ -335,13 +346,14 @@ class Panel extends PureComponent<PanelProps, PanelState> {
       isRenamable,
     } = this.props;
     const { tab: glTab } = glContainer;
-    const { showRenameDialog, title } = this.state;
+    const { showRenameDialog, title, isWithinPanel } = this.state;
 
     return (
       <div
         className={classNames('h-100 w-100 iris-panel', className)}
         onFocusCapture={this.handleFocus}
         onBlurCapture={this.handleBlur}
+        ref={this.ref}
       >
         {children}
         <LoadingOverlay
@@ -349,7 +361,8 @@ class Panel extends PureComponent<PanelProps, PanelState> {
           isLoaded={isLoaded}
           isLoading={isLoading}
         />
-        {glTab != null &&
+        {!isWithinPanel &&
+          glTab != null &&
           ReactDOM.createPortal(
             <>
               <PanelContextMenu

--- a/packages/dashboard-core-plugins/src/panels/Panel.tsx
+++ b/packages/dashboard-core-plugins/src/panels/Panel.tsx
@@ -146,6 +146,11 @@ class Panel extends PureComponent<PanelProps, PanelState> {
       InputFilterEvent.CLEAR_ALL_FILTERS,
       this.handleClearAllFilters
     );
+
+    this.setState({
+      isWithinPanel:
+        this.ref.current?.parentElement?.closest('.dh-panel') != null,
+    });
   }
 
   componentDidUpdate(prevProps: PanelProps): void {
@@ -155,11 +160,6 @@ class Panel extends PureComponent<PanelProps, PanelState> {
     if (prevProps.componentPanel == null && componentPanel != null) {
       glEventHub.emit(PanelEvent.MOUNT, componentPanel);
     }
-
-    this.setState({
-      isWithinPanel:
-        this.ref.current?.parentElement?.closest('.iris-panel') != null,
-    });
   }
 
   componentWillUnmount(): void {
@@ -350,7 +350,7 @@ class Panel extends PureComponent<PanelProps, PanelState> {
 
     return (
       <div
-        className={classNames('h-100 w-100 iris-panel', className)}
+        className={classNames('h-100 w-100 dh-panel', className)}
         onFocusCapture={this.handleFocus}
         onBlurCapture={this.handleBlur}
         ref={this.ref}

--- a/packages/dashboard-core-plugins/src/useHydrateGrid.ts
+++ b/packages/dashboard-core-plugins/src/useHydrateGrid.ts
@@ -8,8 +8,8 @@ import { useConnection } from '@deephaven/jsapi-components';
 import { Table } from '@deephaven/jsapi-types';
 import { IrisGridModelFactory } from '@deephaven/iris-grid';
 import {
-  IrisGridPanelMetadata,
-  IrisGridPanelProps,
+  type IrisGridPanelMetadata,
+  type IrisGridPanelProps,
   isIrisGridPanelMetadata,
   isLegacyIrisGridPanelMetadata,
 } from './panels';


### PR DESCRIPTION
Fixes #1573 

This fix should be adequate for furthering the Deephaven UI alpha. Rather than trying to refactor 2 1k+ line files (IrisGridPanel and ChartPanel), I opted to add some DOM detection to the `Panel` component to prevent rendering tab context menu/tooltips if it is nested within another panel.

For Deephaven UI, we will need to ensure the UI panel uses `Panel` at least and passes through `glContainer` and `glEventHub` to the child elements so grids and charts function roughly as normal.


### Testing

To test how something would look/function when wrapped, remove the `panelComponent` line from either of the plugin configs. This will wrap in a generic `WidgetPanel` which you can see in dev tools. The panel tab will not have any of the custom tooltip for grid or custom context menus.

Test by opening grids/figures, applying some filters/sorts and then reloading the page to ensure the state persisted. Also test adding links and ensuring those persisted on reload. Test that a chart built with chart builder works and survives a reload as well.

### Followup

We might be able to convert `MarkdownPlugin` and `FilterPlugin`, but I wanted to get the main components in first. Not sure if those would work as WidgetPlugins as currently constructed since they don't listen for `PanelEvent.OPEN`. `FilterPlugin` probably makes sense to split into a suite of plugins for each filter type which would need #1587 