### PR TITLE
fix: PouchStorageTable using incorrect $ne operator

### DIFF
--- a/jest.config.base.cjs
+++ b/jest.config.base.cjs
@@ -63,6 +63,12 @@ module.exports = {
     ),
     // Handle monaco worker files
     '\\.worker.*$': 'identity-obj-proxy',
+    // Handle pouchdb modules
+    '^pouchdb-browser$': path.join(
+      __dirname,
+      './packages/mocks/src/pouchdb-browser.js'
+    ),
+    '^pouchdb-find': 'identity-obj-proxy',
     // All packages except icons and jsapi-types use src code
     '^@deephaven/(?!icons|jsapi-types)(.*)$': path.join(
       __dirname,

--- a/packages/pouch-storage/src/PouchStorageTable.test.ts
+++ b/packages/pouch-storage/src/PouchStorageTable.test.ts
@@ -1,0 +1,26 @@
+import { makePouchFilter } from './PouchStorageTable';
+
+describe('PouchStorageTable - Filter Functions', () => {
+  describe('makePouchFilter', () => {
+    it.each([
+      ['eq', 'value', { $eq: 'value' }],
+      ['notEq', 'value', { $ne: 'value' }],
+      ['greaterThan', 'value', { $gt: 'value' }],
+      ['greaterThanOrEqualTo', 'value', { $gte: 'value' }],
+      ['lessThan', 'value', { $lt: 'value' }],
+      ['lessThanOrEqualTo', 'value', { $lte: 'value' }],
+    ])(
+      'should create a PouchFilter for %s operator',
+      (type, value, expected) => {
+        const filter = makePouchFilter(type, value);
+        expect(filter).toEqual(expected);
+      }
+    );
+
+    it('should throw an error for unsupported filter types', () => {
+      expect(() => makePouchFilter('unsupported', 'value')).toThrow(
+        'Unsupported type: unsupported'
+      );
+    });
+  });
+});

--- a/packages/pouch-storage/src/PouchStorageTable.test.ts
+++ b/packages/pouch-storage/src/PouchStorageTable.test.ts
@@ -9,6 +9,9 @@ describe('PouchStorageTable - Filter Functions', () => {
       ['greaterThanOrEqualTo', 'value', { $gte: 'value' }],
       ['lessThan', 'value', { $lt: 'value' }],
       ['lessThanOrEqualTo', 'value', { $lte: 'value' }],
+      ['startsWith', 'val', { $regex: `/^val.*/` }],
+      ['contains', 'value', { $regex: '/value/' }],
+      ['inIgnoreCase', ['value1', 'value2'], { $regex: '/value1,value2/i' }],
     ])(
       'should create a PouchFilter for %s operator',
       (type, value, expected) => {

--- a/packages/pouch-storage/src/PouchStorageTable.ts
+++ b/packages/pouch-storage/src/PouchStorageTable.ts
@@ -43,8 +43,7 @@ type PouchFilter = OnlyOneProp<{
   $lt: FilterValue | FilterValue[];
   $lte: FilterValue | FilterValue[];
   $regex: RegExp | string;
-}> &
-  Omit<PouchDB.Find.ConditionOperators, '$regex'>;
+}>;
 
 export function makePouchFilter(
   type: string,

--- a/packages/pouch-storage/src/PouchStorageTable.ts
+++ b/packages/pouch-storage/src/PouchStorageTable.ts
@@ -35,15 +35,12 @@ export type PouchDBSort = Array<
   string | { [propName: string]: 'asc' | 'desc' }
 >;
 
-type PouchFilter = OnlyOneProp<{
-  $eq: FilterValue | FilterValue[];
-  $ne: FilterValue | FilterValue[];
-  $gt: FilterValue | FilterValue[];
-  $gte: FilterValue | FilterValue[];
-  $lt: FilterValue | FilterValue[];
-  $lte: FilterValue | FilterValue[];
-  $regex: RegExp | string;
-}>;
+type PouchFilter = OnlyOneProp<
+  Pick<
+    PouchDB.Find.ConditionOperators,
+    '$eq' | '$ne' | '$gt' | '$gte' | '$lt' | '$lte' | '$regex'
+  >
+>;
 
 export function makePouchFilter(
   type: string,
@@ -52,9 +49,9 @@ export function makePouchFilter(
   switch (type) {
     case FilterType.in:
     case FilterType.contains:
-      return { $regex: new RegExp(`${value}`) };
+      return { $regex: new RegExp(`${value}`).toString() };
     case FilterType.inIgnoreCase:
-      return { $regex: new RegExp(`${value}`, 'i') };
+      return { $regex: new RegExp(`${value}`, 'i').toString() };
     case FilterType.eq:
       return { $eq: value };
     case FilterType.notEq:
@@ -68,7 +65,7 @@ export function makePouchFilter(
     case FilterType.lessThanOrEqualTo:
       return { $lte: value };
     case FilterType.startsWith:
-      return { $regex: new RegExp(`^(?${value}).*`) };
+      return { $regex: new RegExp(`^(?${value}).*`).toString() };
     default:
       throw new Error(`Unsupported type: ${type}`);
   }

--- a/packages/pouch-storage/src/PouchStorageTable.ts
+++ b/packages/pouch-storage/src/PouchStorageTable.ts
@@ -65,7 +65,7 @@ export function makePouchFilter(
     case FilterType.lessThanOrEqualTo:
       return { $lte: value };
     case FilterType.startsWith:
-      return { $regex: new RegExp(`^(?${value}).*`).toString() };
+      return { $regex: new RegExp(`^${value}.*`).toString() };
     default:
       throw new Error(`Unsupported type: ${type}`);
   }

--- a/packages/pouch-storage/src/PouchStorageTable.ts
+++ b/packages/pouch-storage/src/PouchStorageTable.ts
@@ -35,20 +35,19 @@ export type PouchDBSort = Array<
   string | { [propName: string]: 'asc' | 'desc' }
 >;
 
-// We may want to use `PouchDB.Find.ConditionOperators` instead of this, but
-// there are some mismatches in how we use this with the types.
-// https://github.com/deephaven/web-client-ui/issues/1505 to address this
 type PouchFilter = OnlyOneProp<{
   $eq: FilterValue | FilterValue[];
-  $neq: FilterValue | FilterValue[];
+  $ne: FilterValue | FilterValue[];
   $gt: FilterValue | FilterValue[];
   $gte: FilterValue | FilterValue[];
   $lt: FilterValue | FilterValue[];
   $lte: FilterValue | FilterValue[];
-  $regex: RegExp;
-}>;
+  $regex: RegExp | string;
+}> &
+  Omit<PouchDB.Find.ConditionOperators, '$regex'>;
 
-function makePouchFilter(
+// eslint-disable-next-line import/prefer-default-export
+export function makePouchFilter(
   type: string,
   value: FilterValue | FilterValue[]
 ): PouchFilter {
@@ -61,8 +60,7 @@ function makePouchFilter(
     case FilterType.eq:
       return { $eq: value };
     case FilterType.notEq:
-      // This should be `$ne` https://github.com/deephaven/web-client-ui/issues/1505
-      return { $neq: value };
+      return { $ne: value };
     case FilterType.greaterThan:
       return { $gt: value };
     case FilterType.greaterThanOrEqualTo:

--- a/packages/pouch-storage/src/PouchStorageTable.ts
+++ b/packages/pouch-storage/src/PouchStorageTable.ts
@@ -46,7 +46,6 @@ type PouchFilter = OnlyOneProp<{
 }> &
   Omit<PouchDB.Find.ConditionOperators, '$regex'>;
 
-// eslint-disable-next-line import/prefer-default-export
 export function makePouchFilter(
   type: string,
   value: FilterValue | FilterValue[]


### PR DESCRIPTION
Resolves https://github.com/deephaven/web-client-ui/issues/1505

Changes:
- Modified `PouchFilter` type to use $ne instead of $neq
- Modified `$regex` prop to be able to accept `RegExp` and `string`, rather than just string by default

Steps Moving Forward:
- Code change is implemented, having difficulty with imports when trying to run Unit Tests (did not commit the file yet)

Update: Apparently, there are some issues with PouchDB and jest tests, since it has not been updated to an ES6 module. (https://stackoverflow.com/questions/64905287/import-error-when-running-jest-tests-that-use-the-pouchdb-asyncstorage-adapter). Could create a `babel.config.js`, but not sure if we want to do that just for a function that is never used beyond an internal scope. Thus, going to **omit** unit tests for now.  