### PR TITLE
fix: hide expand all when not available

### DIFF
--- a/packages/iris-grid/src/IrisGrid.tsx
+++ b/packages/iris-grid/src/IrisGrid.tsx
@@ -3765,6 +3765,9 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
       }
 
       const { expandTooltipDisplayValue } = this.state;
+      const { model } = this.props;
+      const isExpandAllAvailable =
+        isExpandableGridModel(model) && model.isExpandAllAvailable;
 
       const wrapperStyle: CSSProperties = {
         position: 'absolute',
@@ -3785,9 +3788,13 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
           >
             <div style={{ textAlign: 'left' }}>
               Click to {expandTooltipDisplayValue} row
-              <br />
-              {ContextActionUtils.isMacPlatform() ? '⌘' : 'Ctrl+'}Click to
-              expand row and all children
+              {isExpandAllAvailable && (
+                <>
+                  <br />
+                  {ContextActionUtils.isMacPlatform() ? '⌘' : 'Ctrl+'}Click to
+                  expand row and all children
+                </>
+              )}
             </div>
           </Tooltip>
         </div>


### PR DESCRIPTION
- Fix #1822 
  - Add a check for `isExpandAllAvailable` to render the list on the tooltip