### PR TITLE
feat: DH-16336: usePickerWithSelectedValues - boolean flags should be calculated based on trimmed search text

### DIFF
--- a/packages/components/src/modal/DebouncedModal.tsx
+++ b/packages/components/src/modal/DebouncedModal.tsx
@@ -28,7 +28,7 @@ function DebouncedModal({
   debounceMs,
   isOpen = false,
 }: DebouncedModalProps): JSX.Element {
-  const debouncedIsOpen = useDebouncedValue(isOpen, debounceMs);
+  const { value: debouncedIsOpen } = useDebouncedValue(isOpen, debounceMs);
 
   return (
     <>

--- a/packages/jsapi-components/src/useCheckIfExistsValue.ts
+++ b/packages/jsapi-components/src/useCheckIfExistsValue.ts
@@ -36,7 +36,10 @@ export function useCheckIfExistsValue(
   const tableUtils = useTableUtils();
 
   const [valueTrimmed, setValueTrimmed] = useState('');
-  const valueTrimmedDebounced = useDebouncedValue(valueTrimmed, debounceMs);
+  const { value: valueTrimmedDebounced } = useDebouncedValue(
+    valueTrimmed,
+    debounceMs
+  );
 
   const trimAndUpdateValue = useCallback((text: string) => {
     setValueTrimmed(text.trim());

--- a/packages/jsapi-components/src/useDebouncedViewportSelectionFilter.test.ts
+++ b/packages/jsapi-components/src/useDebouncedViewportSelectionFilter.test.ts
@@ -32,7 +32,10 @@ const mockViewportData =
   createMockProxy<WindowedListData<KeyedItem<unknown>>>();
 
 const mockSelection = {
-  useDebounceValueResult: { selection: new Set('a'), isInverted: true },
+  useDebounceValueResult: {
+    isDebouncing: false,
+    value: { selection: new Set('a'), isInverted: true },
+  },
   useIsEqualMemoResult: { selection: new Set('b'), isInverted: true },
   useMappedSelectionResult: { selection: new Set('c'), isInverted: true },
 } as const;
@@ -96,7 +99,7 @@ it('should memoize debounced selection based on value equality', () => {
   renderHook(() => useDebouncedViewportSelectionFilter(options));
 
   expect(useIsEqualMemo).toHaveBeenCalledWith(
-    mockSelection.useDebounceValueResult,
+    mockSelection.useDebounceValueResult.value,
     isSelectionMaybeInvertedEqual
   );
 });

--- a/packages/jsapi-components/src/useDebouncedViewportSelectionFilter.ts
+++ b/packages/jsapi-components/src/useDebouncedViewportSelectionFilter.ts
@@ -44,7 +44,7 @@ export function useDebouncedViewportSelectionFilter<TItem, TValue>({
 
   // Debounce so user can rapidly select multiple items in a row without the
   // cost of updating the table on each change
-  const debouncedValuesSelection = useDebouncedValue(
+  const { value: debouncedValuesSelection } = useDebouncedValue(
     valuesSelection,
     DEBOUNCE_MS
   );

--- a/packages/jsapi-components/src/usePickerWithSelectedValues.ts
+++ b/packages/jsapi-components/src/usePickerWithSelectedValues.ts
@@ -7,6 +7,7 @@ import {
 } from '@deephaven/jsapi-utils';
 import {
   useDebouncedCallback,
+  useDebouncedValue,
   usePromiseFactory,
 } from '@deephaven/react-hooks';
 import {
@@ -42,24 +43,45 @@ export interface UsePickerWithSelectedValuesResult<TItem, TValue> {
  * items are removed from the list and managed in a selectedValueMap data
  * structure. Useful for components that contain a picker but show selected
  * values in a separate component.
- * @param maybeTable
- * @param columnName
- * @param mapItemToValue
- * @param filterConditionFactories
+ * @param maybeTable The table to get the list of items from
+ * @param columnName The column name to get the list of items from
+ * @param mapItemToValue A function to map an item to a value
+ * @param filterConditionFactories Optional filter condition factories to apply to the list
+ * @param trimSearchText Whether to trim the search text before filtering. Defaults to false
  */
-export function usePickerWithSelectedValues<TItem, TValue>(
-  maybeTable: Table | null,
-  columnName: string,
-  mapItemToValue: (item: KeyedItem<TItem>) => TValue,
-  ...filterConditionFactories: FilterConditionFactory[]
-): UsePickerWithSelectedValuesResult<TItem, TValue> {
+export function usePickerWithSelectedValues<TItem, TValue>({
+  maybeTable,
+  columnName,
+  mapItemToValue,
+  filterConditionFactories = [],
+  trimSearchText = false,
+}: {
+  maybeTable: Table | null;
+  columnName: string;
+  mapItemToValue: (item: KeyedItem<TItem>) => TValue;
+  filterConditionFactories?: FilterConditionFactory[];
+  trimSearchText?: boolean;
+}): UsePickerWithSelectedValuesResult<TItem, TValue> {
   const tableUtils = useTableUtils();
 
   // `searchText` should always be up to date for controlled search input.
-  // `debouncedSearchText` will get updated after a delay to avoid updating
-  // filters on every key stroke.
+  // `appliedSearchText` will get updated after a delay to avoid updating
+  // filters on every key stroke. It will also be trimmed of leading / trailing
+  // spaces if `trimSearchText` is true.
   const [searchText, setSearchText] = useState('');
-  const [debouncedSearchText, setDebouncedSearchText] = useState('');
+  const [appliedSearchText, setAppliedSearchText] = useState('');
+
+  const applySearchText = useCallback(
+    (text: string) => {
+      setAppliedSearchText(trimSearchText ? text.trim() : text);
+    },
+    [trimSearchText]
+  );
+
+  const searchTextMaybeTrimmed = useMemo(
+    () => (trimSearchText ? searchText.trim() : searchText),
+    [searchText, trimSearchText]
+  );
 
   const [selectedKey, setSelectedKey] = useState<Key | null>(null);
   const [selectedValueMap, setSelectedValueMap] = useState<
@@ -70,20 +92,31 @@ export function usePickerWithSelectedValues<TItem, TValue>(
     usePromiseFactory(tableUtils.doesColumnValueExist, [
       maybeTable,
       columnName,
-      debouncedSearchText,
+      appliedSearchText,
       false /* isCaseSensitive */,
     ]);
+
+  // The `searchTextFilter` starts getting applied to the list whenever
+  // `appliedSearchText` changes, after which there is a small delay before the
+  // items are in sync. Use a debounce timer to allow a little extra time
+  // before calculating `searchTextExists` below. Note that there are 2 debounce
+  // timers at play here:
+  // 1. `onDebouncedSearchTextChange` applies the search text after user stops typing
+  // 2. `useDebouncedValue` debounces whenever the result of the first debounce
+  //    changes, and `isApplyingFilter` will be true while this 2nd timer is active.
+  const { isDebouncing: isApplyingFilter } = useDebouncedValue(
+    appliedSearchText,
+    SEARCH_DEBOUNCE_MS
+  );
 
   // If value exists check is still loading or if debounce hasn't completed, set
   // `searchTextExists` to null since it is indeterminate.
   const searchTextExists =
-    valueExistsIsLoading || debouncedSearchText !== searchText
-      ? null
-      : valueExists;
+    isApplyingFilter || valueExistsIsLoading ? null : valueExists;
 
   const searchTextFilter = useMemo(
-    () => createSearchTextFilter(tableUtils, columnName, debouncedSearchText),
-    [columnName, debouncedSearchText, tableUtils]
+    () => createSearchTextFilter(tableUtils, columnName, appliedSearchText),
+    [appliedSearchText, columnName, tableUtils]
   );
 
   // Filter out selected values from the picker
@@ -113,13 +146,14 @@ export function usePickerWithSelectedValues<TItem, TValue>(
     viewportPadding: VIEWPORT_PADDING,
   });
 
-  const hasSearchTextWithZeroResults = searchText.length > 0 && list.size === 0;
+  const hasSearchTextWithZeroResults =
+    searchTextMaybeTrimmed.length > 0 && list.size === 0;
   const searchTextIsInSelectedValues = selectedValueMap.has(
-    searchText as TValue
+    searchTextMaybeTrimmed as TValue
   );
 
   const onDebouncedSearchTextChange = useDebouncedCallback(
-    setDebouncedSearchText,
+    applySearchText,
     SEARCH_DEBOUNCE_MS
   );
 
@@ -136,7 +170,7 @@ export function usePickerWithSelectedValues<TItem, TValue>(
   const onSelectKey = useCallback(
     (key: Key | null) => {
       setSearchText('');
-      setDebouncedSearchText('');
+      applySearchText('');
 
       // Set the selection temporarily to avoid the picker staying open
       setSelectedKey(key);
@@ -165,7 +199,12 @@ export function usePickerWithSelectedValues<TItem, TValue>(
         return next;
       });
     },
-    [setSelectedKeyOnNextFrame, list.viewportData, mapItemToValue]
+    [
+      applySearchText,
+      setSelectedKeyOnNextFrame,
+      list.viewportData,
+      mapItemToValue,
+    ]
   );
 
   const onAddValues = useCallback((values: ReadonlySet<TValue>) => {

--- a/packages/react-hooks/src/useDebouncedValue.test.ts
+++ b/packages/react-hooks/src/useDebouncedValue.test.ts
@@ -15,7 +15,7 @@ it('should return the initial value', () => {
   const { result } = renderHook(() =>
     useDebouncedValue(value, DEFAULT_DEBOUNCE_MS)
   );
-  expect(result.current).toBe(value);
+  expect(result.current).toEqual({ isDebouncing: true, value });
 });
 
 it('should return the initial value after the debounce time has elapsed', () => {
@@ -23,14 +23,18 @@ it('should return the initial value after the debounce time has elapsed', () => 
   const { result, rerender } = renderHook(() =>
     useDebouncedValue(value, DEFAULT_DEBOUNCE_MS)
   );
-  expect(result.current).toBe(value);
+  expect(result.current).toEqual({ isDebouncing: true, value });
   expect(result.all.length).toBe(1);
+
   rerender();
+  expect(result.current).toEqual({ isDebouncing: true, value });
+  expect(result.all.length).toBe(2);
+
   act(() => {
     jest.advanceTimersByTime(DEFAULT_DEBOUNCE_MS);
   });
-  expect(result.current).toBe(value);
-  expect(result.all.length).toBe(2);
+  expect(result.current).toEqual({ isDebouncing: false, value });
+  expect(result.all.length).toBe(3);
 });
 
 it('should return the updated value after the debounce time has elapsed', () => {
@@ -39,12 +43,15 @@ it('should return the updated value after the debounce time has elapsed', () => 
   const { result, rerender } = renderHook((val = value) =>
     useDebouncedValue(val, DEFAULT_DEBOUNCE_MS)
   );
-  expect(result.current).toBe(value);
+  expect(result.current).toEqual({ isDebouncing: true, value });
+
   rerender(newValue);
+  expect(result.current).toEqual({ isDebouncing: true, value });
+
   act(() => {
     jest.advanceTimersByTime(DEFAULT_DEBOUNCE_MS);
   });
-  expect(result.current).toBe(newValue);
+  expect(result.current).toEqual({ isDebouncing: false, value: newValue });
 });
 
 it('should not return an intermediate value if the debounce time has not elapsed', () => {
@@ -54,19 +61,19 @@ it('should not return an intermediate value if the debounce time has not elapsed
   const { result, rerender } = renderHook((val = value) =>
     useDebouncedValue(val, DEFAULT_DEBOUNCE_MS)
   );
-  expect(result.current).toBe(value);
+  expect(result.current).toEqual({ isDebouncing: true, value });
   rerender(intermediateValue);
   act(() => {
     jest.advanceTimersByTime(DEFAULT_DEBOUNCE_MS - 5);
   });
-  expect(result.current).toBe(value);
+  expect(result.current).toEqual({ isDebouncing: true, value });
   rerender(newValue);
   act(() => {
     jest.advanceTimersByTime(DEFAULT_DEBOUNCE_MS - 5);
   });
-  expect(result.current).toBe(value);
+  expect(result.current).toEqual({ isDebouncing: true, value });
   act(() => {
     jest.advanceTimersByTime(DEFAULT_DEBOUNCE_MS);
   });
-  expect(result.current).toBe(newValue);
+  expect(result.current).toEqual({ isDebouncing: false, value: newValue });
 });

--- a/packages/react-hooks/src/useDebouncedValue.ts
+++ b/packages/react-hooks/src/useDebouncedValue.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 /**
  * Debounces a value.
@@ -13,15 +13,18 @@ export function useDebouncedValue<T>(
   debounceMs: number
 ): { isDebouncing: boolean; value: T } {
   const [isDebouncing, setIsDebouncing] = useState(true);
-  const [debouncedValue, setDebouncedValue] = useState<T>(value);
+  const [debouncedValue, setDebouncedValue] = useState(value);
 
-  // Set isDebouncing to true immediately whenever the value changes. Using
-  // `useMemo` instead of `useEffect` so that state is never out of sync whenever
-  // value and / or debounceMs have changed.
-  useMemo(() => {
+  // Keep `isDebouncing` in sync with `value` and `debounceMs` by setting state
+  // during render instead of in `useEffect`
+  // https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes
+  const [previousValue, setPreviousValue] = useState(value);
+  const [previousDebounceMs, setPreviousDebounceMs] = useState(debounceMs);
+  if (value !== previousValue || debounceMs !== previousDebounceMs) {
     setIsDebouncing(true);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [value, debounceMs]);
+    setPreviousValue(value);
+    setPreviousDebounceMs(debounceMs);
+  }
 
   useEffect(() => {
     let isCancelled = false;


### PR DESCRIPTION
Supports DH-16336:
- Added an `isDebouncing` prop to `useDebouncedValue`
- Added support for search text trimming to `usePickerWithSelectedValues`
- Introduced a validation delay to account for viewport filtering to improve UX and avoid flicker of validation message

resolves #1747

Note that there's not any place in DHC that uses the `usePickerWithSelectedValues` hook yet. I've been testing locally as part of DH-16336.

BREAKING CHANGE: `usePickerWithSelectedValues` now takes an object as an argument instead of positional args
