### PR TITLE
fix: Made some plugin types generic

### DIFF
--- a/packages/dashboard-core-plugins/src/ChartPanelPlugin.tsx
+++ b/packages/dashboard-core-plugins/src/ChartPanelPlugin.tsx
@@ -114,7 +114,7 @@ async function createChartModel(
 }
 
 export const ChartPanelPlugin = forwardRef(
-  (props: WidgetPanelProps, ref: React.Ref<ChartPanel>) => {
+  (props: WidgetPanelProps<Figure>, ref: React.Ref<ChartPanel>) => {
     const dh = useApi();
     const chartTheme = useChartTheme();
     const connection = useConnection();
@@ -139,7 +139,7 @@ export const ChartPanelPlugin = forwardRef(
             chartTheme,
             connection,
             metadata as ChartPanelMetadata,
-            fetch as () => Promise<Figure>,
+            fetch,
             panelState
           );
         },

--- a/packages/dashboard-core-plugins/src/ChartPluginConfig.ts
+++ b/packages/dashboard-core-plugins/src/ChartPluginConfig.ts
@@ -1,9 +1,10 @@
 import { PluginType, type WidgetPlugin } from '@deephaven/plugin';
 import { vsGraph } from '@deephaven/icons';
+import type { Figure } from '@deephaven/jsapi-types';
 import { ChartWidgetPlugin } from './ChartWidgetPlugin';
 import { ChartPanelPlugin } from './ChartPanelPlugin';
 
-const ChartPluginConfig: WidgetPlugin = {
+const ChartPluginConfig: WidgetPlugin<Figure> = {
   name: 'ChartPanel',
   title: 'Chart',
   type: PluginType.WIDGET_PLUGIN,

--- a/packages/dashboard-core-plugins/src/ChartWidgetPlugin.tsx
+++ b/packages/dashboard-core-plugins/src/ChartWidgetPlugin.tsx
@@ -10,7 +10,7 @@ import type { Figure } from '@deephaven/jsapi-types';
 import { type WidgetComponentProps } from '@deephaven/plugin';
 
 export function ChartWidgetPlugin(
-  props: WidgetComponentProps
+  props: WidgetComponentProps<Figure>
 ): JSX.Element | null {
   const dh = useApi();
   const chartTheme = useChartTheme();

--- a/packages/dashboard-core-plugins/src/GridPanelPlugin.tsx
+++ b/packages/dashboard-core-plugins/src/GridPanelPlugin.tsx
@@ -7,12 +7,9 @@ import ConnectedIrisGridPanel, {
 } from './panels/IrisGridPanel';
 
 export const GridPanelPlugin = forwardRef(
-  (props: WidgetPanelProps, ref: React.Ref<IrisGridPanel>) => {
+  (props: WidgetPanelProps<Table>, ref: React.Ref<IrisGridPanel>) => {
     const { localDashboardId, fetch } = props;
-    const hydratedProps = useHydrateGrid(
-      fetch as () => Promise<Table>,
-      localDashboardId
-    );
+    const hydratedProps = useHydrateGrid(fetch, localDashboardId);
 
     // eslint-disable-next-line react/jsx-props-no-spreading
     return <ConnectedIrisGridPanel ref={ref} {...props} {...hydratedProps} />;

--- a/packages/dashboard-core-plugins/src/PandasPanelPlugin.tsx
+++ b/packages/dashboard-core-plugins/src/PandasPanelPlugin.tsx
@@ -5,12 +5,9 @@ import { PandasPanel } from './panels';
 import useHydrateGrid from './useHydrateGrid';
 
 export const PandasPanelPlugin = forwardRef(
-  (props: WidgetPanelProps, ref: React.Ref<PandasPanel>) => {
+  (props: WidgetPanelProps<Table>, ref: React.Ref<PandasPanel>) => {
     const { localDashboardId, fetch } = props;
-    const hydratedProps = useHydrateGrid(
-      fetch as () => Promise<Table>,
-      localDashboardId
-    );
+    const hydratedProps = useHydrateGrid(fetch, localDashboardId);
 
     return (
       // eslint-disable-next-line react/jsx-props-no-spreading

--- a/packages/dashboard-core-plugins/src/PandasPluginConfig.ts
+++ b/packages/dashboard-core-plugins/src/PandasPluginConfig.ts
@@ -1,9 +1,10 @@
 import { PluginType, WidgetPlugin } from '@deephaven/plugin';
 import { dhPandas } from '@deephaven/icons';
+import type { Table } from '@deephaven/jsapi-types';
 import { PandasWidgetPlugin } from './PandasWidgetPlugin';
 import { PandasPanelPlugin } from './PandasPanelPlugin';
 
-const PandasPluginConfig: WidgetPlugin = {
+const PandasPluginConfig: WidgetPlugin<Table> = {
   name: 'PandasPanel',
   title: 'Pandas',
   type: PluginType.WIDGET_PLUGIN,

--- a/packages/dashboard-core-plugins/src/PandasWidgetPlugin.tsx
+++ b/packages/dashboard-core-plugins/src/PandasWidgetPlugin.tsx
@@ -10,7 +10,7 @@ import { LoadingOverlay } from '@deephaven/components';
 import { PandasReloadButton } from './panels/PandasReloadButton';
 
 export function PandasWidgetPlugin(
-  props: WidgetComponentProps
+  props: WidgetComponentProps<Table>
 ): JSX.Element | null {
   const dh = useApi();
   const [model, setModel] = useState<IrisGridModel>();
@@ -20,7 +20,7 @@ export function PandasWidgetPlugin(
   const { fetch } = props;
 
   const makeModel = useCallback(async () => {
-    const table = (await fetch()) as unknown as Table;
+    const table = await fetch();
     return IrisGridModelFactory.makeModel(dh, table);
   }, [dh, fetch]);
 

--- a/packages/plugin/src/PluginTypes.ts
+++ b/packages/plugin/src/PluginTypes.ts
@@ -109,7 +109,7 @@ export interface WidgetComponentProps<T = unknown> {
   fetch: () => Promise<T>;
 }
 
-export interface WidgetPanelProps extends WidgetComponentProps {
+export interface WidgetPanelProps<T = unknown> extends WidgetComponentProps<T> {
   metadata?: {
     id?: string;
     name?: string;
@@ -154,7 +154,7 @@ export interface WidgetPlugin<T = unknown> extends Plugin {
    *
    * See @deephaven/dashboard-core-plugins WidgetPanel for the component that should be used here.
    */
-  panelComponent?: React.ComponentType<WidgetPanelProps>;
+  panelComponent?: React.ComponentType<WidgetPanelProps<T>>;
 
   /**
    * The icon to display next to the console button.


### PR DESCRIPTION
I missed making `WidgetPanelProps` generic in the last PR which is needed to version bump plotly express.
resolves #1759