### PR TITLE
test: set pull_policy to always for e2e:docker tests

### DIFF
--- a/tests/docker-scripts/docker-compose.yml
+++ b/tests/docker-scripts/docker-compose.yml
@@ -3,6 +3,7 @@ version: '3.8'
 services:
   dhc-server:
     image: ghcr.io/deephaven/server:${DHC_VERSION:-edge}
+    pull_policy: always
     expose:
       - 10000
     environment:


### PR DESCRIPTION
Always pull the latest edge server, as unless you manally pull this regularly your tests can fail.