### PR TITLE
fix: swap goto tooltips

### DIFF
--- a/packages/iris-grid/src/GotoRow.tsx
+++ b/packages/iris-grid/src/GotoRow.tsx
@@ -386,7 +386,7 @@ const GotoRow = forwardRef<GotoRowElement, GotoRowProps>(
 
                 <div>
                   <Button
-                    tooltip="Next match"
+                    tooltip="Previous match"
                     icon={vsArrowUp}
                     kind="ghost"
                     disabled={gotoValue === ''}
@@ -395,7 +395,7 @@ const GotoRow = forwardRef<GotoRowElement, GotoRowProps>(
                     }}
                   />
                   <Button
-                    tooltip="Previous match"
+                    tooltip="Next match"
                     icon={vsArrowDown}
                     kind="ghost"
                     disabled={gotoValue === ''}

--- a/tests/context-menu.spec.ts
+++ b/tests/context-menu.spec.ts
@@ -219,13 +219,13 @@ test('go to', async ({ page }) => {
   await waitForLoadingDone(page);
   await expect(page.locator('.iris-grid-column')).toHaveScreenshot();
 
-  await page.locator('[aria-label="Previous match"]').first().click();
-  await page.locator('[aria-label="Previous match"]').first().click();
+  await page.locator('[aria-label="Next match"]').first().click();
+  await page.locator('[aria-label="Next match"]').first().click();
 
   await waitForLoadingDone(page);
   await expect(page.locator('.iris-grid-column')).toHaveScreenshot();
 
-  await page.locator('[aria-label="Next match"]').first().click();
+  await page.locator('[aria-label="Previous match"]').first().click();
 
   await waitForLoadingDone(page);
   await expect(page.locator('.iris-grid-column')).toHaveScreenshot();


### PR DESCRIPTION
- Fixes #1826 
  - Swap "Previous match" and "Next match"