### PR TITLE
fix: e2e test status reporting incorrectly

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -121,3 +121,12 @@ jobs:
           name: playwright-report
           path: playwright-report
           retention-days: 30
+
+  e2e-results:
+    if: ${{ always() }}
+    runs-on: ubuntu-22.04
+    needs: [e2e-tests]
+    steps:
+      - name: Check if any tests failed or cancelled
+        run: exit 1
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -127,6 +127,6 @@ jobs:
     runs-on: ubuntu-22.04
     needs: [e2e-tests]
     steps:
-      - name: Check if any tests failed or cancelled
+      - name: Fail if any tests failed or cancelled
         run: exit 1
         if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}

--- a/tests/console.spec.ts
+++ b/tests/console.spec.ts
@@ -34,7 +34,7 @@ test.describe('console input tests', () => {
     // Expect the output to show up in the log
     await expect(
       page.locator('.console-history .log-message').filter({ hasText: message })
-    ).toHaveCount(2);
+    ).toHaveCount(1);
   });
 
   test('object button is created when creating a table', async ({

--- a/tests/console.spec.ts
+++ b/tests/console.spec.ts
@@ -34,7 +34,7 @@ test.describe('console input tests', () => {
     // Expect the output to show up in the log
     await expect(
       page.locator('.console-history .log-message').filter({ hasText: message })
-    ).toHaveCount(0);
+    ).toHaveCount(2);
   });
 
   test('object button is created when creating a table', async ({

--- a/tests/console.spec.ts
+++ b/tests/console.spec.ts
@@ -34,7 +34,7 @@ test.describe('console input tests', () => {
     // Expect the output to show up in the log
     await expect(
       page.locator('.console-history .log-message').filter({ hasText: message })
-    ).toHaveCount(1);
+    ).toHaveCount(0);
   });
 
   test('object button is created when creating a table', async ({


### PR DESCRIPTION
Fixes #2044

Infra PR https://github.com/deephaven/infra/pull/301

You can see the e2e-results job failed on my 2nd commit to this PR. It should fail if any of the matrix jobs fail or are cancelled.