### PR TITLE
feat: expose spectrum `Flex` component as wrapped deephaven component

### DIFF
--- a/packages/components/src/spectrum/Flex.tsx
+++ b/packages/components/src/spectrum/Flex.tsx
@@ -1,0 +1,4 @@
+import { Flex } from '@adobe/react-spectrum';
+export type { FlexProps } from '@adobe/react-spectrum';
+export { Flex };
+export default Flex;

--- a/packages/components/src/spectrum/Flex.tsx
+++ b/packages/components/src/spectrum/Flex.tsx
@@ -1,4 +1,5 @@
 import { Flex } from '@adobe/react-spectrum';
+
 export type { FlexProps } from '@adobe/react-spectrum';
 export { Flex };
 export default Flex;

--- a/packages/components/src/spectrum/index.ts
+++ b/packages/components/src/spectrum/index.ts
@@ -1,3 +1,4 @@
-export * from './picker';
+export * from './Flex';
 export * from './Item';
+export * from './picker';
 export * from './Section';


### PR DESCRIPTION
Simple wrapping of the flex component.

I don't see anything we need to custiomize, so just re-export it I guess.