### PR TITLE
feat: Change autoclosing bracket behavior to beforeWhitespace

### DIFF
--- a/packages/console/src/ConsoleInput.tsx
+++ b/packages/console/src/ConsoleInput.tsx
@@ -183,6 +183,7 @@ export class ConsoleInput extends PureComponent<
       },
       value: '',
       wordWrap: 'on',
+      autoClosingBrackets: 'beforeWhitespace',
     } as const;
 
     const element = this.commandContainer.current;

--- a/packages/console/src/notebook/Editor.tsx
+++ b/packages/console/src/notebook/Editor.tsx
@@ -91,6 +91,7 @@ class Editor extends Component<EditorProps, Record<string, never>> {
       value: '',
       wordWrap: 'off',
       links: true,
+      autoClosingBrackets: 'beforeWhitespace',
       ...settings,
     };
     assertNotNull(this.container);

--- a/packages/iris-grid/src/sidebar/InputEditor.tsx
+++ b/packages/iris-grid/src/sidebar/InputEditor.tsx
@@ -88,6 +88,7 @@ export class InputEditor extends Component<InputEditorProps, InputEditorState> {
       value,
       wordWrap: 'on',
       automaticLayout: true,
+      autoClosingBrackets: 'beforeWhitespace',
       ...editorSettings,
     } as monaco.editor.IStandaloneEditorConstructionOptions;
     if (!this.editorContainer) {


### PR DESCRIPTION
Checked enterprise and we don't call `editor.create` anywhere there. We should really centralize these in `MonacoUtils` with a `createEditor` or something, but not doing that here.