### PR TITLE
fix: re-export remaining types needed by dh ui from @react-types/shared

### DIFF
--- a/packages/components/src/spectrum/shared.ts
+++ b/packages/components/src/spectrum/shared.ts
@@ -15,7 +15,12 @@ import type {
 } from '@react-types/shared';
 
 export { Item } from '@adobe/react-spectrum';
-export type { ItemProps } from '@react-types/shared';
+export type {
+  ItemProps,
+  Orientation,
+  PressEvent,
+  SelectionMode,
+} from '@react-types/shared';
 
 /*
  * We support primitive values as shorthand for `Item` elements in certain


### PR DESCRIPTION
Resolves https://github.com/deephaven/web-client-ui/issues/2084

**Steps Moving Forward:**
- Once this PR has merged, will go into plugins repo and use the re-exported types, and remove @react-types/shared dependency (in order to further eliminate spectrum dependency)