### PR TITLE
fix: popper blur in styleguide

### DIFF
--- a/packages/code-studio/src/styleguide/StyleGuide.tsx
+++ b/packages/code-studio/src/styleguide/StyleGuide.tsx
@@ -43,74 +43,78 @@ function StyleGuide(): React.ReactElement {
   const isolateSection = window.location.search.includes('isolateSection=true');
 
   return (
-    <div className="container style-guide-container">
-      {/* For e2e tests this allows us to isolate sections for snapshots. This 
+    // Needs a tabindex to capture focus on popper blur
+    // AppMainContainer has a tabindex of -1 in the app itself
+    <div tabIndex={-1} role="main">
+      <div className="container style-guide-container">
+        {/* For e2e tests this allows us to isolate sections for snapshots. This 
       mitigates an issue where a change to a section in the styleguide can cause
       subtle pixel shifts in other sections */}
-      {isolateSection && (
-        <style>
-          {`.${HIDE_FROM_E2E_TESTS_CLASS}, .sample-section:not(${window.location.hash}), :not(.sample-section) > h2 {
+        {isolateSection && (
+          <style>
+            {`.${HIDE_FROM_E2E_TESTS_CLASS}, .sample-section:not(${window.location.hash}), :not(.sample-section) > h2 {
           display: none;
         }`}
-        </style>
-      )}
-      <Flex
-        justifyContent="space-between"
-        alignItems="center"
-        marginTop="2rem"
-        marginBottom="1rem"
-      >
-        <h1 style={{ paddingTop: '2rem' }}>Deephaven UI Components</h1>
-      </Flex>
+          </style>
+        )}
+        <Flex
+          justifyContent="space-between"
+          alignItems="center"
+          marginTop="2rem"
+          marginBottom="1rem"
+        >
+          <h1 style={{ paddingTop: '2rem' }}>Deephaven UI Components</h1>
+        </Flex>
 
-      <Flex
-        {...stickyProps}
-        UNSAFE_className={HIDE_FROM_E2E_TESTS_CLASS}
-        marginTop={-56}
-        top={20}
-      >
-        <SamplesMenu />
-      </Flex>
-      <Flex
-        {...stickyProps}
-        UNSAFE_className={HIDE_FROM_E2E_TESTS_CLASS}
-        top="calc(100vh - 40px)"
-        marginTop={-32}
-      >
-        <GotoTopButton />
-      </Flex>
+        <Flex
+          {...stickyProps}
+          UNSAFE_className={HIDE_FROM_E2E_TESTS_CLASS}
+          marginTop={-56}
+          top={20}
+        >
+          <SamplesMenu />
+        </Flex>
+        <Flex
+          {...stickyProps}
+          UNSAFE_className={HIDE_FROM_E2E_TESTS_CLASS}
+          top="calc(100vh - 40px)"
+          marginTop={-32}
+        >
+          <GotoTopButton />
+        </Flex>
 
-      <Typograpy />
+        <Typograpy />
 
-      <SampleMenuCategory data-menu-category="Colors" />
-      <Colors />
-      <ThemeColors />
+        <SampleMenuCategory data-menu-category="Colors" />
+        <Colors />
+        <ThemeColors />
 
-      <SampleMenuCategory data-menu-category="Layout" />
-      <GoldenLayout />
+        <SampleMenuCategory data-menu-category="Layout" />
+        <GoldenLayout />
 
-      <SampleMenuCategory data-menu-category="Components" />
-      <Buttons />
-      <Progress />
-      <Alerts />
-      <Inputs />
-      <ItemListInputs />
-      <DraggableLists />
-      <TimeSliderInputs />
-      <Dialog />
-      <Modals />
-      <ContextMenus />
-      <DropdownMenus />
-      <Navigations />
-      <Tooltips />
-      <Icons />
-      <Editors />
-      <Grids />
-      <Charts />
-      <ContextMenuRoot />
+        <SampleMenuCategory data-menu-category="Components" />
+        <Buttons />
+        <Progress />
+        <Alerts />
+        <Inputs />
+        <ItemListInputs />
+        <DraggableLists />
+        <TimeSliderInputs />
+        <Dialog />
+        <Modals />
+        <ContextMenus />
+        <DropdownMenus />
+        <Navigations />
+        <Tooltips />
+        <Icons />
+        <Editors />
+        <Grids />
+        <Charts />
+        <ContextMenuRoot />
 
-      <SampleMenuCategory data-menu-category="Spectrum Components" />
-      <SpectrumComponents />
+        <SampleMenuCategory data-menu-category="Spectrum Components" />
+        <SpectrumComponents />
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
Poppers such as menu dropdowns aren't closing in the styleguide on outside clicks, this is because no element has focus on the outside click, as e.relatedTarget was null. The main app doens't have this problem since tabindex=-1 is on the appmaincontainer. Add a wrapper (that includes the side marigins) to have a -1  tabindex.