### PR TITLE
build: Use conventionalcommits template instead of Angular

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -4,6 +4,9 @@
   "command": {
     "publish": {
       "distTag": "latest"
+    },
+    "version": {
+      "changelogPreset": "conventionalcommits"
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -98,6 +98,7 @@
         "@vitejs/plugin-react-swc": "^3.3.0",
         "@vscode/codicons": "0.0.36",
         "chokidar-cli": "^2.1.0",
+        "conventional-changelog-conventionalcommits": "^7.0.0",
         "cross-env": "^7.0.2",
         "eslint": "^8.29.0",
         "identity-obj-proxy": "^3.0.0",
@@ -11510,6 +11511,18 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-7.0.0.tgz",
       "integrity": "sha512-ROjNchA9LgfNMTTFSIWPzebCwOGFdgkEq45EnvvrmSLvCtAw0HSmrCs7/ty+wAeYUZyNay0YMUNYFTRL72PkBQ==",
+      "dev": true,
+      "dependencies": {
+        "compare-func": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/conventional-changelog-conventionalcommits": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-7.0.2.tgz",
+      "integrity": "sha512-NKXYmMR/Hr1DevQegFB4MwfM5Vv0m4UIxKZTTYuD98lpTknaZlSRrDOG4X7wIXpGkfsYxZTghUN+Qq+T0YQI7w==",
       "dev": true,
       "dependencies": {
         "compare-func": "^2.0.0"
@@ -38936,6 +38949,15 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-7.0.0.tgz",
       "integrity": "sha512-ROjNchA9LgfNMTTFSIWPzebCwOGFdgkEq45EnvvrmSLvCtAw0HSmrCs7/ty+wAeYUZyNay0YMUNYFTRL72PkBQ==",
+      "dev": true,
+      "requires": {
+        "compare-func": "^2.0.0"
+      }
+    },
+    "conventional-changelog-conventionalcommits": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-7.0.2.tgz",
+      "integrity": "sha512-NKXYmMR/Hr1DevQegFB4MwfM5Vv0m4UIxKZTTYuD98lpTknaZlSRrDOG4X7wIXpGkfsYxZTghUN+Qq+T0YQI7w==",
       "dev": true,
       "requires": {
         "compare-func": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "@vitejs/plugin-react-swc": "^3.3.0",
     "@vscode/codicons": "0.0.36",
     "chokidar-cli": "^2.1.0",
+    "conventional-changelog-conventionalcommits": "^7.0.0",
     "cross-env": "^7.0.2",
     "eslint": "^8.29.0",
     "identity-obj-proxy": "^3.0.0",


### PR DESCRIPTION
- This template sorts Breaking Changes, Features, Fixes, and then everything else which is what we want
  - Sort order defined by the config. See [constants.js](https://github.com/conventional-changelog/conventional-changelog/blob/master/packages/conventional-changelog-conventionalcommits/src/constants.js) and [commitGroupOrder](https://github.com/conventional-changelog/conventional-changelog/blob/d3b8aaa16337993bbad4d91db1ffac5a7568756b/packages/conventional-changelog-conventionalcommits/src/writer.js#L70C9-L70C25)
  - It also puts Breaking Changes first (which are just notes) [in the template](https://github.com/conventional-changelog/conventional-changelog/blob/d3b8aaa16337993bbad4d91db1ffac5a7568756b/packages/conventional-changelog-conventionalcommits/src/templates/template.hbs#L5).
- See an example of how [v0.78.0 release notes would look with this template](https://github.com/mofojed/web-client-ui/blob/1921-changelog-updates-3/CHANGELOG.md#0780-2024-06-03) compared to the [previously generated release notes for v0.78.0](https://github.com/deephaven/web-client-ui/releases/tag/v0.78.0).
- Fixes #1921 
