### PR TITLE
fix: Made WidgetComponentProps generic

### DIFF
--- a/packages/dashboard-core-plugins/src/GridPluginConfig.ts
+++ b/packages/dashboard-core-plugins/src/GridPluginConfig.ts
@@ -1,9 +1,10 @@
 import { PluginType, type WidgetPlugin } from '@deephaven/plugin';
 import { dhTable } from '@deephaven/icons';
+import { Table } from '@deephaven/jsapi-types';
 import { GridWidgetPlugin } from './GridWidgetPlugin';
 import { GridPanelPlugin } from './GridPanelPlugin';
 
-const GridPluginConfig: WidgetPlugin = {
+const GridPluginConfig: WidgetPlugin<Table> = {
   name: 'IrisGridPanel',
   title: 'Table',
   type: PluginType.WIDGET_PLUGIN,

--- a/packages/dashboard-core-plugins/src/GridWidgetPlugin.tsx
+++ b/packages/dashboard-core-plugins/src/GridWidgetPlugin.tsx
@@ -9,7 +9,7 @@ import {
 } from '@deephaven/iris-grid';
 
 export function GridWidgetPlugin(
-  props: WidgetComponentProps
+  props: WidgetComponentProps<Table>
 ): JSX.Element | null {
   const dh = useApi();
   const [model, setModel] = useState<IrisGridModel>();
@@ -19,7 +19,7 @@ export function GridWidgetPlugin(
   useEffect(() => {
     let cancelled = false;
     async function init() {
-      const table = (await fetch()) as unknown as Table;
+      const table = await fetch();
       const newModel = await IrisGridModelFactory.makeModel(dh, table);
       if (!cancelled) {
         setModel(newModel);

--- a/packages/plugin/src/PluginTypes.ts
+++ b/packages/plugin/src/PluginTypes.ts
@@ -105,8 +105,8 @@ export function isDashboardPlugin(
   return 'type' in plugin && plugin.type === PluginType.DASHBOARD_PLUGIN;
 }
 
-export interface WidgetComponentProps {
-  fetch: () => Promise<unknown>;
+export interface WidgetComponentProps<T = unknown> {
+  fetch: () => Promise<T>;
 }
 
 export interface WidgetPanelProps extends WidgetComponentProps {
@@ -120,7 +120,7 @@ export interface WidgetPanelProps extends WidgetComponentProps {
   glEventHub: EventEmitter;
 }
 
-export interface WidgetPlugin extends Plugin {
+export interface WidgetPlugin<T = unknown> extends Plugin {
   type: typeof PluginType.WIDGET_PLUGIN;
   /**
    * The component that can render the widget types the plugin supports.
@@ -129,7 +129,7 @@ export interface WidgetPlugin extends Plugin {
    * then `panelComponent` will be used instead.
    * The component will be wrapped in a default panel if `panelComponent` is not provided.
    */
-  component: React.ComponentType<WidgetComponentProps>;
+  component: React.ComponentType<WidgetComponentProps<T>>;
 
   /**
    * The server widget types that this plugin will handle.


### PR DESCRIPTION
Made `PluginType` generic. This fixes a breaking change that impacts `PlotlyExpressChartPanel` and `PlotlyExpressChart` in the plugins repo so that our next version bump will be cleaner.

fixes #1759