### PR TITLE
fix: Panels not reinitializing if makeModel changes

### DIFF
--- a/packages/app-utils/src/plugins/remote-component.config.ts
+++ b/packages/app-utils/src/plugins/remote-component.config.ts
@@ -1,4 +1,3 @@
-/* eslint-disable global-require */
 /**
  * remote-component.config.js
  *
@@ -20,6 +19,7 @@ import * as DeephavenJsapiComponents from '@deephaven/jsapi-components';
 import * as DeephavenJsapiUtils from '@deephaven/jsapi-utils';
 import DeephavenLog from '@deephaven/log';
 import * as DeephavenReactHooks from '@deephaven/react-hooks';
+import * as DeephavenPlugin from '@deephaven/plugin';
 
 // eslint-disable-next-line import/prefer-default-export
 export const resolve = {
@@ -38,5 +38,6 @@ export const resolve = {
   '@deephaven/jsapi-components': DeephavenJsapiComponents,
   '@deephaven/jsapi-utils': DeephavenJsapiUtils,
   '@deephaven/log': DeephavenLog,
+  '@deephaven/plugin': DeephavenPlugin,
   '@deephaven/react-hooks': DeephavenReactHooks,
 };

--- a/packages/dashboard-core-plugins/src/ChartPlugin.tsx
+++ b/packages/dashboard-core-plugins/src/ChartPlugin.tsx
@@ -15,7 +15,6 @@ import type {
 import { IrisGridUtils } from '@deephaven/iris-grid';
 import { getTimeZone, store } from '@deephaven/redux';
 import { type WidgetComponentProps } from '@deephaven/plugin';
-import { assertNotNull } from '@deephaven/utils';
 import {
   ChartPanelMetadata,
   GLChartPanelState,
@@ -99,9 +98,11 @@ async function createChartModel(
     type: dh.VariableType.TABLE,
   };
   const table = await connection.getObject(definition);
-  const timeZone = getTimeZone(store.getState());
-  assertNotNull(timeZone);
-  new IrisGridUtils(dh).applyTableSettings(table, tableSettings, timeZone);
+  new IrisGridUtils(dh).applyTableSettings(
+    table,
+    tableSettings,
+    getTimeZone(store.getState())
+  );
 
   return ChartModelFactory.makeModelFromSettings(
     dh,

--- a/packages/dashboard-core-plugins/src/GridPlugin.tsx
+++ b/packages/dashboard-core-plugins/src/GridPlugin.tsx
@@ -1,30 +1,21 @@
-import { forwardRef, useMemo } from 'react';
+import { forwardRef } from 'react';
 import { type WidgetComponentProps } from '@deephaven/plugin';
-import { type DashboardPanelProps } from '@deephaven/dashboard';
+import { type Table } from '@deephaven/jsapi-types';
 import useHydrateGrid from './useHydrateGrid';
 import ConnectedIrisGridPanel, {
-  IrisGridPanelProps,
   type IrisGridPanel,
 } from './panels/IrisGridPanel';
 
 export const GridPlugin = forwardRef(
   (props: WidgetComponentProps, ref: React.Ref<IrisGridPanel>) => {
-    const hydrate = useHydrateGrid<
-      DashboardPanelProps & Pick<IrisGridPanelProps, 'panelState'>
-    >();
-    const { localDashboardId } = props;
-    const hydratedProps = useMemo(
-      () =>
-        hydrate(
-          props as WidgetComponentProps &
-            Pick<IrisGridPanelProps, 'panelState'>,
-          localDashboardId
-        ),
-      [hydrate, props, localDashboardId]
+    const { localDashboardId, fetch } = props;
+    const hydratedProps = useHydrateGrid(
+      fetch as unknown as () => Promise<Table>,
+      localDashboardId
     );
 
     // eslint-disable-next-line react/jsx-props-no-spreading
-    return <ConnectedIrisGridPanel ref={ref} {...hydratedProps} />;
+    return <ConnectedIrisGridPanel ref={ref} {...props} {...hydratedProps} />;
   }
 );
 

--- a/packages/dashboard-core-plugins/src/PandasPlugin.tsx
+++ b/packages/dashboard-core-plugins/src/PandasPlugin.tsx
@@ -1,20 +1,19 @@
-import { DashboardPanelProps } from '@deephaven/dashboard';
+import { forwardRef } from 'react';
 import { WidgetComponentProps } from '@deephaven/plugin';
-import { forwardRef, useMemo } from 'react';
+import { type Table } from '@deephaven/jsapi-types';
 import { PandasPanel } from './panels';
 import useHydrateGrid from './useHydrateGrid';
 
 export const PandasPlugin = forwardRef(
   (props: WidgetComponentProps, ref: React.Ref<PandasPanel>) => {
-    const hydrate = useHydrateGrid<DashboardPanelProps>();
-    const { localDashboardId } = props;
-    const hydratedProps = useMemo(
-      () => hydrate(props, localDashboardId),
-      [hydrate, props, localDashboardId]
+    const { localDashboardId, fetch } = props;
+    const hydratedProps = useHydrateGrid(
+      fetch as unknown as () => Promise<Table>,
+      localDashboardId
     );
 
     // eslint-disable-next-line react/jsx-props-no-spreading
-    return <PandasPanel ref={ref} {...hydratedProps} />;
+    return <PandasPanel ref={ref} {...props} {...hydratedProps} />;
   }
 );
 

--- a/packages/dashboard-core-plugins/src/panels/ChartPanelUtils.ts
+++ b/packages/dashboard-core-plugins/src/panels/ChartPanelUtils.ts
@@ -2,6 +2,7 @@ import { DehydratedDashboardPanelProps } from '@deephaven/dashboard';
 import type {
   ChartPanelMetadata,
   ChartPanelTableMetadata,
+  ChartPanelFigureMetadata,
   GLChartPanelState,
 } from './ChartPanel';
 
@@ -9,6 +10,12 @@ export function isChartPanelTableMetadata(
   metadata: ChartPanelMetadata
 ): metadata is ChartPanelTableMetadata {
   return (metadata as ChartPanelTableMetadata).settings !== undefined;
+}
+
+export function isChartPanelFigureMetadata(
+  metadata: ChartPanelMetadata
+): metadata is ChartPanelFigureMetadata {
+  return (metadata as ChartPanelFigureMetadata).figure !== undefined;
 }
 
 export type DehydratedChartPanelProps = DehydratedDashboardPanelProps & {

--- a/packages/dashboard-core-plugins/src/panels/IrisGridPanel.tsx
+++ b/packages/dashboard-core-plugins/src/panels/IrisGridPanel.tsx
@@ -134,7 +134,7 @@ type LoadedPanelState = PanelState & {
 
 export interface OwnProps extends DashboardPanelProps {
   children?: ReactNode;
-  panelState: LoadedPanelState | null;
+  panelState?: LoadedPanelState | null;
   makeModel: () => IrisGridModel | Promise<IrisGridModel>;
 
   onStateChange?: (irisGridState: IrisGridState, gridState: GridState) => void;
@@ -205,7 +205,7 @@ interface IrisGridPanelState {
   columnHeaderGroups?: readonly ColumnHeaderGroup[];
 
   // eslint-disable-next-line react/no-unused-state
-  panelState: PanelState | null; // Dehydrated panel state that can load this panel
+  panelState?: PanelState | null; // Dehydrated panel state that can load this panel
   irisGridStateOverrides: Partial<DehydratedIrisGridState>;
   gridStateOverrides: Partial<GridState>;
 }
@@ -324,8 +324,12 @@ export class IrisGridPanel extends PureComponent<
     this.initModel();
   }
 
-  componentDidUpdate(_: never, prevState: IrisGridPanelState): void {
+  componentDidUpdate(
+    prevProps: IrisGridPanelProps,
+    prevState: IrisGridPanelState
+  ): void {
     const { model } = this.state;
+    const { makeModel } = this.props;
     if (model !== prevState.model) {
       if (prevState.model != null) {
         this.stopModelListening(prevState.model);
@@ -334,6 +338,10 @@ export class IrisGridPanel extends PureComponent<
       if (model != null) {
         this.startModelListening(model);
       }
+    }
+
+    if (makeModel !== prevProps.makeModel) {
+      this.initModel();
     }
   }
 

--- a/packages/dashboard-core-plugins/src/panels/Panel.scss
+++ b/packages/dashboard-core-plugins/src/panels/Panel.scss
@@ -1,0 +1,3 @@
+.dh-panel {
+  position: relative;
+}

--- a/packages/dashboard-core-plugins/src/panels/Panel.tsx
+++ b/packages/dashboard-core-plugins/src/panels/Panel.tsx
@@ -27,6 +27,7 @@ import type { IdeSession } from '@deephaven/jsapi-types';
 import { ConsoleEvent, InputFilterEvent, TabEvent } from '../events';
 import PanelContextMenu from './PanelContextMenu';
 import RenameDialog from './RenameDialog';
+import './Panel.scss';
 
 const log = Log.module('Panel');
 

--- a/packages/dashboard-core-plugins/src/useHydrateGrid.ts
+++ b/packages/dashboard-core-plugins/src/useHydrateGrid.ts
@@ -1,64 +1,33 @@
-import { useCallback } from 'react';
-import {
-  DehydratedDashboardPanelProps,
-  PanelHydrateFunction,
-} from '@deephaven/dashboard';
+import { useMemo } from 'react';
 import { useApi } from '@deephaven/jsapi-bootstrap';
-import { useConnection } from '@deephaven/jsapi-components';
 import { Table } from '@deephaven/jsapi-types';
 import { IrisGridModelFactory } from '@deephaven/iris-grid';
-import {
-  type IrisGridPanelMetadata,
-  type IrisGridPanelProps,
-  isIrisGridPanelMetadata,
-  isLegacyIrisGridPanelMetadata,
-} from './panels';
+import { type IrisGridPanelProps } from './panels';
 import { useLoadTablePlugin } from './useLoadTablePlugin';
 
-export function useHydrateGrid<
-  P extends DehydratedDashboardPanelProps = DehydratedDashboardPanelProps,
->(): PanelHydrateFunction<
-  P,
-  P & Pick<IrisGridPanelProps, 'loadPlugin' | 'makeModel'>
+export function useHydrateGrid(
+  fetch: () => Promise<Table>,
+  id: string
+): { localDashboardId: string } & Pick<
+  IrisGridPanelProps,
+  'loadPlugin' | 'makeModel'
 > {
   const dh = useApi();
-  const connection = useConnection();
   const loadPlugin = useLoadTablePlugin();
 
-  const hydrate = useCallback(
-    (hydrateProps: P, id: string) => {
-      let metadata: IrisGridPanelMetadata;
-      if (isIrisGridPanelMetadata(hydrateProps.metadata)) {
-        metadata = hydrateProps.metadata;
-      } else if (isLegacyIrisGridPanelMetadata(hydrateProps.metadata)) {
-        metadata = {
-          name: hydrateProps.metadata.table,
-          type: hydrateProps.metadata.type ?? dh.VariableType.TABLE,
-        };
-      } else {
-        throw new Error('Metadata is required for table panel');
-      }
-
-      return {
-        ...hydrateProps,
-        loadPlugin,
-        localDashboardId: id,
-        makeModel: async () => {
-          const { name: tableName, type } = metadata;
-          const definition = {
-            title: tableName,
-            name: tableName,
-            type,
-          };
-          const table = (await connection.getObject(definition)) as Table;
-          return IrisGridModelFactory.makeModel(dh, table);
-        },
-      };
-    },
-    [dh, connection, loadPlugin]
+  const hydratedProps = useMemo(
+    () => ({
+      loadPlugin,
+      localDashboardId: id,
+      makeModel: async () => {
+        const table = await fetch();
+        return IrisGridModelFactory.makeModel(dh, table);
+      },
+    }),
+    [dh, loadPlugin, fetch, id]
   );
 
-  return hydrate;
+  return hydratedProps;
 }
 
 export default useHydrateGrid;


### PR DESCRIPTION
Mostly needed for Deephaven UI w/ widget plugin loading which will recreate the `makeModel` method if a new widget is created