### PR TITLE
fix: Save/load plugin data with layout

### DIFF
--- a/packages/code-studio/src/main/AppDashboards.tsx
+++ b/packages/code-studio/src/main/AppDashboards.tsx
@@ -18,6 +18,7 @@ interface AppDashboardsProps {
   dashboards: {
     id: string;
     layoutConfig: ItemConfigType[];
+    key?: string;
   }[];
   activeDashboard: string;
   onGoldenLayoutChange: (goldenLayout: LayoutManager) => void;
@@ -65,6 +66,7 @@ export function AppDashboards({
         >
           <LazyDashboard
             id={d.id}
+            key={d.key}
             isActive={d.id === activeDashboard}
             emptyDashboard={
               d.id === DEFAULT_DASHBOARD_ID ? (

--- a/packages/code-studio/src/main/AppMainContainer.tsx
+++ b/packages/code-studio/src/main/AppMainContainer.tsx
@@ -843,7 +843,7 @@ export class AppMainContainer extends Component<
       {
         id: DEFAULT_DASHBOARD_ID,
         layoutConfig: layoutConfig as ItemConfigType[],
-        key: `${DEFAULT_DASHBOARD_ID}|${layoutIteration}`,
+        key: `${DEFAULT_DASHBOARD_ID}-${layoutIteration}`,
       },
       ...tabs.map(tab => ({
         id: tab.key,

--- a/packages/code-studio/src/main/AppMainContainer.tsx
+++ b/packages/code-studio/src/main/AppMainContainer.tsx
@@ -577,13 +577,7 @@ export class AppMainContainer extends Component<
     try {
       const { workspace } = this.props;
       const { data } = workspace;
-      const exportedConfig = UserLayoutUtils.exportLayout(
-        data as {
-          filterSets: FilterSet[];
-          links: Link[];
-          layoutConfig: ItemConfigType[];
-        }
-      );
+      const exportedConfig = UserLayoutUtils.exportLayout(data);
 
       log.info('handleExportLayoutClick exportedConfig', exportedConfig);
 
@@ -658,13 +652,14 @@ export class AppMainContainer extends Component<
       const { updateDashboardData, updateWorkspaceData } = this.props;
       const fileText = await file.text();
       const exportedLayout = JSON.parse(fileText);
-      const { filterSets, layoutConfig, links } =
+      const { filterSets, layoutConfig, links, pluginDataMap } =
         UserLayoutUtils.normalizeLayout(exportedLayout);
 
       updateWorkspaceData({ layoutConfig });
       updateDashboardData(DEFAULT_DASHBOARD_ID, {
         filterSets,
         links,
+        pluginDataMap,
       });
     } catch (e) {
       log.error('Unable to import layout', e);

--- a/packages/code-studio/src/main/AppMainContainer.tsx
+++ b/packages/code-studio/src/main/AppMainContainer.tsx
@@ -50,8 +50,6 @@ import {
   getDashboardSessionWrapper,
   ControlType,
   ToolType,
-  FilterSet,
-  Link,
   getDashboardConnection,
   NotebookPanel,
 } from '@deephaven/dashboard-core-plugins';
@@ -155,6 +153,9 @@ interface AppMainContainerState {
   widgets: DhType.ide.VariableDefinition[];
   tabs: NavTabItem[];
   activeTabKey: string;
+
+  // Number of times the layout has been re-initialized
+  layoutIteration: number;
 }
 
 export class AppMainContainer extends Component<
@@ -255,6 +256,7 @@ export class AppMainContainer extends Component<
           title: value.title ?? 'Untitled',
         })),
       activeTabKey: DEFAULT_DASHBOARD_ID,
+      layoutIteration: 0,
     };
   }
 
@@ -661,6 +663,9 @@ export class AppMainContainer extends Component<
         links,
         pluginDataMap,
       });
+      this.setState(({ layoutIteration }) => ({
+        layoutIteration: layoutIteration + 1,
+      }));
     } catch (e) {
       log.error('Unable to import layout', e);
     }
@@ -827,8 +832,9 @@ export class AppMainContainer extends Component<
   getDashboards(): {
     id: string;
     layoutConfig: ItemConfigType[];
+    key?: string;
   }[] {
-    const { tabs } = this.state;
+    const { layoutIteration, tabs } = this.state;
     const { allDashboardData, workspace } = this.props;
     const { data: workspaceData } = workspace;
     const { layoutConfig } = workspaceData;
@@ -837,6 +843,7 @@ export class AppMainContainer extends Component<
       {
         id: DEFAULT_DASHBOARD_ID,
         layoutConfig: layoutConfig as ItemConfigType[],
+        key: `${DEFAULT_DASHBOARD_ID}|${layoutIteration}`,
       },
       ...tabs.map(tab => ({
         id: tab.key,

--- a/packages/code-studio/src/main/AppMainContainer.tsx
+++ b/packages/code-studio/src/main/AppMainContainer.tsx
@@ -1021,6 +1021,7 @@ export class AppMainContainer extends Component<
           accept=".json"
           style={{ display: 'none' }}
           onChange={this.handleImportLayoutFiles}
+          data-testid="btn-import-layout"
         />
         <DebouncedModal
           isOpen={isDisconnected && !isAuthFailed}

--- a/packages/code-studio/src/main/UserLayoutUtils.ts
+++ b/packages/code-studio/src/main/UserLayoutUtils.ts
@@ -2,12 +2,10 @@ import {
   CommandHistoryPanel,
   ConsolePanel,
   FileExplorerPanel,
-  FilterSet,
-  Link,
   LogPanel,
 } from '@deephaven/dashboard-core-plugins';
-import type { ItemConfigType } from '@deephaven/golden-layout';
 import Log from '@deephaven/log';
+import { CustomizableWorkspaceData } from '@deephaven/redux';
 import LayoutStorage, {
   ExportedLayout,
   ExportedLayoutV2,
@@ -137,16 +135,18 @@ export async function getDefaultLayout(
     : DEFAULT_LAYOUT_CONFIG_NO_CONSOLE;
 }
 
-export function exportLayout(data: {
-  filterSets: FilterSet[];
-  links: Link[];
-  layoutConfig: ItemConfigType[];
-}): ExportedLayoutV2 {
-  const { filterSets, layoutConfig, links } = data;
+export function exportLayout(
+  data: CustomizableWorkspaceData
+): ExportedLayoutV2 {
+  const { filterSets, layoutConfig, links, pluginDataMap } = data as Omit<
+    ExportedLayoutV2,
+    'version'
+  >;
   const exportedLayout: ExportedLayoutV2 = {
     filterSets,
     layoutConfig,
     links,
+    pluginDataMap,
     version: 2,
   };
   return exportedLayout;

--- a/packages/code-studio/src/storage/LayoutStorage.ts
+++ b/packages/code-studio/src/storage/LayoutStorage.ts
@@ -1,5 +1,6 @@
 import type { ItemConfigType } from '@deephaven/golden-layout';
 import { FilterSet, Link } from '@deephaven/dashboard-core-plugins';
+import { PluginDataMap } from '@deephaven/redux';
 
 /**
  * Have a different version to support legacy layout exports
@@ -10,6 +11,7 @@ export type ExportedLayoutV2 = {
   filterSets: FilterSet[];
   links: Link[];
   layoutConfig: ItemConfigType[];
+  pluginDataMap?: PluginDataMap;
   version: 2;
 };
 


### PR DESCRIPTION
- Plugin data was not getting saved with the workspace
- Reload the dashboard when a layout is imported by updating the key