### PR TITLE
feat: disable "Changes you made may not be saved." prompt in dev mode

### DIFF
--- a/packages/code-studio/src/main/AppMainContainer.tsx
+++ b/packages/code-studio/src/main/AppMainContainer.tsx
@@ -165,6 +165,7 @@ export class AppMainContainer extends Component<
   AppMainContainerState
 > {
   static handleWindowBeforeUnload(event: BeforeUnloadEvent): void {
+    // in development, allow auto-reload
     if (import.meta.env.PROD) {
       event.preventDefault();
       // returnValue is required for beforeReload event prompt

--- a/packages/code-studio/src/main/AppMainContainer.tsx
+++ b/packages/code-studio/src/main/AppMainContainer.tsx
@@ -165,11 +165,13 @@ export class AppMainContainer extends Component<
   AppMainContainerState
 > {
   static handleWindowBeforeUnload(event: BeforeUnloadEvent): void {
-    event.preventDefault();
-    // returnValue is required for beforeReload event prompt
-    // https://developer.mozilla.org/en-US/docs/Web/API/WindowEventHandlers/onbeforeunload#example
-    // eslint-disable-next-line no-param-reassign
-    event.returnValue = '';
+    if (import.meta.env.PROD) {
+      event.preventDefault();
+      // returnValue is required for beforeReload event prompt
+      // https://developer.mozilla.org/en-US/docs/Web/API/WindowEventHandlers/onbeforeunload#example
+      // eslint-disable-next-line no-param-reassign
+      event.returnValue = '';
+    }
   }
 
   static hydrateConsole(


### PR DESCRIPTION
When developing, the prompt to reload is a pretty annoying feature. I am not worried about lost query progress in dev mode, auto-refresh is more important.