### PR TITLE
fix: TimeInput not triggering onChange on incomplete values

### DIFF
--- a/packages/components/src/TimeInput.test.tsx
+++ b/packages/components/src/TimeInput.test.tsx
@@ -114,7 +114,7 @@ describe('selection', () => {
 
     input.focus();
     input.setSelectionRange(selectionStart, selectionEnd, selectionDirection);
-    user.type(input, '{Shift}', {
+    await user.type(input, '{Shift}', {
       skipClick: true,
       initialSelectionStart: selectionStart,
       initialSelectionEnd: selectionEnd,


### PR DESCRIPTION
Update TimeInput to trigger onChange on incomplete input values, missing chars filled in with zeros. Update internal/displayed value on blur to match the last onChange.

fixes #1710