### PR TITLE
fix: Handle undefined DashboardData props

### DIFF
--- a/packages/code-studio/src/main/AppMainContainer.tsx
+++ b/packages/code-studio/src/main/AppMainContainer.tsx
@@ -123,7 +123,7 @@ interface AppMainContainerProps {
   match: {
     params: { notebookPath: string };
   };
-  connection: IdeConnection;
+  connection?: IdeConnection;
   session?: IdeSession;
   sessionConfig?: SessionConfig;
   setActiveTool: (tool: string) => void;
@@ -255,6 +255,10 @@ export class AppMainContainer extends Component<
 
   initWidgets(): void {
     const { connection } = this.props;
+    if (connection == null) {
+      return;
+    }
+
     if (connection.subscribeToFieldUpdates == null) {
       log.warn(
         'subscribeToFieldUpdates not supported, not initializing widgets'
@@ -614,6 +618,10 @@ export class AppMainContainer extends Component<
 
   startListeningForDisconnect(): void {
     const { connection } = this.props;
+    if (connection == null) {
+      return;
+    }
+
     connection.addEventListener(
       dh.IdeConnection.EVENT_DISCONNECT,
       this.handleDisconnect
@@ -630,6 +638,10 @@ export class AppMainContainer extends Component<
 
   stopListeningForDisconnect(): void {
     const { connection } = this.props;
+    if (connection == null) {
+      return;
+    }
+
     connection.removeEventListener(
       dh.IdeConnection.EVENT_DISCONNECT,
       this.handleDisconnect
@@ -650,6 +662,7 @@ export class AppMainContainer extends Component<
   ): DehydratedDashboardPanelProps & { fetch?: () => Promise<unknown> } {
     const { connection } = this.props;
     const { metadata } = props;
+
     if (
       metadata?.type != null &&
       (metadata?.id != null || metadata?.name != null)
@@ -666,12 +679,14 @@ export class AppMainContainer extends Component<
               name: metadata.name,
               title: metadata.name,
             };
+
       return {
-        fetch: () => connection.getObject(widget),
+        fetch: async () => connection?.getObject(widget),
         ...props,
         localDashboardId: id,
       };
     }
+
     return DashboardUtils.hydrate(props, id);
   }
 
@@ -684,7 +699,7 @@ export class AppMainContainer extends Component<
     const { connection } = this.props;
     this.emitLayoutEvent(PanelEvent.OPEN, {
       dragEvent,
-      fetch: () => connection.getObject(widget),
+      fetch: async () => connection?.getObject(widget),
       widget,
     });
   }

--- a/packages/console/src/HeapUsage.tsx
+++ b/packages/console/src/HeapUsage.tsx
@@ -4,7 +4,7 @@ import { Tooltip } from '@deephaven/components';
 import type { QueryConnectable } from '@deephaven/jsapi-types';
 import { Plot, useChartTheme } from '@deephaven/chart';
 import Log from '@deephaven/log';
-import { useAsyncInterval } from '@deephaven/react-hooks';
+import { useAsyncInterval, useIsMountedRef } from '@deephaven/react-hooks';
 import './HeapUsage.scss';
 
 const log = Log.module('HeapUsage');
@@ -41,9 +41,16 @@ function HeapUsage({
     usages: [],
   });
 
+  const isMountedRef = useIsMountedRef();
+
   const setUsageUpdateInterval = useCallback(async () => {
     try {
       const newUsage = await connection.getWorkerHeapInfo();
+
+      if (!isMountedRef.current) {
+        return;
+      }
+
       setMemoryUsage(newUsage);
 
       if (bgMonitoring || isOpen) {
@@ -69,7 +76,7 @@ function HeapUsage({
     } catch (e) {
       log.warn('Unable to get heap usage', e);
     }
-  }, [isOpen, connection, monitorDuration, bgMonitoring]);
+  }, [connection, isMountedRef, bgMonitoring, isOpen, monitorDuration]);
 
   useAsyncInterval(
     setUsageUpdateInterval,

--- a/packages/dashboard-core-plugins/src/panels/ConsolePanel.tsx
+++ b/packages/dashboard-core-plugins/src/panels/ConsolePanel.tsx
@@ -4,6 +4,7 @@ import React, { PureComponent, ReactElement, RefObject } from 'react';
 import shortid from 'shortid';
 import debounce from 'lodash.debounce';
 import { connect } from 'react-redux';
+import { LoadingOverlay } from '@deephaven/components';
 import {
   CommandHistoryStorage,
   Console,
@@ -377,7 +378,12 @@ export class ConsolePanel extends PureComponent<
     } = this.props;
 
     if (sessionWrapper == null) {
-      return null;
+      return (
+        <LoadingOverlay
+          isLoading={false}
+          errorMessage="Console option is disabled."
+        />
+      );
     }
 
     const { consoleSettings, error, objectMap } = this.state;

--- a/packages/dashboard-core-plugins/src/panels/ConsolePanel.tsx
+++ b/packages/dashboard-core-plugins/src/panels/ConsolePanel.tsx
@@ -63,7 +63,7 @@ interface ConsolePanelProps extends DashboardPanelProps {
 
   panelState?: PanelState;
 
-  sessionWrapper: SessionWrapper;
+  sessionWrapper?: SessionWrapper;
 
   timeZone: string;
   unzip?: (file: File) => Promise<JSZipObject[]>;
@@ -159,6 +159,10 @@ export class ConsolePanel extends PureComponent<
 
   subscribeToFieldUpdates(): void {
     const { sessionWrapper } = this.props;
+    if (sessionWrapper == null) {
+      return;
+    }
+
     const { session } = sessionWrapper;
 
     this.objectSubscriptionCleanup = session.subscribeToFieldUpdates(
@@ -244,6 +248,9 @@ export class ConsolePanel extends PureComponent<
 
   handleOpenObject(object: VariableDefinition, forceOpen = true): void {
     const { sessionWrapper } = this.props;
+    if (sessionWrapper == null) {
+      return;
+    }
     const { session } = sessionWrapper;
     const { root } = this.context;
     const oldPanelId =
@@ -359,7 +366,7 @@ export class ConsolePanel extends PureComponent<
     return <ObjectIcon type={type} />;
   }
 
-  render(): ReactElement {
+  render(): ReactElement | null {
     const {
       commandHistoryStorage,
       glContainer,
@@ -368,6 +375,11 @@ export class ConsolePanel extends PureComponent<
       timeZone,
       unzip,
     } = this.props;
+
+    if (sessionWrapper == null) {
+      return null;
+    }
+
     const { consoleSettings, error, objectMap } = this.state;
     const { config, session, connection, details = {}, dh } = sessionWrapper;
     const { workerName, processInfoId } = details;

--- a/packages/dashboard-core-plugins/src/panels/ConsolePanel.tsx
+++ b/packages/dashboard-core-plugins/src/panels/ConsolePanel.tsx
@@ -379,10 +379,7 @@ export class ConsolePanel extends PureComponent<
 
     if (sessionWrapper == null) {
       return (
-        <LoadingOverlay
-          isLoading={false}
-          errorMessage="Console option is disabled."
-        />
+        <LoadingOverlay isLoading={false} errorMessage="Console is disabled." />
       );
     }
 

--- a/packages/dashboard-core-plugins/src/panels/FileExplorerPanel.tsx
+++ b/packages/dashboard-core-plugins/src/panels/FileExplorerPanel.tsx
@@ -21,7 +21,7 @@ const log = Log.module('FileExplorerPanel');
 
 type StateProps = {
   fileStorage: FileStorage;
-  language: string;
+  language?: string;
   session?: IdeSession;
 };
 

--- a/packages/dashboard-core-plugins/src/panels/LogPanel.tsx
+++ b/packages/dashboard-core-plugins/src/panels/LogPanel.tsx
@@ -14,11 +14,11 @@ import { getDashboardSessionWrapper } from '../redux';
 const log = Log.module('LogPanel');
 
 interface LogPanelProps extends DashboardPanelProps {
-  session: IdeSession;
+  session?: IdeSession;
 }
 
 interface LogPanelState {
-  session: IdeSession;
+  session?: IdeSession;
 }
 
 class LogPanel extends PureComponent<LogPanelProps, LogPanelState> {

--- a/packages/dashboard-core-plugins/src/panels/NotebookPanel.tsx
+++ b/packages/dashboard-core-plugins/src/panels/NotebookPanel.tsx
@@ -64,7 +64,7 @@ interface Metadata extends PanelMetadata {
   id: string;
 }
 interface NotebookSetting {
-  isMinimapEnabled: boolean;
+  isMinimapEnabled?: boolean;
 }
 
 interface FileMetadata {
@@ -78,16 +78,21 @@ interface PanelState {
   fileMetadata: FileMetadata | null;
 }
 
-interface NotebookPanelProps extends DashboardPanelProps {
+interface NotebookPanelMappedProps {
+  defaultNotebookSettings: NotebookSetting;
   fileStorage: FileStorage;
+  session?: IdeSession;
+  sessionLanguage?: string;
+}
+
+interface NotebookPanelProps
+  extends DashboardPanelProps,
+    NotebookPanelMappedProps {
   isDashboardActive: boolean;
   isPreview: boolean;
   metadata: Metadata;
-  session: IdeSession;
-  sessionLanguage: string;
   panelState: PanelState;
   notebooksUrl: string;
-  defaultNotebookSettings: NotebookSetting;
   updateSettings: (settings: Partial<WorkspaceSettings>) => void;
 }
 
@@ -790,7 +795,7 @@ class NotebookPanel extends Component<NotebookPanelProps, NotebookPanelState> {
     const { defaultNotebookSettings, updateSettings } = this.props;
     const newSettings = {
       defaultNotebookSettings: {
-        isMinimapEnabled: !defaultNotebookSettings.isMinimapEnabled,
+        isMinimapEnabled: !(defaultNotebookSettings.isMinimapEnabled ?? false),
       },
     };
     updateSettings(newSettings);
@@ -1176,10 +1181,10 @@ class NotebookPanel extends Component<NotebookPanelProps, NotebookPanelState> {
     const { defaultNotebookSettings } = this.props;
     const { settings: initialSettings } = this.state;
     return this.getOverflowActions(
-      defaultNotebookSettings.isMinimapEnabled,
+      defaultNotebookSettings.isMinimapEnabled ?? false,
       this.getSettings(
         initialSettings,
-        defaultNotebookSettings.isMinimapEnabled
+        defaultNotebookSettings.isMinimapEnabled ?? false
       ).wordWrap === 'on'
     );
   }
@@ -1216,7 +1221,7 @@ class NotebookPanel extends Component<NotebookPanelProps, NotebookPanelState> {
     const isExistingItem = fileMetadata?.id != null;
     const settings = this.getSettings(
       initialSettings,
-      defaultNotebookSettings.isMinimapEnabled
+      defaultNotebookSettings.isMinimapEnabled ?? false
     );
     const isSessionConnected = session != null;
     const isLanguageMatching = sessionLanguage === settings.language;
@@ -1428,10 +1433,7 @@ class NotebookPanel extends Component<NotebookPanelProps, NotebookPanelState> {
 const mapStateToProps = (
   state: RootState,
   ownProps: { localDashboardId: string }
-): Pick<
-  NotebookPanelProps,
-  'defaultNotebookSettings' | 'fileStorage' | 'session' | 'sessionLanguage'
-> => {
+): NotebookPanelMappedProps => {
   const fileStorage = getFileStorage(state);
   const defaultNotebookSettings = getDefaultNotebookSettings(state);
   const sessionWrapper = getDashboardSessionWrapper(
@@ -1443,7 +1445,7 @@ const mapStateToProps = (
   const { type: sessionLanguage } = sessionConfig ?? {};
   return {
     fileStorage,
-    defaultNotebookSettings: defaultNotebookSettings as NotebookSetting,
+    defaultNotebookSettings,
     session,
     sessionLanguage,
   };

--- a/packages/dashboard-core-plugins/src/redux/selectors.ts
+++ b/packages/dashboard-core-plugins/src/redux/selectors.ts
@@ -7,6 +7,8 @@ import { Link } from '../linker/LinkerUtils';
 import { FilterSet } from '../panels';
 import { ColumnSelectionValidator } from '../linker/ColumnSelectionValidator';
 
+const EMPTY_OBJECT = Object.freeze({});
+
 const EMPTY_MAP = new Map();
 
 const EMPTY_ARRAY = Object.freeze([]);
@@ -107,10 +109,8 @@ export const getDashboardConsoleSettings = (
   store: RootState,
   dashboardId: string
 ): Record<string, unknown> =>
-  getDashboardData(store, dashboardId).consoleSettings as Record<
-    string,
-    unknown
-  >;
+  (getDashboardData(store, dashboardId).consoleSettings ??
+    EMPTY_OBJECT) as Record<string, unknown>;
 
 /**
  *
@@ -121,8 +121,8 @@ export const getDashboardConsoleSettings = (
 export const getDashboardConnection = (
   store: RootState,
   dashboardId: string
-): IdeConnection =>
-  getDashboardData(store, dashboardId).connection as IdeConnection;
+): IdeConnection | undefined =>
+  getDashboardData(store, dashboardId).connection as IdeConnection | undefined;
 
 /**
  *
@@ -133,5 +133,7 @@ export const getDashboardConnection = (
 export const getDashboardSessionWrapper = (
   store: RootState,
   dashboardId: string
-): SessionWrapper =>
-  getDashboardData(store, dashboardId).sessionWrapper as SessionWrapper;
+): SessionWrapper | undefined =>
+  getDashboardData(store, dashboardId).sessionWrapper as
+    | SessionWrapper
+    | undefined;

--- a/packages/react-hooks/src/useAsyncInterval.test.ts
+++ b/packages/react-hooks/src/useAsyncInterval.test.ts
@@ -1,8 +1,23 @@
 import { renderHook, act } from '@testing-library/react-hooks';
+import Log from '@deephaven/log';
 import { TestUtils } from '@deephaven/utils';
 import useAsyncInterval from './useAsyncInterval';
 
+jest.mock('@deephaven/log', () => {
+  const logger = {
+    error: jest.fn(),
+  };
+  return {
+    __esModule: true,
+    default: {
+      module: jest.fn(() => logger),
+    },
+  };
+});
+
 const { asMock } = TestUtils;
+
+const mockLoggerInstance = Log.module('mock.logger');
 
 beforeEach(() => {
   jest.clearAllMocks();
@@ -16,12 +31,22 @@ afterAll(() => {
 });
 
 describe('useAsyncInterval', () => {
-  function createCallback(ms: number) {
+  /**
+   * Creates a callback function that resolves after the given number of
+   * milliseconds. Accepts an optional array of booleans that determine whether
+   * calls to the callback will reject instead of resolve. They are mapped by
+   * index to the order in which the callback is called.
+   */
+  function createCallback(ms: number, rejectWith: (Error | undefined)[] = []) {
     return jest
       .fn(
         async (): Promise<void> =>
-          new Promise(resolve => {
-            setTimeout(resolve, ms);
+          new Promise((resolve, reject) => {
+            const rejectArg = rejectWith.shift();
+            setTimeout(
+              rejectArg == null ? resolve : () => reject(rejectArg),
+              ms
+            );
 
             // Don't track the above call to `setTimeout`
             asMock(setTimeout).mock.calls.pop();
@@ -154,5 +179,30 @@ describe('useAsyncInterval', () => {
     await TestUtils.flushPromises();
 
     expect(window.setTimeout).not.toHaveBeenCalled();
+  });
+
+  it('should handle tick errors', async () => {
+    const callbackDelayMs = 50;
+    const mockError = new Error('mock.error');
+    const callback = createCallback(callbackDelayMs, [mockError, undefined]);
+
+    renderHook(() => useAsyncInterval(callback, targetIntervalMs));
+
+    // First callback fires immediately
+    expect(callback).toHaveBeenCalledTimes(1);
+
+    // Mimick the callback Promise rejecting
+    act(() => jest.advanceTimersByTime(callbackDelayMs));
+    await TestUtils.flushPromises();
+
+    expect(mockLoggerInstance.error).toHaveBeenCalledWith(
+      'A tick error occurred:',
+      mockError
+    );
+
+    // Advance to next interval
+    act(() => jest.advanceTimersByTime(targetIntervalMs));
+
+    expect(callback).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/react-hooks/src/useAsyncInterval.test.ts
+++ b/packages/react-hooks/src/useAsyncInterval.test.ts
@@ -33,9 +33,9 @@ afterAll(() => {
 describe('useAsyncInterval', () => {
   /**
    * Creates a callback function that resolves after the given number of
-   * milliseconds. Accepts an optional array of booleans that determine whether
-   * calls to the callback will reject instead of resolve. They are mapped by
-   * index to the order in which the callback is called.
+   * milliseconds. Accepts an optional array of Error | undefined. They are
+   * mapped by index to the order in which the callback is called. An Error
+   * instance will cause a rejection, undefined will cause a resolution.
    */
   function createCallback(ms: number, rejectWith: (Error | undefined)[] = []) {
     return jest

--- a/packages/react-hooks/src/useAsyncInterval.ts
+++ b/packages/react-hooks/src/useAsyncInterval.ts
@@ -1,8 +1,5 @@
 import { useCallback, useEffect, useRef } from 'react';
-import Log from '@deephaven/log';
 import { useIsMountedRef } from './useIsMountedRef';
-
-const log = Log.module('useAsyncInterval');
 
 /**
  * Calls the given async callback at a target interval.
@@ -41,12 +38,6 @@ export function useAsyncInterval(
         ? targetIntervalMs
         : now - trackingStartedRef.current;
 
-    log.debug(
-      `tick #${trackingCountRef.current}.`,
-      elapsedSinceLastTick,
-      'ms elapsed since last tick.'
-    );
-
     trackingStartedRef.current = now;
 
     await callback();
@@ -62,21 +53,10 @@ export function useAsyncInterval(
 
     const nextTickInterval = Math.max(0, targetIntervalMs - overage);
 
-    log.debug(
-      'Next tick target:',
-      targetIntervalMs,
-      ', overage',
-      overage,
-      ', adjusted:',
-      nextTickInterval
-    );
-
     setTimeoutRef.current = window.setTimeout(tick, nextTickInterval);
   }, [callback, isMountedRef, targetIntervalMs]);
 
   useEffect(() => {
-    log.debug('Setting target interval:', targetIntervalMs);
-
     trackingStartedRef.current = null;
     tick();
 

--- a/packages/react-hooks/src/useAsyncInterval.ts
+++ b/packages/react-hooks/src/useAsyncInterval.ts
@@ -1,5 +1,8 @@
 import { useCallback, useEffect, useRef } from 'react';
+import Log from '@deephaven/log';
 import { useIsMountedRef } from './useIsMountedRef';
+
+const log = Log.module('useAsyncInterval');
 
 /**
  * Calls the given async callback at a target interval.
@@ -40,7 +43,11 @@ export function useAsyncInterval(
 
     trackingStartedRef.current = now;
 
-    await callback();
+    try {
+      await callback();
+    } catch (err) {
+      log.error('A tick error occurred:', err);
+    }
 
     if (!isMountedRef.current) {
       return;


### PR DESCRIPTION
- Handle undefined props on DashboardData. Don't render console panel if no session
- Fixed a set state on unmounted HeapUsage bug
- Removed chatty async interval debug logging

fixes #1684

**Testing**
- Run server with PSK enabled
- Login and open any file
- Logout should no longer show "ConsolePanel.tsx:372 Uncaught TypeError: Cannot destructure property 'config' of 'sessionWrapper' as it is undefined." error in debug console (Note that login will still fail until #1685 is done)