### PR TITLE
fix: Bind this to utils that moved from static to non-static with js api de-globalization

### DIFF
--- a/packages/chart/src/ChartUtils.ts
+++ b/packages/chart/src/ChartUtils.ts
@@ -34,7 +34,7 @@ import type {
   OhlcData,
   MarkerSymbol,
 } from 'plotly.js';
-import { assertNotNull, Range } from '@deephaven/utils';
+import { assertNotNull, bindAllMethods, Range } from '@deephaven/utils';
 import { ChartTheme } from './ChartTheme';
 
 export type FilterColumnMap = Map<
@@ -548,6 +548,7 @@ class ChartUtils {
   constructor(dh: DhType) {
     this.dh = dh;
     this.daysOfWeek = Object.freeze(dh.calendar.DayOfWeek.values());
+    bindAllMethods(this);
   }
 
   /**

--- a/packages/iris-grid/src/IrisGrid.tsx
+++ b/packages/iris-grid/src/IrisGrid.tsx
@@ -96,7 +96,6 @@ import {
   PromiseUtils,
   ValidationError,
   getOrThrow,
-  bindAllMethods,
 } from '@deephaven/utils';
 import {
   Type as FilterType,
@@ -533,7 +532,86 @@ export class IrisGrid extends Component<IrisGridProps, IrisGridState> {
   constructor(props: IrisGridProps) {
     super(props);
 
-    bindAllMethods(this);
+    this.handleAdvancedFilterChange =
+      this.handleAdvancedFilterChange.bind(this);
+    this.handleAdvancedFilterSortChange =
+      this.handleAdvancedFilterSortChange.bind(this);
+    this.handleAdvancedFilterDone = this.handleAdvancedFilterDone.bind(this);
+    this.handleAdvancedMenuOpened = this.handleAdvancedMenuOpened.bind(this);
+    this.handleGotoRowOpened = this.handleGotoRowOpened.bind(this);
+    this.handleGotoRowClosed = this.handleGotoRowClosed.bind(this);
+    this.handleAdvancedMenuClosed = this.handleAdvancedMenuClosed.bind(this);
+    this.handleAggregationChange = this.handleAggregationChange.bind(this);
+    this.handleAggregationsChange = this.handleAggregationsChange.bind(this);
+    this.handleAggregationEdit = this.handleAggregationEdit.bind(this);
+    this.handleAnimationLoop = this.handleAnimationLoop.bind(this);
+    this.handleAnimationStart = this.handleAnimationStart.bind(this);
+    this.handleAnimationEnd = this.handleAnimationEnd.bind(this);
+    this.handleChartChange = this.handleChartChange.bind(this);
+    this.handleChartCreate = this.handleChartCreate.bind(this);
+    this.handleGridError = this.handleGridError.bind(this);
+    this.handleFilterBarChange = this.handleFilterBarChange.bind(this);
+    this.handleFilterBarDone = this.handleFilterBarDone.bind(this);
+    this.handleFilterBarTab = this.handleFilterBarTab.bind(this);
+    this.handleCancel = this.handleCancel.bind(this);
+    this.handleMenu = this.handleMenu.bind(this);
+    this.handleMenuClose = this.handleMenuClose.bind(this);
+    this.handleMenuSelect = this.handleMenuSelect.bind(this);
+    this.handleMenuBack = this.handleMenuBack.bind(this);
+    this.handleRequestFailed = this.handleRequestFailed.bind(this);
+    this.handleSelectionChanged = this.handleSelectionChanged.bind(this);
+    this.handleMovedColumnsChanged = this.handleMovedColumnsChanged.bind(this);
+    this.handleHeaderGroupsChanged = this.handleHeaderGroupsChanged.bind(this);
+    this.handleUpdate = this.handleUpdate.bind(this);
+    this.handleTooltipRef = this.handleTooltipRef.bind(this);
+    this.handleViewChanged = this.handleViewChanged.bind(this);
+    this.handleFormatSelection = this.handleFormatSelection.bind(this);
+    this.handleConditionalFormatCreate =
+      this.handleConditionalFormatCreate.bind(this);
+    this.handleConditionalFormatEdit =
+      this.handleConditionalFormatEdit.bind(this);
+    this.handleConditionalFormatsChange =
+      this.handleConditionalFormatsChange.bind(this);
+    this.handleConditionalFormatEditorSave =
+      this.handleConditionalFormatEditorSave.bind(this);
+    this.handleConditionalFormatEditorCancel =
+      this.handleConditionalFormatEditorCancel.bind(this);
+    this.handleUpdateCustomColumns = this.handleUpdateCustomColumns.bind(this);
+    this.handleCustomColumnsChanged =
+      this.handleCustomColumnsChanged.bind(this);
+    this.handleSelectDistinctChanged =
+      this.handleSelectDistinctChanged.bind(this);
+    this.handlePendingDataUpdated = this.handlePendingDataUpdated.bind(this);
+    this.handlePendingCommitClicked =
+      this.handlePendingCommitClicked.bind(this);
+    this.handlePendingDiscardClicked =
+      this.handlePendingDiscardClicked.bind(this);
+    this.handleGotoRowSelectedRowNumberSubmit =
+      this.handleGotoRowSelectedRowNumberSubmit.bind(this);
+    this.focusRowInGrid = this.focusRowInGrid.bind(this);
+    this.handleDownloadTable = this.handleDownloadTable.bind(this);
+    this.handleDownloadTableStart = this.handleDownloadTableStart.bind(this);
+    this.handleCancelDownloadTable = this.handleCancelDownloadTable.bind(this);
+    this.handleDownloadCanceled = this.handleDownloadCanceled.bind(this);
+    this.handleDownloadCompleted = this.handleDownloadCompleted.bind(this);
+    this.handlePartitionChange = this.handlePartitionChange.bind(this);
+    this.handleColumnVisibilityChanged =
+      this.handleColumnVisibilityChanged.bind(this);
+    this.handleColumnVisibilityReset =
+      this.handleColumnVisibilityReset.bind(this);
+    this.handleCrossColumnSearch = this.handleCrossColumnSearch.bind(this);
+    this.handleRollupChange = this.handleRollupChange.bind(this);
+    this.handleOverflowClose = this.handleOverflowClose.bind(this);
+    this.getColumnBoundingRect = this.getColumnBoundingRect.bind(this);
+    this.handleGotoRowSelectedRowNumberChanged =
+      this.handleGotoRowSelectedRowNumberChanged.bind(this);
+    this.handleGotoValueSelectedColumnNameChanged =
+      this.handleGotoValueSelectedColumnNameChanged.bind(this);
+    this.handleGotoValueSelectedFilterChanged =
+      this.handleGotoValueSelectedFilterChanged.bind(this);
+    this.handleGotoValueChanged = this.handleGotoValueChanged.bind(this);
+    this.handleGotoValueSubmitted = this.handleGotoValueSubmitted.bind(this);
+    this.makeQuickFilter = this.makeQuickFilter.bind(this);
 
     this.grid = null;
     this.lastLoadedConfig = null;

--- a/packages/iris-grid/src/IrisGrid.tsx
+++ b/packages/iris-grid/src/IrisGrid.tsx
@@ -96,6 +96,7 @@ import {
   PromiseUtils,
   ValidationError,
   getOrThrow,
+  bindAllMethods,
 } from '@deephaven/utils';
 import {
   Type as FilterType,
@@ -532,85 +533,7 @@ export class IrisGrid extends Component<IrisGridProps, IrisGridState> {
   constructor(props: IrisGridProps) {
     super(props);
 
-    this.handleAdvancedFilterChange =
-      this.handleAdvancedFilterChange.bind(this);
-    this.handleAdvancedFilterSortChange =
-      this.handleAdvancedFilterSortChange.bind(this);
-    this.handleAdvancedFilterDone = this.handleAdvancedFilterDone.bind(this);
-    this.handleAdvancedMenuOpened = this.handleAdvancedMenuOpened.bind(this);
-    this.handleGotoRowOpened = this.handleGotoRowOpened.bind(this);
-    this.handleGotoRowClosed = this.handleGotoRowClosed.bind(this);
-    this.handleAdvancedMenuClosed = this.handleAdvancedMenuClosed.bind(this);
-    this.handleAggregationChange = this.handleAggregationChange.bind(this);
-    this.handleAggregationsChange = this.handleAggregationsChange.bind(this);
-    this.handleAggregationEdit = this.handleAggregationEdit.bind(this);
-    this.handleAnimationLoop = this.handleAnimationLoop.bind(this);
-    this.handleAnimationStart = this.handleAnimationStart.bind(this);
-    this.handleAnimationEnd = this.handleAnimationEnd.bind(this);
-    this.handleChartChange = this.handleChartChange.bind(this);
-    this.handleChartCreate = this.handleChartCreate.bind(this);
-    this.handleGridError = this.handleGridError.bind(this);
-    this.handleFilterBarChange = this.handleFilterBarChange.bind(this);
-    this.handleFilterBarDone = this.handleFilterBarDone.bind(this);
-    this.handleFilterBarTab = this.handleFilterBarTab.bind(this);
-    this.handleCancel = this.handleCancel.bind(this);
-    this.handleMenu = this.handleMenu.bind(this);
-    this.handleMenuClose = this.handleMenuClose.bind(this);
-    this.handleMenuSelect = this.handleMenuSelect.bind(this);
-    this.handleMenuBack = this.handleMenuBack.bind(this);
-    this.handleRequestFailed = this.handleRequestFailed.bind(this);
-    this.handleSelectionChanged = this.handleSelectionChanged.bind(this);
-    this.handleMovedColumnsChanged = this.handleMovedColumnsChanged.bind(this);
-    this.handleHeaderGroupsChanged = this.handleHeaderGroupsChanged.bind(this);
-    this.handleUpdate = this.handleUpdate.bind(this);
-    this.handleTooltipRef = this.handleTooltipRef.bind(this);
-    this.handleViewChanged = this.handleViewChanged.bind(this);
-    this.handleFormatSelection = this.handleFormatSelection.bind(this);
-    this.handleConditionalFormatCreate =
-      this.handleConditionalFormatCreate.bind(this);
-    this.handleConditionalFormatEdit =
-      this.handleConditionalFormatEdit.bind(this);
-    this.handleConditionalFormatsChange =
-      this.handleConditionalFormatsChange.bind(this);
-    this.handleConditionalFormatEditorSave =
-      this.handleConditionalFormatEditorSave.bind(this);
-    this.handleConditionalFormatEditorCancel =
-      this.handleConditionalFormatEditorCancel.bind(this);
-    this.handleUpdateCustomColumns = this.handleUpdateCustomColumns.bind(this);
-    this.handleCustomColumnsChanged =
-      this.handleCustomColumnsChanged.bind(this);
-    this.handleSelectDistinctChanged =
-      this.handleSelectDistinctChanged.bind(this);
-    this.handlePendingDataUpdated = this.handlePendingDataUpdated.bind(this);
-    this.handlePendingCommitClicked =
-      this.handlePendingCommitClicked.bind(this);
-    this.handlePendingDiscardClicked =
-      this.handlePendingDiscardClicked.bind(this);
-    this.handleGotoRowSelectedRowNumberSubmit =
-      this.handleGotoRowSelectedRowNumberSubmit.bind(this);
-    this.focusRowInGrid = this.focusRowInGrid.bind(this);
-    this.handleDownloadTable = this.handleDownloadTable.bind(this);
-    this.handleDownloadTableStart = this.handleDownloadTableStart.bind(this);
-    this.handleCancelDownloadTable = this.handleCancelDownloadTable.bind(this);
-    this.handleDownloadCanceled = this.handleDownloadCanceled.bind(this);
-    this.handleDownloadCompleted = this.handleDownloadCompleted.bind(this);
-    this.handlePartitionChange = this.handlePartitionChange.bind(this);
-    this.handleColumnVisibilityChanged =
-      this.handleColumnVisibilityChanged.bind(this);
-    this.handleColumnVisibilityReset =
-      this.handleColumnVisibilityReset.bind(this);
-    this.handleCrossColumnSearch = this.handleCrossColumnSearch.bind(this);
-    this.handleRollupChange = this.handleRollupChange.bind(this);
-    this.handleOverflowClose = this.handleOverflowClose.bind(this);
-    this.getColumnBoundingRect = this.getColumnBoundingRect.bind(this);
-    this.handleGotoRowSelectedRowNumberChanged =
-      this.handleGotoRowSelectedRowNumberChanged.bind(this);
-    this.handleGotoValueSelectedColumnNameChanged =
-      this.handleGotoValueSelectedColumnNameChanged.bind(this);
-    this.handleGotoValueSelectedFilterChanged =
-      this.handleGotoValueSelectedFilterChanged.bind(this);
-    this.handleGotoValueChanged = this.handleGotoValueChanged.bind(this);
-    this.handleGotoValueSubmitted = this.handleGotoValueSubmitted.bind(this);
+    bindAllMethods(this);
 
     this.grid = null;
     this.lastLoadedConfig = null;

--- a/packages/iris-grid/src/IrisGridUtils.ts
+++ b/packages/iris-grid/src/IrisGridUtils.ts
@@ -28,7 +28,12 @@ import {
   FormattingRule,
 } from '@deephaven/jsapi-utils';
 import Log from '@deephaven/log';
-import { assertNotNull, EMPTY_ARRAY, EMPTY_MAP } from '@deephaven/utils';
+import {
+  assertNotNull,
+  bindAllMethods,
+  EMPTY_ARRAY,
+  EMPTY_MAP,
+} from '@deephaven/utils';
 import AggregationUtils from './sidebar/aggregations/AggregationUtils';
 import AggregationOperation from './sidebar/aggregations/AggregationOperation';
 import { FilterData, IrisGridProps, IrisGridState } from './IrisGrid';
@@ -1144,6 +1149,7 @@ class IrisGridUtils {
   constructor(dh: DhType) {
     this.dh = dh;
     this.tableUtils = new TableUtils(dh);
+    bindAllMethods(this);
   }
 
   /**

--- a/packages/iris-grid/src/mousehandlers/IrisGridContextMenuHandler.tsx
+++ b/packages/iris-grid/src/mousehandlers/IrisGridContextMenuHandler.tsx
@@ -160,6 +160,8 @@ class IrisGridContextMenuHandler extends GridMouseHandler {
   constructor(irisGrid: IrisGrid, dh: DhType) {
     super();
 
+    bindAllMethods(this);
+
     this.debouncedUpdateCustomFormat = debounce(
       irisGrid.handleFormatSelection,
       DEBOUNCE_UPDATE_FORMAT
@@ -167,7 +169,6 @@ class IrisGridContextMenuHandler extends GridMouseHandler {
 
     this.dh = dh;
     this.irisGrid = irisGrid;
-    bindAllMethods(this);
   }
 
   componentWillUnmount(): void {

--- a/packages/iris-grid/src/mousehandlers/IrisGridContextMenuHandler.tsx
+++ b/packages/iris-grid/src/mousehandlers/IrisGridContextMenuHandler.tsx
@@ -50,6 +50,7 @@ import {
   assertNotNaN,
   assertNotNull,
   copyToClipboard,
+  bindAllMethods,
 } from '@deephaven/utils';
 import {
   DateTimeFormatContextMenu,
@@ -166,6 +167,7 @@ class IrisGridContextMenuHandler extends GridMouseHandler {
 
     this.dh = dh;
     this.irisGrid = irisGrid;
+    bindAllMethods(this);
   }
 
   componentWillUnmount(): void {

--- a/packages/iris-grid/src/mousehandlers/IrisGridContextMenuHandler.tsx
+++ b/packages/iris-grid/src/mousehandlers/IrisGridContextMenuHandler.tsx
@@ -50,7 +50,6 @@ import {
   assertNotNaN,
   assertNotNull,
   copyToClipboard,
-  bindAllMethods,
 } from '@deephaven/utils';
 import {
   DateTimeFormatContextMenu,
@@ -160,7 +159,10 @@ class IrisGridContextMenuHandler extends GridMouseHandler {
   constructor(irisGrid: IrisGrid, dh: DhType) {
     super();
 
-    bindAllMethods(this);
+    this.getNumberValueEqualsFilter =
+      this.getNumberValueEqualsFilter.bind(this);
+    this.getFilterValueForNumberOrChar =
+      this.getFilterValueForNumberOrChar.bind(this);
 
     this.debouncedUpdateCustomFormat = debounce(
       irisGrid.handleFormatSelection,

--- a/packages/iris-grid/src/sidebar/ChartBuilder.tsx
+++ b/packages/iris-grid/src/sidebar/ChartBuilder.tsx
@@ -16,6 +16,7 @@ import type {
   SeriesPlotStyle,
 } from '@deephaven/jsapi-types';
 import Log from '@deephaven/log';
+import { bindAllMethods } from '@deephaven/utils';
 import shortid from 'shortid';
 import {
   BarIcon,
@@ -105,15 +106,7 @@ class ChartBuilder extends PureComponent<ChartBuilderProps, ChartBuilderState> {
   constructor(props: ChartBuilderProps) {
     super(props);
 
-    this.handleAddSeries = this.handleAddSeries.bind(this);
-    this.handleLinkStateChange = this.handleLinkStateChange.bind(this);
-    this.handleReset = this.handleReset.bind(this);
-    this.handleSeriesChange = this.handleSeriesChange.bind(this);
-    this.handleSeriesDeleteClick = this.handleSeriesDeleteClick.bind(this);
-    this.handleSubmit = this.handleSubmit.bind(this);
-    this.handleTypeClick = this.handleTypeClick.bind(this);
-    this.handleXAxisChange = this.handleXAxisChange.bind(this);
-    this.sendChange = this.sendChange.bind(this);
+    bindAllMethods(this);
 
     const { model } = props;
     const { columns, dh } = model;


### PR DESCRIPTION
I noticed this issue while investigating https://github.com/deephaven/deephaven-plugins/issues/179 and switching a param of `(v)  => this.chartUtils.unwrapValue(v)` to just `this.chartUtils.unwrapValue`

Looked through the other de-globalization PRs and added `bindAllMethods` to any classes where there were some static methods moved to non-static so that they can be used this way