### PR TITLE
fix: Default to `Skip` operation instead of `Sum` operation

### DIFF
--- a/packages/iris-grid/src/IrisGrid.tsx
+++ b/packages/iris-grid/src/IrisGrid.tsx
@@ -1287,7 +1287,12 @@ export class IrisGrid extends Component<IrisGridProps, IrisGridState> {
       const operationMap = this.getOperationMap(columns, aggregations);
       const operationOrder = this.getOperationOrder(aggregations);
 
-      return { operationMap, operationOrder, showOnTop };
+      return {
+        operationMap,
+        operationOrder,
+        showOnTop,
+        defaultOperation: AggregationOperation.SKIP,
+      };
     }
   );
 

--- a/packages/iris-grid/src/IrisGridTableModel.ts
+++ b/packages/iris-grid/src/IrisGridTableModel.ts
@@ -185,53 +185,6 @@ class IrisGridTableModel extends IrisGridTableModelTemplate<Table, UIRow> {
     );
   }
 
-  set totalsConfig(totalsConfig: UITotalsTableConfig | null) {
-    log.debug('set totalsConfig', totalsConfig);
-
-    if (totalsConfig === this.totals) {
-      // Totals already set, or it will be set when the next model actually gets set
-      return;
-    }
-
-    this.totals = totalsConfig;
-    this.formattedStringData = [];
-
-    if (this.totalsTablePromise != null) {
-      this.totalsTablePromise.cancel();
-    }
-
-    this.setTotalsTable(null);
-
-    if (totalsConfig == null) {
-      this.dispatchEvent(new EventShimCustomEvent(IrisGridModel.EVENT.UPDATED));
-      return;
-    }
-
-    this.totalsTablePromise = PromiseUtils.makeCancelable(
-      this.table.getTotalsTable(totalsConfig),
-      table => table.close()
-    );
-    this.totalsTablePromise
-      .then(totalsTable => {
-        this.totalsTablePromise = null;
-        this.setTotalsTable(totalsTable);
-      })
-      .catch(err => {
-        if (PromiseUtils.isCanceled(err)) {
-          return;
-        }
-
-        log.error('Unable to set next totalsTable', err);
-        this.totalsTablePromise = null;
-
-        this.dispatchEvent(
-          new EventShimCustomEvent(IrisGridModel.EVENT.REQUEST_FAILED, {
-            detail: err,
-          })
-        );
-      });
-  }
-
   get isFilterRequired(): boolean {
     return this.table.isUncoalesced;
   }

--- a/packages/iris-grid/src/IrisGridTableModel.ts
+++ b/packages/iris-grid/src/IrisGridTableModel.ts
@@ -13,13 +13,9 @@ import type {
 } from '@deephaven/jsapi-types';
 import Log from '@deephaven/log';
 import { Formatter } from '@deephaven/jsapi-utils';
-import {
-  EventShimCustomEvent,
-  PromiseUtils,
-  assertNotNull,
-} from '@deephaven/utils';
+import { EventShimCustomEvent, assertNotNull } from '@deephaven/utils';
 import IrisGridModel from './IrisGridModel';
-import { ColumnName, UITotalsTableConfig, UIRow } from './CommonTypes';
+import { ColumnName, UIRow } from './CommonTypes';
 import IrisGridTableModelTemplate from './IrisGridTableModelTemplate';
 
 const log = Log.module('IrisGridTableModel');


### PR DESCRIPTION
- Previously we were unable to remove columns from an aggregate selection
- Default to `Skip` operation unless the user has actually applied one or more operations for a column
- Requires https://github.com/deephaven/deephaven-core/pull/4780
- Tested using the steps in the description of #1355
- Fixes #1355