### PR TITLE
fix: Update IrisGridContextMenuHandler getHeaderActions return type to be more permissive

### DIFF
--- a/packages/iris-grid/src/mousehandlers/IrisGridContextMenuHandler.tsx
+++ b/packages/iris-grid/src/mousehandlers/IrisGridContextMenuHandler.tsx
@@ -177,7 +177,7 @@ class IrisGridContextMenuHandler extends GridMouseHandler {
   getHeaderActions(
     modelIndex: ModelIndex,
     gridPoint: GridPoint
-  ): ContextAction[] {
+  ): ResolvableContextAction[] {
     const { irisGrid } = this;
     const { column: visibleIndex } = gridPoint;
     assertNotNull(visibleIndex);


### PR DESCRIPTION
Needed for proper TS in https://github.com/deephaven/deephaven-plugins/pull/522. Otherwise the class complains it can't properly extend `IrisGridContextMenuHandler`.