### PR TITLE
fix: view border styling

### DIFF
--- a/packages/components/src/spectrum/View.tsx
+++ b/packages/components/src/spectrum/View.tsx
@@ -43,6 +43,8 @@ export const View = forwardRef<DOMRefValue<HTMLElement>, ViewProps>(
       ...rest
     } = props;
 
+    // Using shorthand to define border styling. Removing a style property during rerender can lead to styling bugs
+    // ex. changing from borderXColor = blue to borderColor = blue will cause the left and right borders to disappear
     const defaultBorderColor = colorValueStyle(borderColor) ?? 'transparent';
     const defaultBorderXColor =
       colorValueStyle(borderXColor) ?? defaultBorderColor;
@@ -71,7 +73,7 @@ export const View = forwardRef<DOMRefValue<HTMLElement>, ViewProps>(
       borderXColor,
       borderYColor,
     ]);
-    
+
     return <SpectrumView {...rest} ref={forwardedRef} UNSAFE_style={style} />;
   }
 );

--- a/packages/components/src/spectrum/View.tsx
+++ b/packages/components/src/spectrum/View.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/jsx-props-no-spreading */
-import { forwardRef, useMemo } from 'react';
+import { forwardRef, useMemo, useEffect, CSSProperties } from 'react';
 import {
   View as SpectrumView,
   type ViewProps as SpectrumViewProps,
@@ -9,6 +9,13 @@ import { type ColorValue, colorValueStyle } from '../theme/colorUtils';
 
 export type ViewProps = Omit<SpectrumViewProps<6>, 'backgroundColor'> & {
   backgroundColor?: ColorValue;
+  borderColor?: ColorValue;
+  borderStartColor?: ColorValue;
+  borderEndColor?: ColorValue;
+  borderTopColor?: ColorValue;
+  borderBottomColor?: ColorValue;
+  borderXColor?: ColorValue;
+  borderYColor?: ColorValue;
 };
 
 /**
@@ -23,15 +30,48 @@ export type ViewProps = Omit<SpectrumViewProps<6>, 'backgroundColor'> & {
 
 export const View = forwardRef<DOMRefValue<HTMLElement>, ViewProps>(
   (props, forwardedRef): JSX.Element => {
-    const { backgroundColor, UNSAFE_style, ...rest } = props;
-    const style = useMemo(
-      () => ({
+    const {
+      backgroundColor,
+      borderColor,
+      borderStartColor,
+      borderEndColor,
+      borderTopColor,
+      borderBottomColor,
+      borderXColor,
+      borderYColor,
+      UNSAFE_style,
+      ...rest
+    } = props;
+
+    const defaultBorderColor = colorValueStyle(borderColor) ?? 'transparent';
+    const defaultBorderXColor =
+      colorValueStyle(borderXColor) ?? defaultBorderColor;
+    const defaultBorderYColor =
+      colorValueStyle(borderYColor) ?? defaultBorderColor;
+    const topColor = colorValueStyle(borderTopColor) ?? defaultBorderYColor;
+    const bottomColor =
+      colorValueStyle(borderBottomColor) ?? defaultBorderYColor;
+    const leftColor = colorValueStyle(borderStartColor) ?? defaultBorderXColor;
+    const rightColor = colorValueStyle(borderEndColor) ?? defaultBorderXColor;
+
+    const style = useMemo(() => {
+      return {
         ...UNSAFE_style,
         backgroundColor: colorValueStyle(backgroundColor),
-      }),
-      [backgroundColor, UNSAFE_style]
-    );
-
+        borderColor: `${topColor} ${rightColor} ${bottomColor} ${leftColor}`,
+      };
+    }, [
+      backgroundColor,
+      UNSAFE_style,
+      borderColor,
+      borderStartColor,
+      borderEndColor,
+      borderTopColor,
+      borderBottomColor,
+      borderXColor,
+      borderYColor,
+    ]);
+    
     return <SpectrumView {...rest} ref={forwardedRef} UNSAFE_style={style} />;
   }
 );


### PR DESCRIPTION
Exposed border color style props for view component.

Had to define border color styling using shorthand properties instead to avoid re-rendering bugs. Left comment in code explaining why this approach was taken

![image](https://github.com/deephaven/web-client-ui/assets/55671206/58c72097-7517-4242-9271-081c44bc2832)
