### PR TITLE
fix: Cannot import CSV with LOCAL_TIME (#1434)

### DIFF
--- a/packages/console/src/Console.tsx
+++ b/packages/console/src/Console.tsx
@@ -772,7 +772,6 @@ export class Console extends PureComponent<ConsoleProps, ConsoleState> {
   addConsoleHistoryMessage(message?: string, error?: string): void {
     const { consoleHistory } = this.state;
     const historyItem = {
-      command: '',
       startTime: Date.now(),
       endTime: Date.now(),
       result: { message, error },

--- a/packages/console/src/console-history/ConsoleHistoryItem.tsx
+++ b/packages/console/src/console-history/ConsoleHistoryItem.tsx
@@ -55,9 +55,10 @@ class ConsoleHistoryItem extends PureComponent<
   render(): ReactElement {
     const { disabled, item, language } = this.props;
     const { disabledObjects, result } = item;
+    const hasCommand = item.command != null && item.command !== '';
 
     let commandElement = null;
-    if (item.command != null && item.command !== '') {
+    if (hasCommand) {
       commandElement = (
         <div className="console-history-item-command">
           <div className="console-history-gutter">&gt;</div>
@@ -101,7 +102,7 @@ class ConsoleHistoryItem extends PureComponent<
       }
 
       // If the error has an associated command, we'll actually get a separate ERROR item printed out, so only print an error if there isn't an associated command
-      if (error != null && item.command == null) {
+      if (error != null && !hasCommand) {
         let errorMessage = `${(error as { message: string }).message ?? error}`;
         if (!errorMessage) {
           errorMessage = error as string;

--- a/packages/console/src/csv/CsvTypeParser.ts
+++ b/packages/console/src/csv/CsvTypeParser.ts
@@ -5,7 +5,7 @@ import Papa, { Parser, ParseResult, ParseLocalConfig } from 'papaparse';
 /* eslint-disable no-restricted-globals */
 import NewTableColumnTypes from './NewTableColumnTypes';
 
-// Initially column types start al unknown
+// Initially column types start as unknown
 const UNKNOWN = 'unknown';
 
 const MAX_INT = 2147483647;
@@ -286,7 +286,12 @@ class CsvTypeParser {
     if (results == null || !results.meta.aborted) {
       onFileCompleted(
         types.map(type =>
-          type === UNKNOWN ? NewTableColumnTypes.STRING : type
+          // If the type is still unknown or a local time, just map it to a string.
+          // Local times are not supported by the backend in DHC, and probably should have more context to parse safely anyway (such as a date or a time zone).
+          // In these cases, we just map it to a string, and the user can use an `.update_view` later if they want to parse it into a different type.
+          type === UNKNOWN || type === NewTableColumnTypes.LOCAL_TIME
+            ? NewTableColumnTypes.STRING
+            : type
         )
       );
     }


### PR DESCRIPTION
- Fix adding error console history items
- They weren't appearing as anything because the command was `''` instead of `undefined`
- Map LOCAL_TIME to STRING on CSV import
- `LOCAL_TIME` isn't supported on the server in DHC, and isn't really "safe" anyways since we should have other info in there as well (e.g. date or time zone)
- When exporting, should be exporting the 'unformatted' value, which gives you the full timestamp
- By mapping to String, user can then do an `.update_view` to map it to a timestamp if they wish
- Fixes #1432
- Cherry-pick back for DH-15013. Tested against dev-vermilion.