### PR TITLE
fix: Console scroll bar following dynamic output

### DIFF
--- a/packages/console/src/Console.tsx
+++ b/packages/console/src/Console.tsx
@@ -262,7 +262,7 @@ export class Console extends PureComponent<ConsoleProps, ConsoleState> {
         this.consolePane.current.scrollHeight -
           this.consolePane.current.clientHeight -
           this.consolePane.current.scrollTop
-      ) < 1
+      ) < 0.5
     ) {
       this.scrollConsoleHistoryToBottom();
     }
@@ -669,7 +669,7 @@ export class Console extends PureComponent<ConsoleProps, ConsoleState> {
           scrollPane.scrollHeight -
             scrollPane.clientHeight -
             scrollPane.scrollTop
-        ) <= 1,
+        ) <= 0.5,
     });
   }
 

--- a/packages/console/src/Console.tsx
+++ b/packages/console/src/Console.tsx
@@ -662,16 +662,16 @@ export class Console extends PureComponent<ConsoleProps, ConsoleState> {
   handleScrollPaneScroll(): void {
     const scrollPane = this.consoleHistoryScrollPane.current;
     assertNotNull(scrollPane);
-    const isAtBottom =
-      Math.abs(
-        scrollPane.scrollHeight - scrollPane.clientHeight - scrollPane.scrollTop
-      ) >= 1;
-
     this.setState({
       isScrollDecorationShown:
         scrollPane.scrollTop > 0 &&
         scrollPane.scrollHeight > scrollPane.clientHeight,
-      isStuckToBottom: isAtBottom,
+      isStuckToBottom:
+        Math.abs(
+          scrollPane.scrollHeight -
+            scrollPane.clientHeight -
+            scrollPane.scrollTop
+        ) >= 1,
     });
   }
 

--- a/packages/console/src/Console.tsx
+++ b/packages/console/src/Console.tsx
@@ -255,7 +255,15 @@ export class Console extends PureComponent<ConsoleProps, ConsoleState> {
       this.updateObjectMap();
     }
 
-    if (state.isStuckToBottom) {
+    if (
+      state.isStuckToBottom &&
+      this.consolePane.current != null &&
+      Math.abs(
+        this.consolePane.current.scrollHeight -
+          this.consolePane.current.clientHeight -
+          this.consolePane.current.scrollTop
+      ) < 1
+    ) {
       this.scrollConsoleHistoryToBottom();
     }
   }

--- a/packages/console/src/Console.tsx
+++ b/packages/console/src/Console.tsx
@@ -111,6 +111,7 @@ interface ConsoleState {
   csvPaste: string | null;
   dragError: string | null;
   csvUploadInProgress: boolean;
+  isStuckToBottom: boolean;
   isAutoLaunchPanelsEnabled: boolean;
   isPrintStdOutEnabled: boolean;
   isClosePanelsOnDisconnectEnabled: boolean;
@@ -226,6 +227,7 @@ export class Console extends PureComponent<ConsoleProps, ConsoleState> {
       csvPaste: null,
       dragError: null,
       csvUploadInProgress: false,
+      isStuckToBottom: true,
 
       ...DEFAULT_SETTINGS,
       ...settings,
@@ -250,6 +252,10 @@ export class Console extends PureComponent<ConsoleProps, ConsoleState> {
 
     if (props.objectMap !== prevProps.objectMap) {
       this.updateObjectMap();
+    }
+
+    if (state.isStuckToBottom) {
+      this.scrollConsoleHistoryToBottom();
     }
   }
 
@@ -656,14 +662,17 @@ export class Console extends PureComponent<ConsoleProps, ConsoleState> {
   handleScrollPaneScroll(): void {
     const scrollPane = this.consoleHistoryScrollPane.current;
     assertNotNull(scrollPane);
-    if (
-      scrollPane.scrollTop > 0 &&
-      scrollPane.scrollHeight > scrollPane.clientHeight
-    ) {
-      this.setState({ isScrollDecorationShown: true });
-    } else {
-      this.setState({ isScrollDecorationShown: false });
-    }
+    const isAtBottom =
+      Math.abs(
+        scrollPane.scrollHeight - scrollPane.clientHeight - scrollPane.scrollTop
+      ) >= 1;
+
+    this.setState({
+      isScrollDecorationShown:
+        scrollPane.scrollTop > 0 &&
+        scrollPane.scrollHeight > scrollPane.clientHeight,
+      isStuckToBottom: isAtBottom,
+    });
   }
 
   handleToggleAutoLaunchPanels(): void {

--- a/packages/console/src/Console.tsx
+++ b/packages/console/src/Console.tsx
@@ -304,7 +304,6 @@ export class Console extends PureComponent<ConsoleProps, ConsoleState> {
     }
     const { scrollHeight, clientHeight, scrollTop } =
       this.consoleHistoryScrollPane.current;
-    console.log({ scrollHeight, clientHeight, scrollTop });
     return Math.abs(scrollHeight - clientHeight - scrollTop) <= 1;
   }
 

--- a/packages/console/src/Console.tsx
+++ b/packages/console/src/Console.tsx
@@ -255,15 +255,7 @@ export class Console extends PureComponent<ConsoleProps, ConsoleState> {
       this.updateObjectMap();
     }
 
-    if (
-      state.isStuckToBottom &&
-      this.consolePane.current != null &&
-      Math.abs(
-        this.consolePane.current.scrollHeight -
-          this.consolePane.current.clientHeight -
-          this.consolePane.current.scrollTop
-      ) < 0.5
-    ) {
+    if (state.isStuckToBottom && !this.isAtBottom()) {
       this.scrollConsoleHistoryToBottom();
     }
   }
@@ -304,6 +296,16 @@ export class Console extends PureComponent<ConsoleProps, ConsoleState> {
       this.cancelListener();
       this.cancelListener = undefined;
     }
+  }
+
+  isAtBottom(): boolean {
+    if (this.consoleHistoryScrollPane.current == null) {
+      return false;
+    }
+    const { scrollHeight, clientHeight, scrollTop } =
+      this.consoleHistoryScrollPane.current;
+    console.log({ scrollHeight, clientHeight, scrollTop });
+    return Math.abs(scrollHeight - clientHeight - scrollTop) <= 1;
   }
 
   handleClearShortcut(event: Event): void {
@@ -664,12 +666,7 @@ export class Console extends PureComponent<ConsoleProps, ConsoleState> {
       isScrollDecorationShown:
         scrollPane.scrollTop > 0 &&
         scrollPane.scrollHeight > scrollPane.clientHeight,
-      isStuckToBottom:
-        Math.abs(
-          scrollPane.scrollHeight -
-            scrollPane.clientHeight -
-            scrollPane.scrollTop
-        ) <= 0.5,
+      isStuckToBottom: this.isAtBottom(),
     });
   }
 

--- a/packages/console/src/Console.tsx
+++ b/packages/console/src/Console.tsx
@@ -98,6 +98,7 @@ interface ConsoleState {
   // Height of the viewport of the console input and history
   consoleHeight: number;
 
+  // Scroll decoration is a drop shadow across the top border of the console
   isScrollDecorationShown: boolean;
 
   // Location of objects in the console history
@@ -336,7 +337,7 @@ export class Console extends PureComponent<ConsoleProps, ConsoleState> {
         consoleHistory: state.consoleHistory.concat(historyItem),
       }),
       () => {
-        this.scrollConsoleHistoryToBottom(true);
+        this.scrollConsoleHistoryToBottom();
       }
     );
 
@@ -463,8 +464,6 @@ export class Console extends PureComponent<ConsoleProps, ConsoleState> {
   }
 
   processLogMessageQueue = throttle(() => {
-    this.scrollConsoleHistoryToBottom();
-
     this.setState(state => {
       log.debug2(
         'processLogMessageQueue',
@@ -521,8 +520,6 @@ export class Console extends PureComponent<ConsoleProps, ConsoleState> {
     }
 
     historyItem.endTime = Date.now();
-
-    this.scrollConsoleHistoryToBottom();
 
     // Update history to re-render items as necessary
     this.setState(state => {
@@ -644,19 +641,12 @@ export class Console extends PureComponent<ConsoleProps, ConsoleState> {
       });
   }
 
-  scrollConsoleHistoryToBottom(force = false): void {
+  scrollConsoleHistoryToBottom(): void {
     const pane = this.consoleHistoryScrollPane.current;
-    assertNotNull(pane);
-    if (
-      !force &&
-      Math.abs(pane.scrollHeight - pane.clientHeight - pane.scrollTop) >= 1
-    ) {
+    if (pane == null) {
       return;
     }
-
-    window.requestAnimationFrame(() => {
-      pane.scrollTop = pane.scrollHeight;
-    });
+    pane.scrollTo({ top: pane.scrollHeight });
   }
 
   handleScrollPaneScroll(): void {
@@ -671,7 +661,7 @@ export class Console extends PureComponent<ConsoleProps, ConsoleState> {
           scrollPane.scrollHeight -
             scrollPane.clientHeight -
             scrollPane.scrollTop
-        ) >= 1,
+        ) <= 1,
     });
   }
 
@@ -791,7 +781,7 @@ export class Console extends PureComponent<ConsoleProps, ConsoleState> {
 
     const history = consoleHistory.concat(historyItem);
     this.setState({ consoleHistory: history });
-    this.scrollConsoleHistoryToBottom(true);
+    this.scrollConsoleHistoryToBottom();
     this.updateKnownObjects(historyItem);
     openObject({ name: title, type: dh.VariableType.TABLE });
     commandHistoryStorage.addItem(language, scope, title, {
@@ -886,7 +876,7 @@ export class Console extends PureComponent<ConsoleProps, ConsoleState> {
         endTime: Date.now(),
       };
 
-      this.scrollConsoleHistoryToBottom(true);
+      this.scrollConsoleHistoryToBottom();
 
       this.setState(state => ({
         consoleHistory: state.consoleHistory.concat(historyItem),
@@ -934,7 +924,7 @@ export class Console extends PureComponent<ConsoleProps, ConsoleState> {
     this.consoleInput.current.setConsoleText(command, focus, execute);
 
     if (focus) {
-      this.scrollConsoleHistoryToBottom(true);
+      this.scrollConsoleHistoryToBottom();
     }
   }
 


### PR DESCRIPTION
Resolves https://github.com/deephaven/web-client-ui/issues/2060

**Changes Implemented:**
- Added `isStuckToBottom` state that is updated on each scroll (in `handleScrollPaneScroll`), then in `componentDidUpdate`, call the `scrollConsoleHistoryToBottom` based on `isStuckToBottom`