### PR TITLE
fix: package-lock missing pinned dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31031,7 +31031,7 @@
         "@fortawesome/fontawesome-svg-core": "^6.2.1",
         "@fortawesome/react-fontawesome": "^0.2.0",
         "@react-spectrum/theme-default": "^3.5.1",
-        "@react-spectrum/utils": "*",
+        "@react-spectrum/utils": "^3.11.5",
         "@react-types/shared": "^3.22.1",
         "@react-types/textfield": "^3.9.1",
         "bootstrap": "4.6.2",


### PR DESCRIPTION
`@react-spectrum/utils` some how ended up with a * for dependency in the last push. Fixing. Unsure how that happened.