### PR TITLE
fix: convert organize columns component to purecomponent

### DIFF
--- a/packages/iris-grid/src/sidebar/visibility-ordering-builder/VisibilityOrderingBuilder.tsx
+++ b/packages/iris-grid/src/sidebar/visibility-ordering-builder/VisibilityOrderingBuilder.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent, Component, ReactElement } from 'react';
+import React, { ChangeEvent, PureComponent, ReactElement } from 'react';
 import classNames from 'classnames';
 import {
   GridUtils,
@@ -71,7 +71,7 @@ interface VisibilityOrderingBuilderState {
   searchFilter: string;
 }
 
-class VisibilityOrderingBuilder extends Component<
+class VisibilityOrderingBuilder extends PureComponent<
   VisibilityOrderingBuilderProps,
   VisibilityOrderingBuilderState
 > {


### PR DESCRIPTION
Minor drop in the bucket against #1650, reduces at least some of the re-rendering.