### PR TITLE
ci: Set gitHub reporter for Playwright tests

### DIFF
--- a/packages/code-studio/src/styleguide/Buttons.tsx
+++ b/packages/code-studio/src/styleguide/Buttons.tsx
@@ -123,7 +123,6 @@ class Buttons extends Component<Record<string, never>, ButtonsState> {
         <Button kind="ghost" icon={dhTruck}>
           Text Button
         </Button>
-        <Button kind="danger">Fail Button</Button>
       </div>
     );
   }


### PR DESCRIPTION
- Add the `github` reporter to add annotations directly in our code when playwright tests fail
- See an example summary report from a previous run: https://github.com/deephaven/web-client-ui/actions/runs/7121141960?pr=1673
- The annotations show up in the Summary, along with the HTML report that you can download:
![image](https://github.com/deephaven/web-client-ui/assets/4505624/02a7df03-11fb-46fe-83fd-2c12e15489e6)
- Annotations also show up in the Files Changed tab, annotating the test case explicitly that failed:
![image](https://github.com/deephaven/web-client-ui/assets/4505624/28c07ea6-b2e3-4118-868d-5a7cc450f2c7)
