### PR TITLE
fix: re-colorize command codeblocks when theme changes

### DIFF
--- a/packages/console/src/common/Code.tsx
+++ b/packages/console/src/common/Code.tsx
@@ -1,51 +1,39 @@
-import React, { Component, ReactElement, ReactNode } from 'react';
+import React, { cloneElement, useEffect, useRef, useState } from 'react';
 import * as monaco from 'monaco-editor';
+import { useTheme } from '@deephaven/components';
 
 interface CodeProps {
-  children: ReactNode;
+  children: React.ReactNode;
   language: string;
 }
 
-class Code extends Component<CodeProps, Record<string, never>> {
-  constructor(props: CodeProps) {
-    super(props);
+function Code({ children, language }: CodeProps) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const { activeThemes } = useTheme();
 
-    this.container = null;
-  }
+  useEffect(() => {
+    if (activeThemes != null) colorize();
+  }, [activeThemes]);
 
-  componentDidMount(): void {
-    this.colorize();
-  }
-
-  container: HTMLDivElement | null;
-
-  colorize(): void {
-    const { children } = this.props;
-    if (this.container && children != null) {
-      monaco.editor.colorizeElement(this.container, {
-        theme: 'dh-dark',
-      });
+  const colorize = async () => {
+    if (containerRef.current && children != null) {
+      const result = await monaco.editor.colorize(
+        children.toString(),
+        language,
+        {}
+      );
+      containerRef.current.innerHTML = result;
     }
-  }
+  };
 
-  render(): ReactElement {
-    const { children, language } = this.props;
-    return (
-      <div>
-        <div
-          data-lang={language}
-          ref={container => {
-            this.container = container;
-          }}
-          // Add pointerEvents: 'none' has huge benefits on performance with Hit Test testing on large colorized elements.
-          // You can still select the text event with this set
-          style={{ pointerEvents: 'none' }}
-        >
-          {children}
-        </div>
-      </div>
-    );
-  }
+  return (
+    <div
+      ref={containerRef}
+      // Add pointerEvents: 'none' has huge benefits on performance with Hit Test testing on large colorized elements.
+      // You can still select the text event with this set
+      style={{ pointerEvents: 'none' }}
+    ></div>
+  );
 }
 
 export default Code;

--- a/packages/console/src/common/Code.tsx
+++ b/packages/console/src/common/Code.tsx
@@ -14,7 +14,7 @@ function Code({ children, language }: CodeProps): JSX.Element {
   useEffect(() => {
     let isCanceled = false;
     async function colorize() {
-      if (children != null) {
+      if (children != null && activeThemes != null) {
         const result = await monaco.editor.colorize(
           children.toString(),
           language,

--- a/packages/console/src/common/Code.tsx
+++ b/packages/console/src/common/Code.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, ReactNode, ReactElement } from 'react';
+import React, { useEffect, useState, ReactNode } from 'react';
 import * as monaco from 'monaco-editor';
 import { useTheme } from '@deephaven/components';
 

--- a/packages/console/src/common/Code.tsx
+++ b/packages/console/src/common/Code.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, ReactNode } from 'react';
+import React, { useEffect, useRef, ReactNode, useCallback } from 'react';
 import * as monaco from 'monaco-editor';
 import { useTheme } from '@deephaven/components';
 
@@ -7,15 +7,11 @@ interface CodeProps {
   language: string;
 }
 
-function Code({ children, language }: CodeProps) {
+function Code({ children, language }: CodeProps): JSX.Element {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const { activeThemes } = useTheme();
 
-  useEffect(() => {
-    if (activeThemes != null) colorize();
-  }, [activeThemes]);
-
-  const colorize = async () => {
+  const colorize = useCallback(async () => {
     if (containerRef.current && children != null) {
       const result = await monaco.editor.colorize(
         children.toString(),
@@ -24,7 +20,11 @@ function Code({ children, language }: CodeProps) {
       );
       containerRef.current.innerHTML = result;
     }
-  };
+  }, [children, language]);
+
+  useEffect(() => {
+    if (activeThemes != null) colorize();
+  }, [activeThemes, colorize]);
 
   return (
     <div
@@ -32,7 +32,7 @@ function Code({ children, language }: CodeProps) {
       // Add pointerEvents: 'none' has huge benefits on performance with Hit Test testing on large colorized elements.
       // You can still select the text event with this set
       style={{ pointerEvents: 'none' }}
-    ></div>
+    />
   );
 }
 

--- a/packages/console/src/common/Code.tsx
+++ b/packages/console/src/common/Code.tsx
@@ -1,9 +1,9 @@
-import React, { cloneElement, useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, ReactNode } from 'react';
 import * as monaco from 'monaco-editor';
 import { useTheme } from '@deephaven/components';
 
 interface CodeProps {
-  children: React.ReactNode;
+  children: ReactNode;
   language: string;
 }
 


### PR DESCRIPTION
Fixes an issues where the command history doesn't get re-colorized when the theme changes.

Steps to reproduce:
Run a command, then change theme (depends on which theme you started on, but history will look wrong):
![image](https://github.com/deephaven/web-client-ui/assets/1576283/a3087cc5-0f00-4d3f-b8c3-c778515b57fa)
