### PR TITLE
feat: improve table loading

### DIFF
--- a/packages/iris-grid/src/IrisGrid.scss
+++ b/packages/iris-grid/src/IrisGrid.scss
@@ -154,7 +154,6 @@ $cell-invalid-box-shadow:
 
 .iris-grid-loading {
   position: absolute;
-  top: 0;
   bottom: 0;
   left: 0;
   right: 0;

--- a/packages/iris-grid/src/IrisGrid.tsx
+++ b/packages/iris-grid/src/IrisGrid.tsx
@@ -610,7 +610,7 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
       this.handleGotoValueSelectedFilterChanged.bind(this);
     this.handleGotoValueChanged = this.handleGotoValueChanged.bind(this);
     this.handleGotoValueSubmitted = this.handleGotoValueSubmitted.bind(this);
-    this.onViewportUpdate = this.onViewportUpdate.bind(this);
+    this.handleViewportUpdate = this.handleViewportUpdate.bind(this);
     this.makeQuickFilter = this.makeQuickFilter.bind(this);
 
     this.grid = null;
@@ -2513,7 +2513,7 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
     onError(error);
   }
 
-  onViewportUpdate(): void {
+  handleViewportUpdate(): void {
     const { model } = this.props;
     // pending and no timer already exists
     if (model.isViewportPending && this.viewportLoadingTimeout === null) {
@@ -4754,7 +4754,7 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
                 frozenColumns={frozenColumns}
                 columnHeaderGroups={columnHeaderGroups}
                 partitionConfig={partitionConfig}
-                onViewportUpdate={this.onViewportUpdate}
+                onViewportUpdate={this.handleViewportUpdate}
               />
             )}
             {!isMenuShown && (

--- a/packages/iris-grid/src/IrisGrid.tsx
+++ b/packages/iris-grid/src/IrisGrid.tsx
@@ -381,6 +381,7 @@ export interface IrisGridState {
   loadingText: string | null;
   loadingScrimProgress: number | null;
   loadingSpinnerShown: boolean;
+  loadingCancelShown: boolean;
 
   movedColumns: readonly MoveOperation[];
   movedRows: readonly MoveOperation[];
@@ -800,6 +801,7 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
       loadingText: null,
       loadingScrimProgress: null,
       loadingSpinnerShown: false,
+      loadingCancelShown: false,
 
       movedColumns,
       movedRows,
@@ -2149,7 +2151,11 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
     }
   }
 
-  startLoading(loadingText: string, resetRanges = false): void {
+  startLoading(
+    loadingText: string,
+    resetRanges = false,
+    loadingSpinnerShown = true
+  ): void {
     this.setState({ loadingText });
 
     const theme = this.getTheme();
@@ -2174,11 +2180,13 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
       this.setState({
         loadingScrimProgress: 0,
       });
-      this.loadingTimer = setTimeout(() => {
-        this.setState({
-          loadingSpinnerShown: true,
-        });
-      }, IrisGrid.loadingSpinnerDelay);
+      if (loadingSpinnerShown) {
+        this.loadingTimer = setTimeout(() => {
+          this.setState({
+            loadingSpinnerShown,
+          });
+        }, IrisGrid.loadingSpinnerDelay);
+      }
     }
   }
 
@@ -2189,6 +2197,7 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
       loadingText: null,
       loadingScrimProgress: null,
       loadingSpinnerShown: false,
+      loadingCancelShown: false,
     });
 
     if (this.loadingTimer != null) {
@@ -2520,7 +2529,7 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
       this.viewportLoadingTimeout = setTimeout(() => {
         // still pending after timeout
         if (model.isViewportPending) {
-          this.startLoading('Waiting for viewport...');
+          this.startLoading('Waiting for viewport...', false);
         }
         this.viewportLoadingTimeout = null;
       }, VIEWPORT_LOADING_DELAY);
@@ -4116,6 +4125,7 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
       loadingText,
       loadingScrimProgress,
       loadingSpinnerShown,
+      loadingCancelShown,
       shownColumnTooltip,
       hoverAdvancedFilter,
       shownAdvancedFilter,
@@ -4288,7 +4298,7 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
             type="button"
             onClick={this.handleCancel}
             className={classNames('iris-grid-btn-cancel', {
-              show: loadingSpinnerShown,
+              show: loadingCancelShown,
             })}
           >
             <FontAwesomeIcon icon={vsClose} transform="down-1" />

--- a/packages/iris-grid/src/IrisGridModel.ts
+++ b/packages/iris-grid/src/IrisGridModel.ts
@@ -485,6 +485,13 @@ abstract class IrisGridModel<
   abstract commitPending(): Promise<void>;
 
   /**
+   * Check if viewport is still loading data
+   */
+  get hasPendingOperations(): boolean {
+    return false;
+  }
+
+  /**
    * Check if a column is filterable
    * @param columnIndex The column index to check for filterability
    * @returns True if the current provided column index is filterable, false otherwise

--- a/packages/iris-grid/src/IrisGridModel.ts
+++ b/packages/iris-grid/src/IrisGridModel.ts
@@ -75,6 +75,7 @@ abstract class IrisGridModel<
     RECONNECT: 'RECONNECT',
     TOTALS_UPDATED: 'TOTALS_UPDATED',
     PENDING_DATA_UPDATED: 'PENDING_DATA_UPDATED',
+    VIEWPORT_UPDATED: 'VIEWPORT_UPDATED',
   } as const);
 
   constructor(dh: typeof DhType) {

--- a/packages/iris-grid/src/IrisGridModel.ts
+++ b/packages/iris-grid/src/IrisGridModel.ts
@@ -74,6 +74,7 @@ abstract class IrisGridModel<
     DISCONNECT: 'DISCONNECT',
     RECONNECT: 'RECONNECT',
     TOTALS_UPDATED: 'TOTALS_UPDATED',
+    /** Fired when the viewport is applied to the table and we're waiting for a response. */
     PENDING_DATA_UPDATED: 'PENDING_DATA_UPDATED',
     VIEWPORT_UPDATED: 'VIEWPORT_UPDATED',
   } as const);

--- a/packages/iris-grid/src/IrisGridModel.ts
+++ b/packages/iris-grid/src/IrisGridModel.ts
@@ -487,7 +487,7 @@ abstract class IrisGridModel<
   /**
    * Check if viewport is still loading data
    */
-  get hasPendingOperations(): boolean {
+  get isViewportPending(): boolean {
     return false;
   }
 

--- a/packages/iris-grid/src/IrisGridModelUpdater.tsx
+++ b/packages/iris-grid/src/IrisGridModelUpdater.tsx
@@ -40,7 +40,6 @@ interface IrisGridModelUpdaterProps {
   pendingRowCount?: number;
   pendingDataMap?: PendingDataMap;
   partitionConfig?: PartitionConfig;
-  onViewportUpdate?: () => void;
 }
 
 /**
@@ -71,7 +70,6 @@ const IrisGridModelUpdater = React.memo(
     formatColumns,
     columnHeaderGroups,
     partitionConfig,
-    onViewportUpdate,
   }: IrisGridModelUpdaterProps) => {
     const columns = useMemo(
       () =>
@@ -135,9 +133,8 @@ const IrisGridModelUpdater = React.memo(
     useEffect(
       function updateViewport() {
         model.setViewport(top, bottom, columns);
-        onViewportUpdate?.();
       },
-      [model, top, bottom, columns, onViewportUpdate]
+      [model, top, bottom, columns]
     );
     useEffect(
       function updateRollupCOnfig() {

--- a/packages/iris-grid/src/IrisGridModelUpdater.tsx
+++ b/packages/iris-grid/src/IrisGridModelUpdater.tsx
@@ -40,6 +40,7 @@ interface IrisGridModelUpdaterProps {
   pendingRowCount?: number;
   pendingDataMap?: PendingDataMap;
   partitionConfig?: PartitionConfig;
+  onViewportUpdate?: () => void;
 }
 
 /**
@@ -70,6 +71,7 @@ const IrisGridModelUpdater = React.memo(
     formatColumns,
     columnHeaderGroups,
     partitionConfig,
+    onViewportUpdate,
   }: IrisGridModelUpdaterProps) => {
     const columns = useMemo(
       () =>
@@ -133,8 +135,9 @@ const IrisGridModelUpdater = React.memo(
     useEffect(
       function updateViewport() {
         model.setViewport(top, bottom, columns);
+        onViewportUpdate?.();
       },
-      [model, top, bottom, columns]
+      [model, top, bottom, columns, onViewportUpdate]
     );
     useEffect(
       function updateRollupCOnfig() {

--- a/packages/iris-grid/src/IrisGridProxyModel.ts
+++ b/packages/iris-grid/src/IrisGridProxyModel.ts
@@ -697,8 +697,8 @@ class IrisGridProxyModel extends IrisGridModel implements PartitionedGridModel {
     return isEditableGridModel(this.model) && this.model.isEditable;
   }
 
-  get hasPendingOperations(): boolean {
-    return this.model.hasPendingOperations;
+  get isViewportPending(): boolean {
+    return this.model.isViewportPending;
   }
 
   isEditableRange: IrisGridTableModel['isEditableRange'] = (

--- a/packages/iris-grid/src/IrisGridProxyModel.ts
+++ b/packages/iris-grid/src/IrisGridProxyModel.ts
@@ -697,6 +697,10 @@ class IrisGridProxyModel extends IrisGridModel implements PartitionedGridModel {
     return isEditableGridModel(this.model) && this.model.isEditable;
   }
 
+  get hasPendingOperations(): boolean {
+    return this.model.hasPendingOperations;
+  }
+
   isEditableRange: IrisGridTableModel['isEditableRange'] = (
     ...args
   ): boolean => {

--- a/packages/iris-grid/src/IrisGridTableModelTemplate.ts
+++ b/packages/iris-grid/src/IrisGridTableModelTemplate.ts
@@ -1346,6 +1346,9 @@ class IrisGridTableModelTemplate<
     viewportBottom: number,
     columns?: DhType.Column[]
   ): void {
+    this.dispatchEvent(
+      new EventShimCustomEvent(IrisGridModel.EVENT.VIEWPORT_UPDATED)
+    );
     log.debug2('applyBufferedViewport', viewportTop, viewportBottom, columns);
     if (this.subscription == null) {
       log.debug2('applyBufferedViewport creating new subscription');

--- a/packages/iris-grid/src/IrisGridTableModelTemplate.ts
+++ b/packages/iris-grid/src/IrisGridTableModelTemplate.ts
@@ -456,18 +456,35 @@ class IrisGridTableModelTemplate<
   }
 
   get isViewportPending(): boolean {
-    if (this.viewport == null || this.viewportData == null) {
+    if (
+      this.viewport == null ||
+      this.viewport.columns === undefined ||
+      this.viewportData == null
+    ) {
       return true;
     }
+    // no columns
+    if (this.viewport.columns.length === 0) {
+      return false;
+    }
 
-    // offset + row.length is last row of loaded data
     // offset is first row of loaded data
-    // last row of loaded data < last row of viewport
-    // first row of viewport < first row of loaded data
-    return (
+    const pendingTop = this.viewport.top < this.viewportData.offset;
+    // offset + row.length is last row of loaded data
+    const pendingBottom =
       this.viewportData.offset + this.viewportData.rows.length <
-        this.viewport.bottom || this.viewport.top < this.viewportData.offset
-    );
+      this.viewport.bottom;
+    // left column doesn't exist in data
+    const pendingLeft =
+      this.viewportData.rows[0].data.get(this.viewport.columns[0].index) ===
+      undefined;
+    // right column doesn't exist in data
+    const pendingRight =
+      this.viewportData.rows[0].data.get(
+        this.viewport.columns[this.viewport.columns.length - 1].index
+      ) === undefined;
+
+    return pendingTop || pendingBottom || pendingLeft || pendingRight;
   }
 
   cacheFormattedValue(x: ModelIndex, y: ModelIndex, text: string | null): void {

--- a/packages/iris-grid/src/IrisGridTableModelTemplate.ts
+++ b/packages/iris-grid/src/IrisGridTableModelTemplate.ts
@@ -455,7 +455,7 @@ class IrisGridTableModelTemplate<
     return !this.isSaveInProgress && this.inputTable != null;
   }
 
-  get hasPendingOperations(): boolean {
+  get isViewportPending(): boolean {
     if (this.viewport == null || this.viewportData == null) {
       return true;
     }

--- a/packages/iris-grid/src/IrisGridTableModelTemplate.ts
+++ b/packages/iris-grid/src/IrisGridTableModelTemplate.ts
@@ -463,8 +463,11 @@ class IrisGridTableModelTemplate<
     ) {
       return true;
     }
-    // no columns
-    if (this.viewport.columns.length === 0) {
+    // no columns or no rows
+    if (
+      this.viewport.columns.length === 0 ||
+      this.viewportData.rows.length === 0
+    ) {
       return false;
     }
 

--- a/packages/iris-grid/src/IrisGridTableModelTemplate.ts
+++ b/packages/iris-grid/src/IrisGridTableModelTemplate.ts
@@ -455,6 +455,21 @@ class IrisGridTableModelTemplate<
     return !this.isSaveInProgress && this.inputTable != null;
   }
 
+  get hasPendingOperations(): boolean {
+    if (this.viewport == null || this.viewportData == null) {
+      return true;
+    }
+
+    // offset + row.length is last row of loaded data
+    // offset is first row of loaded data
+    // last row of loaded data < last row of viewport
+    // first row of viewport < first row of loaded data
+    return (
+      this.viewportData.offset + this.viewportData.rows.length <
+        this.viewport.bottom || this.viewport.top < this.viewportData.offset
+    );
+  }
+
   cacheFormattedValue(x: ModelIndex, y: ModelIndex, text: string | null): void {
     if (this.formattedStringData[x] == null) {
       this.formattedStringData[x] = [];


### PR DESCRIPTION
- Adds #1865
  - Add a check for if there is still data being loaded in the viewport
  - Add a new loading message if the above is true for >500ms
  - Add state to determine whether `startLoading` will block the grid or show the cancel button