### PR TITLE
fix: Load full uncoalesced table if no partition columns available

### DIFF
--- a/packages/iris-grid/src/IrisGridTableModel.ts
+++ b/packages/iris-grid/src/IrisGridTableModel.ts
@@ -285,7 +285,11 @@ class IrisGridTableModel
   }
 
   get isPartitionRequired(): boolean {
-    return this.table.isUncoalesced && this.isValuesTableAvailable;
+    return (
+      this.table.isUncoalesced &&
+      this.isValuesTableAvailable &&
+      this.partitionColumns.length > 0
+    );
   }
 
   isFilterable(columnIndex: ModelIndex): boolean {


### PR DESCRIPTION
- When there are no partition columns, we should just load the whole table instead of hanging
- Tested with the snippet in the ticket
- Fixes #1763
