### PR TITLE
build: Update distTag to v0.78 instead of `latest` for v0.78 branch

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -3,7 +3,7 @@
   "version": "0.78.2",
   "command": {
     "publish": {
-      "distTag": "latest"
+      "distTag": "v0.78"
     }
   }
 }


### PR DESCRIPTION
- Publishing new versions shouldn't clobber the `latest` tag, since this is a release branch