### PR TITLE
fix: sorting frozen columns

### DIFF
--- a/packages/iris-grid/src/sidebar/visibility-ordering-builder/VisibilityOrderingBuilder.test.tsx
+++ b/packages/iris-grid/src/sidebar/visibility-ordering-builder/VisibilityOrderingBuilder.test.tsx
@@ -763,7 +763,7 @@ test('Sorts items', async () => {
   );
 });
 
-test('Sort ascending items with frozen columns', async () => {
+test('Sort ascending items with frozen/front/back columns', async () => {
   const user = userEvent.setup({ delay: null });
   const mockHandler = jest.fn();
   const sortButton = () => screen.getByLabelText('Sort ascending');
@@ -771,7 +771,9 @@ test('Sort ascending items with frozen columns', async () => {
     irisGridTestUtils.makeTable({
       columns: COLUMNS,
       layoutHints: {
-        frozenColumns: [`${COLUMN_PREFIX}0`, `${COLUMN_PREFIX}3`],
+        frontColumns: [`${COLUMN_PREFIX}2`, `${COLUMN_PREFIX}3`],
+        frozenColumns: [`${COLUMN_PREFIX}0`, `${COLUMN_PREFIX}1`],
+        backColumns: [`${COLUMN_PREFIX}9`],
       },
     })
   );
@@ -779,11 +781,11 @@ test('Sort ascending items with frozen columns', async () => {
 
   await selectItems(user, [1]);
   await user.click(sortButton());
-  const newMoves = [{ from: 3, to: 1 }];
+  const newMoves = [];
   expect(mockHandler).toBeCalledWith(newMoves);
 });
 
-test('Sort descending items with frozen columns', async () => {
+test('Sort descending items with frozen/front/back columns', async () => {
   const user = userEvent.setup({ delay: null });
   const mockHandler = jest.fn();
   const sortButton = () => screen.getByLabelText('Sort descending');
@@ -791,7 +793,9 @@ test('Sort descending items with frozen columns', async () => {
     irisGridTestUtils.makeTable({
       columns: COLUMNS,
       layoutHints: {
-        frozenColumns: [`${COLUMN_PREFIX}1`, `${COLUMN_PREFIX}3`],
+        frontColumns: [`${COLUMN_PREFIX}1`],
+        frozenColumns: [`${COLUMN_PREFIX}0`],
+        backColumns: [`${COLUMN_PREFIX}9`],
       },
     })
   );
@@ -800,15 +804,12 @@ test('Sort descending items with frozen columns', async () => {
   await selectItems(user, [1]);
   await user.click(sortButton());
   const newMoves = [
-    { from: 1, to: 0 },
-    { from: 3, to: 1 },
-    { from: 9, to: 2 },
-    { from: 9, to: 3 },
-    { from: 9, to: 4 },
-    { from: 9, to: 5 },
-    { from: 9, to: 6 },
-    { from: 9, to: 7 },
-    { from: 9, to: 8 },
+    { from: 8, to: 2 },
+    { from: 8, to: 3 },
+    { from: 8, to: 4 },
+    { from: 8, to: 5 },
+    { from: 8, to: 6 },
+    { from: 8, to: 7 },
   ];
   expect(mockHandler).toBeCalledWith(newMoves);
 });

--- a/packages/iris-grid/src/sidebar/visibility-ordering-builder/VisibilityOrderingBuilder.test.tsx
+++ b/packages/iris-grid/src/sidebar/visibility-ordering-builder/VisibilityOrderingBuilder.test.tsx
@@ -801,7 +801,7 @@ test('Sort descending items with frozen columns', async () => {
   await user.click(sortButton());
   const newMoves = [
     { from: 1, to: 0 },
-    { from: 3, to: 0 },
+    { from: 3, to: 1 },
     { from: 9, to: 2 },
     { from: 9, to: 3 },
     { from: 9, to: 4 },

--- a/packages/iris-grid/src/sidebar/visibility-ordering-builder/VisibilityOrderingBuilder.test.tsx
+++ b/packages/iris-grid/src/sidebar/visibility-ordering-builder/VisibilityOrderingBuilder.test.tsx
@@ -763,6 +763,56 @@ test('Sorts items', async () => {
   );
 });
 
+test('Sort ascending items with frozen columns', async () => {
+  const user = userEvent.setup({ delay: null });
+  const mockHandler = jest.fn();
+  const sortButton = () => screen.getByLabelText('Sort ascending');
+  const model = irisGridTestUtils.makeModel(
+    irisGridTestUtils.makeTable({
+      columns: COLUMNS,
+      layoutHints: {
+        frozenColumns: [`${COLUMN_PREFIX}0`, `${COLUMN_PREFIX}3`],
+      },
+    })
+  );
+  render(<Builder model={model} onMovedColumnsChanged={mockHandler} />);
+
+  await selectItems(user, [1]);
+  await user.click(sortButton());
+  const newMoves = [{ from: 3, to: 1 }];
+  expect(mockHandler).toBeCalledWith(newMoves);
+});
+
+test('Sort descending items with frozen columns', async () => {
+  const user = userEvent.setup({ delay: null });
+  const mockHandler = jest.fn();
+  const sortButton = () => screen.getByLabelText('Sort descending');
+  const model = irisGridTestUtils.makeModel(
+    irisGridTestUtils.makeTable({
+      columns: COLUMNS,
+      layoutHints: {
+        frozenColumns: [`${COLUMN_PREFIX}1`, `${COLUMN_PREFIX}3`],
+      },
+    })
+  );
+  render(<Builder model={model} onMovedColumnsChanged={mockHandler} />);
+
+  await selectItems(user, [1]);
+  await user.click(sortButton());
+  const newMoves = [
+    { from: 1, to: 0 },
+    { from: 3, to: 0 },
+    { from: 9, to: 2 },
+    { from: 9, to: 3 },
+    { from: 9, to: 4 },
+    { from: 9, to: 5 },
+    { from: 9, to: 6 },
+    { from: 9, to: 7 },
+    { from: 9, to: 8 },
+  ];
+  expect(mockHandler).toBeCalledWith(newMoves);
+});
+
 test('Creates groups', async () => {
   const user = userEvent.setup({ delay: null });
   const model = makeModel();

--- a/packages/iris-grid/src/sidebar/visibility-ordering-builder/VisibilityOrderingBuilder.tsx
+++ b/packages/iris-grid/src/sidebar/visibility-ordering-builder/VisibilityOrderingBuilder.tsx
@@ -583,7 +583,8 @@ class VisibilityOrderingBuilder extends PureComponent<
   getSortMoves(
     itemsParam: readonly IrisGridTreeItem[],
     option: keyof typeof VisibilityOrderingBuilder.SORTING_OPTIONS,
-    movedColumns: readonly MoveOperation[]
+    movedColumns: readonly MoveOperation[],
+    frozenColumns: readonly string[]
   ): MoveOperation[] {
     const items = [...itemsParam];
     // Sort all the movable columns
@@ -592,6 +593,11 @@ class VisibilityOrderingBuilder extends PureComponent<
     items.sort((a, b) => {
       const aName = a.id.toUpperCase();
       const bName = b.id.toUpperCase();
+      if (frozenColumns.includes(a.id) && frozenColumns.includes(b.id)) {
+        return TextUtils.sort(aName, bName, isAscending);
+      }
+      if (frozenColumns.includes(a.id)) return -1;
+      if (frozenColumns.includes(b.id)) return 1;
       return TextUtils.sort(aName, bName, isAscending);
     });
 
@@ -622,7 +628,12 @@ class VisibilityOrderingBuilder extends PureComponent<
 
       if (Array.isArray(visibleIndex)) {
         // Recursively sort groups
-        newMoves = this.getSortMoves(item.children, option, newMoves);
+        newMoves = this.getSortMoves(
+          item.children,
+          option,
+          newMoves,
+          frozenColumns
+        );
       }
 
       moveToIndex += Array.isArray(modelIndex) ? modelIndex.length : 1;
@@ -639,7 +650,8 @@ class VisibilityOrderingBuilder extends PureComponent<
     const newMoves = this.getSortMoves(
       this.getTreeItems(),
       option,
-      model.initialMovedColumns
+      model.initialMovedColumns,
+      model.frozenColumns
     );
 
     onMovedColumnsChanged(newMoves);

--- a/packages/iris-grid/src/sidebar/visibility-ordering-builder/VisibilityOrderingBuilder.tsx
+++ b/packages/iris-grid/src/sidebar/visibility-ordering-builder/VisibilityOrderingBuilder.tsx
@@ -644,29 +644,13 @@ class VisibilityOrderingBuilder extends PureComponent<
     const initialAndFrozenMovedColumns = [...model.initialMovedColumns];
     for (let i = 0; i < model.frozenColumns.length; i += 1) {
       const frozenColumn = model.frozenColumns[i];
-      // get index of frozenColumn
-      let frozenIndex = 0;
-      for (let j = 0; j < model.columns.length; j += 1) {
-        if (model.columns[j].name === frozenColumn) {
-          frozenIndex = j;
-          break;
-        }
-      }
-      // offset by move changes
-      for (let j = 0; j < initialAndFrozenMovedColumns.length; j += 1) {
-        const { from, to } = initialAndFrozenMovedColumns[j];
-        // taken from in front, decrease index
-        if (Array.isArray(from)) {
-          if (from[0] < frozenIndex) frozenIndex -= 1;
-        } else if (from < frozenIndex) {
-          frozenIndex -= 1;
-        }
-        // placed in front, increase index
-        if (to < frozenIndex) frozenIndex += 1;
-      }
-      if (frozenIndex !== i) {
+      const newFrozenIndex = GridUtils.getVisibleIndex(
+        model.getColumnIndexByName(frozenColumn) ?? 0,
+        initialAndFrozenMovedColumns
+      );
+      if (newFrozenIndex !== i) {
         initialAndFrozenMovedColumns.push({
-          from: frozenIndex,
+          from: newFrozenIndex,
           to: i,
         });
       }

--- a/packages/iris-grid/src/sidebar/visibility-ordering-builder/VisibilityOrderingBuilder.tsx
+++ b/packages/iris-grid/src/sidebar/visibility-ordering-builder/VisibilityOrderingBuilder.tsx
@@ -591,13 +591,18 @@ class VisibilityOrderingBuilder extends PureComponent<
     const isAscending =
       option === VisibilityOrderingBuilder.SORTING_OPTIONS.ASC;
     items.sort((a, b) => {
+      const aFrozenIndex = frozenColumns.indexOf(a.id);
+      const bFrozenIndex = frozenColumns.indexOf(b.id);
       const aName = a.id.toUpperCase();
       const bName = b.id.toUpperCase();
-      if (frozenColumns.includes(a.id) && frozenColumns.includes(b.id)) {
-        return TextUtils.sort(aName, bName, isAscending);
+      // both frozen
+      if (aFrozenIndex !== -1 && bFrozenIndex !== -1) {
+        return aFrozenIndex < bFrozenIndex ? -1 : 1;
       }
-      if (frozenColumns.includes(a.id)) return -1;
-      if (frozenColumns.includes(b.id)) return 1;
+      // one frozen
+      if (aFrozenIndex !== -1) return -1;
+      if (bFrozenIndex !== -1) return 1;
+      // no frozen
       return TextUtils.sort(aName, bName, isAscending);
     });
 


### PR DESCRIPTION
- Fixes #1645 
  - Moves are now generated for frozen columns (like front/end for initial moved columns) and only used when sorting
  - The range being sorted is truncated to remove frozen/front/end columns
- Added tests to make sure the sort is correct