### PR TITLE
fix: Typing in notebooks is laggy

### DIFF
--- a/packages/dashboard/src/DashboardLayout.tsx
+++ b/packages/dashboard/src/DashboardLayout.tsx
@@ -14,10 +14,9 @@ import type {
   ReactComponentConfig,
 } from '@deephaven/golden-layout';
 import Log from '@deephaven/log';
-import { usePrevious } from '@deephaven/react-hooks';
+import { usePrevious, useThrottledCallback } from '@deephaven/react-hooks';
 import { RootState } from '@deephaven/redux';
 import { useDispatch, useSelector } from 'react-redux';
-import throttle from 'lodash.throttle';
 import PanelManager, { ClosedPanels } from './PanelManager';
 import PanelErrorBoundary from './PanelErrorBoundary';
 import LayoutUtils from './layout/LayoutUtils';
@@ -221,9 +220,10 @@ export function DashboardLayout({
   );
 
   // Throttle the calls so that we don't flood comparing these layouts
-  const throttledProcessDehydratedLayoutConfig = useMemo(
-    () => throttle(processDehydratedLayoutConfig, STATE_CHANGE_DEBOUNCE_MS),
-    [processDehydratedLayoutConfig]
+  const throttledProcessDehydratedLayoutConfig = useThrottledCallback(
+    processDehydratedLayoutConfig,
+    STATE_CHANGE_DEBOUNCE_MS,
+    { flushOnUnmount: true }
   );
 
   useEffect(

--- a/packages/dashboard/src/DashboardLayout.tsx
+++ b/packages/dashboard/src/DashboardLayout.tsx
@@ -197,9 +197,9 @@ export function DashboardLayout({
     ]
   );
 
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const processDehydratedLayoutConfig = useCallback(
-    dehydratedLayoutConfig => {
+  // Throttle the calls so that we don't flood comparing these layouts
+  const throttledProcessDehydratedLayoutConfig = useThrottledCallback(
+    (dehydratedLayoutConfig: DashboardLayoutConfig) => {
       const hasChanged =
         lastConfig == null ||
         !LayoutUtils.isEqual(lastConfig, dehydratedLayoutConfig);
@@ -216,12 +216,6 @@ export function DashboardLayout({
         setLayoutChildren(layout.getReactChildren());
       }
     },
-    [lastConfig, layout, onLayoutChange]
-  );
-
-  // Throttle the calls so that we don't flood comparing these layouts
-  const throttledProcessDehydratedLayoutConfig = useThrottledCallback(
-    processDehydratedLayoutConfig,
     STATE_CHANGE_DEBOUNCE_MS,
     { flushOnUnmount: true }
   );

--- a/packages/dashboard/src/DashboardLayout.tsx
+++ b/packages/dashboard/src/DashboardLayout.tsx
@@ -46,7 +46,7 @@ const DEFAULT_LAYOUT_CONFIG: DashboardLayoutConfig = [];
 
 const DEFAULT_CALLBACK = (): void => undefined;
 
-const STATE_CHANGE_DEBOUNCE_MS = 1000;
+const STATE_CHANGE_THROTTLE_MS = 1000;
 
 // If a component isn't registered, just pass through the props so they are saved if a plugin is loaded later
 const FALLBACK_CALLBACK = (props: unknown): unknown => props;
@@ -216,7 +216,7 @@ export function DashboardLayout({
         setLayoutChildren(layout.getReactChildren());
       }
     },
-    STATE_CHANGE_DEBOUNCE_MS,
+    STATE_CHANGE_THROTTLE_MS,
     { flushOnUnmount: true }
   );
 

--- a/packages/dashboard/src/DashboardLayout.tsx
+++ b/packages/dashboard/src/DashboardLayout.tsx
@@ -14,9 +14,10 @@ import type {
   ReactComponentConfig,
 } from '@deephaven/golden-layout';
 import Log from '@deephaven/log';
-import { usePrevious, useThrottledCallback } from '@deephaven/react-hooks';
+import { usePrevious } from '@deephaven/react-hooks';
 import { RootState } from '@deephaven/redux';
 import { useDispatch, useSelector } from 'react-redux';
+import throttle from 'lodash.throttle';
 import PanelManager, { ClosedPanels } from './PanelManager';
 import PanelErrorBoundary from './PanelErrorBoundary';
 import LayoutUtils from './layout/LayoutUtils';
@@ -220,9 +221,14 @@ export function DashboardLayout({
   );
 
   // Throttle the calls so that we don't flood comparing these layouts
-  const throttledProcessDehydratedLayoutConfig = useThrottledCallback(
-    processDehydratedLayoutConfig,
-    STATE_CHANGE_DEBOUNCE_MS
+  const throttledProcessDehydratedLayoutConfig = useMemo(
+    () => throttle(processDehydratedLayoutConfig, STATE_CHANGE_DEBOUNCE_MS),
+    [processDehydratedLayoutConfig]
+  );
+
+  useEffect(
+    () => () => throttledProcessDehydratedLayoutConfig.flush(),
+    [throttledProcessDehydratedLayoutConfig]
   );
 
   const handleLayoutStateChanged = useCallback(() => {

--- a/packages/dashboard/src/DashboardLayout.tsx
+++ b/packages/dashboard/src/DashboardLayout.tsx
@@ -14,8 +14,9 @@ import type {
   ReactComponentConfig,
 } from '@deephaven/golden-layout';
 import Log from '@deephaven/log';
-import { useDebouncedCallback, usePrevious } from '@deephaven/react-hooks';
+import { usePrevious } from '@deephaven/react-hooks';
 import { RootState } from '@deephaven/redux';
+import throttle from 'lodash.throttle';
 import { useDispatch, useSelector } from 'react-redux';
 import PanelManager, { ClosedPanels } from './PanelManager';
 import PanelErrorBoundary from './PanelErrorBoundary';
@@ -230,9 +231,9 @@ export function DashboardLayout({
     }
   }, [dehydrateComponent, isItemDragging, lastConfig, layout, onLayoutChange]);
 
-  const debouncedHandleLayoutStateChanged = useDebouncedCallback(
-    handleLayoutStateChanged,
-    STATE_CHANGE_DEBOUNCE_MS
+  const throttledHandleLayoutStateChanged = useMemo(
+    () => throttle(handleLayoutStateChanged, STATE_CHANGE_DEBOUNCE_MS),
+    [handleLayoutStateChanged]
   );
 
   const handleLayoutItemPickedUp = useCallback(
@@ -276,7 +277,7 @@ export function DashboardLayout({
     setLayoutChildren(layout.getReactChildren());
   }, [layout]);
 
-  useListener(layout, 'stateChanged', debouncedHandleLayoutStateChanged);
+  useListener(layout, 'stateChanged', throttledHandleLayoutStateChanged);
   useListener(layout, 'itemPickedUp', handleLayoutItemPickedUp);
   useListener(layout, 'itemDropped', handleLayoutItemDropped);
   useListener(layout, 'componentCreated', handleComponentCreated);

--- a/packages/react-hooks/package.json
+++ b/packages/react-hooks/package.json
@@ -25,6 +25,7 @@
     "@deephaven/log": "file:../log",
     "@deephaven/utils": "file:../utils",
     "lodash.debounce": "^4.0.8",
+    "lodash.throttle": "^4.1.1",
     "shortid": "^2.2.16"
   },
   "peerDependencies": {

--- a/packages/react-hooks/src/index.ts
+++ b/packages/react-hooks/src/index.ts
@@ -7,6 +7,7 @@ export * from './useCheckOverflow';
 export * from './useContentRect';
 export { default as useContextOrThrow } from './useContextOrThrow';
 export * from './useDebouncedCallback';
+export * from './useThrottledCallback';
 export * from './useDelay';
 export * from './useDependentState';
 export * from './useEffectNTimesWhen';

--- a/packages/react-hooks/src/useDebouncedCallback.test.ts
+++ b/packages/react-hooks/src/useDebouncedCallback.test.ts
@@ -10,6 +10,10 @@ beforeEach(() => {
   jest.useFakeTimers();
 });
 
+afterEach(() => {
+  jest.useRealTimers();
+});
+
 it('should debounce a given callback', () => {
   const { result } = renderHook(() =>
     useDebouncedCallback(callback, debounceMs)

--- a/packages/react-hooks/src/useThrottledCallback.test.ts
+++ b/packages/react-hooks/src/useThrottledCallback.test.ts
@@ -1,0 +1,86 @@
+import { renderHook } from '@testing-library/react-hooks';
+import useThrottledCallback from './useThrottledCallback';
+
+const callback = jest.fn((text: string) => undefined);
+const arg = 'mock.arg';
+const arg2 = 'mock.arg2';
+const throttleMs = 400;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest.useFakeTimers();
+});
+
+it('should throttle a given callback', () => {
+  const { result } = renderHook(() =>
+    useThrottledCallback(callback, throttleMs)
+  );
+
+  result.current(arg);
+  result.current(arg);
+
+  jest.advanceTimersByTime(5);
+
+  result.current(arg);
+
+  result.current(arg2);
+
+  expect(callback).toHaveBeenCalledTimes(1);
+  expect(callback).toHaveBeenCalledWith(arg);
+
+  jest.clearAllMocks();
+
+  jest.advanceTimersByTime(throttleMs);
+  expect(callback).toHaveBeenCalledTimes(1);
+  expect(callback).toHaveBeenCalledWith(arg2);
+});
+
+it('should cancel throttle if component unmounts', () => {
+  const { result, unmount } = renderHook(() =>
+    useThrottledCallback(callback, throttleMs)
+  );
+
+  result.current(arg);
+  result.current(arg2);
+
+  jest.advanceTimersByTime(throttleMs - 1);
+
+  expect(callback).toHaveBeenCalledTimes(1);
+  expect(callback).toHaveBeenCalledWith(arg);
+  callback.mockClear();
+
+  jest.spyOn(result.current, 'cancel');
+
+  unmount();
+
+  expect(result.current.cancel).toHaveBeenCalled();
+
+  jest.advanceTimersByTime(5);
+
+  expect(callback).not.toHaveBeenCalled();
+});
+
+it('should cancel throttle if callback reference changes', () => {
+  const { rerender, result } = renderHook(
+    fn => useThrottledCallback(fn, throttleMs),
+    {
+      initialProps: callback,
+    }
+  );
+
+  result.current(arg);
+  result.current(arg2);
+
+  // Leading is always called
+  expect(callback).toHaveBeenCalledTimes(1);
+  expect(callback).toHaveBeenCalledWith(arg);
+  callback.mockClear();
+
+  jest.advanceTimersByTime(throttleMs - 1);
+
+  rerender(jest.fn());
+
+  jest.advanceTimersByTime(5);
+
+  expect(callback).not.toHaveBeenCalled();
+});

--- a/packages/react-hooks/src/useThrottledCallback.test.ts
+++ b/packages/react-hooks/src/useThrottledCallback.test.ts
@@ -11,6 +11,10 @@ beforeEach(() => {
   jest.useFakeTimers();
 });
 
+afterEach(() => {
+  jest.useRealTimers();
+});
+
 it('should throttle a given callback', () => {
   const { result } = renderHook(() =>
     useThrottledCallback(callback, throttleMs)

--- a/packages/react-hooks/src/useThrottledCallback.ts
+++ b/packages/react-hooks/src/useThrottledCallback.ts
@@ -4,11 +4,12 @@ import throttle from 'lodash.throttle';
 
 /**
  * Wraps a given callback in a cancelable, throttled function. The throttled
- * callback is automatically cancelled if the callback reference changes or the
- * component unmounts.
- * @param callback callback function to throttle
+ * callback is stable and will never change. It will be automatically cancelled
+ * on unmount, unless the `flushOnUnmount` option is passed in, then it will be flushed on unmount.
+ * At the time the throttled function is called, it will call the latest callback that has been passed in.
+ * @param callback callback function to call with throttling
  * @param throttleMs throttle milliseconds
- * @param options lodash throttle options. Will not react to changes to this param
+ * @param initialOptions lodash throttle options. Will not react to changes to this param
  * @returns a cancelable, throttled function
  */
 export function useThrottledCallback<TArgs extends unknown[], TResult>(

--- a/packages/react-hooks/src/useThrottledCallback.ts
+++ b/packages/react-hooks/src/useThrottledCallback.ts
@@ -1,5 +1,5 @@
-import { useEffect, useMemo } from 'react';
-import type { DebouncedFunc } from 'lodash';
+import { useEffect, useMemo, useRef } from 'react';
+import type { DebouncedFunc, ThrottleSettings } from 'lodash';
 import throttle from 'lodash.throttle';
 
 /**
@@ -8,18 +8,42 @@ import throttle from 'lodash.throttle';
  * component unmounts.
  * @param callback callback function to throttle
  * @param throttleMs throttle milliseconds
+ * @param options lodash throttle options. Will not react to changes to this param
  * @returns a cancelable, throttled function
  */
 export function useThrottledCallback<TArgs extends unknown[], TResult>(
   callback: (...args: TArgs) => TResult,
-  throttleMs: number
+  throttleMs: number,
+  initialOptions?: ThrottleSettings & { flushOnUnmount?: boolean }
 ): DebouncedFunc<(...args: TArgs) => TResult> {
+  const options = useRef(initialOptions);
+
+  // Use a ref for the callback
+  // We want to keep a stable callback so the flush/cancel works as expected
+  // So we keep a ref to the current callback, then we have a throttled callback that will just call this
+  const callbackRef = useRef(callback);
+  callbackRef.current = callback;
+
   const throttledCallback = useMemo(
-    () => throttle(callback, throttleMs),
-    [callback, throttleMs]
+    () =>
+      throttle(
+        (...args: TArgs) => callbackRef.current(...args),
+        throttleMs,
+        options.current
+      ),
+    [throttleMs]
   );
 
-  useEffect(() => () => throttledCallback.cancel(), [throttledCallback]);
+  useEffect(
+    () => () => {
+      if (options.current?.flushOnUnmount ?? false) {
+        throttledCallback.flush();
+      } else {
+        throttledCallback.cancel();
+      }
+    },
+    [throttledCallback]
+  );
 
   return throttledCallback;
 }

--- a/packages/react-hooks/src/useThrottledCallback.ts
+++ b/packages/react-hooks/src/useThrottledCallback.ts
@@ -1,0 +1,27 @@
+import { useEffect, useMemo } from 'react';
+import type { DebouncedFunc } from 'lodash';
+import throttle from 'lodash.throttle';
+
+/**
+ * Wraps a given callback in a cancelable, throttled function. The throttled
+ * callback is automatically cancelled if the callback reference changes or the
+ * component unmounts.
+ * @param callback callback function to throttle
+ * @param throttleMs throttle milliseconds
+ * @returns a cancelable, throttled function
+ */
+export function useThrottledCallback<TArgs extends unknown[], TResult>(
+  callback: (...args: TArgs) => TResult,
+  throttleMs: number
+): DebouncedFunc<(...args: TArgs) => TResult> {
+  const throttledCallback = useMemo(
+    () => throttle(callback, throttleMs),
+    [callback, throttleMs]
+  );
+
+  useEffect(() => () => throttledCallback.cancel(), [throttledCallback]);
+
+  return throttledCallback;
+}
+
+export default useThrottledCallback;


### PR DESCRIPTION
- We were checking the diff of the layouts on each keystroke
- DashboardLayout should debounce checking that diff
- Tested by displaying FPS counter, having a Code Studio with a bunch of tables in it, adding a notebook, and then typing in it. FPS is much higher after the change
