### PR TITLE
test: improve openPanel

### DIFF
--- a/tests/context-menu.spec.ts
+++ b/tests/context-menu.spec.ts
@@ -1,5 +1,10 @@
 import { test, expect, Page } from '@playwright/test';
-import { waitForLoadingDone, openTable, expectContextMenus } from './utils';
+import {
+  waitForLoadingDone,
+  openTable,
+  expectContextMenus,
+  gotoPage,
+} from './utils';
 
 async function openAdvancedFilters(page: Page) {
   await page
@@ -14,6 +19,7 @@ async function moveMouseAwayFromTable(page: Page) {
 }
 
 test.beforeEach(async ({ page }) => {
+  await gotoPage(page, '');
   await openTable(page, 'all_types');
 
   const tableOperationsMenu = page.locator(

--- a/tests/figure.spec.ts
+++ b/tests/figure.spec.ts
@@ -1,7 +1,8 @@
 import { test, expect } from '@playwright/test';
-import { openPlot } from './utils';
+import { gotoPage, openPlot } from './utils';
 
 test('can open a simple figure', async ({ page }) => {
+  await gotoPage(page, '');
   await openPlot(page, 'simple_plot');
   // Now we should be able to check the snapshot on the plotly container
   await expect(
@@ -10,6 +11,7 @@ test('can open a simple figure', async ({ page }) => {
 });
 
 test('can set point shape and size', async ({ page }) => {
+  await gotoPage(page, '');
   await openPlot(page, 'trig_figure');
   // Now we should be able to check the snapshot on the plotly container
   await expect(

--- a/tests/table-gotorow.spec.ts
+++ b/tests/table-gotorow.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect, Page } from '@playwright/test';
-import { openTable } from './utils';
+import { gotoPage, openTable } from './utils';
 
 // relies on previous
 test.describe.configure({ mode: 'serial' });
@@ -54,6 +54,7 @@ test.describe('GoToRow change column', () => {
 
   test.beforeAll(async ({ browser }) => {
     page = await browser.newPage();
+    await gotoPage(page, '');
     await openTable(page, 'ordered_int_and_offset');
 
     // get the grid

--- a/tests/table-multiselect.spec.ts
+++ b/tests/table-multiselect.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect, Page } from '@playwright/test';
-import { expectContextMenus, openTable } from './utils';
+import { expectContextMenus, gotoPage, openTable } from './utils';
 
 const rowHeight = 19;
 const columnHeight = 30;
@@ -70,6 +70,7 @@ function runSpecialSelectFilter(
   expectedButtons: string[]
 ) {
   test(`select ${columnType} filters`, async ({ page }) => {
+    await gotoPage(page, '');
     await openTable(page, `multiselect_${columnType}`);
     const gridLocation = await getGridLocation(page);
     if (gridLocation === null) return;
@@ -96,6 +97,7 @@ function runMultiSelectFilter(
   filters: { filter: string; name: string }[]
 ) {
   test(`multiselect ${columnType} filters`, async ({ page }) => {
+    await gotoPage(page, '');
     await openTable(page, `multiselect_${columnType}`);
     const gridLocation = await getGridLocation(page);
     if (gridLocation === null) return;
@@ -154,6 +156,7 @@ runMultiSelectFilter('datetime', [
 test('char formatting, non selected right click, preview formatting', async ({
   page,
 }) => {
+  await gotoPage(page, '');
   await openTable(page, 'multiselect_char');
   const gridLocation = await getGridLocation(page);
   if (gridLocation === null) return;

--- a/tests/table-operations.spec.ts
+++ b/tests/table-operations.spec.ts
@@ -8,6 +8,7 @@ import {
   openTableOption,
   generateVarName,
   openTable,
+  gotoPage,
 } from './utils';
 
 async function changeCondFormatComparison(
@@ -104,6 +105,7 @@ async function artificialWait(page: Page, tableNumber = 0) {
 }
 
 test.beforeEach(async ({ page }) => {
+  await gotoPage(page, '');
   await openTable(page, 'all_types');
 
   const tableOperationsMenu = page.locator(

--- a/tests/table.spec.ts
+++ b/tests/table.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect, Page } from '@playwright/test';
-import { openTable } from './utils';
+import { gotoPage, openTable } from './utils';
 
 async function waitForLoadingDone(page: Page) {
   await expect(
@@ -8,12 +8,14 @@ async function waitForLoadingDone(page: Page) {
 }
 
 test('can open a simple table', async ({ page }) => {
+  await gotoPage(page, '');
   await openTable(page, 'simple_table');
   // Now we should be able to check the snapshot
   await expect(page.locator('.iris-grid-panel .iris-grid')).toHaveScreenshot();
 });
 
 test('can make a non-contiguous table row selection', async ({ page }) => {
+  await gotoPage(page, '');
   await openTable(page, 'simple_table');
 
   const grid = await page.locator('.iris-grid-panel .iris-grid');
@@ -43,6 +45,7 @@ test('can make a non-contiguous table row selection', async ({ page }) => {
 });
 
 test('can open a table with column header groups', async ({ page }) => {
+  await gotoPage(page, '');
   await openTable(page, 'simple_table_header_group');
   // Now we should be able to check the snapshot
   await expect(page.locator('.iris-grid-panel .iris-grid')).toHaveScreenshot();
@@ -51,6 +54,7 @@ test('can open a table with column header groups', async ({ page }) => {
 test('can open a table with column header groups and hidden columns', async ({
   page,
 }) => {
+  await gotoPage(page, '');
   await openTable(page, 'simple_table_header_group_hide');
   // Now we should be able to check the snapshot
   await expect(page.locator('.iris-grid-panel .iris-grid')).toHaveScreenshot();
@@ -58,6 +62,7 @@ test('can open a table with column header groups and hidden columns', async ({
 
 test.describe('tests simple table operations', () => {
   test.beforeEach(async ({ page }) => {
+    await gotoPage(page, '');
     await openTable(page, 'simple_table');
     const tableOperationsMenu = page.locator(
       'data-testid=btn-iris-grid-settings-button-table'


### PR DESCRIPTION
- Adds #1815 
  - Move all `page.goto` out of the `openObject` util method and into each test
  - Add util function for to go to page and wait for load
- Fixes #1816 
  - Use app panel menu instead of console panel menu
  - Add check that a new panel is created in `openTable` and `openPlot`