### PR TITLE
feat: Test Utils - Generate exhaustive boolean combinations and MockProxy spread

### DIFF
--- a/packages/console/src/command-history/CommandHistoryActions.test.tsx
+++ b/packages/console/src/command-history/CommandHistoryActions.test.tsx
@@ -1,9 +1,24 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { TestUtils } from '@deephaven/utils';
 import CommandHistoryActions from './CommandHistoryActions';
 
-jest.useFakeTimers();
+const { asMock } = TestUtils;
+
+jest.mock('@fortawesome/react-fontawesome', () => ({
+  FontAwesomeIcon: jest.fn(),
+}));
+
+beforeEach(() => {
+  jest.useFakeTimers();
+  asMock(FontAwesomeIcon).mockReturnValue(<div>Mock FontAwesomeIcon</div>);
+});
+
+afterAll(() => {
+  jest.useRealTimers();
+});
 
 const toBeClicked = jest.fn();
 const makeHistoryActionsMock = () => [

--- a/packages/utils/src/MockProxy.test.ts
+++ b/packages/utils/src/MockProxy.test.ts
@@ -85,4 +85,58 @@ describe('createMockProxy', () => {
     });
     expect(mock.testMethod).toBeInstanceOf(jest.fn().constructor);
   });
+
+  it.each([undefined, 'some label'])('should be spreadable: %s', label => {
+    const overrides = {
+      name: 'mock.name',
+      age: 42,
+    };
+
+    const mock = createMockProxy<{
+      name: string;
+      age: number;
+      testMethod: () => void;
+    }>(overrides, { label });
+
+    expect({ ...mock }).toEqual({
+      [MockProxySymbol.labelSymbol]: label ?? 'Mock Proxy',
+      name: 'mock.name',
+      age: 42,
+    });
+  });
+
+  it.each([undefined, true, false])(
+    'should include accessed auto proxy props if includeAutoProxiesInOwnKeys is true: %s',
+    includeAutoProxiesInOwnKeys => {
+      const overrides = {
+        name: 'mock.name',
+        age: 42,
+      };
+
+      const mock = createMockProxy<{
+        name: string;
+        age: number;
+        testMethod: () => void;
+      }>(overrides, { includeAutoProxiesInOwnKeys });
+
+      const expectedBase = {
+        [MockProxySymbol.labelSymbol]: 'Mock Proxy',
+        name: 'mock.name',
+        age: 42,
+      };
+
+      expect({ ...mock }).toEqual(expectedBase);
+
+      mock.testMethod();
+
+      if (includeAutoProxiesInOwnKeys === true) {
+        expect({ ...mock }).toEqual({
+          ...expectedBase,
+          testMethod: expect.any(Function),
+        });
+      } else {
+        expect({ ...mock }).toEqual(expectedBase);
+      }
+    }
+  );
 });

--- a/packages/utils/src/TestUtils.test.tsx
+++ b/packages/utils/src/TestUtils.test.tsx
@@ -78,6 +78,40 @@ describe('findLastCall', () => {
   });
 });
 
+describe('generateBooleanCombinations', () => {
+  it.each([
+    [1, [[false], [true]]],
+    [
+      2,
+      [
+        [false, false],
+        [false, true],
+        [true, false],
+        [true, true],
+      ],
+    ],
+    [
+      3,
+      [
+        [false, false, false],
+        [false, false, true],
+        [false, true, false],
+        [false, true, true],
+        [true, false, false],
+        [true, false, true],
+        [true, true, false],
+        [true, true, true],
+      ],
+    ],
+  ])(
+    'should generate all possible combinations of boolean values',
+    (n, expected) => {
+      const result = TestUtils.generateBooleanCombinations(n);
+      expect(result).toEqual(expected);
+    }
+  );
+});
+
 describe('makeMockContext', () => {
   it('should make a MockContext object', () => {
     const mockContext = TestUtils.makeMockContext();

--- a/packages/utils/src/TestUtils.ts
+++ b/packages/utils/src/TestUtils.ts
@@ -1,5 +1,6 @@
 import type userEvent from '@testing-library/user-event';
 import createMockProxy from './MockProxy';
+import { Tuple } from './TypeUtils';
 
 interface MockContext {
   arc: jest.Mock<void>;
@@ -101,6 +102,30 @@ class TestUtils {
     predicate: (args: TArgs) => boolean
   ): TArgs | undefined =>
     TestUtils.asMock(fn).mock.calls.reverse().find(predicate);
+
+  /**
+   * Generate all possible combinations of boolean values for a given number of
+   * variables
+   * @param n The number of boolean values to generate combinations for.
+   * @returns An array of tuples representing all possible combinations
+   * of boolean values for the given number of values.
+   */
+  static generateBooleanCombinations = <T extends number>(
+    n: T
+  ): Tuple<boolean, T>[] => {
+    const combinations = 2 ** n;
+    const result: Tuple<boolean, T>[] = [];
+
+    // eslint-disable-next-line no-plusplus
+    for (let i = 0; i < combinations; i++) {
+      // eslint-disable-next-line no-bitwise
+      const binary = (i >>> 0).toString(2).padStart(n, '0');
+      const bitArray = Array.from(binary).map(bit => bit === '1');
+      result.push(bitArray as Tuple<boolean, T>);
+    }
+
+    return result;
+  };
 
   static makeMockContext(): MockContext {
     return {

--- a/packages/utils/src/TypeUtils.ts
+++ b/packages/utils/src/TypeUtils.ts
@@ -28,6 +28,35 @@ export type OnlyOneProp<T> = {
 }[keyof T];
 
 /**
+ * Tuple type.
+ * @param T Type of the items in the tuple
+ * @param N Length of the tuple
+ */
+export type Tuple<T, N extends number> = N extends 0
+  ? []
+  : N extends 1
+  ? [T]
+  : N extends 2
+  ? [T, T]
+  : N extends 3
+  ? [T, T, T]
+  : N extends 4
+  ? [T, T, T, T]
+  : N extends 5
+  ? [T, T, T, T, T]
+  : N extends 6
+  ? [T, T, T, T, T, T]
+  : N extends 7
+  ? [T, T, T, T, T, T, T]
+  : N extends 8
+  ? [T, T, T, T, T, T, T, T]
+  : N extends 9
+  ? [T, T, T, T, T, T, T, T, T]
+  : N extends 10
+  ? [T, T, T, T, T, T, T, T, T, T]
+  : Array<T>;
+
+/**
  * Remove `Partial` wrapper from a type. Note that this is slightly different
  * than `Required` because it will preserve optional properties on the original
  * target type.


### PR DESCRIPTION
New test util features
- Generate exhaustive boolean combinations
- Fixed some type errors in `usePickerWithSelectedValues.test.ts` (also updated it to use the new boolean test util)
- Added spread support to MockProxy to avoid empty objects when making copies
- Fixed a console error that was happening due to `null` icons passed to FontAwesomeIcon component in tests

resolves #1809 