### PR TITLE
chore: Update github actions to Node 20

### DIFF
--- a/.github/workflows/audit-fix.yml
+++ b/.github/workflows/audit-fix.yml
@@ -9,9 +9,9 @@ jobs:
     name: Run npm audit fix
     steps:
       - name: Checkout latest
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
           registry-url: 'https://registry.npmjs.org'
@@ -20,7 +20,7 @@ jobs:
         continue-on-error: true
         run: npm audit fix
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@v6
         with:
           base: main
           title: 'chore: npm audit fix'

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - name: 'CLA Assistant'
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
-        uses: cla-assistant/github-action@v2.2.0
+        uses: contributor-assistant/github-action@v2.3.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_PERSONAL_ACCESS_TOKEN }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Check installed fonts
         run: 'fc-list : family'
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Run core server:${{ env.DOCKER_TAG }}
         run: |
@@ -31,14 +31,14 @@ jobs:
           docker run --detach --publish 10000:10000 --name dh-core-server -v ./tests/docker-scripts/data:/data --env "START_OPTS=-Xmx4g -DAuthHandlers=io.deephaven.auth.AnonymousAuthenticationHandler -Ddeephaven.application.dir=./data/app.d" ghcr.io/deephaven/server:${{ env.DOCKER_TAG }}
 
       - name: Use Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
 
       - name: Cache node modules
         id: cache-node-modules
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             node_modules
@@ -62,7 +62,7 @@ jobs:
         run: PLAYWRIGHT_BROWSERS_PATH=0 npx playwright test --config=playwright-ci.config.ts
 
       - name: Upload Playwright report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: playwright-report
@@ -73,7 +73,7 @@ jobs:
         run: docker logs dh-core-server > /tmp/server-log.txt
       - name: Upload server logs
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: server-logs
           path: /tmp/server-log.txt

--- a/.github/workflows/publish-alpha.yml
+++ b/.github/workflows/publish-alpha.yml
@@ -18,11 +18,11 @@ jobs:
       packages: write
       id-token: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: '0' # Need the history to properly select the canary version number
           ref: ${{ github.event.inputs.ref }}
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/publish-nightly.yml
+++ b/.github/workflows/publish-nightly.yml
@@ -12,7 +12,7 @@ jobs:
     outputs:
       should_run: ${{ steps.should_run.outputs.should_run }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: print latest_commit
         run: echo ${{ github.sha }}
 
@@ -30,10 +30,10 @@ jobs:
       packages: write
       id-token: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: '0' # Need the history to properly select the canary version number
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -12,11 +12,11 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.ref }}
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -18,7 +18,7 @@ jobs:
       group: ${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: true
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: '0' # This action defaults to only getting the latest commit. Setting to 0 makes it retrieve the full git commit history
 
@@ -27,13 +27,13 @@ jobs:
         run: git fetch --no-tags origin ${{ github.event.pull_request.base.ref }}
 
       - name: Use Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
 
       - name: Cache jest
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             .jest-cache
@@ -43,7 +43,7 @@ jobs:
             ${{ runner.os }}-jestcache-
 
       - name: Cache linters
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             .eslintcache
@@ -56,7 +56,7 @@ jobs:
 
       - name: Cache node modules
         id: cache-node-modules
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             node_modules


### PR DESCRIPTION
The only action that is still on Node 16 is the CLA action. I updated it from the Node 12 to Node 16 version though. Also, they changed the repo name, but I didn't see anything in the changelog about it. I did find the commit changing their readme though [here](https://github.com/contributor-assistant/github-action/commit/b2a7f9fb90217ea0b8a0c95c288221457be4a31f)

The only action I saw with a breaking change was `upload-artifact`. We don't use any of the cases in this repo where the breaking change would effect us. [Migration guide](https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md)