### PR TITLE
feat: Tables that have names starting with underscore do not auto-launch from console

### DIFF
--- a/packages/console/src/Console.tsx
+++ b/packages/console/src/Console.tsx
@@ -60,7 +60,14 @@ interface ConsoleProps {
   statusBarChildren: ReactNode;
   settings: Partial<Settings>;
   focusCommandHistory: () => void;
-  openObject: (object: VariableDefinition, autoLaunch?: boolean) => void;
+
+  /**
+   * @param object The object to open
+   * @param forceOpen If true, always open the object. If false, only update existing panels
+   */
+  openObject: (object: VariableDefinition, forceOpen?: boolean) => void;
+
+  /** Closes all panels containing the object */
   closeObject: (object: VariableDefinition) => void;
   session: IdeSession;
   language: string;
@@ -471,7 +478,7 @@ export class Console extends PureComponent<ConsoleProps, ConsoleState> {
   }, Console.LOG_THROTTLE);
 
   openUpdatedItems(changes: VariableChanges): void {
-    log.log('openUpdatedItems', changes);
+    log.debug('openUpdatedItems', changes);
     const { isAutoLaunchPanelsEnabled } = this.state;
     if (changes == null) {
       return;

--- a/packages/console/src/Console.tsx
+++ b/packages/console/src/Console.tsx
@@ -60,7 +60,7 @@ interface ConsoleProps {
   statusBarChildren: ReactNode;
   settings: Partial<Settings>;
   focusCommandHistory: () => void;
-  openObject: (object: VariableDefinition) => void;
+  openObject: (object: VariableDefinition, autoLaunch?: boolean) => void;
   closeObject: (object: VariableDefinition) => void;
   session: IdeSession;
   language: string;
@@ -471,14 +471,19 @@ export class Console extends PureComponent<ConsoleProps, ConsoleState> {
   }, Console.LOG_THROTTLE);
 
   openUpdatedItems(changes: VariableChanges): void {
+    log.log('openUpdatedItems', changes);
     const { isAutoLaunchPanelsEnabled } = this.state;
-    if (changes == null || !isAutoLaunchPanelsEnabled) {
+    if (changes == null) {
       return;
     }
 
     const { openObject } = this.props;
     [...changes.created, ...changes.updated].forEach(object =>
-      openObject(object)
+      openObject(
+        object,
+        isAutoLaunchPanelsEnabled &&
+          (object.title === undefined || !object.title.startsWith('_'))
+      )
     );
   }
 

--- a/packages/dashboard-core-plugins/src/panels/ConsolePanel.tsx
+++ b/packages/dashboard-core-plugins/src/panels/ConsolePanel.tsx
@@ -242,15 +242,14 @@ export class ConsolePanel extends PureComponent<
     this.updateDimensions();
   }
 
-  handleOpenObject(object: VariableDefinition, autoLaunch = true): void {
+  handleOpenObject(object: VariableDefinition, forceOpen = true): void {
     const { sessionWrapper } = this.props;
-    const { itemIds } = this.state;
     const { session } = sessionWrapper;
     const { root } = this.context;
     const oldPanelId =
       object.title != null ? this.getItemId(object.title, false) : null;
     if (
-      autoLaunch ||
+      forceOpen ||
       (oldPanelId != null &&
         LayoutUtils.getStackForRoot(
           root,
@@ -260,7 +259,6 @@ export class ConsolePanel extends PureComponent<
           false
         ) != null)
     ) {
-      log.log('handleOpenObject', autoLaunch, object, itemIds);
       this.openWidget(object, session);
     }
   }


### PR DESCRIPTION
- Creating a table with a name that begins with an underscore will not open it regardless of whether "Auto Launch Panels" is checked
  - Closes #1549
- Fixes a bug where tables will not update if its variable is reassigned while "Auto Launch Panels" is unchecked
  - Closes #1410

### Testing Instructions:

1. Run the following code with the "Auto Launch Panels" option checked:
   ```py
   from deephaven import empty_table
 
   t = empty_table(10).update("x=i")
   _t = empty_table(10).update("x=i")
   ```
2. Table `t` should open automatically but table `_t` should remain closed
3. Clicking on the button for `_t` should open it normally
4. Run `_t = empty_table(10).update("x=i+10")`. This should update the values in `_t` if it is open
   - Nothing should happen if `_t` is closed.

BREAKING CHANGE: Tables assigned to variable beginning with "_" will not open automatically even if "Auto Launch Panels" is checked.