### PR TITLE
fix: DH-16595: Fix null partition filter

### DIFF
--- a/packages/iris-grid/src/IrisGrid.tsx
+++ b/packages/iris-grid/src/IrisGrid.tsx
@@ -2062,7 +2062,7 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
               return;
             }
             const row = data.rows[0];
-            // Core JSAPI returns undefined for null table values, IrisGridPartitionSelector expects null
+            // Core JSAPI returns undefined for null table values, IrisGridPartitionSelector expects null (https://github.com/deephaven/deephaven-core/issues/5400)
             const values = keyTable.columns.map(
               column => row.get(column) ?? null
             );

--- a/packages/iris-grid/src/IrisGrid.tsx
+++ b/packages/iris-grid/src/IrisGrid.tsx
@@ -2062,7 +2062,10 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
               return;
             }
             const row = data.rows[0];
-            const values = keyTable.columns.map(column => row.get(column));
+            // Core JSAPI returns undefined for null table values, IrisGridPartitionSelector expects null
+            const values = keyTable.columns.map(
+              column => row.get(column) ?? null
+            );
             const newPartition: PartitionConfig = {
               partitions: values,
               mode: 'partition',

--- a/packages/iris-grid/src/IrisGrid.tsx
+++ b/packages/iris-grid/src/IrisGrid.tsx
@@ -2062,7 +2062,8 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
               return;
             }
             const row = data.rows[0];
-            // Core JSAPI returns undefined for null table values, IrisGridPartitionSelector expects null (https://github.com/deephaven/deephaven-core/issues/5400)
+            // Core JSAPI returns undefined for null table values, IrisGridPartitionSelector expects null
+            // https://github.com/deephaven/deephaven-core/issues/5400
             const values = keyTable.columns.map(
               column => row.get(column) ?? null
             );

--- a/packages/iris-grid/src/IrisGridPartitionSelector.tsx
+++ b/packages/iris-grid/src/IrisGridPartitionSelector.tsx
@@ -215,7 +215,7 @@ class IrisGridPartitionSelector extends Component<
     const { model } = this.props;
 
     if (value === null) {
-      return 'null';
+      return '(null)';
     }
 
     if (value === undefined || value === '') {

--- a/packages/iris-grid/src/IrisGridPartitionSelector.tsx
+++ b/packages/iris-grid/src/IrisGridPartitionSelector.tsx
@@ -172,20 +172,18 @@ class IrisGridPartitionSelector extends Component<
         .slice(0, index + 1)
         .map((partition, i) => {
           const partitionColumn = t.columns[i];
-          return partitionColumn
-            .filter()
-            .eq(
-              this.tableUtils.makeFilterRawValue(
-                partitionColumn.type,
-                partition
-              )
-            );
+          return this.tableUtils.makeNullableEqFilter(
+            partitionColumn,
+            partition
+          );
         });
       t.applyFilter(partitionFilters);
       t.setViewport(0, 0, t.columns);
       const data = await this.pending.add(t.getViewportData());
       const newConfig: PartitionConfig = {
-        partitions: t.columns.map(column => data.rows[0].get(column)),
+        // Core JSAPI returns undefined for null table values,
+        // coalesce with null to differentiate null from no selection in the dropdown
+        partitions: t.columns.map(column => data.rows[0].get(column) ?? null),
         mode: 'partition',
       };
       t.close();
@@ -271,14 +269,10 @@ class IrisGridPartitionSelector extends Component<
         const previousColumn = model.partitionColumns[i - 1];
         const partitionFilter = [
           ...previousFilter,
-          previousColumn
-            .filter()
-            .eq(
-              this.tableUtils.makeFilterRawValue(
-                previousColumn.type,
-                previousPartition
-              )
-            ),
+          this.tableUtils.makeNullableEqFilter(
+            previousColumn,
+            previousPartition
+          ),
         ];
         partitionFilters.push(partitionFilter);
       }

--- a/packages/iris-grid/src/IrisGridPartitionSelector.tsx
+++ b/packages/iris-grid/src/IrisGridPartitionSelector.tsx
@@ -214,7 +214,11 @@ class IrisGridPartitionSelector extends Component<
   getDisplayValue(index: number, value: unknown): string {
     const { model } = this.props;
 
-    if (value == null || value === '') {
+    if (value === null) {
+      return 'null';
+    }
+
+    if (value === undefined || value === '') {
       return '';
     }
     const column = model.partitionColumns[index];

--- a/packages/iris-grid/src/IrisGridPartitionSelector.tsx
+++ b/packages/iris-grid/src/IrisGridPartitionSelector.tsx
@@ -183,6 +183,7 @@ class IrisGridPartitionSelector extends Component<
       const newConfig: PartitionConfig = {
         // Core JSAPI returns undefined for null table values,
         // coalesce with null to differentiate null from no selection in the dropdown
+        // https://github.com/deephaven/deephaven-core/issues/5400
         partitions: t.columns.map(column => data.rows[0].get(column) ?? null),
         mode: 'partition',
       };

--- a/packages/iris-grid/src/IrisGridTableModel.ts
+++ b/packages/iris-grid/src/IrisGridTableModel.ts
@@ -206,15 +206,11 @@ class IrisGridTableModel
     for (let i = 0; i < this.partitionColumns.length; i += 1) {
       const partition = partitions[i];
       const partitionColumn = this.partitionColumns[i];
-      if (partition == null) {
-        partitionFilters.push(partitionColumn.filter().isNull());
-      } else {
-        const partitionFilter = this.tableUtils.makeFilterRawValue(
-          partitionColumn.type,
-          partition
-        );
-        partitionFilters.push(partitionColumn.filter().eq(partitionFilter));
-      }
+      const partitionFilter = this.tableUtils.makeNullableEqFilter(
+        partitionColumn,
+        partition
+      );
+      partitionFilters.push(partitionFilter);
     }
 
     const t = await this.table.copy();

--- a/packages/iris-grid/src/IrisGridTableModel.ts
+++ b/packages/iris-grid/src/IrisGridTableModel.ts
@@ -206,12 +206,15 @@ class IrisGridTableModel
     for (let i = 0; i < this.partitionColumns.length; i += 1) {
       const partition = partitions[i];
       const partitionColumn = this.partitionColumns[i];
-
-      const partitionFilter = this.tableUtils.makeFilterRawValue(
-        partitionColumn.type,
-        partition
-      );
-      partitionFilters.push(partitionColumn.filter().eq(partitionFilter));
+      if (partition == null) {
+        partitionFilters.push(partitionColumn.filter().isNull());
+      } else {
+        const partitionFilter = this.tableUtils.makeFilterRawValue(
+          partitionColumn.type,
+          partition
+        );
+        partitionFilters.push(partitionColumn.filter().eq(partitionFilter));
+      }
     }
 
     const t = await this.table.copy();

--- a/packages/jsapi-components/src/TableDropdown.tsx
+++ b/packages/jsapi-components/src/TableDropdown.tsx
@@ -84,6 +84,7 @@ export function TableDropdown({
         const { detail } = event;
         // Core JSAPI returns undefined for null table values,
         // coalesce with null to differentiate null from no selection in the dropdown
+        // https://github.com/deephaven/deephaven-core/issues/5400
         const newValues = detail.rows.map(row => row.get(tableColumn) ?? null);
         setValues(newValues);
       }

--- a/packages/jsapi-components/src/TableDropdown.tsx
+++ b/packages/jsapi-components/src/TableDropdown.tsx
@@ -82,7 +82,9 @@ export function TableDropdown({
       dh.Table.EVENT_UPDATED,
       (event: CustomEvent<DhType.ViewportData>) => {
         const { detail } = event;
-        const newValues = detail.rows.map(row => row.get(tableColumn));
+        // Core JSAPI returns undefined for null table values,
+        // coalesce with null to differentiate null from no selection in the dropdown
+        const newValues = detail.rows.map(row => row.get(tableColumn) ?? null);
         setValues(newValues);
       }
     );

--- a/packages/jsapi-utils/src/TableUtils.ts
+++ b/packages/jsapi-utils/src/TableUtils.ts
@@ -1860,6 +1860,22 @@ export class TableUtils {
   }
 
   /**
+   * Creates an Eq filter for the given column and raw value
+   * @param column The column to set the filter on
+   * @param rawValue The nullable value to filter on
+   * @returns The filter for this column/value combination
+   */
+  makeNullableEqFilter(
+    column: DhType.Column,
+    rawValue: unknown
+  ): DhType.FilterCondition {
+    if (rawValue == null) {
+      return column.filter().isNull();
+    }
+    return column.filter().eq(this.makeFilterRawValue(column.type, rawValue));
+  }
+
+  /**
    * Converts a string value to a value appropriate for the column
    * @param columnType The column type to make the value for
    * @param text The string value to make a type for


### PR DESCRIPTION
Closes #1867

Tested in Enterprise using steps from DH-16595 - created a partitioned table and set ACL to `nullFilterGenerator()` to get the `null` value in the partition column. Creating a partitioned table with a `null` in the partition column doesn't seem possible with `db.addTablePartition`  in Enterprise.

```
t=db.t("LearnDeephaven", "StockTrades").where()
db.addPartitionedTableDefinition("<namespace>", "partTable", "Date", t.getDefinition())
test = db.t("<namespace>" , "partTable")

// Set Column ACL on `partTable` to `new NullFilterGenerator()` in swing

test = db.t("<namespace>" , "partTable")
```
![Screenshot 2024-04-23 at 5 26 43 PM](https://github.com/deephaven/web-client-ui/assets/2853653/bbd65305-4616-416d-8af3-96dadcc21fa1)


Core+ Groovy console:
```
t = emptyTable(1).update("X=(String)null","Y=ii").partitionBy("X")
```
![Screenshot 2024-04-23 at 5 23 55 PM](https://github.com/deephaven/web-client-ui/assets/2853653/0564a626-97fa-46d9-8920-200eda19c533)

