### PR TITLE
fix: DH-17242: Partition Table Pickers not partitioning table properly

### DIFF
--- a/packages/iris-grid/src/IrisGridPartitionSelector.scss
+++ b/packages/iris-grid/src/IrisGridPartitionSelector.scss
@@ -19,7 +19,7 @@
   .partition-button-group {
     display: flex;
     border-right: 1px solid var(--dh-color-hr);
-    padding: 0 $spacer-2;
+    padding-right: $spacer-2;
     gap: $spacer-2;
   }
 }

--- a/packages/iris-grid/src/IrisGridPartitionSelector.scss
+++ b/packages/iris-grid/src/IrisGridPartitionSelector.scss
@@ -18,8 +18,7 @@
   }
   .partition-button-group {
     display: flex;
-    border: 1px var(--dh-color-hr);
-    border-style: none solid;
+    border-right: 1px solid var(--dh-color-hr);
     padding: 0 $spacer-2;
     gap: $spacer-2;
   }

--- a/packages/iris-grid/src/IrisGridPartitionSelector.tsx
+++ b/packages/iris-grid/src/IrisGridPartitionSelector.tsx
@@ -172,7 +172,7 @@ class IrisGridPartitionSelector extends Component<
           );
         });
       t.applyFilter(partitionFilters);
-      t.setViewport(0, 10, t.columns);
+      t.setViewport(0, 0, t.columns);
       const data = await this.pending.add(t.getViewportData());
       const newConfig: PartitionConfig = {
         // Core JSAPI returns undefined for null table values,
@@ -291,6 +291,8 @@ class IrisGridPartitionSelector extends Component<
     if (partitionFilters !== null && partitionTables !== null) {
       partitionFilters.forEach((filter, index) => {
         partitionTables[index].applyFilter(filter as dh.FilterCondition[]);
+        // Have to set viewport since it is cleared after making selection in picker
+        // setting it to 50 to avoid loading all the data, but sufficient for most datasets for initial render
         partitionTables[index].setViewport(0, 50);
       });
     }
@@ -321,9 +323,6 @@ class IrisGridPartitionSelector extends Component<
     ));
     return (
       <div className="iris-grid-partition-selector">
-        <div className="table-name">
-          {model.isPartitionRequired ? 'Partitioned Table' : ''}
-        </div>
         <div className="partition-button-group">
           <Button
             onClick={this.handleKeyTableClick}


### PR DESCRIPTION
Resolves https://github.com/deephaven/web-client-ui/issues/2066

This PR is solely to solve the bugs of the partition table; first that the widget was not appearing, and once appearing, the partition selectors not working properly. The `PartitionedTable` design changes and additional functionality specified in https://github.com/deephaven/web-client-ui/issues/2079 to be brought up here https://github.com/deephaven/web-client-ui/pull/2110
