### PR TITLE
refactor: replace html selects with Select component

### DIFF
--- a/packages/code-studio/src/settings/ColumnSpecificSectionContent.tsx
+++ b/packages/code-studio/src/settings/ColumnSpecificSectionContent.tsx
@@ -10,7 +10,7 @@ import memoize from 'memoizee';
 import { CSSTransition, TransitionGroup } from 'react-transition-group';
 import debounce from 'lodash.debounce';
 import classNames from 'classnames';
-import { Button, ThemeExport } from '@deephaven/components';
+import { Button, Select, ThemeExport } from '@deephaven/components';
 import {
   DateTimeColumnFormatter,
   IntegerColumnFormatter,
@@ -362,8 +362,8 @@ export class ColumnSpecificSectionContent extends PureComponent<
       this.handleFormatRuleChange(i, 'columnName', e.target.value);
     const onNameBlur = (): void =>
       this.handleFormatRuleChange(i, 'isNewRule', false);
-    const onTypeChange = (e: ChangeEvent<HTMLSelectElement>): void =>
-      this.handleFormatRuleChange(i, 'columnType', e.target.value);
+    const onTypeChange = (eventTargetValue: string): void =>
+      this.handleFormatRuleChange(i, 'columnType', eventTargetValue);
 
     const ruleError = this.getRuleError(rule);
 
@@ -396,14 +396,14 @@ export class ColumnSpecificSectionContent extends PureComponent<
             />
 
             <label htmlFor={columnTypeId}>Column Type</label>
-            <select
+            <Select
               id={columnTypeId}
               className="custom-select"
               value={rule.columnType}
               onChange={onTypeChange}
             >
               {columnTypeOptions}
-            </select>
+            </Select>
           </div>
         </div>
         <div className="form-row">
@@ -478,14 +478,14 @@ export class ColumnSpecificSectionContent extends PureComponent<
 
     const value = format.formatString ?? '';
     return (
-      <select
+      <Select
         className={classNames('custom-select', { 'is-invalid': isInvalid })}
         value={value}
         id={formatId}
-        onChange={e => {
+        onChange={eventTargetValue => {
           const selectedFormat = DateTimeColumnFormatter.makeFormat(
             '',
-            e.target.value,
+            eventTargetValue,
             DateTimeColumnFormatter.TYPE_GLOBAL
           );
           this.handleFormatRuleChange(i, 'format', selectedFormat);
@@ -499,7 +499,7 @@ export class ColumnSpecificSectionContent extends PureComponent<
           showTimeZone,
           showTSeparator
         )}
-      </select>
+      </Select>
     );
   }
 

--- a/packages/code-studio/src/settings/FormattingSectionContent.tsx
+++ b/packages/code-studio/src/settings/FormattingSectionContent.tsx
@@ -9,7 +9,7 @@ import { vsRefresh } from '@deephaven/icons';
 import memoize from 'memoizee';
 import debounce from 'lodash.debounce';
 import classNames from 'classnames';
-import { Button, Checkbox } from '@deephaven/components';
+import { Button, Checkbox, Select } from '@deephaven/components';
 import {
   IntegerColumnFormatter,
   DecimalColumnFormatter,
@@ -170,12 +170,10 @@ export class FormattingSectionContent extends PureComponent<
     this.debouncedCommitChanges();
   }
 
-  handleDefaultDateTimeFormatChange(
-    event: ChangeEvent<HTMLSelectElement>
-  ): void {
-    log.debug('handleDefaultDateTimeFormatChange', event.target.value);
+  handleDefaultDateTimeFormatChange(value: string): void {
+    log.debug('handleDefaultDateTimeFormatChange', value);
     const update = {
-      defaultDateTimeFormat: event.target.value,
+      defaultDateTimeFormat: value,
     };
     this.setState(update);
     this.queueUpdate(update);
@@ -233,8 +231,8 @@ export class FormattingSectionContent extends PureComponent<
     this.queueUpdate(update);
   }
 
-  handleTimeZoneChange(event: ChangeEvent<HTMLSelectElement>): void {
-    const update = { timeZone: event.target.value };
+  handleTimeZoneChange(value: string): void {
+    const update = { timeZone: value };
     this.setState(update);
     this.queueUpdate(update);
   }
@@ -364,14 +362,14 @@ export class FormattingSectionContent extends PureComponent<
               Time zone
             </label>
             <div className="col pr-0">
-              <select
+              <Select
                 className="custom-select"
                 value={timeZone}
                 onChange={this.handleTimeZoneChange}
                 id="select-reset-timezone"
               >
                 <TimeZoneOptions />
-              </select>
+              </Select>
             </div>
             <div className="col-1 btn-col">
               <Button
@@ -393,7 +391,7 @@ export class FormattingSectionContent extends PureComponent<
               DateTime
             </label>
             <div className="col pr-0">
-              <select
+              <Select
                 className="custom-select"
                 value={defaultDateTimeFormat}
                 onChange={this.handleDefaultDateTimeFormatChange}
@@ -406,7 +404,7 @@ export class FormattingSectionContent extends PureComponent<
                   true,
                   defaultDateTimeFormat
                 )}
-              </select>
+              </Select>
             </div>
             <div className="col-1 btn-col">
               <Button

--- a/packages/code-studio/src/styleguide/Inputs.tsx
+++ b/packages/code-studio/src/styleguide/Inputs.tsx
@@ -235,25 +235,38 @@ function Inputs(): React.ReactElement {
         <div className="col">
           <div className="form-group">
             <h5>Selection Menu</h5>
-            <select defaultValue="0" className="custom-select">
+            <Select
+              onChange={v => {
+                // no-op
+              }}
+              defaultValue="0"
+              className="custom-select"
+            >
               <option disabled value="0">
                 Custom Selection
               </option>
               <option value="1">One</option>
               <option value="2">Two</option>
               <option value="3">Three</option>
-            </select>
+            </Select>
           </div>
 
           <div className="form-group">
-            <select defaultValue="0" className="custom-select" disabled>
+            <Select
+              onChange={v => {
+                // no-op
+              }}
+              defaultValue="0"
+              className="custom-select"
+              disabled
+            >
               <option disabled value="0">
                 Custom Selection
               </option>
               <option value="1">One</option>
               <option value="2">Two</option>
               <option value="3">Three</option>
-            </select>
+            </Select>
           </div>
 
           <div className="form-group">
@@ -308,7 +321,9 @@ function Inputs(): React.ReactElement {
               labelText="Dropdown"
             >
               <Select
-                onChange={newValue => setValidateOption(newValue)}
+                onChange={eventTargetValue =>
+                  setValidateOption(eventTargetValue)
+                }
                 value={validateOption}
               >
                 {VALIDATE_OPTIONS.map(option => (

--- a/packages/components/src/Select.tsx
+++ b/packages/components/src/Select.tsx
@@ -9,6 +9,12 @@ export type SelectProps = baseSelectProps & {
   'data-testid'?: string;
 };
 
+/**
+ * A custom select component with styling, which is a wrapper around the
+ * native select element.
+ * @param props.onChange returns a string value and not the event
+ */
+
 const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
   (props, forwardedRef) => {
     const {

--- a/packages/components/src/Select.tsx
+++ b/packages/components/src/Select.tsx
@@ -2,38 +2,20 @@ import React, { useCallback } from 'react';
 import classNames from 'classnames';
 import { useForwardedRef } from '@deephaven/react-hooks';
 
-export type SelectProps = {
-  children: React.ReactNode;
-  onBlur?: React.FocusEventHandler<HTMLSelectElement>;
+type baseSelectProps = Omit<React.HTMLProps<HTMLSelectElement>, 'onChange'>;
+
+export type SelectProps = baseSelectProps & {
   onChange: (value: string) => void;
-  onKeyDown?: React.KeyboardEventHandler<HTMLSelectElement>;
-  id?: string;
-  className?: string;
-  defaultValue?: string;
-  name?: string;
-  title?: string;
-  value?: string;
-  disabled?: boolean;
   'data-testid'?: string;
-  'aria-label'?: string;
 };
 
 const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
   (props, forwardedRef) => {
     const {
       children,
-      onBlur,
-      onChange,
-      onKeyDown,
-      id,
       className,
-      defaultValue,
-      name,
-      title,
-      value,
-      disabled,
+      onChange,
       'data-testid': dataTestId,
-      'aria-label': ariaLabel,
       ...rest
     } = props;
 
@@ -48,19 +30,10 @@ const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
 
     return (
       <select
-        id={id}
         ref={ref}
         className={classNames('custom-select', className)}
-        onBlur={onBlur}
         onChange={handleChange}
-        onKeyDown={onKeyDown}
-        defaultValue={defaultValue}
-        value={value}
-        name={name}
-        title={title}
-        disabled={disabled}
         data-testid={dataTestId}
-        aria-label={ariaLabel}
         // eslint-disable-next-line react/jsx-props-no-spreading
         {...rest}
       >

--- a/packages/components/src/Select.tsx
+++ b/packages/components/src/Select.tsx
@@ -1,50 +1,75 @@
 import React, { useCallback } from 'react';
 import classNames from 'classnames';
+import { useForwardedRef } from '@deephaven/react-hooks';
 
 export type SelectProps = {
   children: React.ReactNode;
   onBlur?: React.FocusEventHandler<HTMLSelectElement>;
   onChange: (value: string) => void;
+  onKeyDown?: React.KeyboardEventHandler<HTMLSelectElement>;
+  id?: string;
   className?: string;
   defaultValue?: string;
   name?: string;
+  title?: string;
   value?: string;
   disabled?: boolean;
   'data-testid'?: string;
+  'aria-label'?: string;
 };
 
-function Select({
-  children,
-  onBlur,
-  onChange,
-  className,
-  defaultValue,
-  name,
-  value,
-  disabled,
-  'data-testid': dataTestId,
-}: SelectProps): JSX.Element {
-  const handleChange = useCallback(
-    event => {
-      onChange(event.target.value);
-    },
-    [onChange]
-  );
+const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
+  (props, forwardedRef) => {
+    const {
+      children,
+      onBlur,
+      onChange,
+      onKeyDown,
+      id,
+      className,
+      defaultValue,
+      name,
+      title,
+      value,
+      disabled,
+      'data-testid': dataTestId,
+      'aria-label': ariaLabel,
+      ...rest
+    } = props;
 
-  return (
-    <select
-      className={classNames('custom-select', className)}
-      onBlur={onBlur}
-      onChange={handleChange}
-      defaultValue={defaultValue}
-      value={value}
-      name={name}
-      disabled={disabled}
-      data-testid={dataTestId}
-    >
-      {children}
-    </select>
-  );
-}
+    const ref = useForwardedRef<HTMLSelectElement>(forwardedRef);
+
+    const handleChange = useCallback(
+      (event: React.ChangeEvent<HTMLSelectElement>): void => {
+        onChange(event.target.value);
+      },
+      [onChange]
+    );
+
+    return (
+      <select
+        id={id}
+        ref={ref}
+        className={classNames('custom-select', className)}
+        onBlur={onBlur}
+        onChange={handleChange}
+        onKeyDown={onKeyDown}
+        defaultValue={defaultValue}
+        value={value}
+        name={name}
+        title={title}
+        disabled={disabled}
+        data-testid={dataTestId}
+        aria-label={ariaLabel}
+        // eslint-disable-next-line react/jsx-props-no-spreading
+        {...rest}
+      >
+        {children}
+      </select>
+    );
+  }
+);
+
+Select.displayName = 'Select';
 
 export default Select;

--- a/packages/console/src/csv/CsvInputBar.tsx
+++ b/packages/console/src/csv/CsvInputBar.tsx
@@ -7,7 +7,7 @@ import React, {
 } from 'react';
 import classNames from 'classnames';
 import type { JSZipObject } from 'jszip';
-import { Button, Checkbox } from '@deephaven/components';
+import { Button, Checkbox, Select } from '@deephaven/components';
 import type { IdeSession, Table } from '@deephaven/jsapi-types';
 import Log from '@deephaven/log';
 import { DbNameValidator } from '@deephaven/utils';
@@ -285,9 +285,9 @@ class CsvInputBar extends Component<CsvInputBarProps, CsvInputBarState> {
     onClose();
   }
 
-  handleQueryTypeChange(event: ChangeEvent<HTMLSelectElement>): void {
+  handleQueryTypeChange(eventTargetValue: string): void {
     this.setState({
-      type: event.target.value as keyof typeof CsvFormats.TYPES,
+      type: eventTargetValue as keyof typeof CsvFormats.TYPES,
     });
   }
 
@@ -319,14 +319,14 @@ class CsvInputBar extends Component<CsvInputBarProps, CsvInputBarState> {
             </div>
             <div className="form-group">
               <label htmlFor="formatSelect">File format</label>
-              <select
+              <Select
                 id="formatSelect"
                 className="custom-select"
                 value={type}
                 onChange={this.handleQueryTypeChange}
               >
                 {TYPE_OPTIONS}
-              </select>
+              </Select>
             </div>
             <Checkbox
               className="firstRowHeaders"

--- a/packages/dashboard-core-plugins/src/controls/dropdown-filter/DropdownFilter.test.tsx
+++ b/packages/dashboard-core-plugins/src/controls/dropdown-filter/DropdownFilter.test.tsx
@@ -331,7 +331,7 @@ describe('options when source is selected', () => {
       onChange.mockClear();
 
       // Enter key should send event immediately
-      fireEvent.keyPress(getValueSelect(), {
+      fireEvent.keyDown(getValueSelect(), {
         key: 'Enter',
         code: 'Enter',
         charCode: 13,
@@ -356,7 +356,7 @@ describe('options when source is selected', () => {
     });
 
     it('doesnt fire an event when a key other than `Enter` is pressed', () => {
-      fireEvent.keyPress(getValueSelect(), {
+      fireEvent.keyDown(getValueSelect(), {
         key: 'a',
         code: 'KeyA',
         charCode: 97,

--- a/packages/dashboard-core-plugins/src/controls/dropdown-filter/DropdownFilter.tsx
+++ b/packages/dashboard-core-plugins/src/controls/dropdown-filter/DropdownFilter.tsx
@@ -3,7 +3,6 @@
 // background click is just a convenience method, not an actual a11y issue
 
 import React, {
-  ChangeEvent,
   Component,
   KeyboardEvent,
   MouseEvent,
@@ -11,7 +10,12 @@ import React, {
   RefObject,
 } from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { Button, CardFlip, SocketedButton } from '@deephaven/components';
+import {
+  Button,
+  CardFlip,
+  Select,
+  SocketedButton,
+} from '@deephaven/components';
 import { vsGear } from '@deephaven/icons';
 import type { Column } from '@deephaven/jsapi-types';
 import { TableUtils } from '@deephaven/jsapi-utils';
@@ -228,8 +232,8 @@ export class DropdownFilter extends Component<
     return name;
   });
 
-  handleColumnChange(event: ChangeEvent<HTMLSelectElement>): void {
-    const { value } = event.target;
+  handleColumnChange(eventTargetValue: string): void {
+    const value = eventTargetValue;
     log.debug2('handleColumnChange', value);
     if (value != null && parseInt(value, 10) < 0) {
       this.setState({
@@ -256,8 +260,8 @@ export class DropdownFilter extends Component<
     }
   }
 
-  handleValueChange(event: ChangeEvent<HTMLSelectElement>): void {
-    const { value: valueIndex } = event.target;
+  handleValueChange(eventTargetValue: string): void {
+    const valueIndex = eventTargetValue;
     const index = parseInt(valueIndex, 10);
     // Default empty string value for 'clear filter'
     let value: string | null = '';
@@ -416,15 +420,15 @@ export class DropdownFilter extends Component<
               </div>
 
               <label htmlFor={filterColumnId}>Filter Column</label>
-              <select
+              <Select
                 id={filterColumnId}
-                value={selectedIndex}
+                value={String(selectedIndex)}
                 className="custom-select"
                 onChange={this.handleColumnChange}
                 disabled={columnSelectionDisabled}
               >
                 {columnOptions}
-              </select>
+              </Select>
               <div className="text-muted small">
                 Dropdown filter control will apply its filter to all columns
                 matching this name in this dashboard.
@@ -481,16 +485,16 @@ export class DropdownFilter extends Component<
               </div>
               <div className="dropdown-filter-card-content">
                 <div className="dropdown-filter-value-input d-flex flex-column justify-content-center">
-                  <select
+                  <Select
                     className="custom-select"
-                    value={selectedOption}
+                    value={String(selectedOption)}
                     ref={this.dropdownRef}
                     onChange={this.handleValueChange}
-                    onKeyPress={this.handleDropdownKeyPress}
+                    onKeyDown={this.handleDropdownKeyPress}
                     title="Select Value"
                   >
                     {valueOptions}
-                  </select>
+                  </Select>
                 </div>
                 {settingsError && (
                   <div className="error-message mt-3 text-center">

--- a/packages/dashboard-core-plugins/src/controls/input-filter/InputFilter.tsx
+++ b/packages/dashboard-core-plugins/src/controls/input-filter/InputFilter.tsx
@@ -10,7 +10,7 @@ import React, {
   KeyboardEvent,
   ReactElement,
 } from 'react';
-import { Button, CardFlip } from '@deephaven/components';
+import { Button, CardFlip, Select } from '@deephaven/components';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { vsGear } from '@deephaven/icons';
 import type { Column } from '@deephaven/jsapi-types';
@@ -123,10 +123,9 @@ class InputFilter extends Component<InputFilterProps, InputFilterState> {
     return name;
   });
 
-  handleColumnChange(event: ChangeEvent<HTMLSelectElement>): void {
+  handleColumnChange(eventTargetValue: string): void {
     const { columns } = this.props;
-    const { value } = event.target;
-    const selectedColumn = columns[parseInt(value, 10)];
+    const selectedColumn = columns[parseInt(eventTargetValue, 10)];
 
     log.debug2('handleColumnChange', selectedColumn);
 
@@ -241,11 +240,13 @@ class InputFilter extends Component<InputFilterProps, InputFilterState> {
           <div className="input-filter-settings-content">
             <div className="input-filter-settings-grid">
               <label>Filter Column</label>
-              <select
-                value={columns.findIndex(
-                  item =>
-                    item.name === selectedColumn?.name &&
-                    item.type === selectedColumn?.type
+              <Select
+                value={String(
+                  columns.findIndex(
+                    item =>
+                      item.name === selectedColumn?.name &&
+                      item.type === selectedColumn?.type
+                  )
                 )}
                 className="custom-select"
                 onChange={this.handleColumnChange}
@@ -263,7 +264,7 @@ class InputFilter extends Component<InputFilterProps, InputFilterState> {
                     No Available Columns
                   </option>
                 )}
-              </select>
+              </Select>
               <div className="text-muted small">
                 Input filter control will apply its filter to all columns
                 matching this name in this dashboard.

--- a/packages/dashboard-core-plugins/src/panels/FilterSetManager.tsx
+++ b/packages/dashboard-core-plugins/src/panels/FilterSetManager.tsx
@@ -25,7 +25,13 @@ import {
   vsArrowSmallUp,
 } from '@deephaven/icons';
 import Log from '@deephaven/log';
-import { Button, CardFlip, RadioGroup, RadioItem } from '@deephaven/components';
+import {
+  Button,
+  CardFlip,
+  RadioGroup,
+  RadioItem,
+  Select,
+} from '@deephaven/components';
 
 import './FilterSetManager.scss';
 
@@ -193,13 +199,12 @@ class FilterSetManager extends Component<
     }
   }
 
-  handleEditDropdownChange(event: ChangeEvent<HTMLSelectElement>): void {
-    const { value: editId } = event.target;
-    this.setState({ editId });
+  handleEditDropdownChange(eventTargetValue: string): void {
+    this.setState({ editId: eventTargetValue });
   }
 
-  handleFilterChange(event: ChangeEvent<HTMLSelectElement>): void {
-    const { value: selectedId } = event.target;
+  handleFilterChange(eventTargetValue: string): void {
+    const selectedId = eventTargetValue;
     const { isValueShown, onChange } = this.props;
     this.applyFilterSet(selectedId);
     onChange({ isValueShown, selectedId });
@@ -595,7 +600,7 @@ class FilterSetManager extends Component<
                   <div className="form-group">
                     <label>Edit filter sets</label>
                     <div className="filter-select-container">
-                      <select
+                      <Select
                         data-testid="settings-card-filter-select"
                         ref={this.editDropdownRef}
                         value={editId ?? '-1'}
@@ -613,7 +618,7 @@ class FilterSetManager extends Component<
                             {title}
                           </option>
                         ))}
-                      </select>
+                      </Select>
 
                       <Button
                         kind="ghost"
@@ -679,10 +684,10 @@ class FilterSetManager extends Component<
             <div className="filter-set-manager-card-content">
               <div className="filter-set-manager-value-input">
                 <div className="filter-select-container">
-                  <select
+                  <Select
                     data-testid="value-card-filter-select"
                     ref={this.dropdownRef}
-                    value={selectedId}
+                    value={selectedId ?? '-1'}
                     className="custom-select filter-value-select"
                     onChange={this.handleFilterChange}
                   >
@@ -696,7 +701,7 @@ class FilterSetManager extends Component<
                         {title}
                       </option>
                     ))}
-                  </select>
+                  </Select>
                   <Button
                     data-testid="filter-apply-button"
                     kind="ghost"

--- a/packages/iris-grid/src/AdvancedFilterCreatorFilterItem.tsx
+++ b/packages/iris-grid/src/AdvancedFilterCreatorFilterItem.tsx
@@ -1,6 +1,6 @@
 /* eslint react/no-did-update-set-state: "off" */
 import React, { PureComponent } from 'react';
-import { Button } from '@deephaven/components';
+import { Button, Select } from '@deephaven/components';
 import {
   getLabelForBooleanFilter,
   getLabelForDateFilter,
@@ -98,8 +98,8 @@ export class AdvancedFilterCreatorFilterItem extends PureComponent<
 
   typeDropdown: HTMLSelectElement | null;
 
-  handleTypeChange(event: React.ChangeEvent<HTMLSelectElement>): void {
-    const selectedType = event.target.value as FilterTypeValue;
+  handleTypeChange(eventTargetValue: string): void {
+    const selectedType = eventTargetValue as FilterTypeValue;
     log.debug2('typeChange', selectedType);
     this.setState({ selectedType });
 
@@ -186,8 +186,8 @@ export class AdvancedFilterCreatorFilterItem extends PureComponent<
       <div className="advanced-filter-creator-filter-item">
         <div className="form-row">
           <div className="form-group col">
-            <select
-              className="form-control custom-select"
+            <Select
+              className="form-control"
               value={selectedType}
               onChange={this.handleTypeChange}
               ref={typeDropdown => {
@@ -195,7 +195,7 @@ export class AdvancedFilterCreatorFilterItem extends PureComponent<
               }}
             >
               {typeOptionElements}
-            </select>
+            </Select>
           </div>
           {showValueInput && (
             <div className="form-group col">

--- a/packages/iris-grid/src/GotoRow.tsx
+++ b/packages/iris-grid/src/GotoRow.tsx
@@ -16,7 +16,7 @@ import {
   Type as FilterType,
   TypeValue as FilterTypeValue,
 } from '@deephaven/filters';
-import { Button, DateTimeInput } from '@deephaven/components';
+import { Button, DateTimeInput, Select } from '@deephaven/components';
 import { TableUtils } from '@deephaven/jsapi-utils';
 import classNames from 'classnames';
 import './GotoRow.scss';
@@ -208,11 +208,11 @@ const GotoRow = forwardRef<GotoRowElement, GotoRowProps>(
           return (
             <>
               <div className="goto-row-input">
-                <select
+                <Select
                   className="custom-select"
-                  onChange={event => {
+                  onChange={eventTargetValue => {
                     onGotoValueSelectedFilterChanged(
-                      event.target.value as FilterTypeValue
+                      eventTargetValue as FilterTypeValue
                     );
                   }}
                   value={gotoValueFilter}
@@ -236,7 +236,7 @@ const GotoRow = forwardRef<GotoRowElement, GotoRowProps>(
                   <option key={FilterType.contains} value={FilterType.contains}>
                     Contains
                   </option>
-                </select>
+                </Select>
               </div>
               <div className="goto-row-input">
                 <input
@@ -256,10 +256,10 @@ const GotoRow = forwardRef<GotoRowElement, GotoRowProps>(
         case TableUtils.dataType.BOOLEAN:
           return (
             <div className="goto-row-input">
-              <select
+              <Select
                 className="custom-select"
-                onChange={event => {
-                  onGotoValueInputChanged(event.target.value);
+                onChange={eventTargetValue => {
+                  onGotoValueInputChanged(eventTargetValue);
                 }}
                 value={gotoValue}
                 aria-label="Value Input"
@@ -271,7 +271,7 @@ const GotoRow = forwardRef<GotoRowElement, GotoRowProps>(
                 <option key="false" value="false">
                   false
                 </option>
-              </select>
+              </Select>
             </div>
           );
         default:
@@ -364,10 +364,10 @@ const GotoRow = forwardRef<GotoRowElement, GotoRowProps>(
               >
                 <div className="goto-row-text">Go to value</div>
                 <div className="goto-row-input">
-                  <select
+                  <Select
                     className="custom-select"
-                    onChange={event => {
-                      const columnName = event.target.value;
+                    onChange={eventTargetValue => {
+                      const columnName = eventTargetValue;
                       onGotoValueSelectedColumnNameChanged(columnName);
                     }}
                     value={gotoValueSelectedColumnName}
@@ -378,7 +378,7 @@ const GotoRow = forwardRef<GotoRowElement, GotoRowProps>(
                         {column.name}
                       </option>
                     ))}
-                  </select>
+                  </Select>
                 </div>
 
                 {renderValueInput()}

--- a/packages/iris-grid/src/sidebar/ChartBuilder.tsx
+++ b/packages/iris-grid/src/sidebar/ChartBuilder.tsx
@@ -1,7 +1,7 @@
 import React, { PureComponent } from 'react';
 import classNames from 'classnames';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { Button, RadioGroup, RadioItem } from '@deephaven/components';
+import { Button, RadioGroup, RadioItem, Select } from '@deephaven/components';
 import {
   vsLink,
   dhUnlink,
@@ -248,32 +248,24 @@ class ChartBuilder extends PureComponent<ChartBuilderProps, ChartBuilderState> {
     this.setState({ type, seriesItems, xAxis, isLinked }, this.sendChange);
   }
 
-  handleSeriesChange(event: React.ChangeEvent<HTMLSelectElement>): void {
-    const { value } = event.target;
-    const index = event.target.getAttribute('data-index') as string;
-    const intIndex = parseInt(index, 10);
+  handleSeriesChange(eventTargetValue: string, index: number): void {
+    const value = eventTargetValue;
 
     this.setState(state => {
       let { seriesItems } = state;
-
       seriesItems = [...seriesItems];
-      seriesItems[intIndex].value = value;
+      seriesItems[index].value = value;
 
       return { seriesItems };
     }, this.sendChange);
   }
 
-  handleSeriesDeleteClick(event: React.MouseEvent<HTMLButtonElement>): void {
-    const changeEvent =
-      event as unknown as React.ChangeEvent<HTMLButtonElement>;
-    const index = changeEvent.target.getAttribute('data-index') as string;
-    const intIndex = parseInt(index, 10);
-
+  handleSeriesDeleteClick(index: number): void {
     this.setState(state => {
       const { seriesItems } = state;
       const newSeriesItems = [...seriesItems];
 
-      newSeriesItems.splice(intIndex, 1);
+      newSeriesItems.splice(index, 1);
 
       return { seriesItems: newSeriesItems };
     }, this.sendChange);
@@ -293,13 +285,8 @@ class ChartBuilder extends PureComponent<ChartBuilderProps, ChartBuilderState> {
     });
   }
 
-  handleTypeClick(event: React.MouseEvent<HTMLButtonElement>): void {
-    const changeEvent =
-      event as unknown as React.ChangeEvent<HTMLButtonElement>;
-    const index = changeEvent.target.getAttribute('data-index') as string;
-    const intIndex = parseInt(index, 10);
-
-    const type = this.getTypes()[intIndex];
+  handleTypeClick(index: number): void {
+    const type = this.getTypes()[index];
 
     log.debug2('handleTypeSelect', type);
 
@@ -318,8 +305,8 @@ class ChartBuilder extends PureComponent<ChartBuilderProps, ChartBuilderState> {
     }, this.sendChange);
   }
 
-  handleXAxisChange(event: React.ChangeEvent<HTMLSelectElement>): void {
-    const xAxis = event.target.value;
+  handleXAxisChange(eventTargetValue: string): void {
+    const xAxis = eventTargetValue;
     log.debug2('x-axis change', xAxis);
 
     this.setState({ xAxis }, this.sendChange);
@@ -363,8 +350,7 @@ class ChartBuilder extends PureComponent<ChartBuilderProps, ChartBuilderState> {
                           active: chartType === type,
                         }
                       )}
-                      data-index={index}
-                      onClick={this.handleTypeClick}
+                      onClick={() => this.handleTypeClick(index)}
                     >
                       {this.getTypeIcon(chartType)}
                       {this.getTypeName(chartType)}
@@ -377,8 +363,8 @@ class ChartBuilder extends PureComponent<ChartBuilderProps, ChartBuilderState> {
           <hr />
           <div className="form-row form-inline">
             <label className="col-2 label-left">{xAxisLabel}</label>
-            <select
-              className="form-control custom-select select-x-axis col"
+            <Select
+              className="form-control select-x-axis col"
               value={xAxis}
               onChange={this.handleXAxisChange}
             >
@@ -387,7 +373,7 @@ class ChartBuilder extends PureComponent<ChartBuilderProps, ChartBuilderState> {
                   {column.name}
                 </option>
               ))}
-            </select>
+            </Select>
           </div>
           {isSeriesVisible && <hr />}
           {seriesItems.map((seriesItem, i) => (
@@ -399,26 +385,26 @@ class ChartBuilder extends PureComponent<ChartBuilderProps, ChartBuilderState> {
               <label className="col-2 label-left">
                 {i === 0 ? seriesLabel : ''}
               </label>
-              <select
-                className="form-control custom-select select-series col"
+              <Select
+                className="form-control select-series col"
                 value={seriesItem.value}
-                onChange={this.handleSeriesChange}
+                onChange={v => this.handleSeriesChange(v, i)}
                 data-testid={`select-series-item-${i}`}
-                data-index={i}
               >
                 {columns.map(column => (
-                  <option key={column.name} value={column.name} data-index={i}>
+                  <option key={column.name} value={column.name}>
                     {column.name}
                   </option>
                 ))}
-              </select>
+              </Select>
               {seriesItems.length > 1 && (
                 <Button
                   kind="ghost"
                   className="btn-delete-series ml-2 px-2"
-                  data-index={i}
                   data-testid={`delete-series-${i}`}
-                  onClick={this.handleSeriesDeleteClick}
+                  onClick={() => {
+                    this.handleSeriesDeleteClick(i);
+                  }}
                   icon={vsTrash}
                   tooltip="Delete"
                 />

--- a/packages/iris-grid/src/sidebar/SelectDistinctBuilder.tsx
+++ b/packages/iris-grid/src/sidebar/SelectDistinctBuilder.tsx
@@ -2,7 +2,7 @@ import React, { Component, ReactElement } from 'react';
 import deepEqual from 'deep-equal';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { dhNewCircleLargeFilled, vsTrash } from '@deephaven/icons';
-import { Button } from '@deephaven/components';
+import { Button, Select } from '@deephaven/components';
 import Log from '@deephaven/log';
 import type { Column } from '@deephaven/jsapi-types';
 import { ModelIndex } from '@deephaven/grid';
@@ -81,12 +81,8 @@ class SelectDistinctBuilder extends Component<
     }));
   }
 
-  handleDropdownChanged(
-    index: number,
-    event: React.ChangeEvent<HTMLSelectElement>
-  ): void {
-    log.debug('handleDropdownChanged', index, event);
-    const { value } = event.target;
+  handleDropdownChanged(index: number, value: string): void {
+    log.debug('handleDropdownChanged', index, value);
     this.setState(({ inputs: prevInputs }) => {
       const inputs = [...prevInputs];
       inputs[index] = value;
@@ -108,14 +104,16 @@ class SelectDistinctBuilder extends Component<
       return (
         // eslint-disable-next-line react/no-array-index-key
         <div className="form-inline px-3 pb-3" key={index}>
-          <select
+          <Select
             className="form-control custom-select col"
             value={value}
-            onChange={event => this.handleDropdownChanged(index, event)}
+            onChange={(eventTargetValue: string) =>
+              this.handleDropdownChanged(index, eventTargetValue)
+            }
           >
             <option value="">Select a column</option>
             {options}
-          </select>
+          </Select>
 
           {(inputs.length > 1 || value !== '') && (
             <Button

--- a/packages/iris-grid/src/sidebar/TableCsvExporter.tsx
+++ b/packages/iris-grid/src/sidebar/TableCsvExporter.tsx
@@ -7,6 +7,7 @@ import {
   LoadingSpinner,
   RadioGroup,
   RadioItem,
+  Select,
 } from '@deephaven/components';
 import {
   GridRange,
@@ -270,10 +271,8 @@ class TableCsvExporter extends Component<
     this.setState({ downloadRowOption: event.target.value });
   }
 
-  handleCustomizedDownloadRowOptionChanged(
-    event: React.ChangeEvent<HTMLSelectElement>
-  ): void {
-    this.setState({ customizedDownloadRowOption: event.target.value });
+  handleCustomizedDownloadRowOptionChanged(eventTargetValue: string): void {
+    this.setState({ customizedDownloadRowOption: eventTargetValue });
   }
 
   handleCustomizedDownloadRowsChanged(
@@ -406,7 +405,7 @@ class TableCsvExporter extends Component<
                   });
                 }}
               >
-                <select
+                <Select
                   value={customizedDownloadRowOption}
                   data-testid="select-csv-exporter-customized-rows"
                   className="custom-select"
@@ -415,7 +414,7 @@ class TableCsvExporter extends Component<
                 >
                   <option value="FIRST">First</option>
                   <option value="LAST">Last</option>
-                </select>
+                </Select>
                 <input
                   type="number"
                   className="form-control"

--- a/packages/iris-grid/src/sidebar/conditional-formatting/ConditionEditor.tsx
+++ b/packages/iris-grid/src/sidebar/conditional-formatting/ConditionEditor.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { TableUtils } from '@deephaven/jsapi-utils';
 import type { dh as DhType } from '@deephaven/jsapi-types';
 import Log from '@deephaven/log';
+import { Select } from '@deephaven/components';
 import {
   StringCondition,
   DateCondition,
@@ -15,6 +16,7 @@ import {
   getLabelForBooleanCondition,
   BooleanCondition,
   CharCondition,
+  Condition,
   getLabelForCharCondition,
   isDateConditionValid,
   getDefaultValueForType,
@@ -293,10 +295,9 @@ function ConditionEditor(props: ConditionEditorProps): JSX.Element {
     }
   }, [selectedColumnType]);
 
-  const handleConditionChange = useCallback(e => {
-    const { value } = e.target;
+  const handleConditionChange = useCallback((value: string) => {
     log.debug('handleConditionChange', value);
-    setCondition(value);
+    setCondition(value as Condition);
   }, []);
 
   const handleValueChange = useCallback(e => {
@@ -429,14 +430,14 @@ function ConditionEditor(props: ConditionEditorProps): JSX.Element {
 
   return (
     <div className="condition-editor mb-2">
-      <select
+      <Select
         value={selectedCondition}
         data-testid="condition-select"
         className="custom-select mb-2"
         onChange={handleConditionChange}
       >
         {conditions}
-      </select>
+      </Select>
       {conditionInputs}
     </div>
   );


### PR DESCRIPTION
Replaces all the places we used raw html select components with the Select component.

This was orignally needed for themeing so we could re-style the Select component, but we came up with an alternate solution.