### PR TITLE
fix: remove extra padding on column statistic refresh button

### DIFF
--- a/packages/iris-grid/src/ColumnStatistics.tsx
+++ b/packages/iris-grid/src/ColumnStatistics.tsx
@@ -248,7 +248,7 @@ class ColumnStatistics extends Component<
             kind="ghost"
             className="px-0"
             onClick={this.handleGenerateStatistics}
-            icon={<FontAwesomeIcon icon={dhRefresh} className="mr-1" />}
+            icon={dhRefresh}
           >
             Refresh
           </Button>


### PR DESCRIPTION
Had double padding on it, looked weird.

![image](https://github.com/deephaven/web-client-ui/assets/1576283/c84b9ae5-468a-4f93-bda2-c9c3151ad63d)
