### PR TITLE
fix: address chrome 121 scrollbar style behaviour change (#1787)

### DIFF
--- a/packages/components/scss/BaseStyleSheet.scss
+++ b/packages/components/scss/BaseStyleSheet.scss
@@ -26,7 +26,6 @@ body {
   padding: 0;
   overscroll-behavior: none;
   -ms-scroll-chaining: none;
-  scrollbar-color: rgba($white, 0.1) rgba($black, 0.1); //applies to firefox only
 }
 
 #root {


### PR DESCRIPTION
Chrome adopted offical support for scrollbar-color in chrome 121. However, if you have both scrollbar-color and ::webkit-scrollbar styling, they conflict and chrome will only honour the native styling. This is bad because the native chrome mac scrollbars become really small, and overlap too much with out golden-layout drag.

Our webkit styling forces scrollbars that match monaco and grid, and are preferred. By removing `scrollbar-color` native styling, our webkit styles work. We only had scrollbar-color to style firefox in dark mode (`//applies to firefox only` is no longer true), however the most recent versions of firefox appear to color scrollbars automatically based on the theme, so this is no longer necessary.

The crappy part here is since this is browser change, we will have to backport this for several active enterprise versions.

See:
-
https://stackoverflow.com/questions/77919700/scrollbars-chrome-update-121
- https://issues.chromium.org/issues/41494676