### PR TITLE
feat: Partitioned Table UI Enhancements

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -51,5 +51,8 @@
         "description": "Test pattern or filename"
       }
     ]
+  },
+  "[typescriptreact]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
   }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -51,8 +51,5 @@
         "description": "Test pattern or filename"
       }
     ]
-  },
-  "[typescriptreact]": {
-    "editor.defaultFormatter": "esbenp.prettier-vscode"
   }
 }

--- a/packages/iris-grid/src/IrisGrid.tsx
+++ b/packages/iris-grid/src/IrisGrid.tsx
@@ -899,8 +899,8 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
     const changedInputFilters =
       inputFilters !== prevProps.inputFilters
         ? inputFilters.filter(
-          inputFilter => !prevProps.inputFilters.includes(inputFilter)
-        )
+            inputFilter => !prevProps.inputFilters.includes(inputFilter)
+          )
         : [];
     if (changedInputFilters.length > 0) {
       const { advancedSettings } = this.props;
@@ -1384,11 +1384,11 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
       advancedFilters: ReadonlyAdvancedFilterMap,
       searchFilter: DhType.FilterCondition | undefined
     ) => [
-        ...(customFilters ?? []),
-        ...IrisGridUtils.getFiltersFromFilterMap(quickFilters),
-        ...IrisGridUtils.getFiltersFromFilterMap(advancedFilters),
-        ...(searchFilter !== undefined ? [searchFilter] : []),
-      ],
+      ...(customFilters ?? []),
+      ...IrisGridUtils.getFiltersFromFilterMap(quickFilters),
+      ...IrisGridUtils.getFiltersFromFilterMap(advancedFilters),
+      ...(searchFilter !== undefined ? [searchFilter] : []),
+    ],
     { max: 1 }
   );
 
@@ -2108,12 +2108,13 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
     assertNotNull(rowIndex);
     keyTable.setViewport(rowIndex, rowIndex);
     try {
-      const data = await this.pending.add(keyTable.getViewportData());
-      // Core JSAPI returns undefined for null table values, IrisGridPartitionSelector expects null
-      // https://github.com/deephaven/deephaven-core/issues/5400
-      const values = keyTable.columns.map(
-        column => data.rows[0].get(column) ?? null
-      );
+      const data = this.getRowDataMap(rowIndex);
+      const values = Object.entries(data)
+        .filter(([key, value]) =>
+          model.partitionColumns.map(column => column.name).includes(key)
+        )
+        .map(column => column[1].value);
+
       const newPartition: PartitionConfig = {
         partitions: values,
         mode: 'partition',
@@ -3160,10 +3161,10 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
         pendingRowCount = Math.max(
           0,
           bottomViewport -
-          (model.rowCount - model.pendingRowCount) -
-          model.floatingTopRowCount -
-          model.floatingBottomRowCount -
-          1
+            (model.rowCount - model.pendingRowCount) -
+            model.floatingTopRowCount -
+            model.floatingBottomRowCount -
+            1
         );
       }
     }
@@ -3494,7 +3495,8 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
     this.clearAllFilters();
 
     this.startLoading(
-      `Selecting distinct values in ${columnNames.length > 0 ? columnNames.join(', ') : ''
+      `Selecting distinct values in ${
+        columnNames.length > 0 ? columnNames.join(', ') : ''
       }...`
     );
 
@@ -4302,9 +4304,9 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
 
     const debounceMs = metrics
       ? Math.min(
-        Math.max(IrisGrid.minDebounce, Math.round(metrics.rowCount / 200)),
-        IrisGrid.maxDebounce
-      )
+          Math.max(IrisGrid.minDebounce, Math.round(metrics.rowCount / 200)),
+          IrisGrid.maxDebounce
+        )
       : IrisGrid.maxDebounce;
 
     if (isFilterBarShown && focusedFilterBarColumn != null && metrics != null) {
@@ -4500,19 +4502,19 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
           const xFilterBar = gridX + columnX + columnWidth - 20;
           const style: CSSProperties = isFilterBarShown
             ? {
-              position: 'absolute',
-              top: columnHeaderHeight,
-              left: xFilterBar,
-              width: 20,
-              height: theme.filterBarHeight,
-            }
+                position: 'absolute',
+                top: columnHeaderHeight,
+                left: xFilterBar,
+                width: 20,
+                height: theme.filterBarHeight,
+              }
             : {
-              position: 'absolute',
-              top: 0,
-              left: xColumnHeader,
-              width: columnWidth,
-              height: columnHeaderHeight,
-            };
+                position: 'absolute',
+                top: 0,
+                left: xColumnHeader,
+                width: columnWidth,
+                height: columnHeaderHeight,
+              };
           const modelColumn = this.getModelColumn(columnIndex);
           if (modelColumn != null) {
             const column = model.columns[modelColumn];

--- a/packages/iris-grid/src/IrisGrid.tsx
+++ b/packages/iris-grid/src/IrisGrid.tsx
@@ -4262,7 +4262,7 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
       gotoValueSelectedFilter,
       partitionConfig,
     } = this.state;
-    if (!isReady || partitionConfig?.mode === 'loading') {
+    if (!isReady) {
       return null;
     }
 
@@ -4362,12 +4362,12 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
     }
 
     let loadingElement = null;
-    if (loadingText != null) {
+    if (loadingText != null && partitionConfig != null) {
       const loadingStatus = (
         <div className="iris-grid-loading-status">
           <div
             className={classNames('iris-grid-loading-status-bar', {
-              show: loadingSpinnerShown,
+              show: loadingSpinnerShown || partitionConfig.mode === 'loading',
             })}
           >
             {loadingText}

--- a/packages/iris-grid/src/IrisGrid.tsx
+++ b/packages/iris-grid/src/IrisGrid.tsx
@@ -897,8 +897,8 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
     const changedInputFilters =
       inputFilters !== prevProps.inputFilters
         ? inputFilters.filter(
-            inputFilter => !prevProps.inputFilters.includes(inputFilter)
-          )
+          inputFilter => !prevProps.inputFilters.includes(inputFilter)
+        )
         : [];
     if (changedInputFilters.length > 0) {
       const { advancedSettings } = this.props;
@@ -1382,11 +1382,11 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
       advancedFilters: ReadonlyAdvancedFilterMap,
       searchFilter: DhType.FilterCondition | undefined
     ) => [
-      ...(customFilters ?? []),
-      ...IrisGridUtils.getFiltersFromFilterMap(quickFilters),
-      ...IrisGridUtils.getFiltersFromFilterMap(advancedFilters),
-      ...(searchFilter !== undefined ? [searchFilter] : []),
-    ],
+        ...(customFilters ?? []),
+        ...IrisGridUtils.getFiltersFromFilterMap(quickFilters),
+        ...IrisGridUtils.getFiltersFromFilterMap(advancedFilters),
+        ...(searchFilter !== undefined ? [searchFilter] : []),
+      ],
     { max: 1 }
   );
 
@@ -2565,7 +2565,6 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
     if (prevConfig !== partitionConfig) {
       this.setState({ partitionConfig });
     }
-    // this.setState({ partitionConfig });
   }
 
   handleTableLoadError(error: unknown): void {
@@ -3158,10 +3157,10 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
         pendingRowCount = Math.max(
           0,
           bottomViewport -
-            (model.rowCount - model.pendingRowCount) -
-            model.floatingTopRowCount -
-            model.floatingBottomRowCount -
-            1
+          (model.rowCount - model.pendingRowCount) -
+          model.floatingTopRowCount -
+          model.floatingBottomRowCount -
+          1
         );
       }
     }
@@ -3492,8 +3491,7 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
     this.clearAllFilters();
 
     this.startLoading(
-      `Selecting distinct values in ${
-        columnNames.length > 0 ? columnNames.join(', ') : ''
+      `Selecting distinct values in ${columnNames.length > 0 ? columnNames.join(', ') : ''
       }...`
     );
 
@@ -4301,9 +4299,9 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
 
     const debounceMs = metrics
       ? Math.min(
-          Math.max(IrisGrid.minDebounce, Math.round(metrics.rowCount / 200)),
-          IrisGrid.maxDebounce
-        )
+        Math.max(IrisGrid.minDebounce, Math.round(metrics.rowCount / 200)),
+        IrisGrid.maxDebounce
+      )
       : IrisGrid.maxDebounce;
 
     if (isFilterBarShown && focusedFilterBarColumn != null && metrics != null) {
@@ -4499,19 +4497,19 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
           const xFilterBar = gridX + columnX + columnWidth - 20;
           const style: CSSProperties = isFilterBarShown
             ? {
-                position: 'absolute',
-                top: columnHeaderHeight,
-                left: xFilterBar,
-                width: 20,
-                height: theme.filterBarHeight,
-              }
+              position: 'absolute',
+              top: columnHeaderHeight,
+              left: xFilterBar,
+              width: 20,
+              height: theme.filterBarHeight,
+            }
             : {
-                position: 'absolute',
-                top: 0,
-                left: xColumnHeader,
-                width: columnWidth,
-                height: columnHeaderHeight,
-              };
+              position: 'absolute',
+              top: 0,
+              left: xColumnHeader,
+              width: columnWidth,
+              height: columnHeaderHeight,
+            };
           const modelColumn = this.getModelColumn(columnIndex);
           if (modelColumn != null) {
             const column = model.columns[modelColumn];

--- a/packages/iris-grid/src/IrisGrid.tsx
+++ b/packages/iris-grid/src/IrisGrid.tsx
@@ -1789,6 +1789,10 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
     const { advancedFilters, quickFilters, partitionConfig } = this.state;
     const { columns, formatter } = model;
 
+    if (advancedFilters.size === 0 && quickFilters.size === 0) {
+      return;
+    }
+
     const newAdvancedFilters = new Map();
     const newQuickFilters = new Map();
 
@@ -4498,7 +4502,7 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
           const xFilterBar = gridX + columnX + columnWidth - 20;
           const style: CSSProperties = isFilterBarShown
             ? {
-                position: 'ßabsolute',
+                position: 'absolute',
                 top: columnHeaderHeight,
                 left: xFilterBar,
                 width: 20,

--- a/packages/iris-grid/src/IrisGrid.tsx
+++ b/packages/iris-grid/src/IrisGrid.tsx
@@ -4262,7 +4262,7 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
       gotoValueSelectedFilter,
       partitionConfig,
     } = this.state;
-    if (!isReady) {
+    if (!isReady || partitionConfig?.mode === 'empty') {
       return null;
     }
 
@@ -4362,12 +4362,12 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
     }
 
     let loadingElement = null;
-    if (loadingText != null && partitionConfig != null) {
+    if (loadingText != null) {
       const loadingStatus = (
         <div className="iris-grid-loading-status">
           <div
             className={classNames('iris-grid-loading-status-bar', {
-              show: loadingSpinnerShown || partitionConfig.mode === 'loading',
+              show: loadingSpinnerShown,
             })}
           >
             {loadingText}

--- a/packages/iris-grid/src/IrisGrid.tsx
+++ b/packages/iris-grid/src/IrisGrid.tsx
@@ -897,8 +897,8 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
     const changedInputFilters =
       inputFilters !== prevProps.inputFilters
         ? inputFilters.filter(
-            inputFilter => !prevProps.inputFilters.includes(inputFilter)
-          )
+          inputFilter => !prevProps.inputFilters.includes(inputFilter)
+        )
         : [];
     if (changedInputFilters.length > 0) {
       const { advancedSettings } = this.props;
@@ -1382,11 +1382,11 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
       advancedFilters: ReadonlyAdvancedFilterMap,
       searchFilter: DhType.FilterCondition | undefined
     ) => [
-      ...(customFilters ?? []),
-      ...IrisGridUtils.getFiltersFromFilterMap(quickFilters),
-      ...IrisGridUtils.getFiltersFromFilterMap(advancedFilters),
-      ...(searchFilter !== undefined ? [searchFilter] : []),
-    ],
+        ...(customFilters ?? []),
+        ...IrisGridUtils.getFiltersFromFilterMap(quickFilters),
+        ...IrisGridUtils.getFiltersFromFilterMap(advancedFilters),
+        ...(searchFilter !== undefined ? [searchFilter] : []),
+      ],
     { max: 1 }
   );
 
@@ -2070,16 +2070,11 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
         (event: CustomEvent<DhType.ViewportData>) => {
           try {
             const { detail: data } = event;
-            if (data.rows.length === 0) {
-              // Table is empty, wait for the next updated event
-              return;
+            let values: unknown[] = [];
+            if (data.rows.length > 0) {
+              const row = data.rows[0];
+              values = keyTable.columns.map(column => row.get(column));
             }
-            const row = data.rows[0];
-            // Core JSAPI returns undefined for null table values, IrisGridPartitionSelector expects null
-            // https://github.com/deephaven/deephaven-core/issues/5400
-            const values = keyTable.columns.map(
-              column => row.get(column) ?? null
-            );
             const newPartition: PartitionConfig = {
               partitions: values,
               mode: model.isPartitionAwareSourceTable ? 'partition' : 'keys',
@@ -3155,10 +3150,10 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
         pendingRowCount = Math.max(
           0,
           bottomViewport -
-            (model.rowCount - model.pendingRowCount) -
-            model.floatingTopRowCount -
-            model.floatingBottomRowCount -
-            1
+          (model.rowCount - model.pendingRowCount) -
+          model.floatingTopRowCount -
+          model.floatingBottomRowCount -
+          1
         );
       }
     }
@@ -3489,8 +3484,7 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
     this.clearAllFilters();
 
     this.startLoading(
-      `Selecting distinct values in ${
-        columnNames.length > 0 ? columnNames.join(', ') : ''
+      `Selecting distinct values in ${columnNames.length > 0 ? columnNames.join(', ') : ''
       }...`
     );
 
@@ -4298,9 +4292,9 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
 
     const debounceMs = metrics
       ? Math.min(
-          Math.max(IrisGrid.minDebounce, Math.round(metrics.rowCount / 200)),
-          IrisGrid.maxDebounce
-        )
+        Math.max(IrisGrid.minDebounce, Math.round(metrics.rowCount / 200)),
+        IrisGrid.maxDebounce
+      )
       : IrisGrid.maxDebounce;
 
     if (isFilterBarShown && focusedFilterBarColumn != null && metrics != null) {
@@ -4496,19 +4490,19 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
           const xFilterBar = gridX + columnX + columnWidth - 20;
           const style: CSSProperties = isFilterBarShown
             ? {
-                position: 'absolute',
-                top: columnHeaderHeight,
-                left: xFilterBar,
-                width: 20,
-                height: theme.filterBarHeight,
-              }
+              position: 'absolute',
+              top: columnHeaderHeight,
+              left: xFilterBar,
+              width: 20,
+              height: theme.filterBarHeight,
+            }
             : {
-                position: 'absolute',
-                top: 0,
-                left: xColumnHeader,
-                width: columnWidth,
-                height: columnHeaderHeight,
-              };
+              position: 'absolute',
+              top: 0,
+              left: xColumnHeader,
+              width: columnWidth,
+              height: columnHeaderHeight,
+            };
           const modelColumn = this.getModelColumn(columnIndex);
           if (modelColumn != null) {
             const column = model.columns[modelColumn];

--- a/packages/iris-grid/src/IrisGrid.tsx
+++ b/packages/iris-grid/src/IrisGrid.tsx
@@ -897,8 +897,8 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
     const changedInputFilters =
       inputFilters !== prevProps.inputFilters
         ? inputFilters.filter(
-          inputFilter => !prevProps.inputFilters.includes(inputFilter)
-        )
+            inputFilter => !prevProps.inputFilters.includes(inputFilter)
+          )
         : [];
     if (changedInputFilters.length > 0) {
       const { advancedSettings } = this.props;
@@ -1382,11 +1382,11 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
       advancedFilters: ReadonlyAdvancedFilterMap,
       searchFilter: DhType.FilterCondition | undefined
     ) => [
-        ...(customFilters ?? []),
-        ...IrisGridUtils.getFiltersFromFilterMap(quickFilters),
-        ...IrisGridUtils.getFiltersFromFilterMap(advancedFilters),
-        ...(searchFilter !== undefined ? [searchFilter] : []),
-      ],
+      ...(customFilters ?? []),
+      ...IrisGridUtils.getFiltersFromFilterMap(quickFilters),
+      ...IrisGridUtils.getFiltersFromFilterMap(advancedFilters),
+      ...(searchFilter !== undefined ? [searchFilter] : []),
+    ],
     { max: 1 }
   );
 
@@ -3155,10 +3155,10 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
         pendingRowCount = Math.max(
           0,
           bottomViewport -
-          (model.rowCount - model.pendingRowCount) -
-          model.floatingTopRowCount -
-          model.floatingBottomRowCount -
-          1
+            (model.rowCount - model.pendingRowCount) -
+            model.floatingTopRowCount -
+            model.floatingBottomRowCount -
+            1
         );
       }
     }
@@ -3489,7 +3489,8 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
     this.clearAllFilters();
 
     this.startLoading(
-      `Selecting distinct values in ${columnNames.length > 0 ? columnNames.join(', ') : ''
+      `Selecting distinct values in ${
+        columnNames.length > 0 ? columnNames.join(', ') : ''
       }...`
     );
 
@@ -4297,9 +4298,9 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
 
     const debounceMs = metrics
       ? Math.min(
-        Math.max(IrisGrid.minDebounce, Math.round(metrics.rowCount / 200)),
-        IrisGrid.maxDebounce
-      )
+          Math.max(IrisGrid.minDebounce, Math.round(metrics.rowCount / 200)),
+          IrisGrid.maxDebounce
+        )
       : IrisGrid.maxDebounce;
 
     if (isFilterBarShown && focusedFilterBarColumn != null && metrics != null) {
@@ -4495,19 +4496,19 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
           const xFilterBar = gridX + columnX + columnWidth - 20;
           const style: CSSProperties = isFilterBarShown
             ? {
-              position: 'absolute',
-              top: columnHeaderHeight,
-              left: xFilterBar,
-              width: 20,
-              height: theme.filterBarHeight,
-            }
+                position: 'absolute',
+                top: columnHeaderHeight,
+                left: xFilterBar,
+                width: 20,
+                height: theme.filterBarHeight,
+              }
             : {
-              position: 'absolute',
-              top: 0,
-              left: xColumnHeader,
-              width: columnWidth,
-              height: columnHeaderHeight,
-            };
+                position: 'absolute',
+                top: 0,
+                left: xColumnHeader,
+                width: columnWidth,
+                height: columnHeaderHeight,
+              };
           const modelColumn = this.getModelColumn(columnIndex);
           if (modelColumn != null) {
             const column = model.columns[modelColumn];

--- a/packages/iris-grid/src/IrisGrid.tsx
+++ b/packages/iris-grid/src/IrisGrid.tsx
@@ -897,8 +897,8 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
     const changedInputFilters =
       inputFilters !== prevProps.inputFilters
         ? inputFilters.filter(
-          inputFilter => !prevProps.inputFilters.includes(inputFilter)
-        )
+            inputFilter => !prevProps.inputFilters.includes(inputFilter)
+          )
         : [];
     if (changedInputFilters.length > 0) {
       const { advancedSettings } = this.props;
@@ -1382,11 +1382,11 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
       advancedFilters: ReadonlyAdvancedFilterMap,
       searchFilter: DhType.FilterCondition | undefined
     ) => [
-        ...(customFilters ?? []),
-        ...IrisGridUtils.getFiltersFromFilterMap(quickFilters),
-        ...IrisGridUtils.getFiltersFromFilterMap(advancedFilters),
-        ...(searchFilter !== undefined ? [searchFilter] : []),
-      ],
+      ...(customFilters ?? []),
+      ...IrisGridUtils.getFiltersFromFilterMap(quickFilters),
+      ...IrisGridUtils.getFiltersFromFilterMap(advancedFilters),
+      ...(searchFilter !== undefined ? [searchFilter] : []),
+    ],
     { max: 1 }
   );
 
@@ -3157,10 +3157,10 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
         pendingRowCount = Math.max(
           0,
           bottomViewport -
-          (model.rowCount - model.pendingRowCount) -
-          model.floatingTopRowCount -
-          model.floatingBottomRowCount -
-          1
+            (model.rowCount - model.pendingRowCount) -
+            model.floatingTopRowCount -
+            model.floatingBottomRowCount -
+            1
         );
       }
     }
@@ -3491,7 +3491,8 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
     this.clearAllFilters();
 
     this.startLoading(
-      `Selecting distinct values in ${columnNames.length > 0 ? columnNames.join(', ') : ''
+      `Selecting distinct values in ${
+        columnNames.length > 0 ? columnNames.join(', ') : ''
       }...`
     );
 
@@ -4299,9 +4300,9 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
 
     const debounceMs = metrics
       ? Math.min(
-        Math.max(IrisGrid.minDebounce, Math.round(metrics.rowCount / 200)),
-        IrisGrid.maxDebounce
-      )
+          Math.max(IrisGrid.minDebounce, Math.round(metrics.rowCount / 200)),
+          IrisGrid.maxDebounce
+        )
       : IrisGrid.maxDebounce;
 
     if (isFilterBarShown && focusedFilterBarColumn != null && metrics != null) {
@@ -4497,19 +4498,19 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
           const xFilterBar = gridX + columnX + columnWidth - 20;
           const style: CSSProperties = isFilterBarShown
             ? {
-              position: 'absolute',
-              top: columnHeaderHeight,
-              left: xFilterBar,
-              width: 20,
-              height: theme.filterBarHeight,
-            }
+                position: 'ßabsolute',
+                top: columnHeaderHeight,
+                left: xFilterBar,
+                width: 20,
+                height: theme.filterBarHeight,
+              }
             : {
-              position: 'absolute',
-              top: 0,
-              left: xColumnHeader,
-              width: columnWidth,
-              height: columnHeaderHeight,
-            };
+                position: 'absolute',
+                top: 0,
+                left: xColumnHeader,
+                width: columnWidth,
+                height: columnHeaderHeight,
+              };
           const modelColumn = this.getModelColumn(columnIndex);
           if (modelColumn != null) {
             const column = model.columns[modelColumn];

--- a/packages/iris-grid/src/IrisGrid.tsx
+++ b/packages/iris-grid/src/IrisGrid.tsx
@@ -2077,7 +2077,7 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
           const values = keyTable.columns.map(column => row.get(column));
           const newPartition: PartitionConfig = {
             partitions: values,
-            mode: 'partition',
+            mode: model.isPartitionAwareSourceTable ? 'partition' : 'keys',
           };
           keyTable.close();
           this.setState({
@@ -4730,15 +4730,13 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
             unmountOnExit
           >
             <div className="iris-grid-partition-selector-wrapper iris-grid-bar iris-grid-bar-primary">
-              {isPartitionedGridModel(model) &&
-                model.isPartitionRequired &&
-                partitionConfig && (
-                  <IrisGridPartitionSelector
-                    model={model}
-                    partitionConfig={partitionConfig}
-                    onChange={this.handlePartitionChange}
-                  />
-                )}
+              {isPartitionedGridModel(model) && model.isPartitionRequired && (
+                <IrisGridPartitionSelector
+                  model={model}
+                  partitionConfig={partitionConfig}
+                  onChange={this.handlePartitionChange}
+                />
+              )}
             </div>
           </CSSTransition>
           <CSSTransition

--- a/packages/iris-grid/src/IrisGrid.tsx
+++ b/packages/iris-grid/src/IrisGrid.tsx
@@ -735,13 +735,11 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
       new IrisGridContextMenuHandler(this, dh),
       new IrisGridDataSelectMouseHandler(this),
       new PendingMouseHandler(this),
+      new IrisGridPartitionedTableMouseHandler(this),
     ];
     if (canCopy) {
       keyHandlers.push(new CopyKeyHandler(this));
       mouseHandlers.push(new IrisGridCopyCellMouseHandler(this));
-    }
-    if (isPartitionedGridModel(model)) {
-      mouseHandlers.push(new IrisGridPartitionedTableMouseHandler(this));
     }
     const movedColumns =
       movedColumnsProp.length > 0
@@ -899,8 +897,8 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
     const changedInputFilters =
       inputFilters !== prevProps.inputFilters
         ? inputFilters.filter(
-            inputFilter => !prevProps.inputFilters.includes(inputFilter)
-          )
+          inputFilter => !prevProps.inputFilters.includes(inputFilter)
+        )
         : [];
     if (changedInputFilters.length > 0) {
       const { advancedSettings } = this.props;
@@ -1384,11 +1382,11 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
       advancedFilters: ReadonlyAdvancedFilterMap,
       searchFilter: DhType.FilterCondition | undefined
     ) => [
-      ...(customFilters ?? []),
-      ...IrisGridUtils.getFiltersFromFilterMap(quickFilters),
-      ...IrisGridUtils.getFiltersFromFilterMap(advancedFilters),
-      ...(searchFilter !== undefined ? [searchFilter] : []),
-    ],
+        ...(customFilters ?? []),
+        ...IrisGridUtils.getFiltersFromFilterMap(quickFilters),
+        ...IrisGridUtils.getFiltersFromFilterMap(advancedFilters),
+        ...(searchFilter !== undefined ? [searchFilter] : []),
+      ],
     { max: 1 }
   );
 
@@ -2097,35 +2095,31 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
     });
   }
 
-  async setPartitionConfig(
-    model: PartitionedGridModel,
-    rowIndex: GridRangeIndex
-  ): Promise<void> {
-    const keyTable = await this.pending.add(
-      model.partitionKeysTable(),
-      resolved => resolved.close()
-    );
+  /**
+   * Selects a partition key from the table based on the provided row index.
+   *
+   * @param rowIndex The index of the row from which the partition will be selected.
+   * @returns A promise that resolves when the partition key has been successfully selected.
+   */
+  selectPartitionKeyFromTable(rowIndex: GridRangeIndex): void {
+    const { model } = this.props;
     assertNotNull(rowIndex);
-    keyTable.setViewport(rowIndex, rowIndex);
-    try {
+    if (isPartitionedGridModel(model)) {
       const data = this.getRowDataMap(rowIndex);
+      const partitionColumnSet = new Set(
+        model.partitionColumns.map(column => column.name)
+      );
       const values = Object.entries(data)
-        .filter(([key, value]) =>
-          model.partitionColumns.map(column => column.name).includes(key)
-        )
-        .map(column => column[1].value);
-
+        .filter(([key, _]) => partitionColumnSet.has(key))
+        .map(([key, columnData]) => columnData.value);
       const newPartition: PartitionConfig = {
         partitions: values,
         mode: 'partition',
       };
-      keyTable.close();
       this.setState({
         isSelectingPartition: true,
         partitionConfig: newPartition,
       });
-    } catch (e) {
-      keyTable.close();
     }
   }
 
@@ -3161,10 +3155,10 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
         pendingRowCount = Math.max(
           0,
           bottomViewport -
-            (model.rowCount - model.pendingRowCount) -
-            model.floatingTopRowCount -
-            model.floatingBottomRowCount -
-            1
+          (model.rowCount - model.pendingRowCount) -
+          model.floatingTopRowCount -
+          model.floatingBottomRowCount -
+          1
         );
       }
     }
@@ -3495,8 +3489,7 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
     this.clearAllFilters();
 
     this.startLoading(
-      `Selecting distinct values in ${
-        columnNames.length > 0 ? columnNames.join(', ') : ''
+      `Selecting distinct values in ${columnNames.length > 0 ? columnNames.join(', ') : ''
       }...`
     );
 
@@ -4304,9 +4297,9 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
 
     const debounceMs = metrics
       ? Math.min(
-          Math.max(IrisGrid.minDebounce, Math.round(metrics.rowCount / 200)),
-          IrisGrid.maxDebounce
-        )
+        Math.max(IrisGrid.minDebounce, Math.round(metrics.rowCount / 200)),
+        IrisGrid.maxDebounce
+      )
       : IrisGrid.maxDebounce;
 
     if (isFilterBarShown && focusedFilterBarColumn != null && metrics != null) {
@@ -4502,19 +4495,19 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
           const xFilterBar = gridX + columnX + columnWidth - 20;
           const style: CSSProperties = isFilterBarShown
             ? {
-                position: 'absolute',
-                top: columnHeaderHeight,
-                left: xFilterBar,
-                width: 20,
-                height: theme.filterBarHeight,
-              }
+              position: 'absolute',
+              top: columnHeaderHeight,
+              left: xFilterBar,
+              width: 20,
+              height: theme.filterBarHeight,
+            }
             : {
-                position: 'absolute',
-                top: 0,
-                left: xColumnHeader,
-                width: columnWidth,
-                height: columnHeaderHeight,
-              };
+              position: 'absolute',
+              top: 0,
+              left: xColumnHeader,
+              width: columnWidth,
+              height: columnHeaderHeight,
+            };
           const modelColumn = this.getModelColumn(columnIndex);
           if (modelColumn != null) {
             const column = model.columns[modelColumn];

--- a/packages/iris-grid/src/IrisGrid.tsx
+++ b/packages/iris-grid/src/IrisGrid.tsx
@@ -2062,32 +2062,34 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
     keyTable.applySort(sorts);
     keyTable.setViewport(0, 0);
 
-    return new Promise((resolve, reject) => {
-      // We want to wait for the first UPDATED event instead of just getting viewport data here
-      // It's possible that the key table does not have any rows of data yet, so just wait until it does have one
-      keyTable.addEventListener(
-        dh.Table.EVENT_UPDATED,
-        (event: CustomEvent<DhType.ViewportData>) => {
-          try {
-            const { detail: data } = event;
-            let values: unknown[] = [];
-            if (data.rows.length > 0) {
-              const row = data.rows[0];
-              values = keyTable.columns.map(column => row.get(column));
-            }
-            const newPartition: PartitionConfig = {
-              partitions: values,
-              mode: model.isPartitionAwareSourceTable ? 'partition' : 'keys',
-            };
-            keyTable.close();
-            resolve(newPartition);
-          } catch (e) {
-            keyTable.close();
-            reject(e);
+    // We want to wait for the first UPDATED event instead of just getting viewport data here
+    // It's possible that the key table does not have any rows of data yet, so just wait until it does have one
+    keyTable.addEventListener(
+      dh.Table.EVENT_UPDATED,
+      (event: CustomEvent<DhType.ViewportData>) => {
+        try {
+          const { detail: data } = event;
+          if (data.rows.length === 0) {
+            this.setState({
+              partitionConfig: { partitions: [], mode: 'empty' },
+            });
+            return partitionConfig;
           }
+          const row = data.rows[0];
+          const values = keyTable.columns.map(column => row.get(column));
+          const newPartition: PartitionConfig = {
+            partitions: values,
+            mode: model.isPartitionAwareSourceTable ? 'partition' : 'keys',
+          };
+          keyTable.close();
+          return newPartition;
+        } catch (e) {
+          keyTable.close();
+          log.error('Error getting initial partition config', e);
         }
-      );
-    });
+      }
+    );
+    return { partitions: [], mode: 'loading' };
   }
 
   /**
@@ -2557,7 +2559,11 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
 
   handlePartitionChange(partitionConfig: PartitionConfig): void {
     this.startLoading('Partitioning...');
-    this.setState({ partitionConfig });
+    const { partitionConfig: prevConfig } = this.state;
+    if (prevConfig !== partitionConfig) {
+      this.setState({ partitionConfig });
+    }
+    // this.setState({ partitionConfig });
   }
 
   handleTableLoadError(error: unknown): void {

--- a/packages/iris-grid/src/IrisGrid.tsx
+++ b/packages/iris-grid/src/IrisGrid.tsx
@@ -1789,9 +1789,9 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
     const { advancedFilters, quickFilters, partitionConfig } = this.state;
     const { columns, formatter } = model;
 
-    if (advancedFilters.size === 0 && quickFilters.size === 0) {
-      return;
-    }
+    // if (advancedFilters.size === 0 && quickFilters.size === 0) {
+    //   return;
+    // }
 
     const newAdvancedFilters = new Map();
     const newQuickFilters = new Map();

--- a/packages/iris-grid/src/IrisGrid.tsx
+++ b/packages/iris-grid/src/IrisGrid.tsx
@@ -1787,11 +1787,6 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
     const { advancedFilters, quickFilters } = this.state;
     const { columns, formatter } = model;
 
-    if (advancedFilters.size === 0 && quickFilters.size === 0) {
-      // No need to rebuild filters if no filters are set
-      return;
-    }
-
     log.debug('Rebuilding filters');
 
     const newAdvancedFilters = new Map();

--- a/packages/iris-grid/src/IrisGrid.tsx
+++ b/packages/iris-grid/src/IrisGrid.tsx
@@ -1789,9 +1789,9 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
     const { advancedFilters, quickFilters, partitionConfig } = this.state;
     const { columns, formatter } = model;
 
-    // if (advancedFilters.size === 0 && quickFilters.size === 0) {
-    //   return;
-    // }
+    if (advancedFilters.size === 0 && quickFilters.size === 0) {
+      return;
+    }
 
     const newAdvancedFilters = new Map();
     const newQuickFilters = new Map();
@@ -4262,7 +4262,7 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
       gotoValueSelectedFilter,
       partitionConfig,
     } = this.state;
-    if (!isReady || partitionConfig?.mode === 'empty') {
+    if (!isReady || partitionConfig?.mode === 'loading') {
       return null;
     }
 

--- a/packages/iris-grid/src/IrisGrid.tsx
+++ b/packages/iris-grid/src/IrisGrid.tsx
@@ -897,8 +897,8 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
     const changedInputFilters =
       inputFilters !== prevProps.inputFilters
         ? inputFilters.filter(
-            inputFilter => !prevProps.inputFilters.includes(inputFilter)
-          )
+          inputFilter => !prevProps.inputFilters.includes(inputFilter)
+        )
         : [];
     if (changedInputFilters.length > 0) {
       const { advancedSettings } = this.props;
@@ -1382,11 +1382,11 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
       advancedFilters: ReadonlyAdvancedFilterMap,
       searchFilter: DhType.FilterCondition | undefined
     ) => [
-      ...(customFilters ?? []),
-      ...IrisGridUtils.getFiltersFromFilterMap(quickFilters),
-      ...IrisGridUtils.getFiltersFromFilterMap(advancedFilters),
-      ...(searchFilter !== undefined ? [searchFilter] : []),
-    ],
+        ...(customFilters ?? []),
+        ...IrisGridUtils.getFiltersFromFilterMap(quickFilters),
+        ...IrisGridUtils.getFiltersFromFilterMap(advancedFilters),
+        ...(searchFilter !== undefined ? [searchFilter] : []),
+      ],
     { max: 1 }
   );
 
@@ -3155,10 +3155,10 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
         pendingRowCount = Math.max(
           0,
           bottomViewport -
-            (model.rowCount - model.pendingRowCount) -
-            model.floatingTopRowCount -
-            model.floatingBottomRowCount -
-            1
+          (model.rowCount - model.pendingRowCount) -
+          model.floatingTopRowCount -
+          model.floatingBottomRowCount -
+          1
         );
       }
     }
@@ -3489,8 +3489,7 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
     this.clearAllFilters();
 
     this.startLoading(
-      `Selecting distinct values in ${
-        columnNames.length > 0 ? columnNames.join(', ') : ''
+      `Selecting distinct values in ${columnNames.length > 0 ? columnNames.join(', ') : ''
       }...`
     );
 
@@ -4298,9 +4297,9 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
 
     const debounceMs = metrics
       ? Math.min(
-          Math.max(IrisGrid.minDebounce, Math.round(metrics.rowCount / 200)),
-          IrisGrid.maxDebounce
-        )
+        Math.max(IrisGrid.minDebounce, Math.round(metrics.rowCount / 200)),
+        IrisGrid.maxDebounce
+      )
       : IrisGrid.maxDebounce;
 
     if (isFilterBarShown && focusedFilterBarColumn != null && metrics != null) {
@@ -4496,19 +4495,19 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
           const xFilterBar = gridX + columnX + columnWidth - 20;
           const style: CSSProperties = isFilterBarShown
             ? {
-                position: 'absolute',
-                top: columnHeaderHeight,
-                left: xFilterBar,
-                width: 20,
-                height: theme.filterBarHeight,
-              }
+              position: 'absolute',
+              top: columnHeaderHeight,
+              left: xFilterBar,
+              width: 20,
+              height: theme.filterBarHeight,
+            }
             : {
-                position: 'absolute',
-                top: 0,
-                left: xColumnHeader,
-                width: columnWidth,
-                height: columnHeaderHeight,
-              };
+              position: 'absolute',
+              top: 0,
+              left: xColumnHeader,
+              width: columnWidth,
+              height: columnHeaderHeight,
+            };
           const modelColumn = this.getModelColumn(columnIndex);
           if (modelColumn != null) {
             const column = model.columns[modelColumn];

--- a/packages/iris-grid/src/IrisGridPartitionSelector.scss
+++ b/packages/iris-grid/src/IrisGridPartitionSelector.scss
@@ -18,8 +18,7 @@
   }
   .partition-button-group {
     display: flex;
-    border: 1px var(--dh-color-hr);
-    border-style: none solid;
+    border-right: 1px solid var(--dh-color-hr);
     padding: 0 $spacer-2;
     gap: $spacer-2;
   }

--- a/packages/iris-grid/src/IrisGridPartitionSelector.test.tsx
+++ b/packages/iris-grid/src/IrisGridPartitionSelector.test.tsx
@@ -17,6 +17,9 @@ function makeModel(
       Promise.resolve(irisGridTestUtils.makeTable())
     ),
     partitionColumns: columns,
+    partitionBaseTable: jest.fn(() =>
+      Promise.resolve(irisGridTestUtils.makeTable())
+    ),
   } as unknown as PartitionedGridModel;
   return model;
 }

--- a/packages/iris-grid/src/IrisGridPartitionSelector.tsx
+++ b/packages/iris-grid/src/IrisGridPartitionSelector.tsx
@@ -15,7 +15,7 @@ const log = Log.module('IrisGridPartitionSelector');
 
 interface IrisGridPartitionSelectorProps {
   model: PartitionedGridModel;
-  partitionConfig: PartitionConfig;
+  partitionConfig?: PartitionConfig;
   onChange: (partitionConfig: PartitionConfig) => void;
 }
 interface IrisGridPartitionSelectorState {
@@ -106,6 +106,7 @@ class IrisGridPartitionSelector extends Component<
     log.debug2('handlePartitionTableClick');
 
     const { partitionConfig } = this.props;
+    assertNotNull(partitionConfig);
 
     const newPartitionConfig = { ...partitionConfig };
     // Toggle between Keys and Partition mode
@@ -118,6 +119,7 @@ class IrisGridPartitionSelector extends Component<
     log.debug2('handleMergeClick');
 
     const { partitionConfig } = this.props;
+    assertNotNull(partitionConfig);
     const newPartitionConfig = { ...partitionConfig };
     // Toggle between Merged and Partition mode
     newPartitionConfig.mode =
@@ -135,6 +137,7 @@ class IrisGridPartitionSelector extends Component<
     selectedValue: unknown
   ): Promise<void> {
     const { partitionConfig: prevConfig } = this.props;
+    assertNotNull(prevConfig);
 
     log.debug('handlePartitionSelect', index, selectedValue, prevConfig);
 
@@ -218,9 +221,12 @@ class IrisGridPartitionSelector extends Component<
    */
   async updatePartitionOptions(): Promise<void> {
     const { model } = this.props;
-    const { keysTable } = this.state;
     const { partitionConfig: prevConfig } = this.props;
+    if (prevConfig == null) {
+      return;
+    }
 
+    const { keysTable } = this.state;
     assertNotNull(keysTable);
 
     const partitionFilters = [...prevConfig.partitions].map((partition, i) => {
@@ -240,6 +246,7 @@ class IrisGridPartitionSelector extends Component<
 
   getPartitionFilters(partitionTables: dh.Table[]): dh.FilterCondition[][] {
     const { model, partitionConfig } = this.props;
+    assertNotNull(partitionConfig);
     const { partitions } = partitionConfig;
     log.debug('getPartitionFilters', partitionConfig);
 
@@ -296,14 +303,14 @@ class IrisGridPartitionSelector extends Component<
             shouldFlip={false}
             keyColumn={partitionTables[index].columns[index].name}
             selectedKey={
-              partitionConfig.mode === 'keys'
-                ? null
-                : (partitionConfig.partitions[index] as ItemKey)
+              partitionConfig?.mode === 'partition'
+                ? (partitionConfig.partitions[index] as ItemKey)
+                : null
             }
             placeholder="Select a key"
             labelColumn={partitionTables[index].columns[index].name}
             onChange={this.getCachedChangeCallback(index)}
-            isDisabled={isLoading || partitionConfig.mode === 'empty'}
+            isDisabled={isLoading || partitionConfig == null}
           />
         )}
         {model.partitionColumns.length - 1 === index || (
@@ -323,8 +330,8 @@ class IrisGridPartitionSelector extends Component<
                 : 'View underlying partition table'
             }
             icon={vsKey}
-            active={partitionConfig.mode === 'keys'}
-            disabled={isLoading || partitionConfig.mode === 'empty'}
+            active={partitionConfig?.mode === 'keys'}
+            disabled={isLoading || partitionConfig == null}
           >
             Partitions
           </Button>
@@ -333,8 +340,8 @@ class IrisGridPartitionSelector extends Component<
             kind="inline"
             tooltip="View all partitions as one merged table"
             icon={<FontAwesomeIcon icon={vsMerge} rotation={90} />}
-            active={partitionConfig.mode === 'merged'}
-            disabled={isLoading || partitionConfig.mode === 'empty'}
+            active={partitionConfig?.mode === 'merged'}
+            disabled={isLoading || partitionConfig == null}
           >
             {model.isPartitionAwareSourceTable ? 'Coalesce' : 'Merge'}
           </Button>

--- a/packages/iris-grid/src/IrisGridPartitionSelector.tsx
+++ b/packages/iris-grid/src/IrisGridPartitionSelector.tsx
@@ -185,7 +185,7 @@ class IrisGridPartitionSelector extends Component<
           );
         });
       t.applyFilter(partitionFilters);
-      t.setViewport(0, 10, t.columns);
+      t.setViewport(0, 0, t.columns);
       const data = await this.pending.add(t.getViewportData());
       const newConfig: PartitionConfig = {
         // Core JSAPI returns undefined for null table values,
@@ -304,7 +304,7 @@ class IrisGridPartitionSelector extends Component<
     if (partitionFilters !== null && partitionTables !== null) {
       partitionFilters.forEach((filter, index) => {
         partitionTables[index].applyFilter(filter as dh.FilterCondition[]);
-        partitionTables[index].setViewport(0, 50);
+        partitionTables[index].setViewport(0, partitionTables[index].size);
       });
     }
     const partitionSelectors = model.partitionColumns.map((column, index) => (

--- a/packages/iris-grid/src/IrisGridPartitionSelector.tsx
+++ b/packages/iris-grid/src/IrisGridPartitionSelector.tsx
@@ -334,7 +334,7 @@ class IrisGridPartitionSelector extends Component<
             tooltip="View all partitions as one merged table"
             icon={<FontAwesomeIcon icon={vsMerge} rotation={90} />}
             active={partitionConfig.mode === 'merged'}
-            disabled={isLoading || model.rowCount === 0}
+            disabled={isLoading || partitionConfig.mode === 'empty'}
           >
             {model.isPartitionAwareSourceTable ? 'Coalesce' : 'Merge'}
           </Button>

--- a/packages/iris-grid/src/IrisGridPartitionSelector.tsx
+++ b/packages/iris-grid/src/IrisGridPartitionSelector.tsx
@@ -65,20 +65,10 @@ class IrisGridPartitionSelector extends Component<
         t.close()
       );
 
-      // load in initial partition tables so that pickers render correctly
-      const partitionTables = await Promise.all(
-        model.partitionColumns.map(async (_, i) =>
-          this.pending.add(
-            keysTable.selectDistinct(model.partitionColumns.slice(0, i + 1)),
-            t => t.close()
-          )
-        )
-      );
       this.setState({
         keysTable,
         baseTable,
         isLoading: false,
-        // partitionTables,
       });
       this.updatePartitionOptions();
     } catch (e) {

--- a/packages/iris-grid/src/IrisGridPartitionSelector.tsx
+++ b/packages/iris-grid/src/IrisGridPartitionSelector.tsx
@@ -77,6 +77,7 @@ class IrisGridPartitionSelector extends Component<
       this.setState({
         keysTable,
         baseTable,
+        isLoading: false,
         // partitionTables,
       });
       this.updatePartitionOptions();
@@ -244,7 +245,7 @@ class IrisGridPartitionSelector extends Component<
       })
     );
 
-    this.setState({ partitionTables, isLoading: false });
+    this.setState({ partitionTables });
   }
 
   getPartitionFilters(partitionTables: dh.Table[]): dh.FilterCondition[][] {
@@ -312,7 +313,7 @@ class IrisGridPartitionSelector extends Component<
             placeholder="Select a key"
             labelColumn={partitionTables[index].columns[index].name}
             onChange={this.getCachedChangeCallback(index)}
-            isDisabled={isLoading || model.rowCount === 0}
+            isDisabled={isLoading || partitionConfig.mode === 'empty'}
           />
         )}
         {model.partitionColumns.length - 1 === index || (
@@ -333,7 +334,7 @@ class IrisGridPartitionSelector extends Component<
             }
             icon={vsKey}
             active={partitionConfig.mode === 'keys'}
-            disabled={isLoading || model.rowCount === 0}
+            disabled={isLoading || partitionConfig.mode === 'empty'}
           >
             Partitions
           </Button>

--- a/packages/iris-grid/src/IrisGridPartitionSelector.tsx
+++ b/packages/iris-grid/src/IrisGridPartitionSelector.tsx
@@ -74,13 +74,12 @@ class IrisGridPartitionSelector extends Component<
           )
         )
       );
-      this.updatePartitionOptions();
       this.setState({
-        isLoading: false,
         keysTable,
         baseTable,
-        partitionTables,
+        // partitionTables,
       });
+      this.updatePartitionOptions();
     } catch (e) {
       if (!PromiseUtils.isCanceled(e)) {
         // Just re-throw the error if it's not a cancel
@@ -245,7 +244,7 @@ class IrisGridPartitionSelector extends Component<
       })
     );
 
-    this.setState({ partitionTables });
+    this.setState({ partitionTables, isLoading: false });
   }
 
   getPartitionFilters(partitionTables: dh.Table[]): dh.FilterCondition[][] {
@@ -313,7 +312,7 @@ class IrisGridPartitionSelector extends Component<
             placeholder="Select a key"
             labelColumn={partitionTables[index].columns[index].name}
             onChange={this.getCachedChangeCallback(index)}
-            isDisabled={isLoading}
+            isDisabled={isLoading || model.rowCount === 0}
           />
         )}
         {model.partitionColumns.length - 1 === index || (
@@ -334,7 +333,7 @@ class IrisGridPartitionSelector extends Component<
             }
             icon={vsKey}
             active={partitionConfig.mode === 'keys'}
-            disabled={isLoading}
+            disabled={isLoading || model.rowCount === 0}
           >
             Partitions
           </Button>
@@ -344,7 +343,7 @@ class IrisGridPartitionSelector extends Component<
             tooltip="View all partitions as one merged table"
             icon={<FontAwesomeIcon icon={vsMerge} rotation={90} />}
             active={partitionConfig.mode === 'merged'}
-            disabled={isLoading}
+            disabled={isLoading || model.rowCount === 0}
           >
             {model.isPartitionAwareSourceTable ? 'Coalesce' : 'Merge'}
           </Button>

--- a/packages/iris-grid/src/IrisGridPartitionSelector.tsx
+++ b/packages/iris-grid/src/IrisGridPartitionSelector.tsx
@@ -322,7 +322,7 @@ class IrisGridPartitionSelector extends Component<
                 ? null
                 : (partitionConfig.partitions[index] as ItemKey)
             }
-            placeholder={'Select an option' as string}
+            placeholder={'Select a key' as string}
             labelColumn={partitionTables[index].columns[index].name}
             onChange={this.getCachedChangeCallback(index)}
             isDisabled={isLoading}
@@ -339,7 +339,11 @@ class IrisGridPartitionSelector extends Component<
           <Button
             onClick={this.handlePartitionTableClick}
             kind="inline"
-            tooltip="View keys as table"
+            tooltip={
+              model.isPartitionAwareSourceTable
+                ? 'View keys as table'
+                : 'View underlying partition table'
+            }
             icon={vsKey}
             active={partitionConfig.mode === 'keys'}
             disabled={isLoading}
@@ -354,7 +358,7 @@ class IrisGridPartitionSelector extends Component<
             active={partitionConfig.mode === 'merged'}
             disabled={isLoading}
           >
-            {model.isPartitionAwareSourceTable ? 'Merge' : 'Coalesce'}
+            {model.isPartitionAwareSourceTable ? 'Coalesce' : 'Merge'}
           </Button>
         </div>
         {partitionSelectors}

--- a/packages/iris-grid/src/IrisGridPartitionSelector.tsx
+++ b/packages/iris-grid/src/IrisGridPartitionSelector.tsx
@@ -322,7 +322,7 @@ class IrisGridPartitionSelector extends Component<
                 ? null
                 : (partitionConfig.partitions[index] as ItemKey)
             }
-            placeholder={'Select a key' as string}
+            placeholder="Select a key"
             labelColumn={partitionTables[index].columns[index].name}
             onChange={this.getCachedChangeCallback(index)}
             isDisabled={isLoading}

--- a/packages/iris-grid/src/IrisGridPartitionSelector.tsx
+++ b/packages/iris-grid/src/IrisGridPartitionSelector.tsx
@@ -21,7 +21,7 @@ interface IrisGridPartitionSelectorProps {
 interface IrisGridPartitionSelectorState {
   isLoading: boolean;
 
-  underlyingTable: dh.Table | null;
+  baseTable: dh.Table | null;
 
   keysTable: dh.Table | null;
 
@@ -49,7 +49,7 @@ class IrisGridPartitionSelector extends Component<
       // We start be loading the partition tables, so we should be in a loading state
       isLoading: true,
 
-      underlyingTable: null,
+      baseTable: null,
       keysTable: null,
       partitionFilters: null,
       partitionTables: null,
@@ -71,9 +71,8 @@ class IrisGridPartitionSelector extends Component<
         t => t.close()
       );
 
-      const underlyingTable = await this.pending.add(
-        model.partitionBaseTable(),
-        t => t.close()
+      const baseTable = await this.pending.add(model.partitionBaseTable(), t =>
+        t.close()
       );
 
       const partitionTables = await Promise.all(
@@ -89,7 +88,7 @@ class IrisGridPartitionSelector extends Component<
       this.setState({
         isLoading: false,
         keysTable,
-        underlyingTable,
+        baseTable,
         partitionFilters,
         partitionTables,
       });
@@ -114,8 +113,8 @@ class IrisGridPartitionSelector extends Component<
   componentWillUnmount(): void {
     this.pending.cancel();
 
-    const { keysTable, underlyingTable, partitionTables } = this.state;
-    underlyingTable?.close();
+    const { keysTable, baseTable, partitionTables } = this.state;
+    baseTable?.close();
     keysTable?.close();
     partitionTables?.forEach(table => table.close());
   }
@@ -163,15 +162,15 @@ class IrisGridPartitionSelector extends Component<
     const newPartitions = [...prevConfig.partitions];
     newPartitions[index] = selectedValue;
 
-    const { underlyingTable } = this.state;
+    const { baseTable } = this.state;
     const { keysTable } = this.state;
 
-    assertNotNull(underlyingTable);
+    assertNotNull(baseTable);
     assertNotNull(keysTable);
     try {
       this.setState({ isLoading: true });
 
-      const t = await this.pending.add(underlyingTable.copy(), tCopy =>
+      const t = await this.pending.add(baseTable.copy(), tCopy =>
         tCopy.close()
       );
 

--- a/packages/iris-grid/src/IrisGridPartitionedTableModel.ts
+++ b/packages/iris-grid/src/IrisGridPartitionedTableModel.ts
@@ -65,7 +65,7 @@ class IrisGridPartitionedTableModel
   }
 
   getColumnIndexByName(columnName: string): number {
-    return this.columns.findIndex(column => column.name === columnName) ?? -1;
+    return this.columns.findIndex(column => column.name === columnName);
   }
 
   textForColumnHeader(

--- a/packages/iris-grid/src/IrisGridPartitionedTableModel.ts
+++ b/packages/iris-grid/src/IrisGridPartitionedTableModel.ts
@@ -60,6 +60,21 @@ class IrisGridPartitionedTableModel
     return this.partitionedTable.keyColumns;
   }
 
+  get columnCount(): number {
+    return this.columns.length;
+  }
+
+  getColumnIndexByName(columnName: string): number {
+    return this.columns.findIndex(column => column.name === columnName) ?? -1;
+  }
+
+  textForColumnHeader(
+    column: number,
+    depth?: number | undefined
+  ): string | undefined {
+    return this.columns[column].name ?? '';
+  }
+
   async partitionKeysTable(): Promise<DhType.Table> {
     return this.partitionedTable.getKeyTable();
   }

--- a/packages/iris-grid/src/IrisGridPartitionedTableModel.ts
+++ b/packages/iris-grid/src/IrisGridPartitionedTableModel.ts
@@ -32,6 +32,10 @@ class IrisGridPartitionedTableModel
     return true;
   }
 
+  get isPartitionAwareSourceTable(): boolean {
+    return false;
+  }
+
   get isReversible(): boolean {
     return false;
   }
@@ -58,6 +62,11 @@ class IrisGridPartitionedTableModel
 
   async partitionKeysTable(): Promise<DhType.Table> {
     return this.partitionedTable.getKeyTable();
+  }
+
+  async partitionBaseTable(): Promise<DhType.Table> {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return (this.partitionedTable as any).getBaseTable();
   }
 
   async partitionMergedTable(): Promise<DhType.Table> {

--- a/packages/iris-grid/src/IrisGridProxyModel.ts
+++ b/packages/iris-grid/src/IrisGridProxyModel.ts
@@ -323,11 +323,6 @@ class IrisGridProxyModel extends IrisGridModel implements PartitionedGridModel {
         modelPromise = this.originalModel
           .partitionMergedTable()
           .then(table => makeModel(this.dh, table, this.formatter));
-      } else if (
-        partitionConfig.mode === 'empty' ||
-        partitionConfig.mode === 'loading'
-      ) {
-        // Empty partition
       } else {
         modelPromise = this.originalModel
           .partitionTable(partitionConfig.partitions)

--- a/packages/iris-grid/src/IrisGridProxyModel.ts
+++ b/packages/iris-grid/src/IrisGridProxyModel.ts
@@ -317,7 +317,7 @@ class IrisGridProxyModel extends IrisGridModel implements PartitionedGridModel {
     ) {
       if (partitionConfig.mode === 'keys') {
         modelPromise = this.originalModel
-          .partitionKeysTable()
+          .partitionBaseTable()
           .then(table => makeModel(this.dh, table, this.formatter));
       } else if (partitionConfig.mode === 'merged') {
         modelPromise = this.originalModel

--- a/packages/iris-grid/src/IrisGridProxyModel.ts
+++ b/packages/iris-grid/src/IrisGridProxyModel.ts
@@ -530,7 +530,7 @@ class IrisGridProxyModel extends IrisGridModel implements PartitionedGridModel {
     ) {
       if (partitionConfig.mode === 'keys') {
         modelPromise = this.originalModel
-          .partitionKeysTable()
+          .partitionBaseTable()
           .then(table => makeModel(this.dh, table, this.formatter));
       } else if (partitionConfig.mode === 'merged') {
         modelPromise = this.originalModel
@@ -551,6 +551,13 @@ class IrisGridProxyModel extends IrisGridModel implements PartitionedGridModel {
       throw new Error('Partitions are not available');
     }
     return this.originalModel.partitionKeysTable();
+  }
+
+  partitionBaseTable(): Promise<DhType.Table> {
+    if (!isPartitionedGridModelProvider(this.originalModel)) {
+      throw new Error('Partitions are not available');
+    }
+    return this.originalModel.partitionBaseTable();
   }
 
   partitionMergedTable(): Promise<DhType.Table> {
@@ -695,6 +702,12 @@ class IrisGridProxyModel extends IrisGridModel implements PartitionedGridModel {
   get isPartitionRequired(): boolean {
     return isPartitionedGridModelProvider(this.originalModel)
       ? this.originalModel.isPartitionRequired
+      : false;
+  }
+
+  get isPartitionAwareSourceTable(): boolean {
+    return isPartitionedGridModelProvider(this.originalModel)
+      ? this.originalModel.isPartitionAwareSourceTable
       : false;
   }
 

--- a/packages/iris-grid/src/IrisGridProxyModel.ts
+++ b/packages/iris-grid/src/IrisGridProxyModel.ts
@@ -323,6 +323,11 @@ class IrisGridProxyModel extends IrisGridModel implements PartitionedGridModel {
         modelPromise = this.originalModel
           .partitionMergedTable()
           .then(table => makeModel(this.dh, table, this.formatter));
+      } else if (
+        partitionConfig.mode === 'empty' ||
+        partitionConfig.mode === 'loading'
+      ) {
+        // Empty partition
       } else {
         modelPromise = this.originalModel
           .partitionTable(partitionConfig.partitions)

--- a/packages/iris-grid/src/IrisGridTableModel.ts
+++ b/packages/iris-grid/src/IrisGridTableModel.ts
@@ -301,7 +301,7 @@ class IrisGridTableModel
   }
 
   get isPartitionAwareSourceTable(): boolean {
-    return true;
+    return this.isPartitionRequired && true;
   }
 
   isFilterable(columnIndex: ModelIndex): boolean {

--- a/packages/iris-grid/src/IrisGridTableModel.ts
+++ b/packages/iris-grid/src/IrisGridTableModel.ts
@@ -301,7 +301,7 @@ class IrisGridTableModel
   }
 
   get isPartitionAwareSourceTable(): boolean {
-    return this.isPartitionRequired && true;
+    return this.isPartitionRequired;
   }
 
   isFilterable(columnIndex: ModelIndex): boolean {

--- a/packages/iris-grid/src/IrisGridTableModel.ts
+++ b/packages/iris-grid/src/IrisGridTableModel.ts
@@ -212,6 +212,10 @@ class IrisGridTableModel
     return t;
   }
 
+  async partitionBaseTable(): Promise<DhType.Table> {
+    return this.valuesTable(this.columns);
+  }
+
   async partitionTable(partitions: unknown[]): Promise<DhType.Table> {
     log.debug('getting partition table for partitions', partitions);
 
@@ -294,6 +298,10 @@ class IrisGridTableModel
       this.isValuesTableAvailable &&
       this.partitionColumns.length > 0
     );
+  }
+
+  get isPartitionAwareSourceTable(): boolean {
+    return true;
   }
 
   isFilterable(columnIndex: ModelIndex): boolean {

--- a/packages/iris-grid/src/IrisGridTableModel.ts
+++ b/packages/iris-grid/src/IrisGridTableModel.ts
@@ -213,7 +213,7 @@ class IrisGridTableModel
   }
 
   async partitionBaseTable(): Promise<DhType.Table> {
-    return this.valuesTable(this.columns);
+    return this.partitionKeysTable();
   }
 
   async partitionTable(partitions: unknown[]): Promise<DhType.Table> {

--- a/packages/iris-grid/src/PartitionedGridModel.ts
+++ b/packages/iris-grid/src/PartitionedGridModel.ts
@@ -27,7 +27,7 @@ export interface PartitionConfig {
   partitions: unknown[];
 
   /** What data to display - the keys table, the merged table, or the selected partition */
-  mode: 'keys' | 'merged' | 'partition';
+  mode: 'keys' | 'merged' | 'partition' | 'loading' | 'empty';
 }
 
 /**

--- a/packages/iris-grid/src/PartitionedGridModel.ts
+++ b/packages/iris-grid/src/PartitionedGridModel.ts
@@ -43,8 +43,13 @@ export interface PartitionedGridModelProvider extends IrisGridModel {
   /** Whether a partition is required to be set on this model */
   get isPartitionRequired(): boolean;
 
+  /** Whether the table is a partition-aware source table or a partition table */
+  get isPartitionAwareSourceTable(): boolean;
+
   /** Get a keys table for the partitions */
   partitionKeysTable: () => Promise<dh.Table>;
+
+  partitionBaseTable: () => Promise<dh.Table>;
 
   /** Get a merged table containing all partitions */
   partitionMergedTable: () => Promise<dh.Table>;

--- a/packages/iris-grid/src/PartitionedGridModel.ts
+++ b/packages/iris-grid/src/PartitionedGridModel.ts
@@ -27,7 +27,7 @@ export interface PartitionConfig {
   partitions: unknown[];
 
   /** What data to display - the keys table, the merged table, or the selected partition */
-  mode: 'keys' | 'merged' | 'partition' | 'loading' | 'empty';
+  mode: 'keys' | 'merged' | 'partition';
 }
 
 /**

--- a/packages/iris-grid/src/PartitionedGridModel.ts
+++ b/packages/iris-grid/src/PartitionedGridModel.ts
@@ -46,9 +46,10 @@ export interface PartitionedGridModelProvider extends IrisGridModel {
   /** Whether the table is a partition-aware source table or a partition table */
   get isPartitionAwareSourceTable(): boolean;
 
-  /** Get a keys table for the partitions */
+  /** Get a keys table for the partitions. Only includes the key columns. */
   partitionKeysTable: () => Promise<dh.Table>;
 
+  /** Get the base table for the partitions. Includes key columns and possibly other columns, such as constituent columns */
   partitionBaseTable: () => Promise<dh.Table>;
 
   /** Get a merged table containing all partitions */

--- a/packages/iris-grid/src/mousehandlers/IrisGridContextMenuHandler.tsx
+++ b/packages/iris-grid/src/mousehandlers/IrisGridContextMenuHandler.tsx
@@ -511,7 +511,7 @@ class IrisGridContextMenuHandler extends GridMouseHandler {
         group: IrisGridContextMenuHandler.GROUP_VIEW_CONTENTS,
         order: 40,
         action: () => {
-          irisGrid.setPartitionConfig(model, rowIndex);
+          irisGrid.selectPartitionKeyFromTable(rowIndex);
         },
       });
     }
@@ -894,7 +894,7 @@ class IrisGridContextMenuHandler extends GridMouseHandler {
       isFilterBarShown
         ? y <= gridY
         : y <= columnHeaderHeight * columnHeaderMaxDepth &&
-          columnHeaderDepth === 0
+        columnHeaderDepth === 0
     ) {
       // grid header context menu options
       if (modelColumn != null) {
@@ -1066,9 +1066,9 @@ class IrisGridContextMenuHandler extends GridMouseHandler {
 
     let newQuickFilter:
       | {
-          filter: null | DhType.FilterCondition | undefined;
-          text: string | null;
-        }
+        filter: null | DhType.FilterCondition | undefined;
+        text: string | null;
+      }
       | undefined
       | null = quickFilter;
     if (!newQuickFilter) {
@@ -1801,9 +1801,9 @@ class IrisGridContextMenuHandler extends GridMouseHandler {
     const filterValue = dh.FilterValue.ofString('');
     let newQuickFilter:
       | {
-          filter: null | DhType.FilterCondition | undefined;
-          text: string | null;
-        }
+        filter: null | DhType.FilterCondition | undefined;
+        text: string | null;
+      }
       | undefined
       | null = quickFilter;
     if (!newQuickFilter) {

--- a/packages/iris-grid/src/mousehandlers/IrisGridContextMenuHandler.tsx
+++ b/packages/iris-grid/src/mousehandlers/IrisGridContextMenuHandler.tsx
@@ -894,7 +894,7 @@ class IrisGridContextMenuHandler extends GridMouseHandler {
       isFilterBarShown
         ? y <= gridY
         : y <= columnHeaderHeight * columnHeaderMaxDepth &&
-        columnHeaderDepth === 0
+          columnHeaderDepth === 0
     ) {
       // grid header context menu options
       if (modelColumn != null) {
@@ -1066,9 +1066,9 @@ class IrisGridContextMenuHandler extends GridMouseHandler {
 
     let newQuickFilter:
       | {
-        filter: null | DhType.FilterCondition | undefined;
-        text: string | null;
-      }
+          filter: null | DhType.FilterCondition | undefined;
+          text: string | null;
+        }
       | undefined
       | null = quickFilter;
     if (!newQuickFilter) {
@@ -1801,9 +1801,9 @@ class IrisGridContextMenuHandler extends GridMouseHandler {
     const filterValue = dh.FilterValue.ofString('');
     let newQuickFilter:
       | {
-        filter: null | DhType.FilterCondition | undefined;
-        text: string | null;
-      }
+          filter: null | DhType.FilterCondition | undefined;
+          text: string | null;
+        }
       | undefined
       | null = quickFilter;
     if (!newQuickFilter) {

--- a/packages/iris-grid/src/mousehandlers/IrisGridContextMenuHandler.tsx
+++ b/packages/iris-grid/src/mousehandlers/IrisGridContextMenuHandler.tsx
@@ -505,11 +505,7 @@ class IrisGridContextMenuHandler extends GridMouseHandler {
       },
     });
 
-    if (
-      isPartitionedGridModel(model) &&
-      !model.isPartitionAwareSourceTable &&
-      model.isPartitionRequired
-    ) {
+    if (isPartitionedGridModel(model) && !model.isPartitionAwareSourceTable) {
       actions.push({
         title: 'View Constituent Table',
         group: IrisGridContextMenuHandler.GROUP_VIEW_CONTENTS,

--- a/packages/iris-grid/src/mousehandlers/IrisGridContextMenuHandler.tsx
+++ b/packages/iris-grid/src/mousehandlers/IrisGridContextMenuHandler.tsx
@@ -505,7 +505,11 @@ class IrisGridContextMenuHandler extends GridMouseHandler {
       },
     });
 
-    if (isPartitionedGridModel(model) && !model.isPartitionAwareSourceTable) {
+    if (
+      isPartitionedGridModel(model) &&
+      !model.isPartitionAwareSourceTable &&
+      model.isPartitionRequired
+    ) {
       actions.push({
         title: 'View Constituent Table',
         group: IrisGridContextMenuHandler.GROUP_VIEW_CONTENTS,

--- a/packages/iris-grid/src/mousehandlers/IrisGridContextMenuHandler.tsx
+++ b/packages/iris-grid/src/mousehandlers/IrisGridContextMenuHandler.tsx
@@ -55,6 +55,7 @@ import './IrisGridContextMenuHandler.scss';
 import SHORTCUTS from '../IrisGridShortcuts';
 import IrisGrid from '../IrisGrid';
 import { QuickFilter } from '../CommonTypes';
+import { isPartitionedGridModel } from '../PartitionedGridModel';
 
 const log = Log.module('IrisGridContextMenuHandler');
 
@@ -504,6 +505,17 @@ class IrisGridContextMenuHandler extends GridMouseHandler {
       },
     });
 
+    if (isPartitionedGridModel(model) && !model.isPartitionAwareSourceTable) {
+      actions.push({
+        title: 'View Constituent Table',
+        group: IrisGridContextMenuHandler.GROUP_VIEW_CONTENTS,
+        order: 40,
+        action: () => {
+          irisGrid.setPartitionConfig(model, rowIndex);
+        },
+      });
+    }
+
     return actions;
   }
 
@@ -882,7 +894,7 @@ class IrisGridContextMenuHandler extends GridMouseHandler {
       isFilterBarShown
         ? y <= gridY
         : y <= columnHeaderHeight * columnHeaderMaxDepth &&
-          columnHeaderDepth === 0
+        columnHeaderDepth === 0
     ) {
       // grid header context menu options
       if (modelColumn != null) {
@@ -1054,9 +1066,9 @@ class IrisGridContextMenuHandler extends GridMouseHandler {
 
     let newQuickFilter:
       | {
-          filter: null | DhType.FilterCondition | undefined;
-          text: string | null;
-        }
+        filter: null | DhType.FilterCondition | undefined;
+        text: string | null;
+      }
       | undefined
       | null = quickFilter;
     if (!newQuickFilter) {
@@ -1789,9 +1801,9 @@ class IrisGridContextMenuHandler extends GridMouseHandler {
     const filterValue = dh.FilterValue.ofString('');
     let newQuickFilter:
       | {
-          filter: null | DhType.FilterCondition | undefined;
-          text: string | null;
-        }
+        filter: null | DhType.FilterCondition | undefined;
+        text: string | null;
+      }
       | undefined
       | null = quickFilter;
     if (!newQuickFilter) {

--- a/packages/iris-grid/src/mousehandlers/IrisGridPartitionedTableMouseHandler.ts
+++ b/packages/iris-grid/src/mousehandlers/IrisGridPartitionedTableMouseHandler.ts
@@ -1,0 +1,39 @@
+/* eslint class-methods-use-this: "off" */
+import {
+  type Grid,
+  GridMouseHandler,
+  GridPoint,
+  EventHandlerResult,
+} from '@deephaven/grid';
+import type IrisGrid from '../IrisGrid';
+import { isPartitionedGridModel } from '../PartitionedGridModel';
+
+/**
+ * Handles sending data selected via double click
+ */
+class IrisGridPartitionedTableMouseHandler extends GridMouseHandler {
+  constructor(irisGrid: IrisGrid) {
+    super(880);
+
+    this.irisGrid = irisGrid;
+  }
+
+  irisGrid: IrisGrid;
+
+  onDoubleClick(gridPoint: GridPoint, grid: Grid): EventHandlerResult {
+    const { column, row } = gridPoint;
+    if (
+      row == null ||
+      column == null ||
+      !isPartitionedGridModel(this.irisGrid.props.model)
+    ) {
+      return false;
+    }
+
+    this.irisGrid.setPartitionConfig(this.irisGrid.props.model, row);
+
+    return true;
+  }
+}
+
+export default IrisGridPartitionedTableMouseHandler;

--- a/packages/iris-grid/src/mousehandlers/IrisGridPartitionedTableMouseHandler.ts
+++ b/packages/iris-grid/src/mousehandlers/IrisGridPartitionedTableMouseHandler.ts
@@ -13,7 +13,7 @@ import { isPartitionedGridModel } from '../PartitionedGridModel';
  */
 class IrisGridPartitionedTableMouseHandler extends GridMouseHandler {
   constructor(irisGrid: IrisGrid) {
-    super(880);
+    super(878);
 
     this.irisGrid = irisGrid;
   }
@@ -22,15 +22,21 @@ class IrisGridPartitionedTableMouseHandler extends GridMouseHandler {
 
   onDoubleClick(gridPoint: GridPoint, grid: Grid): EventHandlerResult {
     const { column, row } = gridPoint;
+    const { irisGrid } = this;
+    const { model } = irisGrid.props;
+    const { partitionConfig } = irisGrid.state;
+
     if (
       row == null ||
       column == null ||
-      !isPartitionedGridModel(this.irisGrid.props.model)
+      !isPartitionedGridModel(model) ||
+      partitionConfig == null ||
+      partitionConfig.mode !== 'keys'
     ) {
       return false;
     }
 
-    this.irisGrid.setPartitionConfig(this.irisGrid.props.model, row);
+    this.irisGrid.selectPartitionKeyFromTable(row);
 
     return true;
   }

--- a/packages/iris-grid/src/mousehandlers/index.ts
+++ b/packages/iris-grid/src/mousehandlers/index.ts
@@ -9,3 +9,4 @@ export { default as IrisGridRowTreeMouseHandler } from './IrisGridRowTreeMouseHa
 export { default as IrisGridSortMouseHandler } from './IrisGridSortMouseHandler';
 export { default as PendingMouseHandler } from './PendingMouseHandler';
 export { default as IrisGridTokenMouseHandler } from './IrisGridTokenMouseHandler';
+export { default as IrisGridPartitionedTableMouseHandler } from './IrisGridPartitionedTableMouseHandler';


### PR DESCRIPTION
Resolves #2079  ( Resolves #2066 , Resolves #2103 , Resolves #2104 , Resolves #2105 , Resolves #2106 , Resolves #2107 , Resolves #2108 , Resolves #2109 , Resolves #2049 ), Resolves #2120, Resolves #1904

**Changes Implemented:**
- Replaced `keysTable` with `baseTable` 
- Made small UI changes to differentiate between Partition Table and Partition-aware source table
- Allow double clicking to set partition
- Add context menu action to set partition

**Sample Visuals:**
_Default Partition Table View_
<img width="798" alt="Screenshot 2024-06-26 at 2 57 09 PM" src="https://github.com/deephaven/web-client-ui/assets/69530774/19059a9f-7e69-470a-818e-c1d6d9ce8118">
_Default Partition-aware source table view:_
<img width="789" alt="Screenshot 2024-06-26 at 2 56 59 PM" src="https://github.com/deephaven/web-client-ui/assets/69530774/af891a26-3395-4842-963f-c8b2f1c9186d">




