### PR TITLE
perf: remove workspace dependancy from iris-grid-panel and memoize settings redux selector

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24212,11 +24212,24 @@
       "integrity": "sha512-/XJ368cyBJ7fzLMwLKv1e4vLxOju2MNAIokcr7meSaNcVbWz/CPcW22cP04mwxOErdA5mwjA8Q6w/cdAQxVn7Q==",
       "dev": true
     },
+    "node_modules/proxy-compare": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/proxy-compare/-/proxy-compare-3.0.0.tgz",
+      "integrity": "sha512-y44MCkgtZUCT9tZGuE278fB7PWVf7fRYy0vbRXAts2o5F0EfC4fIQrvQQGBJo1WJbFcVLXzApOscyJuZqHQc1w=="
+    },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
       "dev": true
+    },
+    "node_modules/proxy-memoize": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/proxy-memoize/-/proxy-memoize-3.0.0.tgz",
+      "integrity": "sha512-2fs4eIg4w6SfOjKHGVdg5tJ9WgHifEXKo2gfS/+tHGajO2YtAu03lLs+ltNKnteGKvq3SvHromkZeKus4J39/g==",
+      "dependencies": {
+        "proxy-compare": "^3.0.0"
+      }
     },
     "node_modules/psl": {
       "version": "1.8.0",
@@ -29777,6 +29790,7 @@
         "@deephaven/log": "file:../log",
         "@deephaven/utils": "file:../utils",
         "lodash.debounce": "^4.0.8",
+        "lodash.throttle": "^4.1.1",
         "shortid": "^2.2.16"
       },
       "engines": {
@@ -29796,6 +29810,7 @@
         "@deephaven/log": "file:../log",
         "@deephaven/plugin": "file:../plugin",
         "fast-deep-equal": "^3.1.3",
+        "proxy-memoize": "^3.0.0",
         "redux-thunk": "2.4.1"
       },
       "engines": {
@@ -31907,6 +31922,7 @@
         "@deephaven/log": "file:../log",
         "@deephaven/utils": "file:../utils",
         "lodash.debounce": "^4.0.8",
+        "lodash.throttle": "^4.1.1",
         "shortid": "^2.2.16"
       }
     },
@@ -31918,6 +31934,7 @@
         "@deephaven/log": "file:../log",
         "@deephaven/plugin": "file:../plugin",
         "fast-deep-equal": "^3.1.3",
+        "proxy-memoize": "^3.0.0",
         "redux-thunk": "2.4.1"
       }
     },
@@ -48031,11 +48048,24 @@
       "integrity": "sha512-/XJ368cyBJ7fzLMwLKv1e4vLxOju2MNAIokcr7meSaNcVbWz/CPcW22cP04mwxOErdA5mwjA8Q6w/cdAQxVn7Q==",
       "dev": true
     },
+    "proxy-compare": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/proxy-compare/-/proxy-compare-3.0.0.tgz",
+      "integrity": "sha512-y44MCkgtZUCT9tZGuE278fB7PWVf7fRYy0vbRXAts2o5F0EfC4fIQrvQQGBJo1WJbFcVLXzApOscyJuZqHQc1w=="
+    },
     "proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
       "dev": true
+    },
+    "proxy-memoize": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/proxy-memoize/-/proxy-memoize-3.0.0.tgz",
+      "integrity": "sha512-2fs4eIg4w6SfOjKHGVdg5tJ9WgHifEXKo2gfS/+tHGajO2YtAu03lLs+ltNKnteGKvq3SvHromkZeKus4J39/g==",
+      "requires": {
+        "proxy-compare": "^3.0.0"
+      }
     },
     "psl": {
       "version": "1.8.0"

--- a/packages/redux/package.json
+++ b/packages/redux/package.json
@@ -27,6 +27,7 @@
     "@deephaven/log": "file:../log",
     "@deephaven/plugin": "file:../plugin",
     "fast-deep-equal": "^3.1.3",
+    "proxy-memoize": "^3.0.0",
     "redux-thunk": "2.4.1"
   },
   "peerDependencies": {

--- a/packages/redux/src/selectors.ts
+++ b/packages/redux/src/selectors.ts
@@ -1,4 +1,5 @@
 import type { UndoPartial } from '@deephaven/utils';
+import { memoize } from 'proxy-memoize';
 import type { RootState, WorkspaceSettings } from './store';
 
 const EMPTY_OBJECT = Object.freeze({});
@@ -55,22 +56,24 @@ export const getWorkspace = <State extends RootState>(
 };
 
 // Settings
-export const getSettings = <State extends RootState>(
-  store: State
-): UndoPartial<State['workspace']['data']['settings']> => {
-  const customizedSettings = getWorkspace(store)?.data.settings ?? {};
+export const getSettings = memoize(
+  <State extends RootState>(
+    store: State
+  ): UndoPartial<State['workspace']['data']['settings']> => {
+    const customizedSettings = getWorkspace(store)?.data.settings ?? {};
 
-  const settings = { ...getDefaultWorkspaceSettings(store) };
-  const keys = Object.keys(customizedSettings) as (keyof WorkspaceSettings)[];
-  for (let i = 0; i < keys.length; i += 1) {
-    const key = keys[i];
-    if (customizedSettings[key] !== undefined) {
-      // @ts-expect-error assign non-undefined customized settings to settings
-      settings[key] = customizedSettings[key];
+    const settings = { ...getDefaultWorkspaceSettings(store) };
+    const keys = Object.keys(customizedSettings) as (keyof WorkspaceSettings)[];
+    for (let i = 0; i < keys.length; i += 1) {
+      const key = keys[i];
+      if (customizedSettings[key] !== undefined) {
+        // @ts-expect-error assign non-undefined customized settings to settings
+        settings[key] = customizedSettings[key];
+      }
     }
+    return settings as UndoPartial<State['workspace']['data']['settings']>;
   }
-  return settings as UndoPartial<State['workspace']['data']['settings']>;
-};
+);
 
 export const getDefaultSettings = <State extends RootState>(
   store: State


### PR DESCRIPTION
Discovered as part of #1977 investigation. Typing in a notebook triggers a workspace update, which was triggering all tables to re-render. Removed deprecated dependeny of workspace from iris-grid.

Further settings is derived from workspace and returns a new settings object. Iris-grid depends on settings, but the object had no changes. Memoize the selector so it always returns the same object if settings haven't changed.

Removes ~100ms of lag that was occuring 400ms after the debounce of notebook key press events.

BREAKING CHANGE: getPluginContent deprecatedProps have been removed from iris-grid