### PR TITLE
feat: Reject promise immediately if var not found

### DIFF
--- a/packages/jsapi-utils/src/ConnectionUtils.ts
+++ b/packages/jsapi-utils/src/ConnectionUtils.ts
@@ -34,10 +34,12 @@ export function fetchVariableDefinition(
      */
     function handleFieldUpdates(changes: VariableChanges): void {
       const definition = changes.created.find(def => def.title === name);
+      clearTimeout(timeoutId);
+      removeListener?.();
       if (definition != null) {
-        clearTimeout(timeoutId);
-        removeListener?.();
         resolve(definition);
+      } else {
+        reject(new TimeoutError(`Variable ${name} not found`));
       }
     }
 

--- a/packages/jsapi-utils/src/ConnectionUtils.ts
+++ b/packages/jsapi-utils/src/ConnectionUtils.ts
@@ -25,7 +25,7 @@ export function fetchVariableDefinition(
 
     const timeoutId = setTimeout(() => {
       removeListener?.();
-      reject(new TimeoutError(`Timeout looking for Variable ${name}`));
+      reject(new TimeoutError(`Timeout looking for variable ${name}`));
     }, timeout);
 
     /**

--- a/packages/jsapi-utils/src/ConnectionUtils.ts
+++ b/packages/jsapi-utils/src/ConnectionUtils.ts
@@ -25,7 +25,7 @@ export function fetchVariableDefinition(
 
     const timeoutId = setTimeout(() => {
       removeListener?.();
-      reject(new TimeoutError(`Variable ${name} not found`));
+      reject(new TimeoutError(`Timeout looking for Variable ${name}`));
     }, timeout);
 
     /**
@@ -39,7 +39,7 @@ export function fetchVariableDefinition(
       if (definition != null) {
         resolve(definition);
       } else {
-        reject(new TimeoutError(`Variable ${name} not found`));
+        reject(new Error(`Variable ${name} not found`));
       }
     }
 


### PR DESCRIPTION
- Implements #1701 
- `fetchVariableDefinition` now throws an `Error` when a variable is not found (instead of throwing `TimeoutError`)
- `TimeoutError` still used and will be thrown on an actual timeout
- Tests added to check for the correct error