### PR TITLE
fix: Interface for IrisGridTableModelTemplate.backgroundColorForCell

### DIFF
--- a/packages/grid/src/index.ts
+++ b/packages/grid/src/index.ts
@@ -11,6 +11,7 @@ export * from './GridRange';
 export * from './GridAxisRange';
 export * from './GridRenderer';
 export { default as GridTestUtils } from './GridTestUtils';
+export * from './GridTheme';
 export { default as GridTheme } from './GridTheme';
 export type { GridTheme as GridThemeType } from './GridTheme';
 export * from './GridUtils';

--- a/packages/iris-grid/src/IrisGrid.tsx
+++ b/packages/iris-grid/src/IrisGrid.tsx
@@ -1363,8 +1363,8 @@ export class IrisGrid extends Component<IrisGridProps, IrisGridState> {
 
   getCachedTheme = memoize(
     (
-      contextTheme: GridThemeType | null,
-      theme: GridThemeType | null,
+      contextTheme: Partial<GridThemeType> | null,
+      theme: Partial<GridThemeType> | null,
       isEditable: boolean,
       floatingRowCount: number
     ): Partial<IrisGridThemeType> => {

--- a/packages/iris-grid/src/IrisGridTableModelTemplate.ts
+++ b/packages/iris-grid/src/IrisGridTableModelTemplate.ts
@@ -625,7 +625,11 @@ class IrisGridTableModelTemplate<
     return theme.textColor;
   }
 
-  backgroundColorForCell(x: ModelIndex, y: ModelIndex): string | null {
+  backgroundColorForCell(
+    x: ModelIndex,
+    y: ModelIndex,
+    theme: IrisGridThemeType
+  ): string | null {
     return this.formatForCell(x, y)?.backgroundColor ?? null;
   }
 


### PR DESCRIPTION
- The implementation for IrisGridTableModelTemplate.backgroundColorForCell did not accept a theme, even though GridModel.backgroundColorForCell does
- This caused issues with classes that extended IrisGridTableModelTemplate or it's subclasses like IrisGridTableModel, as the could not override this method to correctly accept the theme parameter
- Also export all types from GridTheme - there were a few things not being exported (such as `GridColor`)
- Fixes #1697 

BREAKING CHANGE:
- Subclasses of IrisGridTableModelTemplate or it's subclasses that use backgroundColorForCell may need to update their signature to accept the theme if they are calling the superclass