### PR TITLE
feat: Improved preload variable handling

### DIFF
--- a/packages/code-studio/src/styleguide/SpectrumComparison.tsx
+++ b/packages/code-studio/src/styleguide/SpectrumComparison.tsx
@@ -24,6 +24,7 @@ import {
   RadioItem,
   Select,
 } from '@deephaven/components';
+import { EMPTY_FUNCTION } from '@deephaven/utils';
 import {
   SAMPLE_SECTION_E2E_IGNORE,
   SPECTRUM_COMPARISON_SAMPLES_ID,
@@ -43,10 +44,6 @@ const options = [
   { title: 'Two', value: '2' },
   { title: 'Three', value: '3' },
 ];
-
-function noop(): void {
-  // no-op
-}
 
 export function SpectrumComparison(): JSX.Element {
   const [isChecked, setIsChecked] = useState(false);
@@ -77,7 +74,7 @@ export function SpectrumComparison(): JSX.Element {
 
             {buttons.map(([level, variant]) => (
               <Fragment key={level}>
-                <BootstrapButtonOld onClick={noop} kind={level}>
+                <BootstrapButtonOld onClick={EMPTY_FUNCTION} kind={level}>
                   Button
                 </BootstrapButtonOld>
 
@@ -87,7 +84,11 @@ export function SpectrumComparison(): JSX.Element {
               </Fragment>
             ))}
 
-            <BootstrapButtonOld onClick={noop} kind="primary" disabled>
+            <BootstrapButtonOld
+              onClick={EMPTY_FUNCTION}
+              kind="primary"
+              disabled
+            >
               Disabled
             </BootstrapButtonOld>
             <Button variant="accent" style="fill" isDisabled>
@@ -104,7 +105,7 @@ export function SpectrumComparison(): JSX.Element {
 
             {buttons.map(([level, variant]) => (
               <Fragment key={level}>
-                <BootstrapButtonOld onClick={noop} kind={level}>
+                <BootstrapButtonOld onClick={EMPTY_FUNCTION} kind={level}>
                   {level}
                 </BootstrapButtonOld>
                 <Button variant={variant} style="outline">
@@ -113,7 +114,11 @@ export function SpectrumComparison(): JSX.Element {
               </Fragment>
             ))}
 
-            <BootstrapButtonOld onClick={noop} kind="secondary" disabled>
+            <BootstrapButtonOld
+              onClick={EMPTY_FUNCTION}
+              kind="secondary"
+              disabled
+            >
               Disabled
             </BootstrapButtonOld>
             <Button variant="primary" style="outline" isDisabled>
@@ -129,12 +134,12 @@ export function SpectrumComparison(): JSX.Element {
             <label>Bootstrap</label>
             <label>Spectrum</label>
 
-            <BootstrapButtonOld onClick={noop} kind="inline">
+            <BootstrapButtonOld onClick={EMPTY_FUNCTION} kind="inline">
               Inline
             </BootstrapButtonOld>
             <ActionButton>Action</ActionButton>
 
-            <BootstrapButtonOld onClick={noop} kind="inline" disabled>
+            <BootstrapButtonOld onClick={EMPTY_FUNCTION} kind="inline" disabled>
               Disabled
             </BootstrapButtonOld>
             <ActionButton isDisabled>Disabled</ActionButton>

--- a/packages/code-studio/src/styleguide/SpectrumComparison.tsx
+++ b/packages/code-studio/src/styleguide/SpectrumComparison.tsx
@@ -44,6 +44,10 @@ const options = [
   { title: 'Three', value: '3' },
 ];
 
+function noop(): void {
+  // no-op
+}
+
 export function SpectrumComparison(): JSX.Element {
   const [isChecked, setIsChecked] = useState(false);
   const [radioValue, setRadioValue] = useState('1');
@@ -73,7 +77,9 @@ export function SpectrumComparison(): JSX.Element {
 
             {buttons.map(([level, variant]) => (
               <Fragment key={level}>
-                <BootstrapButtonOld kind={level}>Button</BootstrapButtonOld>
+                <BootstrapButtonOld onClick={noop} kind={level}>
+                  Button
+                </BootstrapButtonOld>
 
                 <Button variant={variant} style="fill">
                   Button
@@ -81,7 +87,7 @@ export function SpectrumComparison(): JSX.Element {
               </Fragment>
             ))}
 
-            <BootstrapButtonOld kind="primary" disabled>
+            <BootstrapButtonOld onClick={noop} kind="primary" disabled>
               Disabled
             </BootstrapButtonOld>
             <Button variant="accent" style="fill" isDisabled>
@@ -98,14 +104,16 @@ export function SpectrumComparison(): JSX.Element {
 
             {buttons.map(([level, variant]) => (
               <Fragment key={level}>
-                <BootstrapButtonOld kind={level}>{level}</BootstrapButtonOld>
+                <BootstrapButtonOld onClick={noop} kind={level}>
+                  {level}
+                </BootstrapButtonOld>
                 <Button variant={variant} style="outline">
                   {variant}
                 </Button>
               </Fragment>
             ))}
 
-            <BootstrapButtonOld kind="secondary" disabled>
+            <BootstrapButtonOld onClick={noop} kind="secondary" disabled>
               Disabled
             </BootstrapButtonOld>
             <Button variant="primary" style="outline" isDisabled>
@@ -121,10 +129,12 @@ export function SpectrumComparison(): JSX.Element {
             <label>Bootstrap</label>
             <label>Spectrum</label>
 
-            <BootstrapButtonOld kind="inline">Inline</BootstrapButtonOld>
+            <BootstrapButtonOld onClick={noop} kind="inline">
+              Inline
+            </BootstrapButtonOld>
             <ActionButton>Action</ActionButton>
 
-            <BootstrapButtonOld kind="inline" disabled>
+            <BootstrapButtonOld onClick={noop} kind="inline" disabled>
               Disabled
             </BootstrapButtonOld>
             <ActionButton isDisabled>Disabled</ActionButton>

--- a/packages/components/src/theme/ThemeModel.ts
+++ b/packages/components/src/theme/ThemeModel.ts
@@ -43,7 +43,7 @@ export const DEFAULT_LIGHT_THEME_KEY = 'default-light' satisfies BaseThemeKey;
 
 // Hex versions of some of the default dark theme color palette needed for
 // preload defaults.
-const DEFAULT_DARK_THEME_PALETTE = {
+export const DEFAULT_DARK_THEME_PALETTE = {
   blue: {
     500: '#2f5bc0',
     400: '#254ba4',

--- a/packages/components/src/theme/ThemeProvider.tsx
+++ b/packages/components/src/theme/ThemeProvider.tsx
@@ -1,6 +1,10 @@
 import { createContext, ReactNode, useEffect, useMemo, useState } from 'react';
 import Log from '@deephaven/log';
-import { DEFAULT_DARK_THEME_KEY, ThemeData } from './ThemeModel';
+import {
+  DEFAULT_DARK_THEME_KEY,
+  DEFAULT_PRELOAD_DATA_VARIABLES,
+  ThemeData,
+} from './ThemeModel';
 import {
   calculatePreloadStyleContent,
   getActiveThemes,
@@ -30,11 +34,13 @@ export interface ThemeProviderProps {
    * tell the provider to activate the base themes.
    */
   themes: ThemeData[] | null;
+  defaultPreloadValues?: Record<string, string>;
   children: ReactNode;
 }
 
 export function ThemeProvider({
   themes: customThemes,
+  defaultPreloadValues = DEFAULT_PRELOAD_DATA_VARIABLES,
   children,
 }: ThemeProviderProps): JSX.Element | null {
   const baseThemes = useMemo(() => getDefaultBaseThemes(), []);
@@ -71,9 +77,10 @@ export function ThemeProvider({
 
       // Override fill color for certain inline SVGs (the originals are provided
       // by theme-svg.scss)
-      overrideSVGFillColors();
+      overrideSVGFillColors(defaultPreloadValues);
 
-      const preloadStyleContent = calculatePreloadStyleContent();
+      const preloadStyleContent =
+        calculatePreloadStyleContent(defaultPreloadValues);
 
       log.debug2('updateThemePreloadData:', {
         active: activeThemes.map(theme => theme.themeKey),
@@ -87,7 +94,7 @@ export function ThemeProvider({
         preloadStyleContent,
       });
     },
-    [activeThemes, selectedThemeKey, customThemes]
+    [activeThemes, selectedThemeKey, customThemes, defaultPreloadValues]
   );
 
   useEffect(() => {

--- a/packages/components/src/theme/ThemeUtils.test.ts
+++ b/packages/components/src/theme/ThemeUtils.test.ts
@@ -59,9 +59,9 @@ describe('calculatePreloadStyleContent', () => {
   }
 
   it('should set defaults if css variables are not defined', () => {
-    expect(calculatePreloadStyleContent()).toEqual(
-      expectedContent(DEFAULT_PRELOAD_DATA_VARIABLES)
-    );
+    expect(
+      calculatePreloadStyleContent(DEFAULT_PRELOAD_DATA_VARIABLES)
+    ).toEqual(expectedContent(DEFAULT_PRELOAD_DATA_VARIABLES));
   });
 
   it('should resolve css variables', () => {
@@ -71,7 +71,9 @@ describe('calculatePreloadStyleContent', () => {
     );
     document.body.style.setProperty('--dh-color-bg', 'orange');
 
-    expect(calculatePreloadStyleContent()).toEqual(
+    expect(
+      calculatePreloadStyleContent(DEFAULT_PRELOAD_DATA_VARIABLES)
+    ).toEqual(
       expectedContent({
         ...DEFAULT_PRELOAD_DATA_VARIABLES,
         '--dh-color-loading-spinner-primary': 'pink',
@@ -96,7 +98,10 @@ describe.each([document.body, document.createElement('div')])(
     it('should return empty string if property does not exist and no default value exists', () => {
       asMock(computedStyle.getPropertyValue).mockReturnValue('');
 
-      const resolver = createCssVariableResolver(targetElement);
+      const resolver = createCssVariableResolver(
+        targetElement,
+        DEFAULT_PRELOAD_DATA_VARIABLES
+      );
 
       expect(getComputedStyle).toHaveBeenCalledWith(targetElement);
 
@@ -113,7 +118,10 @@ describe.each([document.body, document.createElement('div')])(
       (key, value) => {
         asMock(computedStyle.getPropertyValue).mockReturnValue('');
 
-        const resolver = createCssVariableResolver(targetElement);
+        const resolver = createCssVariableResolver(
+          targetElement,
+          DEFAULT_PRELOAD_DATA_VARIABLES
+        );
 
         expect(getComputedStyle).toHaveBeenCalledWith(targetElement);
 
@@ -126,7 +134,10 @@ describe.each([document.body, document.createElement('div')])(
         name => `resolved:${name}`
       );
 
-      const resolver = createCssVariableResolver(targetElement);
+      const resolver = createCssVariableResolver(
+        targetElement,
+        DEFAULT_PRELOAD_DATA_VARIABLES
+      );
 
       expect(getComputedStyle).toHaveBeenCalledWith(targetElement);
 
@@ -387,7 +398,7 @@ describe('overrideSVGFillColors', () => {
           : 'red'
       );
 
-      overrideSVGFillColors();
+      overrideSVGFillColors(DEFAULT_PRELOAD_DATA_VARIABLES);
 
       expect(getComputedStyle).toHaveBeenCalledWith(document.body);
       expect(document.body.style.removeProperty).toHaveBeenCalledWith(key);
@@ -418,12 +429,22 @@ describe('preloadTheme', () => {
 
     preloadTheme();
 
-    const styleEl = document.querySelector('style');
+    const [styleElDefaults, styleElPrevious] =
+      document.querySelectorAll('style');
 
-    expect(styleEl).not.toBeNull();
-    expect(styleEl?.innerHTML).toEqual(
-      preloadData?.preloadStyleContent ?? calculatePreloadStyleContent()
+    expect(styleElDefaults).not.toBeNull();
+    expect(styleElDefaults?.innerHTML).toEqual(
+      calculatePreloadStyleContent(DEFAULT_PRELOAD_DATA_VARIABLES)
     );
+
+    if (preloadData?.preloadStyleContent == null) {
+      expect(styleElPrevious).toBeUndefined();
+    } else {
+      expect(styleElPrevious).toBeDefined();
+      expect(styleElPrevious?.innerHTML).toEqual(
+        preloadData?.preloadStyleContent
+      );
+    }
   });
 });
 


### PR DESCRIPTION
- Preload now always applies default preload values before applying cached ones. This ensures that cached preload values don't prevent new defaults from being applied if / when we add new variables to the preload list
- Default preload variables can now be passed in to ThemeUtils + ThemeProvider. This will allow DHE to specify additional variables if needed

resolves #1695 and part of #1679