### PR TITLE
fix: allow plotly plots to shrink inside ui.flex/grid layouts

### DIFF
--- a/packages/chart/src/Chart.tsx
+++ b/packages/chart/src/Chart.tsx
@@ -332,6 +332,10 @@ class Chart extends Component<ChartProps, ChartState> {
       return {
         displaylogo: false,
 
+        // scales the plot to the container size
+        // https://github.com/plotly/react-plotly.js/issues/102
+        responsive: true,
+
         // Display the mode bar if there's an error or downsampling so user can see progress
         // Yes, the value is a boolean or the string 'hover': https://github.com/plotly/plotly.js/blob/master/src/plot_api/plot_config.js#L249
         displayModeBar:
@@ -704,7 +708,6 @@ class Chart extends Component<ChartProps, ChartState> {
             onRelayout={this.handleRelayout}
             onUpdate={this.handlePlotUpdate}
             onRestyle={this.handleRestyle}
-            useResizeHandler
             style={{ height: '100%', width: '100%' }}
           />
         )}

--- a/tests/figure.spec.ts
+++ b/tests/figure.spec.ts
@@ -6,7 +6,7 @@ test('can open a simple figure', async ({ page }) => {
   await openPlot(page, 'simple_plot');
   // Now we should be able to check the snapshot on the plotly container
   await expect(
-    page.locator('.iris-chart-panel .plotly.plot-container')
+    page.locator('.iris-chart-panel .js-plotly-plot')
   ).toHaveScreenshot();
 });
 
@@ -15,6 +15,6 @@ test('can set point shape and size', async ({ page }) => {
   await openPlot(page, 'trig_figure');
   // Now we should be able to check the snapshot on the plotly container
   await expect(
-    page.locator('.iris-chart-panel .plotly.plot-container')
+    page.locator('.iris-chart-panel .js-plotly-plot')
   ).toHaveScreenshot();
 });


### PR DESCRIPTION
- set responsive config to true which allows plots to properly grow and shrink
- removed unnecessary useResizeHandler (which only watches window), as we have our own observer
- fixed failing test by changing locator to plotly parent container. Responsive setting has an absolutely positioned child that makes the other locator have zero height,

Tested with the following script, and resizing golden-layout panels both vertically and horizontally and resizing browser window horizontally and vertically.

```py
from deephaven import ui, empty_table
from deephaven.plot import express as dx

t = empty_table(100).update(["x = i", "y = i"])
p = dx.line(t, x="x", y="y")

@ui.component
def common_example():
    return ui.panel(
        ui.flex(
            ui.text_field(label="Text Field"),
            ui.text_field(label="Text Field"),
            ui.text_field(label="Text Field"),
        ),
        t,
        p
    )

ui_common_example = common_example()


@ui.component
def common_example_row():
    return ui.panel(
        ui.flex(
            ui.text_field(label="Text Field"),
            ui.text_field(label="Text Field"),
            ui.text_field(label="Text Field"),
            direction="column"
        ),
        t,
        p,
        direction="row"
    )

ui_common_example_row = common_example_row()
```