### PR TITLE
fix: Log figure errors, don't show infinite spinner

### DIFF
--- a/__mocks__/dh-core.js
+++ b/__mocks__/dh-core.js
@@ -1589,6 +1589,7 @@ class Figure extends DeephavenObject {
     updateSize = 10,
     rows = 1,
     cols = 1,
+    errors = [],
   } = {}) {
     super();
 
@@ -1603,6 +1604,7 @@ class Figure extends DeephavenObject {
     this.rowIndex = 0;
     this.rows = rows;
     this.cols = cols;
+    this.errors = errors;
   }
 
   addEventListener(...args) {

--- a/packages/chart/src/Chart.scss
+++ b/packages/chart/src/Chart.scss
@@ -108,3 +108,7 @@ $plotly-color-btn-active: rgba(255, 255, 255, 70%);
     }
   }
 }
+
+.chart-error-popper .popper-content {
+  padding: $spacer-1;
+}

--- a/packages/chart/src/Chart.tsx
+++ b/packages/chart/src/Chart.tsx
@@ -691,7 +691,7 @@ export class Chart extends Component<ChartProps, ChartState> {
           {shownError != null && (
             <>
               <div className="chart-error">{shownError}</div>
-              <CopyButton tooltip="Copy error" copy={shownError}>
+              <CopyButton tooltip="Copy Error" copy={shownError}>
                 Copy Error
               </CopyButton>
             </>

--- a/packages/chart/src/Chart.tsx
+++ b/packages/chart/src/Chart.tsx
@@ -692,7 +692,7 @@ export class Chart extends Component<ChartProps, ChartState> {
             <>
               <div className="chart-error">{shownError}</div>
               <CopyButton tooltip="Copy error" copy={shownError}>
-                Copy Versions
+                Copy Error
               </CopyButton>
             </>
           )}

--- a/packages/chart/src/Chart.tsx
+++ b/packages/chart/src/Chart.tsx
@@ -1,6 +1,7 @@
 import React, { Component, ReactElement, RefObject } from 'react';
 import deepEqual from 'deep-equal';
 import memoize from 'memoize-one';
+import { CopyButton, Popper } from '@deephaven/components';
 import {
   vsLoading,
   dhGraphLineDown,
@@ -57,10 +58,15 @@ interface ChartProps {
 
 interface ChartState {
   data: Partial<Data>[] | null;
+  /** An error specific to downsampling */
   downsamplingError: unknown;
   isDownsampleFinished: boolean;
   isDownsampleInProgress: boolean;
   isDownsamplingDisabled: boolean;
+
+  /** Any other kind of error */
+  error: unknown;
+  shownError: string | null;
   layout: Partial<Layout>;
   revision: number;
 }
@@ -130,6 +136,7 @@ export class Chart extends Component<ChartProps, ChartState> {
 
     this.handleAfterPlot = this.handleAfterPlot.bind(this);
     this.handleDownsampleClick = this.handleDownsampleClick.bind(this);
+    this.handleErrorClose = this.handleErrorClose.bind(this);
     this.handleModelEvent = this.handleModelEvent.bind(this);
     this.handlePlotUpdate = this.handlePlotUpdate.bind(this);
     this.handleRelayout = this.handleRelayout.bind(this);
@@ -154,6 +161,8 @@ export class Chart extends Component<ChartProps, ChartState> {
       isDownsampleFinished: false,
       isDownsampleInProgress: false,
       isDownsamplingDisabled: false,
+      error: null,
+      shownError: null,
       layout: {
         datarevision: 0,
       },
@@ -237,7 +246,8 @@ export class Chart extends Component<ChartProps, ChartState> {
       isDownsampleFinished: boolean,
       isDownsampleInProgress: boolean,
       isDownsamplingDisabled: boolean,
-      data: Partial<Data>[]
+      data: Partial<Data>[],
+      error: unknown
     ): Partial<PlotlyConfig> => {
       const customButtons: ModeBarButtonAny[] = [];
       const hasDownsampleError = Boolean(downsamplingError);
@@ -245,7 +255,21 @@ export class Chart extends Component<ChartProps, ChartState> {
         customButtons.push({
           name: `Downsampling failed: ${downsamplingError}`,
           title: 'Downsampling failed',
-          click: () => undefined,
+          click: () => {
+            this.toggleErrorMessage(`${downsamplingError}`);
+          },
+          icon: Chart.convertIcon(dhWarningFilled),
+          attr: 'fill-warning',
+        });
+      }
+      const hasError = Boolean(error);
+      if (hasError) {
+        customButtons.push({
+          name: `Error: ${error}`,
+          title: `Error`,
+          click: () => {
+            this.toggleErrorMessage(`${error}`);
+          },
           icon: Chart.convertIcon(dhWarningFilled),
           attr: 'fill-warning',
         });
@@ -302,7 +326,7 @@ export class Chart extends Component<ChartProps, ChartState> {
         // Yes, the value is a boolean or the string 'hover': https://github.com/plotly/plotly.js/blob/master/src/plot_api/plot_config.js#L249
         displayModeBar:
           // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
-          isDownsampleInProgress || hasDownsampleError
+          isDownsampleInProgress || hasDownsampleError || hasError
             ? true
             : ('hover' as const),
 
@@ -377,6 +401,10 @@ export class Chart extends Component<ChartProps, ChartState> {
     );
   }
 
+  handleErrorClose(): void {
+    this.setState({ shownError: null });
+  }
+
   handleModelEvent(event: CustomEvent): void {
     const { type, detail } = event;
     log.debug2('Received data update', type, detail);
@@ -448,6 +476,7 @@ export class Chart extends Component<ChartProps, ChartState> {
       }
       case ChartModel.EVENT_ERROR: {
         const error = `${detail}`;
+        this.setState({ error });
         const { onError } = this.props;
         onError(new Error(error));
         break;
@@ -507,6 +536,15 @@ export class Chart extends Component<ChartProps, ChartState> {
         onSettingsChanged({ hiddenSeries });
       }
     }
+  }
+
+  /**
+   * Toggle the error message. If it is already being displayed, then hide it.
+   */
+  toggleErrorMessage(error: string): void {
+    this.setState(({ shownError }) => ({
+      shownError: shownError === error ? null : error,
+    }));
   }
 
   /**
@@ -608,6 +646,8 @@ export class Chart extends Component<ChartProps, ChartState> {
       isDownsampleFinished,
       isDownsampleInProgress,
       isDownsamplingDisabled,
+      error,
+      shownError,
       layout,
       revision,
     } = this.state;
@@ -616,7 +656,8 @@ export class Chart extends Component<ChartProps, ChartState> {
       isDownsampleFinished,
       isDownsampleInProgress,
       isDownsamplingDisabled,
-      data ?? []
+      data ?? [],
+      error
     );
     const isPlotShown = data != null;
     return (
@@ -639,6 +680,23 @@ export class Chart extends Component<ChartProps, ChartState> {
             style={{ height: '100%', width: '100%' }}
           />
         )}
+        <Popper
+          className="chart-error-popper"
+          options={{ placement: 'top' }}
+          isShown={shownError != null}
+          onExited={this.handleErrorClose}
+          closeOnBlur
+          interactive
+        >
+          {shownError != null && (
+            <>
+              <div className="chart-error">{shownError}</div>
+              <CopyButton tooltip="Copy error" copy={shownError}>
+                Copy Versions
+              </CopyButton>
+            </>
+          )}
+        </Popper>
       </div>
     );
   }

--- a/packages/chart/src/Chart.tsx
+++ b/packages/chart/src/Chart.tsx
@@ -33,6 +33,7 @@ import Plotly from './plotly/Plotly';
 import ChartModel from './ChartModel';
 import ChartUtils, { ChartModelSettings } from './ChartUtils';
 import './Chart.scss';
+import DownsamplingError from './DownsamplingError';
 
 const log = Log.module('Chart');
 
@@ -442,7 +443,13 @@ export class Chart extends Component<ChartProps, ChartState> {
         });
 
         const { onError } = this.props;
-        onError(new Error(downsamplingError));
+        onError(new DownsamplingError(downsamplingError));
+        break;
+      }
+      case ChartModel.EVENT_ERROR: {
+        const error = `${detail}`;
+        const { onError } = this.props;
+        onError(new Error(error));
         break;
       }
       default:

--- a/packages/chart/src/ChartModel.ts
+++ b/packages/chart/src/ChartModel.ts
@@ -29,6 +29,8 @@ class ChartModel {
 
   static EVENT_LOADFINISHED = 'ChartModel.EVENT_LOADFINISHED';
 
+  static EVENT_ERROR = 'ChartModel.EVENT_ERROR';
+
   constructor(dh: DhType) {
     this.dh = dh;
     this.listeners = [];
@@ -160,6 +162,10 @@ class ChartModel {
 
   fireLoadFinished(): void {
     this.fireEvent(new CustomEvent(ChartModel.EVENT_LOADFINISHED));
+  }
+
+  fireError(detail: string[]): void {
+    this.fireEvent(new CustomEvent(ChartModel.EVENT_ERROR, { detail }));
   }
 }
 

--- a/packages/chart/src/ChartTestUtils.ts
+++ b/packages/chart/src/ChartTestUtils.ts
@@ -131,9 +131,16 @@ class ChartTestUtils {
     charts = [this.makeChart()],
     rows = 1,
     cols = 1,
+    errors = [],
   } = {}): Figure {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    return new (this.dh as any).plot.Figure({ title, charts, rows, cols });
+    return new (this.dh as any).plot.Figure({
+      title,
+      charts,
+      rows,
+      cols,
+      errors,
+    });
   }
 }
 

--- a/packages/chart/src/DownsamplingError.ts
+++ b/packages/chart/src/DownsamplingError.ts
@@ -1,0 +1,5 @@
+export class DownsamplingError extends Error {
+  isDownsamplingError = true;
+}
+
+export default DownsamplingError;

--- a/packages/chart/src/FigureChartModel.test.ts
+++ b/packages/chart/src/FigureChartModel.test.ts
@@ -464,6 +464,23 @@ it('adds new series', () => {
   ]);
 });
 
+it('emits finished loading if no series are added', () => {
+  const figure = chartTestUtils.makeFigure({
+    charts: [],
+  });
+  const model = new FigureChartModel(dh, figure);
+  const callback = jest.fn();
+  model.subscribe(callback);
+
+  jest.runOnlyPendingTimers();
+
+  expect(callback).toHaveBeenCalledWith(
+    expect.objectContaining({
+      type: FigureChartModel.EVENT_LOADFINISHED,
+    })
+  );
+});
+
 describe('legend visibility', () => {
   function testLegend(showLegend: boolean | null): Partial<PlotData>[] {
     const series1 = chartTestUtils.makeSeries({ name: 'S1' });

--- a/packages/chart/src/FigureChartModel.test.ts
+++ b/packages/chart/src/FigureChartModel.test.ts
@@ -1,6 +1,6 @@
 import dh from '@deephaven/jsapi-shim';
 import { TestUtils } from '@deephaven/utils';
-import { PlotData } from 'plotly.js';
+import { Data } from 'plotly.js';
 import ChartTestUtils from './ChartTestUtils';
 import type { ChartTheme } from './ChartTheme';
 import FigureChartModel from './FigureChartModel';
@@ -468,7 +468,7 @@ it('emits finished loading if no series are added', () => {
   const figure = chartTestUtils.makeFigure({
     charts: [],
   });
-  const model = new FigureChartModel(dh, figure);
+  const model = new FigureChartModel(dh, figure, chartTheme);
   const callback = jest.fn();
   model.subscribe(callback);
 
@@ -482,7 +482,7 @@ it('emits finished loading if no series are added', () => {
 });
 
 describe('legend visibility', () => {
-  function testLegend(showLegend: boolean | null): Partial<PlotData>[] {
+  function testLegend(showLegend: boolean | null): Partial<Data>[] {
     const series1 = chartTestUtils.makeSeries({ name: 'S1' });
     const chart = chartTestUtils.makeChart({ series: [series1], showLegend });
     const figure = chartTestUtils.makeFigure({

--- a/packages/chart/src/FigureChartModel.ts
+++ b/packages/chart/src/FigureChartModel.ts
@@ -266,6 +266,15 @@ class FigureChartModel extends ChartModel {
         ? this.dh.plot.DownsampleOptions.DISABLE
         : this.dh.plot.DownsampleOptions.DEFAULT
     );
+
+    if (this.figure.errors.length > 0) {
+      // We don't have a toast or anything we show for errors; just log the error for now
+      log.error('Errors in figure', this.figure.errors);
+    }
+
+    if (this.seriesToProcess.size === 0 && this.seriesDataMap.size === 0) {
+      this.fireLoadFinished();
+    }
   }
 
   unsubscribeFigure(): void {
@@ -459,11 +468,11 @@ class FigureChartModel extends ChartModel {
       }
 
       this.seriesToProcess.delete(series.name);
-      if (this.seriesToProcess.size === 0) {
-        this.fireLoadFinished();
-      }
 
       this.cleanSeries(series);
+    }
+    if (this.seriesToProcess.size === 0) {
+      this.fireLoadFinished();
     }
 
     const { data } = this;

--- a/packages/chart/src/FigureChartModel.ts
+++ b/packages/chart/src/FigureChartModel.ts
@@ -270,10 +270,7 @@ class FigureChartModel extends ChartModel {
     if (this.figure.errors.length > 0) {
       // We don't have a toast or anything we show for errors; just log the error for now
       log.error('Errors in figure', this.figure.errors);
-    }
-
-    if (this.seriesToProcess.size === 0 && this.seriesDataMap.size === 0) {
-      this.fireLoadFinished();
+      this.fireError(this.figure.errors);
     }
   }
 
@@ -481,6 +478,7 @@ class FigureChartModel extends ChartModel {
 
   handleRequestFailed(event: ChartEvent): void {
     log.error('Request failed', event);
+    this.fireError([`${event.detail}`]);
   }
 
   /**

--- a/packages/chart/src/FigureChartModel.ts
+++ b/packages/chart/src/FigureChartModel.ts
@@ -268,7 +268,6 @@ class FigureChartModel extends ChartModel {
     );
 
     if (this.figure.errors.length > 0) {
-      // We don't have a toast or anything we show for errors; just log the error for now
       log.error('Errors in figure', this.figure.errors);
       this.fireError(this.figure.errors);
     }

--- a/packages/chart/src/index.ts
+++ b/packages/chart/src/index.ts
@@ -3,6 +3,7 @@ export { default as ChartModelFactory } from './ChartModelFactory';
 export { default as ChartModel } from './ChartModel';
 export { default as ChartUtils } from './ChartUtils';
 export * from './ChartUtils';
+export * from './DownsamplingError';
 export { default as FigureChartModel } from './FigureChartModel';
 export { default as MockChartModel } from './MockChartModel';
 export { default as Plot } from './plotly/Plot';

--- a/packages/chart/tsconfig.json
+++ b/packages/chart/tsconfig.json
@@ -7,23 +7,12 @@
   "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.js", "src/**/*.jsx"],
   "exclude": ["node_modules", "src/**/*.test.*", "src/**/__mocks__/*"],
   "references": [
-    {
-      "path": "../components"
-    },
-    {
-      "path": "../jsapi-shim"
-    },
-    {
-      "path": "../jsapi-utils"
-    },
-    {
-      "path": "../log"
-    },
-    {
-      "path": "../react-hooks"
-    },
-    {
-      "path": "../utils"
-    }
+    { "path": "../components" },
+    { "path": "../jsapi-shim" },
+    { "path": "../jsapi-types" },
+    { "path": "../jsapi-utils" },
+    { "path": "../log" },
+    { "path": "../react-hooks" },
+    { "path": "../utils" }
   ]
 }

--- a/packages/jsapi-types/src/dh.types.ts
+++ b/packages/jsapi-types/src/dh.types.ts
@@ -330,6 +330,7 @@ export interface Figure extends Evented {
   readonly cols: number;
   readonly rows: number;
   readonly charts: Chart[];
+  readonly errors: string[];
 
   /**
    * Subscribes to all series in this figure.


### PR DESCRIPTION
- Requires Core PR https://github.com/deephaven/deephaven-core/pull/4763
  - Also need to port that to Enterprise
- Actually look at the errors reported by the figure, and log them so we have a clearer idea of what the issue is when plots are reported as not working
- Also show the error message in the chart panel button bar. Clicking the button will display the full error message.
- Don't show the spinner infinitely if there are no series to load