### PR TITLE
chore: Updated @deephaven/jsapi-types to 1.0.0-dev0.34.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "@deephaven/jsapi-bootstrap": "file:packages/jsapi-bootstrap",
         "@deephaven/jsapi-components": "file:packages/jsapi-components",
         "@deephaven/jsapi-shim": "file:packages/jsapi-shim",
-        "@deephaven/jsapi-types": "1.0.0-dev0.33.1",
+        "@deephaven/jsapi-types": "1.0.0-dev0.34.0",
         "@deephaven/jsapi-utils": "file:packages/jsapi-utils",
         "@deephaven/log": "file:packages/log",
         "@deephaven/mocks": "file:packages/mocks",
@@ -2097,9 +2097,9 @@
       "link": true
     },
     "node_modules/@deephaven/jsapi-types": {
-      "version": "1.0.0-dev0.33.1",
-      "resolved": "https://registry.npmjs.org/@deephaven/jsapi-types/-/jsapi-types-1.0.0-dev0.33.1.tgz",
-      "integrity": "sha512-1f0ZsR7zpXGQFs6vyRovBUECUPg7tNYrzCuHA0iJCrTlJ0FfFDVcDg8uZxsH+11cERcAEs5xdSHXqpo/fM6dKQ=="
+      "version": "1.0.0-dev0.34.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/jsapi-types/-/jsapi-types-1.0.0-dev0.34.0.tgz",
+      "integrity": "sha512-UiIbmCaMx5mPOGCWdgOCfZtccMhh55jv3qzeN3qBp3YUi46uGfWY5kfCU3hWRtaQvUgO7n0XhBKTd4K/pxv9ng=="
     },
     "node_modules/@deephaven/jsapi-utils": {
       "resolved": "packages/jsapi-utils",
@@ -28355,7 +28355,7 @@
         "@deephaven/iris-grid": "file:../iris-grid",
         "@deephaven/jsapi-bootstrap": "file:../jsapi-bootstrap",
         "@deephaven/jsapi-components": "file:../jsapi-components",
-        "@deephaven/jsapi-types": "1.0.0-dev0.33.1",
+        "@deephaven/jsapi-types": "1.0.0-dev0.34.0",
         "@deephaven/jsapi-utils": "file:../jsapi-utils",
         "@deephaven/log": "file:../log",
         "@deephaven/plugin": "file:../plugin",
@@ -28435,7 +28435,7 @@
         "@deephaven/components": "file:../components",
         "@deephaven/jsapi-bootstrap": "file:../jsapi-bootstrap",
         "@deephaven/jsapi-components": "file:../jsapi-components",
-        "@deephaven/jsapi-types": "1.0.0-dev0.33.1",
+        "@deephaven/jsapi-types": "1.0.0-dev0.34.0",
         "@deephaven/jsapi-utils": "file:../jsapi-utils",
         "@deephaven/log": "file:../log",
         "@deephaven/redux": "file:../redux",
@@ -28476,7 +28476,7 @@
       "dependencies": {
         "@deephaven/components": "file:../components",
         "@deephaven/icons": "file:../icons",
-        "@deephaven/jsapi-types": "1.0.0-dev0.33.1",
+        "@deephaven/jsapi-types": "1.0.0-dev0.34.0",
         "@deephaven/jsapi-utils": "file:../jsapi-utils",
         "@deephaven/log": "file:../log",
         "@deephaven/react-hooks": "file:../react-hooks",
@@ -28548,7 +28548,7 @@
         "@deephaven/jsapi-bootstrap": "file:../jsapi-bootstrap",
         "@deephaven/jsapi-components": "file:../jsapi-components",
         "@deephaven/jsapi-shim": "file:../jsapi-shim",
-        "@deephaven/jsapi-types": "1.0.0-dev0.33.1",
+        "@deephaven/jsapi-types": "1.0.0-dev0.34.0",
         "@deephaven/jsapi-utils": "file:../jsapi-utils",
         "@deephaven/log": "file:../log",
         "@deephaven/plugin": "file:../plugin",
@@ -28672,7 +28672,7 @@
         "@deephaven/components": "file:../components",
         "@deephaven/icons": "file:../icons",
         "@deephaven/jsapi-bootstrap": "file:../jsapi-bootstrap",
-        "@deephaven/jsapi-types": "1.0.0-dev0.33.1",
+        "@deephaven/jsapi-types": "1.0.0-dev0.34.0",
         "@deephaven/log": "file:../log",
         "@deephaven/react-hooks": "file:../react-hooks",
         "@deephaven/storage": "file:../storage",
@@ -28751,7 +28751,7 @@
         "@deephaven/iris-grid": "file:../iris-grid",
         "@deephaven/jsapi-bootstrap": "file:../jsapi-bootstrap",
         "@deephaven/jsapi-components": "file:../jsapi-components",
-        "@deephaven/jsapi-types": "1.0.0-dev0.33.1",
+        "@deephaven/jsapi-types": "1.0.0-dev0.34.0",
         "@deephaven/jsapi-utils": "file:../jsapi-utils",
         "@deephaven/log": "file:../log",
         "@deephaven/plugin": "file:../plugin",
@@ -29192,7 +29192,7 @@
         "@deephaven/dashboard-core-plugins": "file:../dashboard-core-plugins",
         "@deephaven/jsapi-bootstrap": "file:../jsapi-bootstrap",
         "@deephaven/jsapi-components": "file:../jsapi-components",
-        "@deephaven/jsapi-types": "1.0.0-dev0.33.1",
+        "@deephaven/jsapi-types": "1.0.0-dev0.34.0",
         "@deephaven/jsapi-utils": "file:../jsapi-utils",
         "@deephaven/log": "file:../log",
         "@deephaven/plugin": "file:../plugin",
@@ -29334,7 +29334,7 @@
         "@deephaven/grid": "file:../grid",
         "@deephaven/icons": "file:../icons",
         "@deephaven/jsapi-components": "file:../jsapi-components",
-        "@deephaven/jsapi-types": "1.0.0-dev0.33.1",
+        "@deephaven/jsapi-types": "1.0.0-dev0.34.0",
         "@deephaven/jsapi-utils": "file:../jsapi-utils",
         "@deephaven/log": "file:../log",
         "@deephaven/react-hooks": "file:../react-hooks",
@@ -29375,7 +29375,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@deephaven/components": "file:../components",
-        "@deephaven/jsapi-types": "1.0.0-dev0.33.1",
+        "@deephaven/jsapi-types": "1.0.0-dev0.34.0",
         "@deephaven/log": "file:../log",
         "@deephaven/react-hooks": "file:../react-hooks"
       },
@@ -29396,7 +29396,7 @@
       "dependencies": {
         "@deephaven/components": "file:../components",
         "@deephaven/jsapi-bootstrap": "file:../jsapi-bootstrap",
-        "@deephaven/jsapi-types": "1.0.0-dev0.33.1",
+        "@deephaven/jsapi-types": "1.0.0-dev0.34.0",
         "@deephaven/jsapi-utils": "file:../jsapi-utils",
         "@deephaven/log": "file:../log",
         "@deephaven/react-hooks": "file:../react-hooks",
@@ -29423,7 +29423,7 @@
       "version": "0.74.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@deephaven/jsapi-types": "1.0.0-dev0.33.1",
+        "@deephaven/jsapi-types": "1.0.0-dev0.34.0",
         "prop-types": "^15.7.2"
       },
       "engines": {
@@ -29445,7 +29445,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@deephaven/filters": "file:../filters",
-        "@deephaven/jsapi-types": "1.0.0-dev0.33.1",
+        "@deephaven/jsapi-types": "1.0.0-dev0.34.0",
         "@deephaven/log": "file:../log",
         "@deephaven/utils": "file:../utils",
         "lodash.clamp": "^4.0.3",
@@ -29486,7 +29486,7 @@
         "@deephaven/golden-layout": "file:../golden-layout",
         "@deephaven/icons": "file:../icons",
         "@deephaven/iris-grid": "file:../iris-grid",
-        "@deephaven/jsapi-types": "1.0.0-dev0.33.1",
+        "@deephaven/jsapi-types": "1.0.0-dev0.34.0",
         "@deephaven/log": "file:../log",
         "@deephaven/react-hooks": "file:../react-hooks",
         "@fortawesome/fontawesome-common-types": "^6.1.1",
@@ -29579,7 +29579,7 @@
       "version": "0.74.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@deephaven/jsapi-types": "1.0.0-dev0.33.1",
+        "@deephaven/jsapi-types": "1.0.0-dev0.34.0",
         "@deephaven/jsapi-utils": "file:../jsapi-utils",
         "@deephaven/log": "file:../log",
         "@deephaven/plugin": "file:../plugin",
@@ -30901,7 +30901,7 @@
         "@deephaven/iris-grid": "file:../iris-grid",
         "@deephaven/jsapi-bootstrap": "file:../jsapi-bootstrap",
         "@deephaven/jsapi-components": "file:../jsapi-components",
-        "@deephaven/jsapi-types": "1.0.0-dev0.33.1",
+        "@deephaven/jsapi-types": "1.0.0-dev0.34.0",
         "@deephaven/jsapi-utils": "file:../jsapi-utils",
         "@deephaven/log": "file:../log",
         "@deephaven/plugin": "file:../plugin",
@@ -30925,7 +30925,7 @@
         "@deephaven/components": "file:../components",
         "@deephaven/jsapi-bootstrap": "file:../jsapi-bootstrap",
         "@deephaven/jsapi-components": "file:../jsapi-components",
-        "@deephaven/jsapi-types": "1.0.0-dev0.33.1",
+        "@deephaven/jsapi-types": "1.0.0-dev0.34.0",
         "@deephaven/jsapi-utils": "file:../jsapi-utils",
         "@deephaven/log": "file:../log",
         "@deephaven/redux": "file:../redux",
@@ -30954,7 +30954,7 @@
         "@deephaven/components": "file:../components",
         "@deephaven/icons": "file:../icons",
         "@deephaven/jsapi-shim": "file:../jsapi-shim",
-        "@deephaven/jsapi-types": "1.0.0-dev0.33.1",
+        "@deephaven/jsapi-types": "1.0.0-dev0.34.0",
         "@deephaven/jsapi-utils": "file:../jsapi-utils",
         "@deephaven/log": "file:../log",
         "@deephaven/mocks": "file:../mocks",
@@ -31004,7 +31004,7 @@
         "@deephaven/jsapi-bootstrap": "file:../jsapi-bootstrap",
         "@deephaven/jsapi-components": "file:../jsapi-components",
         "@deephaven/jsapi-shim": "file:../jsapi-shim",
-        "@deephaven/jsapi-types": "1.0.0-dev0.33.1",
+        "@deephaven/jsapi-types": "1.0.0-dev0.34.0",
         "@deephaven/jsapi-utils": "file:../jsapi-utils",
         "@deephaven/log": "file:../log",
         "@deephaven/mocks": "file:../mocks",
@@ -31095,7 +31095,7 @@
         "@deephaven/icons": "file:../icons",
         "@deephaven/jsapi-bootstrap": "file:../jsapi-bootstrap",
         "@deephaven/jsapi-shim": "file:../jsapi-shim",
-        "@deephaven/jsapi-types": "1.0.0-dev0.33.1",
+        "@deephaven/jsapi-types": "1.0.0-dev0.34.0",
         "@deephaven/log": "file:../log",
         "@deephaven/mocks": "file:../mocks",
         "@deephaven/react-hooks": "file:../react-hooks",
@@ -31168,7 +31168,7 @@
         "@deephaven/jsapi-bootstrap": "file:../jsapi-bootstrap",
         "@deephaven/jsapi-components": "file:../jsapi-components",
         "@deephaven/jsapi-shim": "file:../jsapi-shim",
-        "@deephaven/jsapi-types": "1.0.0-dev0.33.1",
+        "@deephaven/jsapi-types": "1.0.0-dev0.34.0",
         "@deephaven/jsapi-utils": "file:../jsapi-utils",
         "@deephaven/log": "file:../log",
         "@deephaven/mocks": "file:../mocks",
@@ -31481,7 +31481,7 @@
         "@deephaven/eslint-config": "file:../eslint-config",
         "@deephaven/jsapi-bootstrap": "file:../jsapi-bootstrap",
         "@deephaven/jsapi-components": "file:../jsapi-components",
-        "@deephaven/jsapi-types": "1.0.0-dev0.33.1",
+        "@deephaven/jsapi-types": "1.0.0-dev0.34.0",
         "@deephaven/jsapi-utils": "file:../jsapi-utils",
         "@deephaven/log": "file:../log",
         "@deephaven/mocks": "file:../mocks",
@@ -31569,7 +31569,7 @@
         "@deephaven/icons": "file:../icons",
         "@deephaven/jsapi-components": "file:../jsapi-components",
         "@deephaven/jsapi-shim": "file:../jsapi-shim",
-        "@deephaven/jsapi-types": "1.0.0-dev0.33.1",
+        "@deephaven/jsapi-types": "1.0.0-dev0.34.0",
         "@deephaven/jsapi-utils": "file:../jsapi-utils",
         "@deephaven/log": "file:../log",
         "@deephaven/mocks": "file:../mocks",
@@ -31598,7 +31598,7 @@
       "version": "file:packages/jsapi-bootstrap",
       "requires": {
         "@deephaven/components": "file:../components",
-        "@deephaven/jsapi-types": "1.0.0-dev0.33.1",
+        "@deephaven/jsapi-types": "1.0.0-dev0.34.0",
         "@deephaven/log": "file:../log",
         "@deephaven/react-hooks": "file:../react-hooks",
         "react": "^17.x"
@@ -31610,7 +31610,7 @@
         "@deephaven/components": "file:../components",
         "@deephaven/jsapi-bootstrap": "file:../jsapi-bootstrap",
         "@deephaven/jsapi-shim": "file:../jsapi-shim",
-        "@deephaven/jsapi-types": "1.0.0-dev0.33.1",
+        "@deephaven/jsapi-types": "1.0.0-dev0.34.0",
         "@deephaven/jsapi-utils": "file:../jsapi-utils",
         "@deephaven/log": "file:../log",
         "@deephaven/react-hooks": "file:../react-hooks",
@@ -31626,21 +31626,21 @@
     "@deephaven/jsapi-shim": {
       "version": "file:packages/jsapi-shim",
       "requires": {
-        "@deephaven/jsapi-types": "1.0.0-dev0.33.1",
+        "@deephaven/jsapi-types": "1.0.0-dev0.34.0",
         "prop-types": "^15.7.2"
       }
     },
     "@deephaven/jsapi-types": {
-      "version": "1.0.0-dev0.33.1",
-      "resolved": "https://registry.npmjs.org/@deephaven/jsapi-types/-/jsapi-types-1.0.0-dev0.33.1.tgz",
-      "integrity": "sha512-1f0ZsR7zpXGQFs6vyRovBUECUPg7tNYrzCuHA0iJCrTlJ0FfFDVcDg8uZxsH+11cERcAEs5xdSHXqpo/fM6dKQ=="
+      "version": "1.0.0-dev0.34.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/jsapi-types/-/jsapi-types-1.0.0-dev0.34.0.tgz",
+      "integrity": "sha512-UiIbmCaMx5mPOGCWdgOCfZtccMhh55jv3qzeN3qBp3YUi46uGfWY5kfCU3hWRtaQvUgO7n0XhBKTd4K/pxv9ng=="
     },
     "@deephaven/jsapi-utils": {
       "version": "file:packages/jsapi-utils",
       "requires": {
         "@deephaven/filters": "file:../filters",
         "@deephaven/jsapi-shim": "file:../jsapi-shim",
-        "@deephaven/jsapi-types": "1.0.0-dev0.33.1",
+        "@deephaven/jsapi-types": "1.0.0-dev0.34.0",
         "@deephaven/log": "file:../log",
         "@deephaven/utils": "file:../utils",
         "lodash.clamp": "^4.0.3",
@@ -31664,7 +31664,7 @@
         "@deephaven/golden-layout": "file:../golden-layout",
         "@deephaven/icons": "file:../icons",
         "@deephaven/iris-grid": "file:../iris-grid",
-        "@deephaven/jsapi-types": "1.0.0-dev0.33.1",
+        "@deephaven/jsapi-types": "1.0.0-dev0.34.0",
         "@deephaven/log": "file:../log",
         "@deephaven/react-hooks": "file:../react-hooks",
         "@fortawesome/fontawesome-common-types": "^6.1.1",
@@ -31701,7 +31701,7 @@
     "@deephaven/redux": {
       "version": "file:packages/redux",
       "requires": {
-        "@deephaven/jsapi-types": "1.0.0-dev0.33.1",
+        "@deephaven/jsapi-types": "1.0.0-dev0.34.0",
         "@deephaven/jsapi-utils": "file:../jsapi-utils",
         "@deephaven/log": "file:../log",
         "@deephaven/plugin": "file:../plugin",

--- a/package.json
+++ b/package.json
@@ -170,7 +170,7 @@
     "@deephaven/jsapi-bootstrap": "file:packages/jsapi-bootstrap",
     "@deephaven/jsapi-components": "file:packages/jsapi-components",
     "@deephaven/jsapi-shim": "file:packages/jsapi-shim",
-    "@deephaven/jsapi-types": "1.0.0-dev0.33.1",
+    "@deephaven/jsapi-types": "1.0.0-dev0.34.0",
     "@deephaven/jsapi-utils": "file:packages/jsapi-utils",
     "@deephaven/log": "file:packages/log",
     "@deephaven/mocks": "file:packages/mocks",

--- a/packages/app-utils/package.json
+++ b/packages/app-utils/package.json
@@ -40,7 +40,7 @@
     "@deephaven/iris-grid": "file:../iris-grid",
     "@deephaven/jsapi-bootstrap": "file:../jsapi-bootstrap",
     "@deephaven/jsapi-components": "file:../jsapi-components",
-    "@deephaven/jsapi-types": "1.0.0-dev0.33.1",
+    "@deephaven/jsapi-types": "1.0.0-dev0.34.0",
     "@deephaven/jsapi-utils": "file:../jsapi-utils",
     "@deephaven/log": "file:../log",
     "@deephaven/plugin": "file:../plugin",

--- a/packages/auth-plugins/package.json
+++ b/packages/auth-plugins/package.json
@@ -36,7 +36,7 @@
     "@deephaven/components": "file:../components",
     "@deephaven/jsapi-bootstrap": "file:../jsapi-bootstrap",
     "@deephaven/jsapi-components": "file:../jsapi-components",
-    "@deephaven/jsapi-types": "1.0.0-dev0.33.1",
+    "@deephaven/jsapi-types": "1.0.0-dev0.34.0",
     "@deephaven/jsapi-utils": "file:../jsapi-utils",
     "@deephaven/log": "file:../log",
     "@deephaven/redux": "file:../redux",

--- a/packages/chart/package.json
+++ b/packages/chart/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@deephaven/components": "file:../components",
     "@deephaven/icons": "file:../icons",
-    "@deephaven/jsapi-types": "1.0.0-dev0.33.1",
+    "@deephaven/jsapi-types": "1.0.0-dev0.34.0",
     "@deephaven/jsapi-utils": "file:../jsapi-utils",
     "@deephaven/log": "file:../log",
     "@deephaven/react-hooks": "file:../react-hooks",

--- a/packages/code-studio/package.json
+++ b/packages/code-studio/package.json
@@ -28,7 +28,7 @@
     "@deephaven/jsapi-bootstrap": "file:../jsapi-bootstrap",
     "@deephaven/jsapi-components": "file:../jsapi-components",
     "@deephaven/jsapi-shim": "file:../jsapi-shim",
-    "@deephaven/jsapi-types": "1.0.0-dev0.33.1",
+    "@deephaven/jsapi-types": "1.0.0-dev0.34.0",
     "@deephaven/jsapi-utils": "file:../jsapi-utils",
     "@deephaven/log": "file:../log",
     "@deephaven/plugin": "file:../plugin",

--- a/packages/console/package.json
+++ b/packages/console/package.json
@@ -27,7 +27,7 @@
     "@deephaven/components": "file:../components",
     "@deephaven/icons": "file:../icons",
     "@deephaven/jsapi-bootstrap": "file:../jsapi-bootstrap",
-    "@deephaven/jsapi-types": "1.0.0-dev0.33.1",
+    "@deephaven/jsapi-types": "1.0.0-dev0.34.0",
     "@deephaven/log": "file:../log",
     "@deephaven/react-hooks": "file:../react-hooks",
     "@deephaven/storage": "file:../storage",

--- a/packages/dashboard-core-plugins/package.json
+++ b/packages/dashboard-core-plugins/package.json
@@ -34,7 +34,7 @@
     "@deephaven/iris-grid": "file:../iris-grid",
     "@deephaven/jsapi-bootstrap": "file:../jsapi-bootstrap",
     "@deephaven/jsapi-components": "file:../jsapi-components",
-    "@deephaven/jsapi-types": "1.0.0-dev0.33.1",
+    "@deephaven/jsapi-types": "1.0.0-dev0.34.0",
     "@deephaven/jsapi-utils": "file:../jsapi-utils",
     "@deephaven/log": "file:../log",
     "@deephaven/plugin": "file:../plugin",

--- a/packages/embed-widget/package.json
+++ b/packages/embed-widget/package.json
@@ -22,7 +22,7 @@
     "@deephaven/dashboard-core-plugins": "file:../dashboard-core-plugins",
     "@deephaven/jsapi-bootstrap": "file:../jsapi-bootstrap",
     "@deephaven/jsapi-components": "file:../jsapi-components",
-    "@deephaven/jsapi-types": "1.0.0-dev0.33.1",
+    "@deephaven/jsapi-types": "1.0.0-dev0.34.0",
     "@deephaven/jsapi-utils": "file:../jsapi-utils",
     "@deephaven/log": "file:../log",
     "@deephaven/plugin": "file:../plugin",

--- a/packages/iris-grid/package.json
+++ b/packages/iris-grid/package.json
@@ -37,7 +37,7 @@
     "@deephaven/grid": "file:../grid",
     "@deephaven/icons": "file:../icons",
     "@deephaven/jsapi-components": "file:../jsapi-components",
-    "@deephaven/jsapi-types": "1.0.0-dev0.33.1",
+    "@deephaven/jsapi-types": "1.0.0-dev0.34.0",
     "@deephaven/jsapi-utils": "file:../jsapi-utils",
     "@deephaven/log": "file:../log",
     "@deephaven/react-hooks": "file:../react-hooks",

--- a/packages/jsapi-bootstrap/package.json
+++ b/packages/jsapi-bootstrap/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@deephaven/components": "file:../components",
-    "@deephaven/jsapi-types": "1.0.0-dev0.33.1",
+    "@deephaven/jsapi-types": "1.0.0-dev0.34.0",
     "@deephaven/log": "file:../log",
     "@deephaven/react-hooks": "file:../react-hooks"
   },

--- a/packages/jsapi-components/package.json
+++ b/packages/jsapi-components/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@deephaven/components": "file:../components",
     "@deephaven/jsapi-bootstrap": "file:../jsapi-bootstrap",
-    "@deephaven/jsapi-types": "1.0.0-dev0.33.1",
+    "@deephaven/jsapi-types": "1.0.0-dev0.34.0",
     "@deephaven/jsapi-utils": "file:../jsapi-utils",
     "@deephaven/log": "file:../log",
     "@deephaven/react-hooks": "file:../react-hooks",

--- a/packages/jsapi-shim/package.json
+++ b/packages/jsapi-shim/package.json
@@ -21,7 +21,7 @@
     "build:babel": "babel ./src --out-dir ./dist --extensions \".ts,.tsx,.js,.jsx\" --source-maps --root-mode upward"
   },
   "dependencies": {
-    "@deephaven/jsapi-types": "1.0.0-dev0.33.1",
+    "@deephaven/jsapi-types": "1.0.0-dev0.34.0",
     "prop-types": "^15.7.2"
   },
   "files": [

--- a/packages/jsapi-utils/package.json
+++ b/packages/jsapi-utils/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@deephaven/filters": "file:../filters",
-    "@deephaven/jsapi-types": "1.0.0-dev0.33.1",
+    "@deephaven/jsapi-types": "1.0.0-dev0.34.0",
     "@deephaven/log": "file:../log",
     "@deephaven/utils": "file:../utils",
     "lodash.clamp": "^4.0.3",

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -26,7 +26,7 @@
     "@deephaven/golden-layout": "file:../golden-layout",
     "@deephaven/icons": "file:../icons",
     "@deephaven/iris-grid": "file:../iris-grid",
-    "@deephaven/jsapi-types": "1.0.0-dev0.33.1",
+    "@deephaven/jsapi-types": "1.0.0-dev0.34.0",
     "@deephaven/log": "file:../log",
     "@deephaven/react-hooks": "file:../react-hooks",
     "@fortawesome/fontawesome-common-types": "^6.1.1",

--- a/packages/redux/package.json
+++ b/packages/redux/package.json
@@ -22,7 +22,7 @@
     "build:babel": "babel ./src --out-dir ./dist --extensions \".ts,.tsx,.js,.jsx\" --source-maps --root-mode upward"
   },
   "dependencies": {
-    "@deephaven/jsapi-types": "1.0.0-dev0.33.1",
+    "@deephaven/jsapi-types": "1.0.0-dev0.34.0",
     "@deephaven/jsapi-utils": "file:../jsapi-utils",
     "@deephaven/log": "file:../log",
     "@deephaven/plugin": "file:../plugin",


### PR DESCRIPTION
Updated @deephaven/jsapi-types to 1.0.0-dev0.34.0

resolves #1974 