### PR TITLE
fix: Fixed re-export (#1894)

### DIFF
--- a/packages/components/src/spectrum/forms.ts
+++ b/packages/components/src/spectrum/forms.ts
@@ -16,4 +16,4 @@ export {
   type SpectrumTextFieldProps as TextFieldProps,
 } from '@adobe/react-spectrum';
 
-export { type SpectrumTextAreaProps as TextAreaProps } from '@react-types/textfield';
+export type { SpectrumTextAreaProps as TextAreaProps } from '@react-types/textfield';

--- a/packages/components/src/spectrum/forms.ts
+++ b/packages/components/src/spectrum/forms.ts
@@ -16,4 +16,5 @@ export {
   type SpectrumTextFieldProps as TextFieldProps,
 } from '@adobe/react-spectrum';
 
+// @react-types/textfield is unecessary if https://github.com/adobe/react-spectrum/pull/6090 merge
 export type { SpectrumTextAreaProps as TextAreaProps } from '@react-types/textfield';


### PR DESCRIPTION
`npm start` should work now without the `@react-types/textfield` error.