### PR TITLE
fix: DH-15864: Scroll position StuckToBottom shouldn't trigger sharing dot

### DIFF
--- a/packages/dashboard/src/layout/LayoutUtils.ts
+++ b/packages/dashboard/src/layout/LayoutUtils.ts
@@ -340,6 +340,7 @@ class LayoutUtils {
    * 1. sorts in grid
    * 2. quick filters in grid
    * 3. active item
+   * 4. isStuckToBottom/isStuckToRight
    *
    * item id is also removed
    */

--- a/packages/dashboard/src/layout/LayoutUtils.ts
+++ b/packages/dashboard/src/layout/LayoutUtils.ts
@@ -360,6 +360,8 @@ class LayoutUtils {
           delete itemConfig.id;
           itemConfig.props.panelState.irisGridState.sorts = [];
           itemConfig.props.panelState.irisGridState.quickFilters = [];
+          itemConfig.props.panelState.gridState.isStuckToBottom = false;
+          itemConfig.props.panelState.gridState.isStuckToRight = false;
         }
       }
     }


### PR DESCRIPTION
Reset `isStuckToBottom` and `isStuckToRight` in `dropLayoutMinorChange`.

The flags are still stored in the shared layout, but don't trigger the sharing dot.

Testing:

- Open a new dashboard, add a table with more rows than fits on the screen
- Share the dashboard layout with the table scrolled up, `isStuckToBottom` is `false`
- Scroll the table to the bottom, confirm the Sharing dot doesn't appear even though the `isStuckToBottom` flag is now set to `true`
- Click on the Sharing button, confirm the dialog shows the "Share updated state" message allowing to share the new `isStuckToBottom` state
- Scroll the table up a few rows to get it un-stuck, confirm the blue dot still doesn't show up. Open the Sharing dialog, confirm the "Share update state" message disappeared since the current `isStuckToBottom` state matches the shared state
- Scroll the table all the way down, discard the layout changes via the Sharing dialog, don't close the dialog. Confirm the table after discard is scrolled up (initial shared `isStuckToBottom: false` state restored).