### PR TITLE
fix: Embed-widget with multiple panels not showing panel headers

### DIFF
--- a/packages/embed-widget/src/App.tsx
+++ b/packages/embed-widget/src/App.tsx
@@ -18,7 +18,6 @@ import {
   getAllDashboardsData,
   listenForCreateDashboard,
   CreateDashboardPayload,
-  DEFAULT_DASHBOARD_ID,
   setDashboardPluginData,
   stopListenForCreateDashboard,
 } from '@deephaven/dashboard';
@@ -98,7 +97,7 @@ function App(): JSX.Element {
   }, [dispatch, user]);
 
   const [goldenLayout, setGoldenLayout] = useState<GoldenLayout | null>(null);
-  const [dashboardId, setDashboardId] = useState(DEFAULT_DASHBOARD_ID);
+  const [dashboardId, setDashboardId] = useState('default-embed-widget'); // Can't be DEFAULT_DASHBOARD_ID because its dashboard layout is not stored in dashboardData
 
   const handleGoldenLayoutChange = useCallback(
     (newLayout: GoldenLayout) => {


### PR DESCRIPTION
This should fix embed-widget not showing the panel headers when there are multiple panels in a widget, but it's not a dashboard.

The issue is embed-widget is loading the layout from `dashboardData` and the `DEFAULT_DASHBOARD_ID` stores its data in `workspaceData` while all other IDs use `dashboardData`.

Tested with widget with just 1 panel, widget with multiple panels, and widget that is a dashboard.