### PR TITLE
fix: DH-16463: isEqual returns false for layouts with undefined and missing props in panelState

### DIFF
--- a/packages/dashboard/src/layout/LayoutUtils.test.ts
+++ b/packages/dashboard/src/layout/LayoutUtils.test.ts
@@ -1,4 +1,7 @@
-import type { ContentItem } from '@deephaven/golden-layout';
+import type {
+  ContentItem,
+  ReactComponentConfig,
+} from '@deephaven/golden-layout';
 import LayoutUtils from './LayoutUtils';
 
 function makeContentItem(type = 'root'): Partial<ContentItem> {
@@ -123,5 +126,35 @@ describe('getContentItemInStack', () => {
       id: 'noItemFound',
     });
     expect(found).toBeNull();
+  });
+});
+
+describe('isEqual', () => {
+  function makeComponentConfig(
+    props: Record<string, unknown>
+  ): ReactComponentConfig {
+    return {
+      component: 'ReactComponent',
+      type: 'component',
+      props,
+    };
+  }
+
+  it('ignores the difference between undefined and missing properties', () => {
+    expect(
+      LayoutUtils.isEqual(
+        [makeComponentConfig({ a: 1, b: undefined })],
+        [makeComponentConfig({ a: 1 })]
+      )
+    ).toBe(true);
+  });
+
+  it('correctly differentiates null from undefined', () => {
+    expect(
+      LayoutUtils.isEqual(
+        [makeComponentConfig({ a: 1, b: undefined })],
+        [makeComponentConfig({ a: 1, b: null })]
+      )
+    ).toBe(false);
   });
 });

--- a/packages/dashboard/src/layout/LayoutUtils.ts
+++ b/packages/dashboard/src/layout/LayoutUtils.ts
@@ -379,14 +379,15 @@ class LayoutUtils {
     layout2: DashboardLayoutConfig,
     major = false
   ): boolean {
+    const layout1Clone = LayoutUtils.cloneLayout(layout1);
+    const layout2Clone = LayoutUtils.cloneLayout(layout2);
     if (major) {
-      const layout1Clone = LayoutUtils.cloneLayout(layout1);
-      const layout2Clone = LayoutUtils.cloneLayout(layout2);
       LayoutUtils.dropLayoutMinorChange(layout1Clone);
       LayoutUtils.dropLayoutMinorChange(layout2Clone);
       return deepEqual(layout1Clone, layout2Clone);
     }
-    return deepEqual(layout1, layout2);
+    // Pass cloned layouts to avoid false positives when comparing undefined with missing properties
+    return deepEqual(layout1Clone, layout2Clone);
   }
 
   static cloneLayout(layout: DashboardLayoutConfig): DashboardLayoutConfig {

--- a/packages/dashboard/src/layout/LayoutUtils.ts
+++ b/packages/dashboard/src/layout/LayoutUtils.ts
@@ -386,7 +386,8 @@ class LayoutUtils {
       LayoutUtils.dropLayoutMinorChange(layout2Clone);
       return deepEqual(layout1Clone, layout2Clone);
     }
-    // Pass cloned layouts to avoid false positives when comparing undefined with missing properties
+    // Pass cloned layouts to avoid false negatives
+    // when comparing layouts with undefined and missing properties
     return deepEqual(layout1Clone, layout2Clone);
   }
 


### PR DESCRIPTION
`LayoutUtils.isEqual` gives a false negative when we compare a dehydrated layout having any undefined property with the same layout passed through `JSON.serialize`/`JSON.parse`, because all undefined properties get deleted when serialized.

Fixes DH-16463