### PR TITLE
test: enable drag test

### DIFF
--- a/tests/table-operations.spec.ts
+++ b/tests/table-operations.spec.ts
@@ -421,7 +421,7 @@ test('custom column', async ({ page }) => {
 
     // TODO: This is disabled due to test failing in CI but not locally. Should
     // be fixed and re-enabled in #1553.
-    // await expect(page.locator('.iris-grid-column')).toHaveScreenshot();
+    await expect(page.locator('.iris-grid-column')).toHaveScreenshot();
   });
 });
 


### PR DESCRIPTION
- Resolves #1553
  - Renable the table operations drag test, which is now flaky instead of failing