### PR TITLE
fix: GoToRow timestamp fails when selected row is out of view

### DIFF
--- a/packages/iris-grid/src/IrisGridUtils.ts
+++ b/packages/iris-grid/src/IrisGridUtils.ts
@@ -188,7 +188,7 @@ function isValidIndex(x: number, array: readonly unknown[]): boolean {
 }
 
 function isDateWrapper(value: unknown): value is DateWrapper {
-  return (value as DateWrapper).asDate != null;
+  return (value as DateWrapper)?.asDate != null;
 }
 
 class IrisGridUtils {


### PR DESCRIPTION
- Fixes #1561 
- Added the optional chaining operator to prevent an error from being thrown