### PR TITLE
test: improve openObject

### DIFF
--- a/tests/context-menu.spec.ts
+++ b/tests/context-menu.spec.ts
@@ -14,6 +14,8 @@ async function moveMouseAwayFromTable(page: Page) {
 }
 
 test.beforeEach(async ({ page }) => {
+  await page.goto('');
+  await expect(page.locator('.loading-spinner')).toHaveCount(0);
   await openTable(page, 'all_types');
 
   const tableOperationsMenu = page.locator(

--- a/tests/context-menu.spec.ts
+++ b/tests/context-menu.spec.ts
@@ -1,5 +1,10 @@
 import { test, expect, Page } from '@playwright/test';
-import { waitForLoadingDone, openTable, expectContextMenus } from './utils';
+import {
+  waitForLoadingDone,
+  openTable,
+  expectContextMenus,
+  gotoPage,
+} from './utils';
 
 async function openAdvancedFilters(page: Page) {
   await page
@@ -14,8 +19,7 @@ async function moveMouseAwayFromTable(page: Page) {
 }
 
 test.beforeEach(async ({ page }) => {
-  await page.goto('');
-  await expect(page.locator('.loading-spinner')).toHaveCount(0);
+  await gotoPage(page, '');
   await openTable(page, 'all_types');
 
   const tableOperationsMenu = page.locator(

--- a/tests/figure.spec.ts
+++ b/tests/figure.spec.ts
@@ -2,6 +2,8 @@ import { test, expect } from '@playwright/test';
 import { openPlot } from './utils';
 
 test('can open a simple figure', async ({ page }) => {
+  await page.goto('');
+  await expect(page.locator('.loading-spinner')).toHaveCount(0);
   await openPlot(page, 'simple_plot');
   // Now we should be able to check the snapshot on the plotly container
   await expect(
@@ -10,6 +12,8 @@ test('can open a simple figure', async ({ page }) => {
 });
 
 test('can set point shape and size', async ({ page }) => {
+  await page.goto('');
+  await expect(page.locator('.loading-spinner')).toHaveCount(0);
   await openPlot(page, 'trig_figure');
   // Now we should be able to check the snapshot on the plotly container
   await expect(

--- a/tests/figure.spec.ts
+++ b/tests/figure.spec.ts
@@ -1,9 +1,8 @@
 import { test, expect } from '@playwright/test';
-import { openPlot } from './utils';
+import { gotoPage, openPlot } from './utils';
 
 test('can open a simple figure', async ({ page }) => {
-  await page.goto('');
-  await expect(page.locator('.loading-spinner')).toHaveCount(0);
+  await gotoPage(page, '');
   await openPlot(page, 'simple_plot');
   // Now we should be able to check the snapshot on the plotly container
   await expect(
@@ -12,8 +11,7 @@ test('can open a simple figure', async ({ page }) => {
 });
 
 test('can set point shape and size', async ({ page }) => {
-  await page.goto('');
-  await expect(page.locator('.loading-spinner')).toHaveCount(0);
+  await gotoPage(page, '');
   await openPlot(page, 'trig_figure');
   // Now we should be able to check the snapshot on the plotly container
   await expect(

--- a/tests/table-gotorow.spec.ts
+++ b/tests/table-gotorow.spec.ts
@@ -54,6 +54,8 @@ test.describe('GoToRow change column', () => {
 
   test.beforeAll(async ({ browser }) => {
     page = await browser.newPage();
+    await page.goto('');
+    await expect(page.locator('.loading-spinner')).toHaveCount(0);
     await openTable(page, 'ordered_int_and_offset');
 
     // get the grid

--- a/tests/table-gotorow.spec.ts
+++ b/tests/table-gotorow.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect, Page } from '@playwright/test';
-import { openTable } from './utils';
+import { gotoPage, openTable } from './utils';
 
 // relies on previous
 test.describe.configure({ mode: 'serial' });
@@ -54,8 +54,7 @@ test.describe('GoToRow change column', () => {
 
   test.beforeAll(async ({ browser }) => {
     page = await browser.newPage();
-    await page.goto('');
-    await expect(page.locator('.loading-spinner')).toHaveCount(0);
+    await gotoPage(page, '');
     await openTable(page, 'ordered_int_and_offset');
 
     // get the grid

--- a/tests/table-multiselect.spec.ts
+++ b/tests/table-multiselect.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect, Page } from '@playwright/test';
-import { expectContextMenus, openTable } from './utils';
+import { expectContextMenus, gotoPage, openTable } from './utils';
 
 const rowHeight = 19;
 const columnHeight = 30;
@@ -70,8 +70,7 @@ function runSpecialSelectFilter(
   expectedButtons: string[]
 ) {
   test(`select ${columnType} filters`, async ({ page }) => {
-    await page.goto('');
-    await expect(page.locator('.loading-spinner')).toHaveCount(0);
+    await gotoPage(page, '');
     await openTable(page, `multiselect_${columnType}`);
     const gridLocation = await getGridLocation(page);
     if (gridLocation === null) return;
@@ -98,8 +97,7 @@ function runMultiSelectFilter(
   filters: { filter: string; name: string }[]
 ) {
   test(`multiselect ${columnType} filters`, async ({ page }) => {
-    await page.goto('');
-    await expect(page.locator('.loading-spinner')).toHaveCount(0);
+    await gotoPage(page, '');
     await openTable(page, `multiselect_${columnType}`);
     const gridLocation = await getGridLocation(page);
     if (gridLocation === null) return;
@@ -158,8 +156,7 @@ runMultiSelectFilter('datetime', [
 test('char formatting, non selected right click, preview formatting', async ({
   page,
 }) => {
-  await page.goto('');
-  await expect(page.locator('.loading-spinner')).toHaveCount(0);
+  await gotoPage(page, '');
   await openTable(page, 'multiselect_char');
   const gridLocation = await getGridLocation(page);
   if (gridLocation === null) return;

--- a/tests/table-multiselect.spec.ts
+++ b/tests/table-multiselect.spec.ts
@@ -70,6 +70,8 @@ function runSpecialSelectFilter(
   expectedButtons: string[]
 ) {
   test(`select ${columnType} filters`, async ({ page }) => {
+    await page.goto('');
+    await expect(page.locator('.loading-spinner')).toHaveCount(0);
     await openTable(page, `multiselect_${columnType}`);
     const gridLocation = await getGridLocation(page);
     if (gridLocation === null) return;
@@ -96,6 +98,8 @@ function runMultiSelectFilter(
   filters: { filter: string; name: string }[]
 ) {
   test(`multiselect ${columnType} filters`, async ({ page }) => {
+    await page.goto('');
+    await expect(page.locator('.loading-spinner')).toHaveCount(0);
     await openTable(page, `multiselect_${columnType}`);
     const gridLocation = await getGridLocation(page);
     if (gridLocation === null) return;
@@ -154,6 +158,8 @@ runMultiSelectFilter('datetime', [
 test('char formatting, non selected right click, preview formatting', async ({
   page,
 }) => {
+  await page.goto('');
+  await expect(page.locator('.loading-spinner')).toHaveCount(0);
   await openTable(page, 'multiselect_char');
   const gridLocation = await getGridLocation(page);
   if (gridLocation === null) return;

--- a/tests/table-operations.spec.ts
+++ b/tests/table-operations.spec.ts
@@ -104,6 +104,8 @@ async function artificialWait(page: Page, tableNumber = 0) {
 }
 
 test.beforeEach(async ({ page }) => {
+  await page.goto('');
+  await expect(page.locator('.loading-spinner')).toHaveCount(0);
   await openTable(page, 'all_types');
 
   const tableOperationsMenu = page.locator(

--- a/tests/table-operations.spec.ts
+++ b/tests/table-operations.spec.ts
@@ -8,6 +8,7 @@ import {
   openTableOption,
   generateVarName,
   openTable,
+  gotoPage,
 } from './utils';
 
 async function changeCondFormatComparison(
@@ -104,8 +105,7 @@ async function artificialWait(page: Page, tableNumber = 0) {
 }
 
 test.beforeEach(async ({ page }) => {
-  await page.goto('');
-  await expect(page.locator('.loading-spinner')).toHaveCount(0);
+  await gotoPage(page, '');
   await openTable(page, 'all_types');
 
   const tableOperationsMenu = page.locator(

--- a/tests/table.spec.ts
+++ b/tests/table.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect, Page } from '@playwright/test';
-import { openTable } from './utils';
+import { gotoPage, openTable } from './utils';
 
 async function waitForLoadingDone(page: Page) {
   await expect(
@@ -8,16 +8,14 @@ async function waitForLoadingDone(page: Page) {
 }
 
 test('can open a simple table', async ({ page }) => {
-  await page.goto('');
-  await expect(page.locator('.loading-spinner')).toHaveCount(0);
+  await gotoPage(page, '');
   await openTable(page, 'simple_table');
   // Now we should be able to check the snapshot
   await expect(page.locator('.iris-grid-panel .iris-grid')).toHaveScreenshot();
 });
 
 test('can make a non-contiguous table row selection', async ({ page }) => {
-  await page.goto('');
-  await expect(page.locator('.loading-spinner')).toHaveCount(0);
+  await gotoPage(page, '');
   await openTable(page, 'simple_table');
 
   const grid = await page.locator('.iris-grid-panel .iris-grid');
@@ -47,8 +45,7 @@ test('can make a non-contiguous table row selection', async ({ page }) => {
 });
 
 test('can open a table with column header groups', async ({ page }) => {
-  await page.goto('');
-  await expect(page.locator('.loading-spinner')).toHaveCount(0);
+  await gotoPage(page, '');
   await openTable(page, 'simple_table_header_group');
   // Now we should be able to check the snapshot
   await expect(page.locator('.iris-grid-panel .iris-grid')).toHaveScreenshot();
@@ -57,8 +54,7 @@ test('can open a table with column header groups', async ({ page }) => {
 test('can open a table with column header groups and hidden columns', async ({
   page,
 }) => {
-  await page.goto('');
-  await expect(page.locator('.loading-spinner')).toHaveCount(0);
+  await gotoPage(page, '');
   await openTable(page, 'simple_table_header_group_hide');
   // Now we should be able to check the snapshot
   await expect(page.locator('.iris-grid-panel .iris-grid')).toHaveScreenshot();
@@ -66,8 +62,7 @@ test('can open a table with column header groups and hidden columns', async ({
 
 test.describe('tests simple table operations', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto('');
-    await expect(page.locator('.loading-spinner')).toHaveCount(0);
+    await gotoPage(page, '');
     await openTable(page, 'simple_table');
     const tableOperationsMenu = page.locator(
       'data-testid=btn-iris-grid-settings-button-table'

--- a/tests/table.spec.ts
+++ b/tests/table.spec.ts
@@ -8,12 +8,16 @@ async function waitForLoadingDone(page: Page) {
 }
 
 test('can open a simple table', async ({ page }) => {
+  await page.goto('');
+  await expect(page.locator('.loading-spinner')).toHaveCount(0);
   await openTable(page, 'simple_table');
   // Now we should be able to check the snapshot
   await expect(page.locator('.iris-grid-panel .iris-grid')).toHaveScreenshot();
 });
 
 test('can make a non-contiguous table row selection', async ({ page }) => {
+  await page.goto('');
+  await expect(page.locator('.loading-spinner')).toHaveCount(0);
   await openTable(page, 'simple_table');
 
   const grid = await page.locator('.iris-grid-panel .iris-grid');
@@ -43,6 +47,8 @@ test('can make a non-contiguous table row selection', async ({ page }) => {
 });
 
 test('can open a table with column header groups', async ({ page }) => {
+  await page.goto('');
+  await expect(page.locator('.loading-spinner')).toHaveCount(0);
   await openTable(page, 'simple_table_header_group');
   // Now we should be able to check the snapshot
   await expect(page.locator('.iris-grid-panel .iris-grid')).toHaveScreenshot();
@@ -51,6 +57,8 @@ test('can open a table with column header groups', async ({ page }) => {
 test('can open a table with column header groups and hidden columns', async ({
   page,
 }) => {
+  await page.goto('');
+  await expect(page.locator('.loading-spinner')).toHaveCount(0);
   await openTable(page, 'simple_table_header_group_hide');
   // Now we should be able to check the snapshot
   await expect(page.locator('.iris-grid-panel .iris-grid')).toHaveScreenshot();
@@ -58,6 +66,8 @@ test('can open a table with column header groups and hidden columns', async ({
 
 test.describe('tests simple table operations', () => {
   test.beforeEach(async ({ page }) => {
+    await page.goto('');
+    await expect(page.locator('.loading-spinner')).toHaveCount(0);
     await openTable(page, 'simple_table');
     const tableOperationsMenu = page.locator(
       'data-testid=btn-iris-grid-settings-button-table'

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -62,17 +62,14 @@ export async function gotoPage(
 async function openPanel(page: Page, name: PanelNames): Promise<void> {
   // open the tables/plot button
   const dropdownButton = page.getByRole('button', { name: 'Panels' });
-  expect(dropdownButton).toBeEnabled();
   await dropdownButton.click();
 
   // search for the table/plot
   const search = page.getByPlaceholder('Find Table, Plot or Widget');
-  expect(search).toBeEnabled();
   await search.type(name);
 
   // open the table/plot
   const openButton = page.getByRole('button', { name, exact: true });
-  expect(openButton).toBeEnabled();
   await openButton.click();
 }
 
@@ -113,9 +110,13 @@ export async function openPlot(
 
   if (waitForLoadFinished) {
     await expect(page.locator('.iris-chart-panel')).toHaveCount(panelCount + 1);
+    await expect(page.locator('.chart-panel-container')).toHaveCount(1);
     await expect(
       page.locator('.chart-panel-container .loading-spinner')
     ).toHaveCount(0);
+    await expect(
+      page.locator('.chart-panel-container .chart-wrapper')
+    ).toHaveCount(1);
   }
 }
 

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -38,6 +38,19 @@ type PlotNames = 'simple_plot' | 'trig_figure';
 
 type ObjectNames = TableNames | PlotNames;
 
+export async function gotoPage(
+  page: Page,
+  url: string,
+  options?: {
+    referer?: string;
+    timeout?: number;
+    waitUntil?: 'load' | 'domcontentloaded' | 'networkidle' | 'commit';
+  }
+): Promise<void> {
+  await page.goto(url, options);
+  await expect(page.locator('.loading-spinner')).toHaveCount(0);
+}
+
 /**
  * Opens an object loaded from application mode
  * @param page
@@ -374,6 +387,7 @@ export async function openTableOption(
 }
 
 export default {
+  gotoPage,
   generateVarName,
   openTable,
   openPlot,

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -48,6 +48,9 @@ export async function gotoPage(
   }
 ): Promise<void> {
   await page.goto(url, options);
+  await expect(
+    page.getByRole('progressbar', { name: 'Loading...', exact: true })
+  ).not.toBeVisible();
 }
 
 /**

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -49,9 +49,6 @@ async function openObject(
   type: 'table' | 'plot',
   name: ObjectNames
 ): Promise<void> {
-  await page.goto('');
-  await expect(page.locator('.loading-spinner')).toHaveCount(0);
-
   // open the tables/plot button
   const dropdownButton = page.getByRole('button', {
     name: type === 'table' ? 'Tables' : 'Widgets',


### PR DESCRIPTION
- Adds #1815 
  - Move all `page.goto` out of the `openObject` util method and into each test
  - Add util function for to go to page and wait for load
- Fixes #1816 
  - Use app panel menu instead of console panel menu
  - Add check that a new panel is created in `openTable` and `openPlot`