### PR TITLE
fix: useViewportData - memoize subscriptions and first row of viewport

### DIFF
--- a/packages/jsapi-components/src/useTableSize.test.ts
+++ b/packages/jsapi-components/src/useTableSize.test.ts
@@ -1,6 +1,6 @@
 import { act, renderHook } from '@testing-library/react-hooks';
 import dh from '@deephaven/jsapi-shim';
-import type { Table } from '@deephaven/jsapi-types';
+import type { dh as DhType } from '@deephaven/jsapi-types';
 import { TestUtils } from '@deephaven/utils';
 import useTableSize from './useTableSize';
 import useTableListener from './useTableListener';
@@ -21,7 +21,7 @@ it.each([null, undefined])('should return 0 if no table', table => {
 
 it('should return the size of the given table', () => {
   const size = 10;
-  const table = TestUtils.createMockProxy<Table>({ size });
+  const table = TestUtils.createMockProxy<DhType.Table>({ size });
 
   const { result } = renderHook(() => useTableSize(table), { wrapper });
 
@@ -33,7 +33,7 @@ it('should re-render if dh.Table.EVENT_SIZECHANGED event occurs', () => {
   const table = {
     addEventListener: jest.fn(),
     size: initialSize,
-  } as unknown as Table;
+  } as unknown as DhType.Table;
 
   const { result } = renderHook(() => useTableSize(table), { wrapper });
 

--- a/packages/jsapi-components/src/useTableSize.ts
+++ b/packages/jsapi-components/src/useTableSize.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 import { useApi } from '@deephaven/jsapi-bootstrap';
 import type { dh } from '@deephaven/jsapi-types';
 import { getSize } from '@deephaven/jsapi-utils';
@@ -18,9 +18,11 @@ export function useTableSize(
 
   const dh = useApi();
 
-  useTableListener(table, dh.Table.EVENT_SIZECHANGED, () => {
+  const onSizeChanged = useCallback(() => {
     forceRerender(i => i + 1);
-  });
+  }, []);
+
+  useTableListener(table, dh.Table.EVENT_SIZECHANGED, onSizeChanged);
 
   return getSize(table);
 }

--- a/packages/jsapi-components/src/useViewportData.ts
+++ b/packages/jsapi-components/src/useViewportData.ts
@@ -120,8 +120,9 @@ export function useViewportData<TItem, TTable extends dh.Table | dh.TreeTable>({
   const dh = useApi();
 
   // Store the memoized callback in a ref so that changes to `viewportData`
-  // don't invalidate the memoization of `onTableUpdated`. This avoids
-  // `useTableListener` from re-subscribing to the same event over and over.
+  // don't invalidate the memoization of `onTableUpdated`. This prevents
+  // `useTableListener` from unnecessarily re-subscribing to the same event over
+  // and over.
   const onTableUpdatedRef = useRef<(event: OnTableUpdatedEvent) => void>();
   onTableUpdatedRef.current = useMemo(
     () => createOnTableUpdatedHandler(viewportData, deserializeRow),

--- a/packages/jsapi-components/src/useViewportData.ts
+++ b/packages/jsapi-components/src/useViewportData.ts
@@ -94,11 +94,6 @@ export function useViewportData<TItem, TTable extends dh.Table | dh.TreeTable>({
 
   const setViewport = useCallback(
     (firstRow: number) => {
-      log.debug('setViewport.', {
-        prev: currentViewportFirstRowRef.current,
-        next: firstRow,
-      });
-
       currentViewportFirstRowRef.current = firstRow;
 
       if (table && !isClosed(table)) {


### PR DESCRIPTION
fixes #2003 - useViewportData - re-subscribes to table any time ViewportData changes
- Memoized `dh.Table.EVENT_SIZECHANGED` handler
- Memoized `dh.Table.EVENT_UPDATED` handler

fixes #1928 - useViewportData - setViewport should maintain last firstRow value when table size changes
- Track last set "first row" to be re-used when table size changes but table reference remains the same

**Tested**
- Ticking table 
   - table update subscriptions no longer occur on each viewportData change
   - size change handler no longer re-subscribes on every render
- ACL Editor - scrolling viewport data still works. Filtering still properly resets viewport to zero