### PR TITLE
fix: e2e test status reporting incorrectly (#2045)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -158,4 +158,13 @@ jobs:
         with:
           name: playwright-report
           path: playwright-report
-          retention-days: 90
+          retention-days: 30
+
+  e2e-results:
+    if: ${{ always() }}
+    runs-on: ubuntu-22.04
+    needs: [e2e-tests]
+    steps:
+      - name: Fail if any tests failed or cancelled
+        run: exit 1
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}


### PR DESCRIPTION
Fixes #2044

Infra PR https://github.com/deephaven/infra/pull/301

You can see the e2e-results job failed on my 2nd commit to this PR. It should fail if any of the matrix jobs fail or are cancelled.