### PR TITLE
feat: log export blacklist

### DIFF
--- a/packages/code-studio/src/log/LogExport.ts
+++ b/packages/code-studio/src/log/LogExport.ts
@@ -10,8 +10,10 @@ const FILENAME_DATE_FORMAT = 'yyyy-MM-dd-HHmmss';
 const KEY_BLACKLIST: string[] = ['client'];
 // Blacklist specific paths (e.g. blacklist foo will only blacklist foo but NOT a.foo or b.foo)
 const PATH_BLACKLIST: string[] = [
+  'api',
   'dashboardData.defaultLayout.connection',
-  'layoutStorage.storageService.connection',
+  'layoutStorage',
+  'storage',
 ];
 
 /**

--- a/packages/code-studio/src/log/LogExport.ts
+++ b/packages/code-studio/src/log/LogExport.ts
@@ -31,6 +31,8 @@ function replacerWithPath(
   r: (key: string, value: unknown, path: string) => unknown
 ) {
   const m = new Map();
+  // code source and explanation;
+  // https://stackoverflow.com/questions/61681176/json-stringify-replacer-how-to-get-full-path
   return function replacer(this: unknown, field: string, value: unknown) {
     const path =
       m.get(this) + (Array.isArray(this) ? `[${field}]` : `.${field}`);

--- a/packages/code-studio/src/log/LogExport.ts
+++ b/packages/code-studio/src/log/LogExport.ts
@@ -36,13 +36,11 @@ function stringifyReplacer(blacklist: string[][]) {
         currPath.every((v, index) => v === blacklist[i][index])
       ) {
         // blacklist match
-        console.log('Blacklist match', currPath);
         return undefined;
       }
     }
 
     // not in blacklist, return value
-    console.log('No blacklist match', currPath);
     return value;
   };
 }

--- a/packages/code-studio/src/log/LogExport.ts
+++ b/packages/code-studio/src/log/LogExport.ts
@@ -9,12 +9,12 @@ const FILENAME_DATE_FORMAT = 'yyyy-MM-dd-HHmmss';
 // List of objects to blacklist
 // '' represents the root object
 export const PATH_BLACKLIST: string[][] = [
-  ['', 'api'],
-  ['', 'client'],
-  ['', 'dashboardData', 'defaultLayout', 'connection'],
-  ['', 'layoutStorage'],
-  ['', 'storage'],
-];
+  ['api'],
+  ['client'],
+  ['dashboardData', 'defaultLayout', 'connection'],
+  ['layoutStorage'],
+  ['storage'],
+].map(path => ['', ...path]);
 
 function stringifyReplacer(blacklist: string[][]) {
   // modified from:
@@ -55,6 +55,7 @@ function stringifyReplacer(blacklist: string[][]) {
  * Then if the object is seen again, it must be a circular ref since that object could not be stringified safely
  *
  * @param obj Object to make safe to stringify
+ * @param blacklist List of JSON paths to blacklist. A JSON path is a list representing the path to that value (e.g. client.data would be `['client', 'data']`)
  */
 function makeSafeToStringify(
   obj: Record<string, unknown>,
@@ -124,6 +125,7 @@ function getMetadata(
 /**
  * Export support logs with the given name.
  * @param fileNamePrefix The zip file name without the .zip extension. Ex: test will be saved as test.zip
+ * @param blacklist List of JSON paths to blacklist. A JSON path is a list representing the path to that value (e.g. client.data would be `['client', 'data']`)
  */
 export async function exportLogs(
   fileNamePrefix = `${dh.i18n.DateTimeFormat.format(

--- a/packages/code-studio/src/log/LogExport.ts
+++ b/packages/code-studio/src/log/LogExport.ts
@@ -9,7 +9,10 @@ const FILENAME_DATE_FORMAT = 'yyyy-MM-dd-HHmmss';
 // Blacklist applies to all keys (e.g. blacklist foo will blacklist foo, a.foo, and b.foo)
 const KEY_BLACKLIST: string[] = ['client'];
 // Blacklist specific paths (e.g. blacklist foo will only blacklist foo but NOT a.foo or b.foo)
-const PATH_BLACKLIST: string[] = [];
+const PATH_BLACKLIST: string[] = [
+  'dashboardData.defaultLayout.connection',
+  'layoutStorage.storageService.connection',
+];
 
 /**
  * Replacer function for JSON.stringify to remove keys that should not be included in the output

--- a/packages/code-studio/src/log/LogExport.ts
+++ b/packages/code-studio/src/log/LogExport.ts
@@ -11,7 +11,8 @@ const FILENAME_DATE_FORMAT = 'yyyy-MM-dd-HHmmss';
 export const DEFAULT_PATH_BLACKLIST: string[][] = [
   ['api'],
   ['client'],
-  ['dashboardData', 'defaultLayout', 'connection'],
+  ['dashboardData', 'default', 'connection'],
+  ['dashboardData', 'default', 'sessionWrapper', 'dh'],
   ['layoutStorage'],
   ['storage'],
 ];


### PR DESCRIPTION
- Adds #1245 
  - Add a replacer function to all `JSON.stringify` to filter out blacklisted path
  - Add the following paths to blacklist: `api`, `client`, `dashboardData.defaultLayout.connection`, `layoutStorage`, `storage`