### PR TITLE
fix: spectrum textfield validation icon position with set content-box

### DIFF
--- a/packages/components/src/theme/theme-spectrum/theme-spectrum-overrides.css
+++ b/packages/components/src/theme/theme-spectrum/theme-spectrum-overrides.css
@@ -9,6 +9,11 @@ label[class^='spectrum-'] {
   margin-bottom: 0;
 }
 
+svg[class*='spectrum-Textfield-validationIcon'] {
+  /* set as border-box by reboot, but spectrum expects this to be content-box */
+  box-sizing: content-box;
+}
+
 .svg-inline--fa[class*='spectrum-Icon--sizeS'] {
   /* 
   Resize fontawesome icons used inside a spectrum icon wrapper to match


### PR DESCRIPTION
Moves a DHE fix to DHC.

fixes text field spectrum validation icon position: 
![image](https://github.com/deephaven/web-client-ui/assets/1576283/9f3ce059-9b50-4ade-b2ef-1cb2e0121ed4)


BREAKING CHANGE: the duplicate `spectrum-Textfield-validationIcon` css in DHE should be removed