### PR TITLE
fix: `isElementOfType` Improved type inference

### DIFF
--- a/packages/react-hooks/src/ElementUtils.test.tsx
+++ b/packages/react-hooks/src/ElementUtils.test.tsx
@@ -1,6 +1,11 @@
 import { createElement } from 'react';
-import { Text } from '@adobe/react-spectrum';
+import { ItemElement, Item, Text } from '@deephaven/components';
 import { isElementOfType } from './ElementUtils';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  expect.hasAssertions();
+});
 
 describe('isElementOfType', () => {
   function MockComponent() {
@@ -21,4 +26,16 @@ describe('isElementOfType', () => {
       expect(isElementOfType(element, type)).toBe(expected);
     }
   );
+
+  it('should derive the `type` prop', () => {
+    const element: ItemElement = createElement(Item);
+
+    if (isElementOfType(element, Item)) {
+      // This is a type check that verifies the type guard narrows this to the
+      // `Item` function instead of `string | JSXElementConstructor<any>`. This
+      // proves that #2094 is working as expected. Namely, the compiler will
+      // complain if it thinks `type` could be a string.
+      expect(element.type.name).toEqual(Item.name);
+    }
+  });
 });

--- a/packages/react-hooks/src/ElementUtils.ts
+++ b/packages/react-hooks/src/ElementUtils.ts
@@ -1,4 +1,9 @@
-import { isValidElement, ReactElement, ReactNode } from 'react';
+import {
+  isValidElement,
+  JSXElementConstructor,
+  ReactElement,
+  ReactNode,
+} from 'react';
 import { InferComponentProps } from '@deephaven/utils';
 
 /**
@@ -7,10 +12,13 @@ import { InferComponentProps } from '@deephaven/utils';
  * @param type The type to check against
  * @returns True if the node is a React element of the specified type
  */
-export function isElementOfType<T>(
-  node: ReactNode,
-  type: T
-): node is ReactElement<InferComponentProps<T>> {
+export function isElementOfType<
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  T extends string | JSXElementConstructor<any> =
+    | string
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    | JSXElementConstructor<any>,
+>(node: ReactNode, type: T): node is ReactElement<InferComponentProps<T>, T> {
   return isValidElement(node) && node.type === type;
 }
 


### PR DESCRIPTION
I missed the 2nd generic argument when I first wrote this util which made the `type` property resolve to `string | React.JSXElementConstructor<any>` in certain cases instead of the actual type. This should fix that.

resolves #2094