### PR TITLE
test: fix open table flakiness

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -50,7 +50,7 @@ const config: PlaywrightTestConfig = {
     baseURL: 'http://localhost:4000/ide/',
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
-    trace: 'on-first-retry',
+    trace: 'on',
 
     /* Retain videos on failure for easier debugging */
     video: 'retain-on-failure',

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -50,7 +50,7 @@ const config: PlaywrightTestConfig = {
     baseURL: 'http://localhost:4000/ide/',
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
-    trace: 'on',
+    trace: 'on-first-retry',
 
     /* Retain videos on failure for easier debugging */
     video: 'retain-on-failure',

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -92,6 +92,7 @@ export async function openTable(
     await expect(
       page.locator('.iris-grid .iris-grid-loading-status')
     ).toHaveCount(0);
+    await expect(page.locator('.iris-grid-panel .iris-grid')).toHaveCount(0);
   }
 }
 

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -92,9 +92,7 @@ export async function openTable(
     await expect(
       page.locator('.iris-grid .iris-grid-loading-status')
     ).toHaveCount(0);
-    await expect(page.locator('.iris-grid-panel .loading-spinner')).toHaveCount(
-      0
-    );
+    await expect(page.locator('.loading-spinner')).toHaveCount(0);
   }
 }
 

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -89,10 +89,12 @@ export async function openTable(
 
   if (waitForLoadFinished) {
     await expect(page.locator('.iris-grid-panel')).toHaveCount(panelCount + 1);
+    await expect(page.locator('.iris-grid-panel .loading-spinner')).toHaveCount(
+      0
+    );
     await expect(
       page.locator('.iris-grid .iris-grid-loading-status')
     ).toHaveCount(0);
-    await expect(page.locator('.loading-spinner')).toHaveCount(0);
   }
 }
 

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -92,7 +92,9 @@ export async function openTable(
     await expect(
       page.locator('.iris-grid .iris-grid-loading-status')
     ).toHaveCount(0);
-    await expect(page.locator('.iris-grid-panel .iris-grid')).toHaveCount(0);
+    await expect(page.locator('.iris-grid-panel .loading-spinner')).toHaveCount(
+      0
+    );
   }
 }
 

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -95,6 +95,7 @@ export async function openTable(
     await expect(
       page.locator('.iris-grid .iris-grid-loading-status')
     ).toHaveCount(0);
+    await expect(page.locator('.grid-wrapper')).toHaveCount(panelCount + 1);
   }
 }
 


### PR DESCRIPTION
- Fixes #1845 
  - Add an expect for loading spinner to disappear

The expects will be in the following order:
1. Table panel is loaded (new `.iris-grid-panel` appears)
2. Grid is lazy loaded (`.iris-grid-panel .loading-spinner` is gone)
3. Grid content is loaded (`.iris-grid .iris-grid-loading-status` is gone)