### PR TITLE
feat: Add support to pass in mouseHandlers into IrisGrid

### DIFF
--- a/packages/grid/src/mouse-handlers/GridSelectionMouseHandler.ts
+++ b/packages/grid/src/mouse-handlers/GridSelectionMouseHandler.ts
@@ -214,6 +214,24 @@ class GridSelectionMouseHandler extends GridMouseHandler {
     return false;
   }
 
+  // eslint-disable-next-line class-methods-use-this
+  onDoubleClick(
+    gridPoint: GridPoint,
+    grid: Grid,
+    event: GridMouseEvent
+  ): EventHandlerResult {
+    const { column, row } = gridPoint;
+    if (row == null || column == null) {
+      return false;
+    }
+
+    grid.clearSelectedRanges();
+    grid.moveCursorToPosition(column, row);
+    grid.commitSelection();
+
+    return true;
+  }
+
   onContextMenu(
     gridPoint: GridPoint,
     grid: Grid,

--- a/packages/iris-grid/src/mousehandlers/IrisGridDataSelectMouseHandler.ts
+++ b/packages/iris-grid/src/mousehandlers/IrisGridDataSelectMouseHandler.ts
@@ -12,7 +12,7 @@ import type IrisGrid from '../IrisGrid';
  */
 class IrisGridDataSelectMouseHandler extends GridMouseHandler {
   constructor(irisGrid: IrisGrid) {
-    super(825);
+    super(880);
 
     this.irisGrid = irisGrid;
   }

--- a/packages/iris-grid/src/mousehandlers/IrisGridDataSelectMouseHandler.ts
+++ b/packages/iris-grid/src/mousehandlers/IrisGridDataSelectMouseHandler.ts
@@ -12,7 +12,7 @@ import type IrisGrid from '../IrisGrid';
  */
 class IrisGridDataSelectMouseHandler extends GridMouseHandler {
   constructor(irisGrid: IrisGrid) {
-    super();
+    super(825);
 
     this.irisGrid = irisGrid;
   }
@@ -27,9 +27,7 @@ class IrisGridDataSelectMouseHandler extends GridMouseHandler {
 
     this.irisGrid.selectData(column, row);
 
-    grid.moveCursorToPosition(column, row);
-
-    return true;
+    return false;
   }
 }
 


### PR DESCRIPTION
- Move the doubleClick behaviour from IrisGridDataSelectMouseHandler into GridSelectionMouseHandler, so it's baked into Grid itself (double-clicking a grid in the styleguide was exhibiting erroneous behaviour)
- Allow passing in mouseHandlers to IrisGrid. Will be necessary to support https://github.com/deephaven/deephaven-plugins/issues/320
- Tested using my branch for `on_row_press` support on deephaven.ui: https://github.com/deephaven/deephaven-plugins/pull/346
- Verified Linker still worked as expected