### PR TITLE
fix: Console does not scroll to bottom when code run from notebook

### DIFF
--- a/packages/console/src/Console.tsx
+++ b/packages/console/src/Console.tsx
@@ -655,7 +655,10 @@ export class Console extends PureComponent<ConsoleProps, ConsoleState> {
     if (pane == null) {
       return;
     }
-    pane.scrollTo({ top: pane.scrollHeight });
+
+    window.requestAnimationFrame(() => {
+      pane.scrollTo({ top: pane.scrollHeight });
+    });
   }
 
   handleScrollPaneScroll(): void {


### PR DESCRIPTION
Noticed running code from a notebook wasn't scrolling to the bottom.

I didn't catch this behavior changing in #2076, but looks like the `componentDidUpdate` doesn't necessarily wait until after the paint or the ref isn't updated for some reason. So the `scrollHeight` can be the old value and then `scrollTo` (or `scrollTop = scrollHeight`) triggers the `scroll` event which sets `isStuckToBottom` to false. Not exactly sure 

The `requestAnimationFrame` call seems to be working. The other option I thought of what ignoring programmatic scrolling, but the only way I saw to do that was to set some state in the class and then check it in the scroll handler and reset it after. There's nothing about the event that indicates if it was triggered via `scrollTo`.

There were some weird update values when I was logging this. Like the height would be 1900 for 3 renders, then 1700, then 1900 again. Guessing it's due to rendering of the console buttons.