### PR TITLE
test: fix flaky tests

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -50,7 +50,7 @@ const config: PlaywrightTestConfig = {
     baseURL: 'http://localhost:4000/ide/',
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
-    trace: 'on-first-retry',
+    trace: 'retain-on-failure',
 
     /* Retain videos on failure for easier debugging */
     video: 'retain-on-failure',

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -50,7 +50,7 @@ const config: PlaywrightTestConfig = {
     baseURL: 'http://localhost:4000/ide/',
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
-    trace: 'retain-on-failure',
+    trace: 'on-first-retry',
 
     /* Retain videos on failure for easier debugging */
     video: 'retain-on-failure',

--- a/tests/context-menu.spec.ts
+++ b/tests/context-menu.spec.ts
@@ -186,7 +186,7 @@ test('filter by value', async ({ page }) => {
   await page
     .locator('.iris-grid .grid-wrapper')
     .click({ button: 'right', position: { x: 20, y: 60 } });
-  await expectContextMenus(page, 1, true);
+  await expectContextMenus(page, 1);
 
   await page.getByRole('button', { name: 'Filter by Value' }).hover();
   await expectContextMenus(page, 2);
@@ -205,7 +205,7 @@ test('go to', async ({ page }) => {
   await page
     .locator('.iris-grid .grid-wrapper')
     .click({ button: 'right', position: { x: 20, y: 60 } });
-  await expectContextMenus(page, 1, true);
+  await expectContextMenus(page, 1);
 
   await page.getByRole('button', { name: 'Go to' }).click();
   await page.getByLabel('filter-type-select').selectOption('Equals');

--- a/tests/table-multiselect.spec.ts
+++ b/tests/table-multiselect.spec.ts
@@ -52,7 +52,7 @@ async function filterAndScreenshot(
   await page.getByRole('button', { name: 'Filter by Values' }).hover();
   await expectContextMenus(page, 2);
   await page.getByRole('button', { name: filterType, exact: true }).click();
-  await waitForLoadingDone(page);
+  await waitForLoadingDone(page, '.iris-grid-loading-status-bar');
   await expect(page.locator('.iris-grid-column')).toHaveScreenshot(
     screenshotName
   );

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -71,7 +71,7 @@ async function openObject(
   expect(openButton).not.toBeNull();
   expect(openButton).not.toBeDisabled();
   await openButton.click();
-  
+
   await expect(page.locator('.loading-spinner')).toHaveCount(0);
 }
 
@@ -303,15 +303,10 @@ export async function waitForLoadingDone(
  */
 export async function expectContextMenus(
   page: Page,
-  count: number,
-  waitForFiltersToLoad = false
+  count: number
 ): Promise<void> {
   await expect(page.locator('.context-menu-container')).toHaveCount(count);
-  if (waitForFiltersToLoad) {
-    await expect(
-      page.getByRole('button', { name: 'Filter by Value' })
-    ).not.toBeNull();
-  }
+  await expect(page.locator('.loading-spinner')).toHaveCount(0);
 }
 
 /**

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -71,6 +71,8 @@ async function openObject(
   expect(openButton).not.toBeNull();
   expect(openButton).not.toBeDisabled();
   await openButton.click();
+  
+  await expect(page.locator('.loading-spinner')).toHaveCount(0);
 }
 
 /**


### PR DESCRIPTION
### Context Menu

- Fixes #1799 
- Add a check that `.loading-spinner` disappears before locating and clicking the Go To button

Multiselect values (#1736) turned the filter options to be async. This results in the context menu having a loading spinner at the bottom for a few milliseconds. Flakiness happens when the filter options are resolved between the Go To value being located and pressed.

![image](https://github.com/deephaven/web-client-ui/assets/93849557/54af9484-e794-4bf1-b098-d65d833ca2d4)
![image](https://github.com/deephaven/web-client-ui/assets/93849557/3e192f86-4142-4674-8920-cd412d5dffa1)


### Multiselect Filter Flakiness

- Add a check for the loading spinner after opening a table/plot
- Add a check for .`iris-grid-loading-status-bar` after applying filter

Upon opening a table/plot, the loading indicator is a `.loading-spinner` instead of `.iris-grid-loading-status`. As such, the check is passed. This causes the mouse click to happen even though the grid isn't loaded yet and Playwright is waiting for a context menu to appear when `.iris-grid-loading-status` is present.

![image](https://github.com/deephaven/web-client-ui/assets/93849557/b05ab37d-3463-47d0-b9b2-0c5e16045336)
![image](https://github.com/deephaven/web-client-ui/assets/93849557/81c6c9d9-0788-4450-aadd-f6a7583387f0)