### PR TITLE
chore: Add buffer as a chart dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10408,7 +10408,6 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -28454,6 +28453,7 @@
         "@deephaven/log": "file:../log",
         "@deephaven/react-hooks": "file:../react-hooks",
         "@deephaven/utils": "file:../utils",
+        "buffer": "^6.0.3",
         "deep-equal": "^2.0.5",
         "lodash.debounce": "^4.0.8",
         "lodash.set": "^4.3.2",
@@ -28473,6 +28473,29 @@
       },
       "peerDependencies": {
         "react": ">=16.8.0"
+      }
+    },
+    "packages/chart/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
       }
     },
     "packages/code-studio": {
@@ -30938,6 +30961,7 @@
         "@deephaven/react-hooks": "file:../react-hooks",
         "@deephaven/utils": "file:../utils",
         "@types/plotly.js": "^2.12.11",
+        "buffer": "*",
         "deep-equal": "^2.0.5",
         "lodash.debounce": "^4.0.8",
         "lodash.set": "^4.3.2",
@@ -30946,6 +30970,17 @@
         "plotly.js": "^2.29.1",
         "prop-types": "^15.7.2",
         "react-plotly.js": "^2.6.0"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+          "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.2.1"
+          }
+        }
       }
     },
     "@deephaven/code-studio": {
@@ -37868,8 +37903,7 @@
     "base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
     },
     "base64id": {
       "version": "2.0.0",

--- a/packages/chart/package.json
+++ b/packages/chart/package.json
@@ -34,6 +34,7 @@
     "@deephaven/log": "file:../log",
     "@deephaven/react-hooks": "file:../react-hooks",
     "@deephaven/utils": "file:../utils",
+    "buffer": "^6.0.3",
     "deep-equal": "^2.0.5",
     "lodash.debounce": "^4.0.8",
     "lodash.set": "^4.3.2",


### PR DESCRIPTION
This adds an explicit dependency to `buffer` to `@deephaven/chart` which we currently get implicitly from `browserify` in `golden-layout`. `plotly.js` depends on `typedarray-pool` which depends on `buffer`, but doesn't list it.

I opened a PR with `typedarray-pool`, but doesn't seem it's an active repo any more. https://github.com/mikolalysenko/typedarray-pool/pull/11

The docs uses webpack 5 w/ docusaurus and I added `buffer` when adding chart support, so this should be all that's needed. https://github.com/deephaven/deephaven.io/commit/6a8bcf29fe32dea1825c6d7f682857cc33b59109#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519