### PR TITLE
fix: hcm caret shouldn't be allowed to shrink

### DIFF
--- a/packages/components/src/HierarchicalCheckboxMenu.scss
+++ b/packages/components/src/HierarchicalCheckboxMenu.scss
@@ -18,6 +18,7 @@
     @include caret-icon;
 
     margin-right: 4px;
+    flex-shrink: 0;
   }
 }
 


### PR DESCRIPTION
Caret shouldn't shrink if component is truncating. Component only used in enterprise right now, and there's a duplicate change in deephaven-ent/iris#1274