### PR TITLE
feat: Add option to disable WebGL rendering (#2134)

### DIFF
--- a/packages/chart/src/ChartModel.ts
+++ b/packages/chart/src/ChartModel.ts
@@ -7,6 +7,12 @@ import type { Layout, Data } from 'plotly.js';
 import { FilterColumnMap, FilterMap } from './ChartUtils';
 
 export type ChartEvent = CustomEvent;
+
+export type RenderOptions = {
+  /** Allow WebGL as an option. Defaults to `true`, explicitly set to `false` to disable. */
+  webgl?: boolean;
+};
+
 /**
  * Model for a Chart
  * All of these methods should return very quickly.
@@ -41,7 +47,10 @@ class ChartModel {
 
   listeners: ((event: ChartEvent) => void)[];
 
+  /** Formatter settings for the chart, such as how to format dates and numbers */
   formatter?: Formatter;
+
+  renderOptions?: RenderOptions;
 
   rect?: DOMRect;
 
@@ -84,6 +93,14 @@ class ChartModel {
    */
   setFormatter(formatter: Formatter): void {
     this.formatter = formatter;
+  }
+
+  /**
+   * Set additional options for rendering the chart
+   * @param renderOptions Options for rendering the chart
+   */
+  setRenderOptions(renderOptions: RenderOptions): void {
+    this.renderOptions = renderOptions;
   }
 
   /**

--- a/packages/chart/src/ChartUtils.ts
+++ b/packages/chart/src/ChartUtils.ts
@@ -681,17 +681,22 @@ class ChartUtils {
    * Converts the Iris plot style into a plotly chart type
    * @param plotStyle The plotStyle to use, see dh.plot.SeriesPlotStyle
    * @param isBusinessTime If the plot is using business time for an axis
+   * @param allowWebGL If WebGL is allowedd
    */
   getPlotlyChartType(
     plotStyle: DhType.plot.SeriesPlotStyle,
-    isBusinessTime: boolean
+    isBusinessTime: boolean,
+    allowWebGL = true
   ): PlotType | undefined {
     const { dh } = this;
     switch (plotStyle) {
       case dh.plot.SeriesPlotStyle.SCATTER:
       case dh.plot.SeriesPlotStyle.LINE:
-        // scattergl mode is more performant, but doesn't support the rangebreaks we need for businessTime calendars
-        return !isBusinessTime && IS_WEBGL_SUPPORTED ? 'scattergl' : 'scatter';
+        // scattergl mode is more performant (usually), but doesn't support the rangebreaks we need for businessTime calendars
+        // In some cases, WebGL is less performant (like in virtual desktop environments), so we also allow the option of the user explicitly disabling it even if it's supported
+        return !isBusinessTime && IS_WEBGL_SUPPORTED && allowWebGL
+          ? 'scattergl'
+          : 'scatter';
       case dh.plot.SeriesPlotStyle.BAR:
       case dh.plot.SeriesPlotStyle.STACKED_BAR:
         return 'bar';
@@ -871,7 +876,8 @@ class ChartUtils {
     series: DhType.plot.Series,
     axisTypeMap: AxisTypeMap,
     seriesVisibility: boolean | 'legendonly',
-    showLegend: boolean | null = null
+    showLegend: boolean | null = null,
+    allowWebGL = true
   ): Partial<PlotData> {
     const {
       name,
@@ -888,7 +894,7 @@ class ChartUtils {
     const isBusinessTime = sources.some(
       source => source.axis?.businessCalendar
     );
-    const type = this.getChartType(plotStyle, isBusinessTime);
+    const type = this.getChartType(plotStyle, isBusinessTime, allowWebGL);
     const mode = this.getPlotlyChartMode(
       plotStyle,
       isLinesVisible ?? undefined,
@@ -1019,7 +1025,8 @@ class ChartUtils {
 
   getChartType(
     plotStyle: DhType.plot.SeriesPlotStyle,
-    isBusinessTime: boolean
+    isBusinessTime: boolean,
+    allowWebGL = true
   ): PlotType | undefined {
     const { dh } = this;
     switch (plotStyle) {
@@ -1028,7 +1035,7 @@ class ChartUtils {
         // plot.ly to calculate the bins and sum values, just convert it to a bar chart
         return 'bar';
       default:
-        return this.getPlotlyChartType(plotStyle, isBusinessTime);
+        return this.getPlotlyChartType(plotStyle, isBusinessTime, allowWebGL);
     }
   }
 

--- a/packages/chart/src/FigureChartModel.ts
+++ b/packages/chart/src/FigureChartModel.ts
@@ -17,7 +17,7 @@ import type {
   DateTimeColumnFormatter,
   Formatter,
 } from '@deephaven/jsapi-utils';
-import ChartModel, { ChartEvent } from './ChartModel';
+import ChartModel, { ChartEvent, RenderOptions } from './ChartModel';
 import ChartUtils, {
   AxisTypeMap,
   ChartModelSettings,
@@ -219,7 +219,8 @@ class FigureChartModel extends ChartModel {
       series,
       axisTypeMap,
       ChartUtils.getSeriesVisibility(series.name, this.settings),
-      showLegend
+      showLegend,
+      this.renderOptions?.webgl ?? true
     );
 
     this.seriesDataMap.set(series.name, seriesData);
@@ -533,6 +534,13 @@ class FigureChartModel extends ChartModel {
     // Unsubscribe and resubscribe to trigger a data update
     // Data may need to be translated again because of the new formatter
     this.resubscribe();
+  }
+
+  setRenderOptions(renderOptions: RenderOptions): void {
+    super.setRenderOptions(renderOptions);
+
+    // Reset all the series to re-render them with the correct rendering options
+    this.initAllSeries();
   }
 
   setDownsamplingDisabled(isDownsamplingDisabled: boolean): void {

--- a/packages/code-studio/src/settings/AdvancedSectionContent.tsx
+++ b/packages/code-studio/src/settings/AdvancedSectionContent.tsx
@@ -1,0 +1,66 @@
+import React, { useCallback } from 'react';
+import { useDispatch } from 'react-redux';
+import {
+  Content,
+  ContextualHelp,
+  Heading,
+  Switch,
+  Text,
+} from '@deephaven/components';
+import { getWebGL, getWebGLEditable, updateSettings } from '@deephaven/redux';
+import { useAppSelector } from '@deephaven/dashboard';
+
+function AdvancedSectionContent(): JSX.Element {
+  const dispatch = useDispatch();
+  const webgl = useAppSelector(getWebGL);
+  const webglEditable = useAppSelector(getWebGLEditable);
+
+  const handleWebglChange = useCallback(
+    newValue => {
+      dispatch(updateSettings({ webgl: newValue }));
+    },
+    [dispatch]
+  );
+
+  const helpText = webglEditable ? (
+    <Text>
+      WebGL in most cases has significant performance improvements, particularly
+      when plotting large datasets. However, in some environments (such as
+      remote desktop environments), WebGL may not use hardware acceleration and
+      have degraded performance. If you are experiencing issues with WebGL, you
+      can disable it here.
+    </Text>
+  ) : (
+    <Text>
+      WebGL is disabled by your system administrator. Contact your system
+      administrator to enable.
+    </Text>
+  );
+
+  return (
+    <>
+      <div className="app-settings-menu-description">
+        Advanced settings here. Be careful!
+      </div>
+
+      <div className="form-row mb-3 pl-1">
+        <Switch
+          isSelected={webgl}
+          isDisabled={!webglEditable}
+          onChange={handleWebglChange}
+          marginEnd="size-0"
+        >
+          Enable WebGL
+        </Switch>
+        <ContextualHelp variant="info" marginTop="size-50">
+          <Heading>Enable WebGL</Heading>
+          <Content>
+            <Text>{helpText}</Text>
+          </Content>
+        </ContextualHelp>
+      </div>
+    </>
+  );
+}
+
+export default AdvancedSectionContent;

--- a/packages/code-studio/src/settings/SettingsMenu.tsx
+++ b/packages/code-studio/src/settings/SettingsMenu.tsx
@@ -9,6 +9,7 @@ import {
   vsPaintcan,
   dhUserIncognito,
   dhUser,
+  vsTools,
 } from '@deephaven/icons';
 import {
   Button,
@@ -38,6 +39,7 @@ import {
   getFormattedPluginInfo,
   getFormattedVersionInfo,
 } from './SettingsUtils';
+import AdvancedSectionContent from './AdvancedSectionContent';
 
 interface SettingsMenuProps {
   serverConfigValues: ServerConfigValues;
@@ -67,6 +69,8 @@ export class SettingsMenu extends Component<
   static SHORTCUT_SECTION_KEY = 'SettingsMenu.shortcuts';
 
   static THEME_SECTION_KEY = 'SettingsMenu.theme';
+
+  static ADVANCED_SECTION_KEY = 'SettingsMenu.advanced';
 
   static focusFirstInputInContainer(container: HTMLDivElement | null): void {
     const input = container?.querySelector('input, select, textarea');
@@ -289,13 +293,36 @@ export class SettingsMenu extends Component<
             )}
             title={
               <>
-                <FontAwesomeIcon icon={vsRecordKeys} transform="grow-2" />{' '}
+                <FontAwesomeIcon
+                  icon={vsRecordKeys}
+                  transform="grow-2"
+                  className="mr-2"
+                />
                 Keyboard Shortcuts
               </>
             }
             onToggle={this.handleSectionToggle}
           >
             <ShortcutSectionContent />
+          </SettingsMenuSection>
+          <SettingsMenuSection
+            sectionKey={SettingsMenu.ADVANCED_SECTION_KEY}
+            isExpanded={this.isSectionExpanded(
+              SettingsMenu.ADVANCED_SECTION_KEY
+            )}
+            title={
+              <>
+                <FontAwesomeIcon
+                  icon={vsTools}
+                  transform="grow-4"
+                  className="mr-2"
+                />
+                Advanced
+              </>
+            }
+            onToggle={this.handleSectionToggle}
+          >
+            <AdvancedSectionContent />
           </SettingsMenuSection>
 
           <div className="app-settings-footer">

--- a/packages/code-studio/src/storage/LocalWorkspaceStorage.ts
+++ b/packages/code-studio/src/storage/LocalWorkspaceStorage.ts
@@ -59,6 +59,8 @@ export class LocalWorkspaceStorage implements WorkspaceStorage {
       defaultNotebookSettings: {
         isMinimapEnabled: false,
       },
+      webgl: true,
+      webglEditable: true,
     };
     const serverSettings = {
       defaultDateTimeFormat: serverConfigValues?.get('dateTimeFormat'),
@@ -109,6 +111,14 @@ export class LocalWorkspaceStorage implements WorkspaceStorage {
               ) as boolean,
             }
           : undefined,
+      webgl: LocalWorkspaceStorage.getBooleanServerConfig(
+        serverConfigValues,
+        'web.webgl'
+      ),
+      webglEditable: LocalWorkspaceStorage.getBooleanServerConfig(
+        serverConfigValues,
+        'web.webgl.editable'
+      ),
     };
 
     const keys = Object.keys(serverSettings) as Array<keyof typeof settings>;

--- a/packages/components/src/theme/theme-dark/theme-dark-components.css
+++ b/packages/components/src/theme/theme-dark/theme-dark-components.css
@@ -166,4 +166,7 @@
     var(--dh-color-visual-gray) 5%,
     transparent
   );
+
+  /* Switch */
+  --dh-toggle-switch-bg: var(--dh-color-gray-500);
 }

--- a/packages/components/src/theme/theme-light/theme-light-components.css
+++ b/packages/components/src/theme/theme-light/theme-light-components.css
@@ -162,4 +162,7 @@
     var(--dh-color-visual-gray) 5%,
     transparent
   );
+
+  /* Switch */
+  --dh-toggle-switch-bg: var(--dh-color-gray-400);
 }

--- a/packages/components/src/theme/theme-spectrum/theme-spectrum-overrides.css
+++ b/packages/components/src/theme/theme-spectrum/theme-spectrum-overrides.css
@@ -86,3 +86,8 @@ span[class*='spectrum-Radio-label'] {
    */
   margin-top: var(--spectrum-global-dimension-size-85);
 }
+
+span[class*='spectrum-ToggleSwitch-switch'] {
+  /* increase contrast of switch in off position */
+  background: var(--dh-toggle-switch-bg);
+}

--- a/packages/dashboard/src/redux/selectors.ts
+++ b/packages/dashboard/src/redux/selectors.ts
@@ -1,9 +1,17 @@
 import {
+  AppStore,
   DashboardData,
   PluginData,
   PluginDataMap,
+  RootDispatch,
   RootState,
 } from '@deephaven/redux';
+import {
+  TypedUseSelectorHook,
+  useDispatch,
+  useSelector,
+  useStore,
+} from 'react-redux';
 import { ClosedPanels, OpenedPanelMap } from '../PanelManager';
 
 const EMPTY_MAP = new Map();
@@ -13,6 +21,13 @@ const EMPTY_OBJECT = Object.freeze({});
 const EMPTY_ARRAY = Object.freeze([]);
 
 type Selector<R> = (state: RootState) => R;
+
+// https://react-redux.js.org/using-react-redux/usage-with-typescript#define-typed-hooks
+// Defined in @deephaven/dashboard, as that's the most common package with React and @deephaven/redux as dependencies
+// We could have another package specifically for this, but it's not really necessary.
+export const useAppDispatch: () => RootDispatch = useDispatch;
+export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector;
+export const useAppStore: () => AppStore = useStore;
 
 /**
  * Retrieve the data for all dashboards

--- a/packages/jsapi-utils/src/Settings.ts
+++ b/packages/jsapi-utils/src/Settings.ts
@@ -26,6 +26,8 @@ export interface NumberFormatSettings {
 export interface Settings
   extends ColumnFormatSettings,
     DateTimeFormatSettings,
-    NumberFormatSettings {}
+    NumberFormatSettings {
+  webgl?: boolean;
+}
 
 export default Settings;

--- a/packages/redux/src/selectors.ts
+++ b/packages/redux/src/selectors.ts
@@ -138,6 +138,14 @@ export const getShortcutOverrides = <State extends RootState>(
   store: State
 ): Settings<State>['shortcutOverrides'] => getSettings(store).shortcutOverrides;
 
+export const getWebGL = <State extends RootState>(
+  store: State
+): Settings<State>['webgl'] => getSettings(store).webgl;
+
+export const getWebGLEditable = <State extends RootState>(
+  store: State
+): Settings<State>['webglEditable'] => getSettings(store).webglEditable;
+
 export const getDefaultNotebookSettings = <State extends RootState>(
   store: State
 ): Settings<State>['defaultNotebookSettings'] =>

--- a/packages/redux/src/store.ts
+++ b/packages/redux/src/store.ts
@@ -57,6 +57,8 @@ export interface WorkspaceSettings {
   defaultNotebookSettings: {
     isMinimapEnabled?: boolean;
   };
+  webgl: boolean;
+  webglEditable: boolean;
 }
 
 export interface WorkspaceData {
@@ -138,6 +140,8 @@ reducerRegistry.setListener(newReducers => {
   store.replaceReducer(combineReducers(newReducers));
 });
 
-export default store;
+export type AppStore = typeof store;
 
 export type RootDispatch = typeof store.dispatch;
+
+export default store;


### PR DESCRIPTION
- Cherry-picked from 011eb33b067412ffb6362237c9f6dc7256476bcd
- Advanced Settings section in the Settings menu, with an option to disable WebGL
- Read from the server config for default values
  - web.webgl: default setting for WebGL being enabled or not
  - web.webgl.editable: disallow the user from enabling WebGL
- Contextual Help item to add more info
- Tested by adding the following to the deephaven.prop config:
```
web.webgl=false
web.webgl.editable=false
client.configuration.list=java.version,deephaven.version,barrage.version,http.session.durationMs,file.separator,web.storage.layout.directory,web.storage.notebook.directory,web.webgl,web.webgl.editable
```
---------