### PR TITLE
fix: allow logout on open file

### DIFF
--- a/packages/app-utils/src/components/AppBootstrap.tsx
+++ b/packages/app-utils/src/components/AppBootstrap.tsx
@@ -1,8 +1,10 @@
 import React, { useCallback, useMemo, useState } from 'react';
 import '@deephaven/components/scss/BaseStyleSheet.scss';
+import { storeCookieToken } from '@deephaven/auth-plugins';
 import { ClientBootstrap } from '@deephaven/jsapi-bootstrap';
 import {
   RefreshTokenBootstrap,
+  storeRefreshToken,
   useBroadcastLoginListener,
 } from '@deephaven/jsapi-components';
 import { type Plugin } from '@deephaven/plugin';
@@ -53,6 +55,8 @@ export function AppBootstrap({
   const onLogin = useCallback(() => undefined, []);
   const onLogout = useCallback(() => {
     setLogoutCount(value => value + 1);
+    storeCookieToken(null);
+    storeRefreshToken(null);
   }, []);
   useBroadcastLoginListener(onLogin, onLogout);
   return (

--- a/packages/auth-plugins/src/AuthPlugin.ts
+++ b/packages/auth-plugins/src/AuthPlugin.ts
@@ -1,4 +1,8 @@
 import React from 'react';
+import Log from '@deephaven/log';
+import Cookies from 'js-cookie';
+
+const log = Log.module('AuthPluginPsk');
 
 /**
  * Map from auth config keys to their values
@@ -41,4 +45,15 @@ export function isAuthPlugin(plugin?: unknown): plugin is AuthPlugin {
     authPlugin.Component !== undefined &&
     typeof authPlugin.isAvailable === 'function'
   );
+}
+
+export const PSK_TOKEN_KEY = 'io.deephaven.web.client.auth.psk.token';
+
+export function storeCookieToken(token: string | null): void {
+  log.debug2('Storing token in cookie', token);
+  if (token != null) {
+    Cookies.set(PSK_TOKEN_KEY, token, { secure: true, sameSite: 'strict' });
+  } else {
+    Cookies.remove(PSK_TOKEN_KEY);
+  }
 }

--- a/packages/auth-plugins/src/AuthPluginPsk.tsx
+++ b/packages/auth-plugins/src/AuthPluginPsk.tsx
@@ -6,7 +6,12 @@ import { useBroadcastLoginListener } from '@deephaven/jsapi-components';
 import Log from '@deephaven/log';
 import { getErrorMessage } from '@deephaven/utils';
 import Cookies from 'js-cookie';
-import { AuthPlugin, AuthPluginProps } from './AuthPlugin';
+import {
+  AuthPlugin,
+  AuthPluginProps,
+  PSK_TOKEN_KEY,
+  storeCookieToken,
+} from './AuthPlugin';
 import LoginForm from './LoginForm';
 import Login from './Login';
 import AuthenticationError from './AuthenticationError';
@@ -14,8 +19,6 @@ import AuthenticationError from './AuthenticationError';
 const AUTH_TYPE = 'io.deephaven.authentication.psk.PskAuthenticationHandler';
 
 const PSK_QUERY_PARAM_KEY = 'psk';
-
-const PSK_TOKEN_KEY = 'io.deephaven.web.client.auth.psk.token';
 
 const log = Log.module('AuthPluginPsk');
 
@@ -33,15 +36,6 @@ function clearWindowToken(): void {
 
 function readCookieToken(): string | null {
   return Cookies.get(PSK_TOKEN_KEY) ?? null;
-}
-
-function storeCookieToken(token: string | null): void {
-  log.debug2('Storing token in cookie', token);
-  if (token != null) {
-    Cookies.set(PSK_TOKEN_KEY, token, { secure: true, sameSite: 'strict' });
-  } else {
-    Cookies.remove(PSK_TOKEN_KEY);
-  }
 }
 
 export type AuthPluginPskProps = AuthPluginProps & {


### PR DESCRIPTION
- Fixes #1685 
  - Moved `storeCookieToken` from `AuthPluginPsk.tsx` to `AuthPlugin.ts`, so it can be exported
  - Logout button now uses that to remove the cookies