### PR TITLE
fix: Console error when opening context menu on tree table (#2047)

### DIFF
--- a/packages/iris-grid/src/IrisGridTreeTableModel.ts
+++ b/packages/iris-grid/src/IrisGridTreeTableModel.ts
@@ -185,15 +185,16 @@ class IrisGridTreeTableModel extends IrisGridTableModelTemplate<
           this.viewportData.rows[r - this.viewportData.offset];
         assertNotNull(intersection.startColumn);
         assertNotNull(intersection.endColumn);
-        for (
-          let c = intersection.startColumn;
-          c <= intersection.endColumn;
-          c += 1
-        ) {
-          assertNotNull(formatValue);
-          resultRow.push(
-            formatValue(viewportRow.data.get(c)?.value, this.columns[c])
-          );
+        if (formatValue != null) {
+          for (
+            let c = intersection.startColumn;
+            c <= intersection.endColumn;
+            c += 1
+          ) {
+            resultRow.push(
+              formatValue(viewportRow.data.get(c)?.value, this.columns[c])
+            );
+          }
         }
         result.push(resultRow);
       }


### PR DESCRIPTION
Resolves https://github.com/deephaven/web-client-ui/issues/2029

**Changes Implemented:** 
- Added null check when call formatValue function, to ensure that it is only called when it is defined