### PR TITLE
fix: DH-17199: Filter by value in the tree table context menu always shows null  (#2078)

### DIFF
--- a/packages/iris-grid/src/IrisGridTreeTableModel.ts
+++ b/packages/iris-grid/src/IrisGridTreeTableModel.ts
@@ -154,7 +154,8 @@ class IrisGridTreeTableModel extends IrisGridTableModelTemplate<
   async snapshot(
     ranges: GridRange[],
     includeHeaders?: boolean,
-    formatValue?: (value: unknown, column: DhType.Column) => unknown
+    formatValue: (value: unknown, column: DhType.Column) => unknown = value =>
+      value
   ): Promise<unknown[][]> {
     assertNotNull(this.viewport);
     assertNotNull(this.viewportData);
@@ -190,7 +191,6 @@ class IrisGridTreeTableModel extends IrisGridTableModelTemplate<
           c <= intersection.endColumn;
           c += 1
         ) {
-          assertNotNull(formatValue);
           resultRow.push(
             formatValue(viewportRow.data.get(c)?.value, this.columns[c])
           );


### PR DESCRIPTION
Provide an initializer for the optional `formatValue` argument in
`IrisGridTreeTableModel` `snapshot` method.
Remove the conditional that caused the `resultRow` to be an empty array
when the `formatValue` argument isn't provided.