### PR TITLE
fix: Load default dashboard data from workspace data

### DIFF
--- a/packages/code-studio/src/main/AppMainContainer.tsx
+++ b/packages/code-studio/src/main/AppMainContainer.tsx
@@ -39,6 +39,7 @@ import {
   PanelEvent,
   setDashboardData as setDashboardDataAction,
   setDashboardPluginData as setDashboardPluginDataAction,
+  stopListenForCreateDashboard,
   updateDashboardData as updateDashboardDataAction,
 } from '@deephaven/dashboard';
 import {
@@ -283,6 +284,13 @@ export class AppMainContainer extends Component<
     this.deinitWidgets();
     this.stopListeningForDisconnect();
 
+    if (this.goldenLayout != null) {
+      stopListenForCreateDashboard(
+        this.goldenLayout.eventHub,
+        this.handleCreateDashboard
+      );
+    }
+
     window.removeEventListener(
       'beforeunload',
       AppMainContainer.handleWindowBeforeUnload
@@ -470,7 +478,17 @@ export class AppMainContainer extends Component<
   }
 
   handleGoldenLayoutChange(goldenLayout: GoldenLayout): void {
+    if (this.goldenLayout === goldenLayout) return;
+
+    if (this.goldenLayout != null) {
+      stopListenForCreateDashboard(
+        this.goldenLayout.eventHub,
+        this.handleCreateDashboard
+      );
+    }
+
     this.goldenLayout = goldenLayout;
+
     listenForCreateDashboard(
       this.goldenLayout.eventHub,
       this.handleCreateDashboard

--- a/packages/code-studio/src/main/AppMainContainer.tsx
+++ b/packages/code-studio/src/main/AppMainContainer.tsx
@@ -262,6 +262,7 @@ export class AppMainContainer extends Component<
 
   componentDidMount(): void {
     this.initWidgets();
+    this.initDashboardData();
     this.startListeningForDisconnect();
 
     window.addEventListener(
@@ -343,6 +344,14 @@ export class AppMainContainer extends Component<
 
   deinitWidgets(): void {
     this.widgetListenerRemover?.();
+  }
+
+  initDashboardData(): void {
+    const { allDashboardData, workspace } = this.props;
+    const { data: workspaceData } = workspace;
+    // const { layoutConfig } = workspaceData;
+    console.log(allDashboardData, workspaceData);
+    debugger;
   }
 
   openNotebookFromURL(): void {
@@ -473,8 +482,8 @@ export class AppMainContainer extends Component<
     const { updateWorkspaceData } = this.props;
 
     // Only save the data that is serializable/we want to persist to the workspace
-    const { closed, filterSets, links } = data;
-    updateWorkspaceData({ closed, filterSets, links });
+    const { closed, filterSets, links, pluginDataMap } = data;
+    updateWorkspaceData({ closed, filterSets, links, pluginDataMap });
   }
 
   handleGoldenLayoutChange(goldenLayout: GoldenLayout): void {

--- a/packages/code-studio/src/main/AppMainContainer.tsx
+++ b/packages/code-studio/src/main/AppMainContainer.tsx
@@ -347,11 +347,17 @@ export class AppMainContainer extends Component<
   }
 
   initDashboardData(): void {
-    const { setDashboardPluginData, workspace } = this.props;
+    // TODO: #1746 We should be loading data from a dashboard storage store
+    // For now only the default dashboard data is stored with the workspace and set on the default dashboard
+    const { setDashboardPluginData, updateDashboardData, workspace } =
+      this.props;
     const { data: workspaceData } = workspace;
-    const { pluginDataMap } = workspaceData;
+    const { filterSets, links, pluginDataMap } = workspaceData;
+    updateDashboardData(DEFAULT_DASHBOARD_ID, {
+      filterSets,
+      links,
+    });
     const pluginKeys = Object.keys(pluginDataMap);
-    // TODO: There should be a more elegant way of loading this data... ie. with the dashboard, not from the workspace data. For now here we are.
     for (let i = 0; i < pluginKeys.length; i += 1) {
       const pluginId = pluginKeys[i];
       const pluginData = pluginDataMap[pluginId];

--- a/packages/code-studio/src/main/AppMainContainer.tsx
+++ b/packages/code-studio/src/main/AppMainContainer.tsx
@@ -347,11 +347,17 @@ export class AppMainContainer extends Component<
   }
 
   initDashboardData(): void {
-    const { allDashboardData, workspace } = this.props;
+    const { setDashboardPluginData, workspace } = this.props;
     const { data: workspaceData } = workspace;
-    // const { layoutConfig } = workspaceData;
-    console.log(allDashboardData, workspaceData);
-    debugger;
+    const { pluginDataMap } = workspaceData;
+    const pluginKeys = Object.keys(pluginDataMap);
+    // TODO: There should be a more elegant way of loading this data... ie. with the dashboard, not from the workspace data. For now here we are.
+    for (let i = 0; i < pluginKeys.length; i += 1) {
+      const pluginId = pluginKeys[i];
+      const pluginData = pluginDataMap[pluginId];
+      log.debug('Initializing with plugin data', pluginId, pluginData);
+      setDashboardPluginData(DEFAULT_DASHBOARD_ID, pluginId, pluginData);
+    }
   }
 
   openNotebookFromURL(): void {

--- a/packages/code-studio/src/storage/LocalWorkspaceStorage.ts
+++ b/packages/code-studio/src/storage/LocalWorkspaceStorage.ts
@@ -127,6 +127,7 @@ export class LocalWorkspaceStorage implements WorkspaceStorage {
       closed: [{}],
       links,
       filterSets,
+      pluginDataMap: {},
     };
   }
 

--- a/packages/dashboard/src/DashboardEvents.ts
+++ b/packages/dashboard/src/DashboardEvents.ts
@@ -2,22 +2,30 @@ import type { EventHub } from '@deephaven/golden-layout';
 
 export const CREATE_DASHBOARD = 'CREATE_DASHBOARD';
 
-export interface CreateDashboardPayload {
+export interface CreateDashboardPayload<T = unknown> {
   pluginId: string;
   title: string;
-  data: unknown;
+  data: T;
 }
 
-export function listenForCreateDashboard(
+export function stopListenForCreateDashboard<T = unknown>(
   eventHub: EventHub,
-  handler: (p: CreateDashboardPayload) => void
+  handler: (p: CreateDashboardPayload<T>) => void
 ): void {
-  eventHub.on(CREATE_DASHBOARD, handler);
+  eventHub.off(CREATE_DASHBOARD, handler);
 }
 
-export function emitCreateDashboard(
+export function listenForCreateDashboard<T = unknown>(
   eventHub: EventHub,
-  payload: CreateDashboardPayload
+  handler: (p: CreateDashboardPayload<T>) => void
+): () => void {
+  eventHub.on(CREATE_DASHBOARD, handler);
+  return () => stopListenForCreateDashboard(eventHub, handler);
+}
+
+export function emitCreateDashboard<T = unknown>(
+  eventHub: EventHub,
+  payload: CreateDashboardPayload<T>
 ): void {
   eventHub.emit(CREATE_DASHBOARD, payload);
 }

--- a/packages/dashboard/src/redux/hooks.ts
+++ b/packages/dashboard/src/redux/hooks.ts
@@ -10,10 +10,10 @@ import { setDashboardPluginData } from './actions';
  * @param pluginId - The ID of the plugin.
  * @returns A tuple containing the plugin data and a function to update the plugin data.
  */
-export function useDashboardPluginData(
+export function useDashboardPluginData<T = PluginData>(
   dashboardId: string,
   pluginId: string
-): [PluginData, (data: PluginData) => void] {
+): [T, (data: T) => void] {
   const dispatch = useDispatch();
   const data = useSelector((store: RootState) =>
     getPluginDataForDashboard(store, dashboardId, pluginId)

--- a/packages/dashboard/src/redux/hooks.ts
+++ b/packages/dashboard/src/redux/hooks.ts
@@ -16,10 +16,11 @@ export function useDashboardPluginData<T = PluginData>(
 ): [T, (data: T) => void] {
   const dispatch = useDispatch();
   const data = useSelector((store: RootState) =>
-    getPluginDataForDashboard(store, dashboardId, pluginId)
+    getPluginDataForDashboard<T>(store, dashboardId, pluginId)
   );
   const setData = useCallback(
-    newData => dispatch(setDashboardPluginData(dashboardId, pluginId, newData)),
+    (newData: T) =>
+      dispatch(setDashboardPluginData(dashboardId, pluginId, newData)),
     [dashboardId, pluginId, dispatch]
   );
   return [data, setData];

--- a/packages/dashboard/src/redux/selectors.ts
+++ b/packages/dashboard/src/redux/selectors.ts
@@ -61,10 +61,10 @@ export const getOpenedPanelMapForDashboard = (
  * @param dashboardId The dashboard ID to get data for
  * @returns The map of plugin IDs to data for all plugins on the dashboard
  */
-export const getPluginDataMapForDashboard = (
+export const getPluginDataMapForDashboard = <T = PluginData>(
   store: RootState,
   dashboardId: string
-): PluginDataMap =>
+): PluginDataMap<T> =>
   getDashboardData(store, dashboardId).pluginDataMap ?? EMPTY_OBJECT;
 
 /**
@@ -73,8 +73,8 @@ export const getPluginDataMapForDashboard = (
  * @param pluginId The plugin ID to get data for
  * @returns The plugin data
  */
-export const getPluginDataForDashboard = (
+export const getPluginDataForDashboard = <T = PluginData>(
   store: RootState,
   dashboardId: string,
   pluginId: string
-): PluginData => getPluginDataMapForDashboard(store, dashboardId)[pluginId];
+): T => getPluginDataMapForDashboard<T>(store, dashboardId)[pluginId];

--- a/packages/redux/src/store.ts
+++ b/packages/redux/src/store.ts
@@ -83,13 +83,16 @@ export interface Workspace {
 
 export type PluginData = unknown;
 
-export type PluginDataMap = Record<string, PluginData>;
+export type PluginDataMap<TData = PluginData> = Record<string, TData>;
 
-export type DashboardData = Record<string, unknown> & {
+export type DashboardData<TPluginData = PluginData> = Record<
+  string,
+  unknown
+> & {
   title?: string;
   closed?: unknown[];
   filterSets?: unknown[];
-  pluginDataMap?: PluginDataMap;
+  pluginDataMap?: PluginDataMap<TPluginData>;
 };
 
 export type WorkspaceStorageLoadOptions = {

--- a/packages/redux/src/store.ts
+++ b/packages/redux/src/store.ts
@@ -58,13 +58,14 @@ export interface WorkspaceSettings {
 }
 
 export interface WorkspaceData {
+  settings: WorkspaceSettings;
+
+  // TODO: #1746 The rest of these options should not be stored with workspace data, we should have a separate DashboardStorage
   closed: unknown[];
   filterSets: unknown[];
   layoutConfig: unknown[];
   links: unknown;
-  // TODO: This should not be stored with workspace data, we should have a separate DashboardStorage
   pluginDataMap: PluginDataMap;
-  settings: WorkspaceSettings;
 }
 
 export interface CustomizableWorkspaceData

--- a/packages/redux/src/store.ts
+++ b/packages/redux/src/store.ts
@@ -62,6 +62,8 @@ export interface WorkspaceData {
   filterSets: unknown[];
   layoutConfig: unknown[];
   links: unknown;
+  // TODO: This should not be stored with workspace data, we should have a separate DashboardStorage
+  pluginDataMap: PluginDataMap;
   settings: WorkspaceSettings;
 }
 


### PR DESCRIPTION
- Until we have support for #1746 , load the default dashboard data from workspace
  - Needed for testing the widget hydration PR
- Tested with my changes for widget hydration
  - Ensured deephaven.ui widgets re-opened upon refresh
  - Ensured links remained between existing tables