### PR TITLE
chore: Update react peer dependency versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28351,8 +28351,8 @@
         "node": ">=16"
       },
       "peerDependencies": {
-        "react": "^17.x",
-        "react-dom": "^17.x",
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0",
         "react-redux": "^7.x",
         "redux": "^4.x"
       }
@@ -28424,8 +28424,8 @@
         "node": ">=16"
       },
       "peerDependencies": {
-        "react": "^17.x",
-        "react-dom": "^17.x"
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
       }
     },
     "packages/babel-preset": {
@@ -28473,7 +28473,7 @@
         "node": ">=16"
       },
       "peerDependencies": {
-        "react": "^17.x"
+        "react": ">=16.8.0"
       }
     },
     "packages/code-studio": {
@@ -28607,8 +28607,8 @@
         "node": ">=10"
       },
       "peerDependencies": {
-        "react": "^17.x",
-        "react-dom": "^17.x"
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
       }
     },
     "packages/console": {
@@ -28647,8 +28647,8 @@
         "node": ">=16"
       },
       "peerDependencies": {
-        "react": "^17.x",
-        "react-dom": "^17.x"
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
       }
     },
     "packages/dashboard": {
@@ -28676,9 +28676,9 @@
         "node": ">=16"
       },
       "peerDependencies": {
-        "react": "^17.0.0",
-        "react-dom": "^17.0.0",
-        "react-is": "^17.0.0",
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0",
+        "react-is": ">=16.8.0",
         "react-redux": "^7.2.4"
       }
     },
@@ -28733,8 +28733,8 @@
         "node": ">=16"
       },
       "peerDependencies": {
-        "react": "^17.0.0",
-        "react-dom": "^17.0.0",
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0",
         "react-redux": "^7.2.4"
       }
     },
@@ -29235,7 +29235,7 @@
         "node": ">=16"
       },
       "peerDependencies": {
-        "react": "^17.0.0"
+        "react": ">=16.8.0"
       }
     },
     "packages/filters": {
@@ -29261,8 +29261,8 @@
         "watchify": "^4.0.0"
       },
       "peerDependencies": {
-        "react": "^17.x",
-        "react-dom": "^17.x"
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
       }
     },
     "packages/grid": {
@@ -29284,7 +29284,7 @@
         "node": ">=16"
       },
       "peerDependencies": {
-        "react": "^17.x"
+        "react": ">=16.8.0"
       }
     },
     "packages/icons": {
@@ -29346,8 +29346,8 @@
         "node": ">=10"
       },
       "peerDependencies": {
-        "react": "^17.x",
-        "react-dom": "^17.x"
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
       }
     },
     "packages/jsapi-bootstrap": {
@@ -29367,7 +29367,7 @@
         "node": ">=16"
       },
       "peerDependencies": {
-        "react": "^17.x"
+        "react": ">=16.8.0"
       }
     },
     "packages/jsapi-components": {
@@ -29396,7 +29396,7 @@
         "node": ">=16"
       },
       "peerDependencies": {
-        "react": "^17.x"
+        "react": ">=16.8.0"
       }
     },
     "packages/jsapi-shim": {
@@ -29477,7 +29477,7 @@
         "node": ">=16"
       },
       "peerDependencies": {
-        "react": "^17.x"
+        "react": ">=16.8.0"
       }
     },
     "packages/plugin-utils": {
@@ -29526,7 +29526,7 @@
         "node": ">=16"
       },
       "peerDependencies": {
-        "react": "^17.x"
+        "react": ">=16.8.0"
       }
     },
     "packages/prettier-config": {
@@ -29552,7 +29552,7 @@
         "node": ">=16"
       },
       "peerDependencies": {
-        "react": "^17.x"
+        "react": ">=16.8.0"
       }
     },
     "packages/redux": {
@@ -29587,7 +29587,7 @@
         "node": ">=16"
       },
       "peerDependencies": {
-        "react": "^17.x"
+        "react": ">=16.8.0"
       }
     },
     "packages/stylelint-config": {

--- a/packages/app-utils/package.json
+++ b/packages/app-utils/package.json
@@ -51,8 +51,8 @@
     "fira": "mozilla/fira#4.202"
   },
   "peerDependencies": {
-    "react": "^17.x",
-    "react-dom": "^17.x",
+    "react": ">=16.8.0",
+    "react-dom": ">=16.8.0",
     "react-redux": "^7.x",
     "redux": "^4.x"
   },

--- a/packages/auth-plugins/package.json
+++ b/packages/auth-plugins/package.json
@@ -49,8 +49,8 @@
     "@types/react": "^17.0.2"
   },
   "peerDependencies": {
-    "react": "^17.x",
-    "react-dom": "^17.x"
+    "react": ">=16.8.0",
+    "react-dom": ">=16.8.0"
   },
   "files": [
     "dist"

--- a/packages/chart/package.json
+++ b/packages/chart/package.json
@@ -44,7 +44,7 @@
     "react-plotly.js": "^2.6.0"
   },
   "peerDependencies": {
-    "react": "^17.x"
+    "react": ">=16.8.0"
   },
   "devDependencies": {
     "@deephaven/jsapi-shim": "file:../jsapi-shim",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -49,8 +49,8 @@
     "shortid": "^2.2.16"
   },
   "peerDependencies": {
-    "react": "^17.x",
-    "react-dom": "^17.x"
+    "react": ">=16.8.0",
+    "react-dom": ">=16.8.0"
   },
   "devDependencies": {
     "@deephaven/mocks": "file:../mocks"

--- a/packages/console/package.json
+++ b/packages/console/package.json
@@ -47,8 +47,8 @@
     "shortid": "^2.2.16"
   },
   "peerDependencies": {
-    "react": "^17.x",
-    "react-dom": "^17.x"
+    "react": ">=16.8.0",
+    "react-dom": ">=16.8.0"
   },
   "devDependencies": {
     "@deephaven/jsapi-shim": "file:../jsapi-shim",

--- a/packages/dashboard-core-plugins/package.json
+++ b/packages/dashboard-core-plugins/package.json
@@ -61,8 +61,8 @@
     "shortid": "^2.2.16"
   },
   "peerDependencies": {
-    "react": "^17.0.0",
-    "react-dom": "^17.0.0",
+    "react": ">=16.8.0",
+    "react-dom": ">=16.8.0",
     "react-redux": "^7.2.4"
   },
   "devDependencies": {

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -35,9 +35,9 @@
     "shortid": "^2.2.16"
   },
   "peerDependencies": {
-    "react": "^17.0.0",
-    "react-dom": "^17.0.0",
-    "react-is": "^17.0.0",
+    "react": ">=16.8.0",
+    "react-dom": ">=16.8.0",
+    "react-is": ">=16.8.0",
     "react-redux": "^7.2.4"
   },
   "devDependencies": {

--- a/packages/file-explorer/package.json
+++ b/packages/file-explorer/package.json
@@ -34,7 +34,7 @@
     "prop-types": "^15.7.2"
   },
   "peerDependencies": {
-    "react": "^17.0.0"
+    "react": ">=16.8.0"
   },
   "devDependencies": {
     "@deephaven/mocks": "file:../mocks"

--- a/packages/golden-layout/package.json
+++ b/packages/golden-layout/package.json
@@ -14,8 +14,8 @@
     "jquery": "^3.6.0"
   },
   "peerDependencies": {
-    "react": "^17.x",
-    "react-dom": "^17.x"
+    "react": ">=16.8.0",
+    "react-dom": ">=16.8.0"
   },
   "scripts": {
     "build": "cross-env NODE_ENV=production run-p build:*",

--- a/packages/grid/package.json
+++ b/packages/grid/package.json
@@ -22,7 +22,7 @@
     "build:sass": "sass --embed-sources --load-path=../../node_modules ./src:./dist"
   },
   "peerDependencies": {
-    "react": "^17.x"
+    "react": ">=16.8.0"
   },
   "files": [
     "dist"

--- a/packages/iris-grid/package.json
+++ b/packages/iris-grid/package.json
@@ -61,8 +61,8 @@
     "shortid": "^2.2.16"
   },
   "peerDependencies": {
-    "react": "^17.x",
-    "react-dom": "^17.x"
+    "react": ">=16.8.0",
+    "react-dom": ">=16.8.0"
   },
   "devDependencies": {
     "@deephaven/jsapi-shim": "file:../jsapi-shim",

--- a/packages/jsapi-bootstrap/package.json
+++ b/packages/jsapi-bootstrap/package.json
@@ -31,7 +31,7 @@
     "react": "^17.x"
   },
   "peerDependencies": {
-    "react": "^17.x"
+    "react": ">=16.8.0"
   },
   "files": [
     "dist"

--- a/packages/jsapi-components/package.json
+++ b/packages/jsapi-components/package.json
@@ -40,7 +40,7 @@
     "react-test-renderer": "^17.0.2"
   },
   "peerDependencies": {
-    "react": "^17.x"
+    "react": ">=16.8.0"
   },
   "files": [
     "dist"

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -33,7 +33,7 @@
     "@fortawesome/react-fontawesome": "^0.2.0"
   },
   "peerDependencies": {
-    "react": "^17.x"
+    "react": ">=16.8.0"
   },
   "files": [
     "dist"

--- a/packages/pouch-storage/package.json
+++ b/packages/pouch-storage/package.json
@@ -31,7 +31,7 @@
     "pouchdb-find": "^7.3.0"
   },
   "peerDependencies": {
-    "react": "^17.x"
+    "react": ">=16.8.0"
   },
   "files": [
     "dist"

--- a/packages/react-hooks/package.json
+++ b/packages/react-hooks/package.json
@@ -28,7 +28,7 @@
     "shortid": "^2.2.16"
   },
   "peerDependencies": {
-    "react": "^17.x"
+    "react": ">=16.8.0"
   },
   "files": [
     "dist"

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -26,7 +26,7 @@
     "lodash.throttle": "^4.1.1"
   },
   "peerDependencies": {
-    "react": "^17.x"
+    "react": ">=16.8.0"
   },
   "files": [
     "dist"


### PR DESCRIPTION
Fixes #1863 

I did `>=16.8.0` because React 17 release notes say "no new features", so we should really be fine with any React that supports hooks. From what I can tell, no changes in React 18 should cause bugs with our packages

In the future if we implement any React 18 specific features we'll need to update the peer deps for those packages.

When React 19 starts publishing alphas/betas I think we would need to bump again (if anybody is testing on react 19 pre-release) to include a `|| 19.0.0-beta.0` or whatever version pattern they use as `>=16.8.0` does not match pre-release versions