### PR TITLE
refactor: 1973 UI constants

### DIFF
--- a/packages/code-studio/src/styleguide/ListViews.tsx
+++ b/packages/code-studio/src/styleguide/ListViews.tsx
@@ -5,6 +5,7 @@ import {
   Grid,
   Icon,
   Item,
+  LIST_VIEW_ROW_HEIGHTS,
   ListView,
   ListViewNormalized,
   ItemKey,
@@ -18,7 +19,6 @@ import {
   ListActionGroup,
 } from '@deephaven/components';
 import { vsAccount, vsEdit, vsPerson, vsTrash } from '@deephaven/icons';
-import { LIST_VIEW_ROW_HEIGHTS } from '@deephaven/utils';
 import { generateNormalizedItems } from './utils';
 import SampleSection from './SampleSection';
 

--- a/packages/code-studio/src/styleguide/Pickers.tsx
+++ b/packages/code-studio/src/styleguide/Pickers.tsx
@@ -1,21 +1,22 @@
 import React, { cloneElement, useCallback, useState } from 'react';
 import {
-  Flex,
-  Item,
-  Picker,
-  ItemKey,
-  Section,
-  Text,
-  PickerNormalized,
   Checkbox,
   ComboBox,
   ComboBoxNormalized,
+  Flex,
+  Item,
+  ItemKey,
+  PICKER_ITEM_HEIGHTS,
+  PICKER_TOP_OFFSET,
+  Picker,
+  PickerNormalized,
+  Section,
+  Text,
 } from '@deephaven/components';
 import { vsPerson } from '@deephaven/icons';
 import { Icon } from '@adobe/react-spectrum';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { getPositionOfSelectedItem } from '@deephaven/react-hooks';
-import { PICKER_ITEM_HEIGHTS, PICKER_TOP_OFFSET } from '@deephaven/utils';
 import { generateItemElements, generateNormalizedItems } from './utils';
 import SampleSection from './SampleSection';
 
@@ -104,8 +105,9 @@ export function Pickers(): JSX.Element {
         {[Picker, ComboBox].map(Component => {
           const label = (suffix: string) =>
             `${Component === Picker ? 'Picker' : 'ComboBox'} (${suffix})`;
+
           return (
-            <Flex key={Component.name} direction="row" gap={14}>
+            <Flex key={Component.displayName} direction="row" gap={14}>
               <Component
                 label={label('Single Child')}
                 tooltip={{ placement: 'bottom-end' }}

--- a/packages/components/src/UIConstants.ts
+++ b/packages/components/src/UIConstants.ts
@@ -1,0 +1,26 @@
+export const ACTION_ICON_HEIGHT = 24;
+
+// Copied from https://github.com/adobe/react-spectrum/blob/b2d25ef23b827ec2427bf47b343e6dbd66326ed3/packages/%40react-spectrum/list/src/ListView.tsx#L78
+export const LIST_VIEW_ROW_HEIGHTS = {
+  compact: {
+    medium: 32,
+    large: 40,
+  },
+  regular: {
+    medium: 40,
+    large: 50,
+  },
+  spacious: {
+    medium: 48,
+    large: 60,
+  },
+} as const;
+
+// https://github.com/adobe/react-spectrum/blob/main/packages/%40react-spectrum/listbox/src/ListBoxBase.tsx#L56
+export const PICKER_ITEM_HEIGHTS = {
+  medium: 32,
+  large: 48,
+} as const;
+
+export const PICKER_TOP_OFFSET = 4;
+export const TABLE_ROW_HEIGHT = 33;

--- a/packages/components/src/actions/ConfirmActionButton.tsx
+++ b/packages/components/src/actions/ConfirmActionButton.tsx
@@ -1,8 +1,8 @@
 import { ReactElement, ReactNode, useCallback } from 'react';
 import type { SpectrumLabelableProps } from '@react-types/shared';
 import { vsTrash } from '@deephaven/icons';
-import { ACTION_ICON_HEIGHT } from '@deephaven/utils';
 import { ActionButtonDialogTrigger, ConfirmationDialog } from '../dialogs';
+import { ACTION_ICON_HEIGHT } from '../UIConstants';
 
 export interface ConfirmActionButtonProps {
   ariaLabel: string;

--- a/packages/components/src/actions/IconActionButton.tsx
+++ b/packages/components/src/actions/IconActionButton.tsx
@@ -6,8 +6,8 @@ import {
 } from '@adobe/react-spectrum';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import type { IconProp } from '@fortawesome/fontawesome-svg-core';
-import { ACTION_ICON_HEIGHT } from '@deephaven/utils';
 import { Tooltip } from '../popper';
+import { ACTION_ICON_HEIGHT } from '../UIConstants';
 
 export interface IconActionButtonProps
   extends Omit<SpectrumActionButtonProps, 'aria-label' | 'isQuiet' | 'height'> {

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -54,4 +54,5 @@ export { default as ThemeExport } from './ThemeExport';
 export { default as TimeInput } from './TimeInput';
 export { default as TimeSlider } from './TimeSlider';
 export { default as ToastNotification } from './ToastNotification';
+export * from './UIConstants';
 export { default as UISwitch } from './UISwitch';

--- a/packages/components/src/spectrum/comboBox/ComboBox.tsx
+++ b/packages/components/src/spectrum/comboBox/ComboBox.tsx
@@ -44,3 +44,4 @@ export const ComboBox = React.forwardRef(function ComboBox(
     />
   );
 });
+ComboBox.displayName = 'ComboBox';

--- a/packages/components/src/spectrum/picker/Picker.tsx
+++ b/packages/components/src/spectrum/picker/Picker.tsx
@@ -50,5 +50,6 @@ export const Picker = React.forwardRef(function Picker(
     />
   );
 });
+Picker.displayName = 'Picker';
 
 export default Picker;

--- a/packages/components/src/spectrum/picker/usePickerItemScale.test.ts
+++ b/packages/components/src/spectrum/picker/usePickerItemScale.test.ts
@@ -1,7 +1,8 @@
-import { PICKER_ITEM_HEIGHTS, TestUtils } from '@deephaven/utils';
+import { TestUtils } from '@deephaven/utils';
 import type { ProviderContext } from '@react-types/provider';
 import { renderHook } from '@testing-library/react-hooks';
 import { useSpectrumThemeProvider } from '../../theme';
+import { PICKER_ITEM_HEIGHTS } from '../../UIConstants';
 import { usePickerItemScale } from './usePickerItemScale';
 
 const { asMock } = TestUtils;

--- a/packages/components/src/spectrum/picker/usePickerItemScale.ts
+++ b/packages/components/src/spectrum/picker/usePickerItemScale.ts
@@ -1,5 +1,5 @@
-import { PICKER_ITEM_HEIGHTS } from '@deephaven/utils';
 import { useSpectrumThemeProvider } from '../../theme';
+import { PICKER_ITEM_HEIGHTS } from '../../UIConstants';
 
 /**
  * Get Picker Item height for current scale.

--- a/packages/components/src/spectrum/picker/usePickerProps.ts
+++ b/packages/components/src/spectrum/picker/usePickerProps.ts
@@ -1,10 +1,7 @@
-import {
-  EMPTY_FUNCTION,
-  ensureArray,
-  PICKER_TOP_OFFSET,
-} from '@deephaven/utils';
+import { EMPTY_FUNCTION, ensureArray } from '@deephaven/utils';
 import { DOMRef } from '@react-types/shared';
 import { useMemo } from 'react';
+import { PICKER_TOP_OFFSET } from '../../UIConstants';
 import {
   normalizeTooltipOptions,
   wrapItemChildren,

--- a/packages/jsapi-components/src/Constants.ts
+++ b/packages/jsapi-components/src/Constants.ts
@@ -1,0 +1,4 @@
+export const SCROLL_DEBOUNCE_MS = 150;
+export const SEARCH_DEBOUNCE_MS = 200;
+export const VIEWPORT_PADDING = 250;
+export const VIEWPORT_SIZE = 500;

--- a/packages/jsapi-components/src/spectrum/ListView.tsx
+++ b/packages/jsapi-components/src/spectrum/ListView.tsx
@@ -1,4 +1,5 @@
 import {
+  LIST_VIEW_ROW_HEIGHTS,
   ListViewNormalized,
   ListViewNormalizedProps,
   NormalizedItemData,
@@ -6,7 +7,6 @@ import {
 } from '@deephaven/components';
 import { dh as DhType } from '@deephaven/jsapi-types';
 import { Settings } from '@deephaven/jsapi-utils';
-import { LIST_VIEW_ROW_HEIGHTS } from '@deephaven/utils';
 import useFormatter from '../useFormatter';
 import useViewportData from '../useViewportData';
 import { useItemRowDeserializer } from './utils';

--- a/packages/jsapi-components/src/spectrum/utils/usePickerProps.ts
+++ b/packages/jsapi-components/src/spectrum/utils/usePickerProps.ts
@@ -3,12 +3,12 @@ import {
   ItemKey,
   NormalizedItem,
   NormalizedSection,
+  PICKER_TOP_OFFSET,
   usePickerItemScale,
 } from '@deephaven/components';
 import { TableUtils } from '@deephaven/jsapi-utils';
 import Log from '@deephaven/log';
 import { usePromiseFactory } from '@deephaven/react-hooks';
-import { PICKER_TOP_OFFSET } from '@deephaven/utils';
 import useFormatter from '../../useFormatter';
 import type { PickerWithTableProps } from '../PickerProps';
 import { getItemKeyColumn, getItemLabelColumn } from './itemUtils';

--- a/packages/jsapi-components/src/usePickerWithSelectedValues.test.ts
+++ b/packages/jsapi-components/src/usePickerWithSelectedValues.test.ts
@@ -11,12 +11,13 @@ import {
   useDebouncedValue,
   type WindowedListData,
 } from '@deephaven/react-hooks';
-import { KeyedItem, SEARCH_DEBOUNCE_MS, TestUtils } from '@deephaven/utils';
+import { KeyedItem, TestUtils } from '@deephaven/utils';
 import usePickerWithSelectedValues from './usePickerWithSelectedValues';
 import useViewportData, { UseViewportDataResult } from './useViewportData';
 import useViewportFilter from './useViewportFilter';
 import useFilterConditionFactories from './useFilterConditionFactories';
 import useTableUtils from './useTableUtils';
+import { SEARCH_DEBOUNCE_MS } from './Constants';
 
 jest.mock('./useFilterConditionFactories');
 jest.mock('./useTableUtils');

--- a/packages/jsapi-components/src/usePickerWithSelectedValues.ts
+++ b/packages/jsapi-components/src/usePickerWithSelectedValues.ts
@@ -11,18 +11,17 @@ import {
   usePromiseFactory,
 } from '@deephaven/react-hooks';
 import { usePickerItemScale } from '@deephaven/components';
-import {
-  KeyedItem,
-  SEARCH_DEBOUNCE_MS,
-  SelectionT,
-  VIEWPORT_PADDING,
-  VIEWPORT_SIZE,
-} from '@deephaven/utils';
+import { KeyedItem, SelectionT } from '@deephaven/utils';
 import useFilterConditionFactories from './useFilterConditionFactories';
 import useViewportData, { UseViewportDataResult } from './useViewportData';
 import useViewportFilter from './useViewportFilter';
 import useTableUtils from './useTableUtils';
 import useTableClose from './useTableClose';
+import {
+  SEARCH_DEBOUNCE_MS,
+  VIEWPORT_PADDING,
+  VIEWPORT_SIZE,
+} from './Constants';
 
 export interface UsePickerWithSelectedValuesResult<TItem, TValue> {
   list: UseViewportDataResult<TItem, dh.Table>;

--- a/packages/jsapi-components/src/useSearchableViewportData.test.ts
+++ b/packages/jsapi-components/src/useSearchableViewportData.test.ts
@@ -8,17 +8,17 @@ import {
   TableUtils,
 } from '@deephaven/jsapi-utils';
 import { useDebouncedCallback } from '@deephaven/react-hooks';
-import {
-  SEARCH_DEBOUNCE_MS,
-  TestUtils,
-  VIEWPORT_PADDING,
-  VIEWPORT_SIZE,
-} from '@deephaven/utils';
+import { TestUtils } from '@deephaven/utils';
 import useSearchableViewportData from './useSearchableViewportData';
 import useViewportData, { UseViewportDataResult } from './useViewportData';
 import useTableUtils from './useTableUtils';
 import useFilterConditionFactories from './useFilterConditionFactories';
 import useViewportFilter from './useViewportFilter';
+import {
+  SEARCH_DEBOUNCE_MS,
+  VIEWPORT_PADDING,
+  VIEWPORT_SIZE,
+} from './Constants';
 
 const { asMock, createMockProxy } = TestUtils;
 

--- a/packages/jsapi-components/src/useSearchableViewportData.test.ts
+++ b/packages/jsapi-components/src/useSearchableViewportData.test.ts
@@ -1,5 +1,6 @@
 import { act, renderHook } from '@testing-library/react-hooks';
 import type { DebouncedFunc } from 'lodash';
+import { TABLE_ROW_HEIGHT } from '@deephaven/components';
 import type { dh as DhType } from '@deephaven/jsapi-types';
 import {
   createSearchTextFilter,
@@ -9,7 +10,6 @@ import {
 import { useDebouncedCallback } from '@deephaven/react-hooks';
 import {
   SEARCH_DEBOUNCE_MS,
-  TABLE_ROW_HEIGHT,
   TestUtils,
   VIEWPORT_PADDING,
   VIEWPORT_SIZE,

--- a/packages/jsapi-components/src/useSearchableViewportData.ts
+++ b/packages/jsapi-components/src/useSearchableViewportData.ts
@@ -1,4 +1,5 @@
 import { useMemo, useState } from 'react';
+import { TABLE_ROW_HEIGHT } from '@deephaven/components';
 import type { dh } from '@deephaven/jsapi-types';
 import {
   createSearchTextFilter,
@@ -6,7 +7,6 @@ import {
 } from '@deephaven/jsapi-utils';
 import {
   SEARCH_DEBOUNCE_MS,
-  TABLE_ROW_HEIGHT,
   VIEWPORT_PADDING,
   VIEWPORT_SIZE,
 } from '@deephaven/utils';

--- a/packages/jsapi-components/src/useSearchableViewportData.ts
+++ b/packages/jsapi-components/src/useSearchableViewportData.ts
@@ -5,11 +5,6 @@ import {
   createSearchTextFilter,
   FilterConditionFactory,
 } from '@deephaven/jsapi-utils';
-import {
-  SEARCH_DEBOUNCE_MS,
-  VIEWPORT_PADDING,
-  VIEWPORT_SIZE,
-} from '@deephaven/utils';
 import { useDebouncedCallback } from '@deephaven/react-hooks';
 import { useTableUtils } from './useTableUtils';
 import useViewportData, {
@@ -18,6 +13,11 @@ import useViewportData, {
 } from './useViewportData';
 import useFilterConditionFactories from './useFilterConditionFactories';
 import useViewportFilter from './useViewportFilter';
+import {
+  SEARCH_DEBOUNCE_MS,
+  VIEWPORT_PADDING,
+  VIEWPORT_SIZE,
+} from './Constants';
 
 export interface UseSearchableViewportDataProps<TData>
   extends UseViewportDataProps<TData, dh.Table> {

--- a/packages/jsapi-components/src/useViewportData.test.tsx
+++ b/packages/jsapi-components/src/useViewportData.test.tsx
@@ -6,17 +6,15 @@ import {
   ViewportRow,
   generateEmptyKeyedItems,
   isClosed,
+  ITEM_KEY_PREFIX,
 } from '@deephaven/jsapi-utils';
 import { useOnScrollOffsetChangeCallback } from '@deephaven/react-hooks';
-import {
-  ITEM_KEY_PREFIX,
-  SCROLL_DEBOUNCE_MS,
-  TestUtils,
-} from '@deephaven/utils';
+import { TestUtils } from '@deephaven/utils';
 import useViewportData, { UseViewportDataProps } from './useViewportData';
 import { makeApiContextWrapper } from './HookTestUtils';
 import { useTableSize } from './useTableSize';
 import { useSetPaddedViewportCallback } from './useSetPaddedViewportCallback';
+import { SCROLL_DEBOUNCE_MS } from './Constants';
 
 jest.mock('@deephaven/react-hooks', () => ({
   ...jest.requireActual('@deephaven/react-hooks'),

--- a/packages/jsapi-components/src/useViewportData.ts
+++ b/packages/jsapi-components/src/useViewportData.ts
@@ -13,11 +13,12 @@ import {
   useOnScrollOffsetChangeCallback,
   WindowedListData,
 } from '@deephaven/react-hooks';
-import { KeyedItem, SCROLL_DEBOUNCE_MS } from '@deephaven/utils';
+import { KeyedItem } from '@deephaven/utils';
 import useInitializeViewportData from './useInitializeViewportData';
 import useSetPaddedViewportCallback from './useSetPaddedViewportCallback';
 import useTableSize from './useTableSize';
 import useTableListener from './useTableListener';
+import { SCROLL_DEBOUNCE_MS } from './Constants';
 
 const log = Log.module('useViewportData');
 

--- a/packages/jsapi-utils/src/ViewportDataUtils.test.ts
+++ b/packages/jsapi-utils/src/ViewportDataUtils.test.ts
@@ -1,7 +1,8 @@
 import { act } from '@testing-library/react-hooks';
 import { dh } from '@deephaven/jsapi-types';
-import { ITEM_KEY_PREFIX, TestUtils } from '@deephaven/utils';
+import { TestUtils } from '@deephaven/utils';
 import {
+  ITEM_KEY_PREFIX,
   OnTableUpdatedEvent,
   RowDeserializer,
   ViewportRow,

--- a/packages/jsapi-utils/src/ViewportDataUtils.ts
+++ b/packages/jsapi-utils/src/ViewportDataUtils.ts
@@ -2,7 +2,9 @@ import type { Key } from 'react';
 import clamp from 'lodash.clamp';
 import type { dh } from '@deephaven/jsapi-types';
 import Log from '@deephaven/log';
-import { ITEM_KEY_PREFIX, KeyedItem, ValueOf } from '@deephaven/utils';
+import { KeyedItem, ValueOf } from '@deephaven/utils';
+
+export const ITEM_KEY_PREFIX = 'DH_ITEM_KEY';
 
 export type OnTableUpdatedEvent = CustomEvent<{
   offset: number;

--- a/packages/react-hooks/src/useSpectrumDisableSpellcheckRef.test.ts
+++ b/packages/react-hooks/src/useSpectrumDisableSpellcheckRef.test.ts
@@ -1,8 +1,11 @@
 import { renderHook } from '@testing-library/react-hooks';
 import { DOMRefValue } from '@react-types/shared';
-import { SPELLCHECK_FALSE_ATTRIBUTE, TestUtils } from '@deephaven/utils';
+import { TestUtils } from '@deephaven/utils';
 import useSetAttributesCallback from './useSetAttributesCallback';
-import useSpectrumDisableSpellcheckRef from './useSpectrumDisableSpellcheckRef';
+import {
+  SPELLCHECK_FALSE_ATTRIBUTE,
+  useSpectrumDisableSpellcheckRef,
+} from './useSpectrumDisableSpellcheckRef';
 
 jest.mock('./useSetAttributesCallback');
 

--- a/packages/react-hooks/src/useSpectrumDisableSpellcheckRef.ts
+++ b/packages/react-hooks/src/useSpectrumDisableSpellcheckRef.ts
@@ -1,8 +1,9 @@
-import { SPELLCHECK_FALSE_ATTRIBUTE } from '@deephaven/utils';
 import type { DOMRefValue } from '@react-types/shared';
 import { extractSpectrumHTMLElement } from './SpectrumUtils';
 import useMappedRef from './useMappedRef';
 import useSetAttributesCallback from './useSetAttributesCallback';
+
+export const SPELLCHECK_FALSE_ATTRIBUTE = { spellCheck: false } as const;
 
 /**
  * Returns a callback ref that can be assigned to a React Spectrum component.

--- a/packages/utils/src/UIConstants.ts
+++ b/packages/utils/src/UIConstants.ts
@@ -1,10 +1,3 @@
-export const ITEM_KEY_PREFIX = 'DH_ITEM_KEY';
-export const SCROLL_DEBOUNCE_MS = 150;
-export const SEARCH_DEBOUNCE_MS = 200;
-export const SPELLCHECK_FALSE_ATTRIBUTE = { spellCheck: false } as const;
-export const VIEWPORT_PADDING = 250;
-export const VIEWPORT_SIZE = 500;
-
 /** @deprecated Use `ACTION_ICON_HEIGHT` from `@deephaven/components` instead. */
 export const ACTION_ICON_HEIGHT = 24;
 
@@ -37,3 +30,18 @@ export const PICKER_TOP_OFFSET = 4;
 
 /** @deprecated Use `TABLE_ROW_HEIGHT` from `@deephaven/components` instead. */
 export const TABLE_ROW_HEIGHT = 33;
+
+/** @deprecated Use `SCROLL_DEBOUNCE_MS` from `@deephaven/jsapi-components` instead. */
+export const SCROLL_DEBOUNCE_MS = 150;
+/** @deprecated Use `SEARCH_DEBOUNCE_MS` from `@deephaven/jsapi-components` instead. */
+export const SEARCH_DEBOUNCE_MS = 200;
+/** @deprecated Use `VIEWPORT_PADDING` from `@deephaven/jsapi-components` instead. */
+export const VIEWPORT_PADDING = 250;
+/** @deprecated Use `VIEWPORT_SIZE` from `@deephaven/jsapi-components` instead. */
+export const VIEWPORT_SIZE = 500;
+
+/** @deprecated Use `ITEM_KEY_PREFIX` from `@deephaven/jsapi-utils` instead. */
+export const ITEM_KEY_PREFIX = 'DH_ITEM_KEY';
+
+/** @deprecated Use `SPELLCHECK_FALSE_ATTRIBUTE` from `@deephaven/react-hooks` instead. */
+export const SPELLCHECK_FALSE_ATTRIBUTE = { spellCheck: false } as const;

--- a/packages/utils/src/UIConstants.ts
+++ b/packages/utils/src/UIConstants.ts
@@ -1,19 +1,14 @@
-export const ACTION_ICON_HEIGHT = 24;
 export const ITEM_KEY_PREFIX = 'DH_ITEM_KEY';
-// https://github.com/adobe/react-spectrum/blob/main/packages/%40react-spectrum/listbox/src/ListBoxBase.tsx#L56
-export const PICKER_ITEM_HEIGHTS = {
-  medium: 32,
-  large: 48,
-} as const;
-export const PICKER_TOP_OFFSET = 4;
-export const TABLE_ROW_HEIGHT = 33;
 export const SCROLL_DEBOUNCE_MS = 150;
 export const SEARCH_DEBOUNCE_MS = 200;
-export const VIEWPORT_SIZE = 500;
-export const VIEWPORT_PADDING = 250;
-
 export const SPELLCHECK_FALSE_ATTRIBUTE = { spellCheck: false } as const;
+export const VIEWPORT_PADDING = 250;
+export const VIEWPORT_SIZE = 500;
 
+/** @deprecated Use `ACTION_ICON_HEIGHT` from `@deephaven/components` instead. */
+export const ACTION_ICON_HEIGHT = 24;
+
+/** @deprecated Use `LIST_VIEW_ROW_HEIGHTS` from `@deephaven/components` instead. */
 // Copied from https://github.com/adobe/react-spectrum/blob/b2d25ef23b827ec2427bf47b343e6dbd66326ed3/packages/%40react-spectrum/list/src/ListView.tsx#L78
 export const LIST_VIEW_ROW_HEIGHTS = {
   compact: {
@@ -29,3 +24,16 @@ export const LIST_VIEW_ROW_HEIGHTS = {
     large: 60,
   },
 } as const;
+
+/** @deprecated Use `PICKER_ITEM_HEIGHTS` from `@deephaven/components` instead. */
+// https://github.com/adobe/react-spectrum/blob/main/packages/%40react-spectrum/listbox/src/ListBoxBase.tsx#L56
+export const PICKER_ITEM_HEIGHTS = {
+  medium: 32,
+  large: 48,
+} as const;
+
+/** @deprecated Use `PICKER_TOP_OFFSET` from `@deephaven/components` instead. */
+export const PICKER_TOP_OFFSET = 4;
+
+/** @deprecated Use `TABLE_ROW_HEIGHT` from `@deephaven/components` instead. */
+export const TABLE_ROW_HEIGHT = 33;


### PR DESCRIPTION
- Moved some UI constants to @deephaven/components and deprecated the current ones
- Added `displayName` to Picker and ComboBox to fix unit test React key warnings

resolves #1973