### PR TITLE
feat: Add functions for PanelEvent.OPEN

### DIFF
--- a/packages/code-studio/src/styleguide/StyleGuide.tsx
+++ b/packages/code-studio/src/styleguide/StyleGuide.tsx
@@ -135,14 +135,14 @@ function StyleGuide(): React.ReactElement {
         <Charts />
         <ContextMenuRoot />
         <RandomAreaPlotAnimation />
+        <ErrorViews />
+        <XComponents />
 
         <SampleMenuCategory data-menu-category="Spectrum Components" />
         <SpectrumComponents />
 
         <SampleMenuCategory data-menu-category="Spectrum Comparison" />
         <SpectrumComparison />
-        <XComponents />
-        <ErrorViews />
       </div>
     </div>
   );

--- a/packages/code-studio/src/styleguide/XComponents.tsx
+++ b/packages/code-studio/src/styleguide/XComponents.tsx
@@ -4,7 +4,6 @@ import {
   createXComponent,
   Button,
 } from '@deephaven/components';
-import { sampleSectionIdAndClasses } from './utils';
 import SampleSection from './SampleSection';
 
 type FooComponentProps = { value: string };

--- a/packages/code-studio/src/styleguide/XComponents.tsx
+++ b/packages/code-studio/src/styleguide/XComponents.tsx
@@ -5,6 +5,7 @@ import {
   Button,
 } from '@deephaven/components';
 import { sampleSectionIdAndClasses } from './utils';
+import SampleSection from './SampleSection';
 
 type FooComponentProps = { value: string };
 
@@ -51,8 +52,7 @@ export function XComponents(): JSX.Element {
   const [value, setValue] = useState('hello');
 
   return (
-    // eslint-disable-next-line react/jsx-props-no-spreading
-    <div {...sampleSectionIdAndClasses('xcomponents')}>
+    <SampleSection name="xcomponents">
       <h2 className="ui-title">XComponents</h2>
       <p>
         XComponents are a way to replace a component with another component
@@ -117,7 +117,7 @@ export function XComponents(): JSX.Element {
           </div>
         </div>
       </div>
-    </div>
+    </SampleSection>
   );
 }
 

--- a/packages/dashboard-core-plugins/src/WidgetLoaderPlugin.tsx
+++ b/packages/dashboard-core-plugins/src/WidgetLoaderPlugin.tsx
@@ -5,12 +5,11 @@ import {
   assertIsDashboardPluginProps,
   DashboardPluginComponentProps,
   DehydratedDashboardPanelProps,
-  PanelEvent,
   PanelOpenEventDetail,
   LayoutUtils,
-  useListener,
   PanelProps,
   canHaveRef,
+  usePanelOpenListener,
 } from '@deephaven/dashboard';
 import Log from '@deephaven/log';
 import {
@@ -162,7 +161,7 @@ export function WidgetLoaderPlugin(
   /**
    * Listen for panel open events so we know when to open a panel
    */
-  useListener(layout.eventHub, PanelEvent.OPEN, handlePanelOpen);
+  usePanelOpenListener(layout.eventHub, handlePanelOpen);
 
   return null;
 }

--- a/packages/dashboard-core-plugins/src/panels/ConsolePanel.tsx
+++ b/packages/dashboard-core-plugins/src/panels/ConsolePanel.tsx
@@ -14,6 +14,7 @@ import {
 } from '@deephaven/console';
 import {
   DashboardPanelProps,
+  emitPanelOpen,
   LayoutManagerContext,
   LayoutUtils,
   PanelEvent,
@@ -312,7 +313,7 @@ export class ConsolePanel extends PureComponent<
 
     log.debug('openWidget', openOptions);
 
-    glEventHub.emit(PanelEvent.OPEN, openOptions);
+    emitPanelOpen(glEventHub, openOptions);
   }
 
   addCommand(command: string, focus = true, execute = false): void {

--- a/packages/dashboard/src/DashboardPlugin.ts
+++ b/packages/dashboard/src/DashboardPlugin.ts
@@ -54,7 +54,7 @@ export type PanelComponentType<
   C extends ComponentType<P> = ComponentType<P>,
 > = (ComponentType<P> | WrappedComponentType<P, C>) & PanelStaticMetaData;
 
-export type PanelMetadata = Partial<WidgetDescriptor>;
+export type PanelMetadata = WidgetDescriptor;
 
 export type PanelProps = GLPanelProps & {
   metadata?: PanelMetadata;

--- a/packages/dashboard/src/PanelEvent.ts
+++ b/packages/dashboard/src/PanelEvent.ts
@@ -7,10 +7,13 @@ export type WidgetDescriptor = {
 };
 
 export type PanelOpenEventDetail<T = unknown> = {
-  /** Opening the widget was triggered by dragging from a list. The coordinates are used as the starting location for the drag.  */
+  /**
+   * Opening the widget was triggered by dragging from a list, such as the Panels dropdown.
+   * The coordinates are used as the starting location for the drag, where we will show the panel until the user drops it in the dashboard.
+   */
   dragEvent?: MouseEvent;
 
-  /** ID of this panel to use */
+  /** ID of the panel to re-use. Will replace any existing panel with this ID. Otherwise a new panel is opened with a randomly generated ID. */
   panelId?: string;
 
   /** Descriptor of the widget. */
@@ -75,6 +78,6 @@ export const {
   useListener: usePanelOpenListener,
 } = makeEventFunctions<PanelOpenEventDetail>(PanelEvent.OPEN);
 
-// TODO: Add the rest of the event functions here. Need to create the correct types for all of them.
+// TODO (#2147): Add the rest of the event functions here. Need to create the correct types for all of them.
 
 export default PanelEvent;

--- a/packages/dashboard/src/PanelEvent.ts
+++ b/packages/dashboard/src/PanelEvent.ts
@@ -1,4 +1,4 @@
-import { DragEvent } from 'react';
+import { makeEventFunctions } from '@deephaven/golden-layout';
 
 export type WidgetDescriptor = {
   type: string;
@@ -7,16 +7,26 @@ export type WidgetDescriptor = {
 };
 
 export type PanelOpenEventDetail<T = unknown> = {
-  dragEvent?: DragEvent;
-  fetch?: () => Promise<T>;
+  /** Opening the widget was triggered by dragging from a list. The coordinates are used as the starting location for the drag.  */
+  dragEvent?: MouseEvent;
+
+  /** ID of this panel to use */
   panelId?: string;
+
+  /** Descriptor of the widget. */
   widget: WidgetDescriptor;
+
+  /**
+   * Function to fetch the instance of the widget
+   * @deprecated Use `useWidget` hook with the `widget` descriptor instead
+   */
+  fetch?: () => Promise<T>;
 };
 
 /**
  * Events emitted by panels and to control panels
  */
-export default Object.freeze({
+export const PanelEvent = Object.freeze({
   // Panel has received focus
   FOCUS: 'PanelEvent.FOCUS',
 
@@ -58,3 +68,13 @@ export default Object.freeze({
   // Panel is dropped
   DROPPED: 'PanelEvent.DROPPED',
 });
+
+export const {
+  listen: listenForPanelOpen,
+  emit: emitPanelOpen,
+  useListener: usePanelOpenListener,
+} = makeEventFunctions<PanelOpenEventDetail>(PanelEvent.OPEN);
+
+// TODO: Add the rest of the event functions here. Need to create the correct types for all of them.
+
+export default PanelEvent;

--- a/packages/dashboard/src/index.ts
+++ b/packages/dashboard/src/index.ts
@@ -14,6 +14,5 @@ export * from './layout';
 export * from './redux';
 export * from './PanelManager';
 export * from './PanelEvent';
-export { default as PanelEvent } from './PanelEvent';
 export { default as PanelErrorBoundary } from './PanelErrorBoundary';
 export { default as PanelManager } from './PanelManager';

--- a/packages/dashboard/src/layout/LayoutUtils.ts
+++ b/packages/dashboard/src/layout/LayoutUtils.ts
@@ -1,4 +1,3 @@
-import { DragEvent } from 'react';
 import deepEqual from 'fast-deep-equal';
 import { nanoid } from 'nanoid';
 import isMatch from 'lodash.ismatch';
@@ -524,7 +523,7 @@ class LayoutUtils {
     replaceConfig?: Partial<ItemConfig>;
     createNewStack?: boolean;
     focusElement?: string;
-    dragEvent?: DragEvent;
+    dragEvent?: MouseEvent;
   } = {}): void {
     // attempt to retain focus after dom manipulation, which can break focus
     const maintainFocusElement = document.activeElement;

--- a/packages/dashboard/src/layout/useDashboardPanel.ts
+++ b/packages/dashboard/src/layout/useDashboardPanel.ts
@@ -9,9 +9,8 @@ import {
   PanelDehydrateFunction,
   PanelHydrateFunction,
 } from '../DashboardPlugin';
-import PanelEvent, { PanelOpenEventDetail } from '../PanelEvent';
+import { PanelOpenEventDetail, usePanelOpenListener } from '../PanelEvent';
 import LayoutUtils from './LayoutUtils';
-import useListener from './useListener';
 import usePanelRegistration from './usePanelRegistration';
 
 /**
@@ -88,7 +87,7 @@ export function useDashboardPanel<
   /**
    * Listen for panel open events so we know when to open a panel
    */
-  useListener(layout.eventHub, PanelEvent.OPEN, handlePanelOpen);
+  usePanelOpenListener(layout.eventHub, handlePanelOpen);
 }
 
 export default useDashboardPanel;

--- a/packages/embed-widget/src/App.tsx
+++ b/packages/embed-widget/src/App.tsx
@@ -27,12 +27,12 @@ import {
 import Log from '@deephaven/log';
 import { useDashboardPlugins } from '@deephaven/plugin';
 import {
-  PanelEvent,
   getAllDashboardsData,
   listenForCreateDashboard,
   CreateDashboardPayload,
   setDashboardPluginData,
   stopListenForCreateDashboard,
+  emitPanelOpen,
 } from '@deephaven/dashboard';
 import {
   getVariableDescriptor,
@@ -190,7 +190,7 @@ function App(): JSX.Element {
     }
 
     setHasEmittedWidget(true);
-    goldenLayout.eventHub.emit(PanelEvent.OPEN, {
+    emitPanelOpen(goldenLayout.eventHub, {
       fetch,
       widget: getVariableDescriptor(definition),
     });

--- a/packages/golden-layout/src/utils/EventUtils.test.ts
+++ b/packages/golden-layout/src/utils/EventUtils.test.ts
@@ -1,0 +1,43 @@
+import EventEmitter from './EventEmitter';
+import {
+  listenForEvent,
+  makeListenFunction,
+  makeEmitFunction,
+} from './EventUtils';
+
+describe('EventUtils', () => {
+  const eventEmitter = {
+    on: jest.fn(),
+    off: jest.fn(),
+    emit: jest.fn(),
+  } as unknown as EventEmitter;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('listenForEvent', () => {
+    const event = 'test';
+    const handler = jest.fn();
+    const remove = listenForEvent(eventEmitter, event, handler);
+    expect(eventEmitter.on).toHaveBeenCalledWith(event, handler);
+    remove();
+    expect(eventEmitter.off).toHaveBeenCalledWith(event, handler);
+  });
+
+  it('makeListenFunction', () => {
+    const event = 'test';
+    const listen = makeListenFunction(event);
+    const handler = jest.fn();
+    listen(eventEmitter, handler);
+    expect(eventEmitter.on).toHaveBeenCalledWith(event, handler);
+  });
+
+  it('makeEmitFunction', () => {
+    const event = 'test';
+    const emit = makeEmitFunction(event);
+    const payload = { test: 'test' };
+    emit(eventEmitter, payload);
+    expect(eventEmitter.emit).toHaveBeenCalledWith(event, payload);
+  });
+});

--- a/packages/golden-layout/src/utils/EventUtils.test.ts
+++ b/packages/golden-layout/src/utils/EventUtils.test.ts
@@ -1,16 +1,23 @@
+import { renderHook } from '@testing-library/react-hooks';
 import EventEmitter from './EventEmitter';
 import {
   listenForEvent,
   makeListenFunction,
   makeEmitFunction,
+  makeEventFunctions,
+  makeUseListenerFunction,
 } from './EventUtils';
 
-describe('EventUtils', () => {
-  const eventEmitter = {
+function makeEventEmitter(): EventEmitter {
+  return {
     on: jest.fn(),
     off: jest.fn(),
     emit: jest.fn(),
   } as unknown as EventEmitter;
+}
+
+describe('EventUtils', () => {
+  const eventEmitter = makeEventEmitter();
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -21,7 +28,10 @@ describe('EventUtils', () => {
     const handler = jest.fn();
     const remove = listenForEvent(eventEmitter, event, handler);
     expect(eventEmitter.on).toHaveBeenCalledWith(event, handler);
+    expect(eventEmitter.off).not.toHaveBeenCalled();
+    jest.clearAllMocks();
     remove();
+    expect(eventEmitter.on).not.toHaveBeenCalled();
     expect(eventEmitter.off).toHaveBeenCalledWith(event, handler);
   });
 
@@ -39,5 +49,90 @@ describe('EventUtils', () => {
     const payload = { test: 'test' };
     emit(eventEmitter, payload);
     expect(eventEmitter.emit).toHaveBeenCalledWith(event, payload);
+  });
+
+  describe('makeUseListenerFunction', () => {
+    it('adds listener on mount, removes on unmount', () => {
+      const event = 'test';
+      const useListener = makeUseListenerFunction(event);
+      const handler = jest.fn();
+      const { unmount } = renderHook(() => useListener(eventEmitter, handler));
+      expect(eventEmitter.on).toHaveBeenCalledWith(event, handler);
+      expect(eventEmitter.off).not.toHaveBeenCalled();
+      jest.clearAllMocks();
+      unmount();
+      expect(eventEmitter.on).not.toHaveBeenCalledWith(event, handler);
+      expect(eventEmitter.off).toHaveBeenCalledWith(event, handler);
+    });
+
+    it('adds listener on handler change, removes old listener', () => {
+      const event = 'test';
+      const useListener = makeUseListenerFunction(event);
+      const handler1 = jest.fn();
+      const handler2 = jest.fn();
+      const { rerender } = renderHook(
+        ({ handler }) => useListener(eventEmitter, handler),
+        { initialProps: { handler: handler1 } }
+      );
+      expect(eventEmitter.on).toHaveBeenCalledWith(event, handler1);
+      expect(eventEmitter.off).not.toHaveBeenCalled();
+      jest.clearAllMocks();
+      rerender({ handler: handler2 });
+      expect(eventEmitter.on).toHaveBeenCalledWith(event, handler2);
+      expect(eventEmitter.off).toHaveBeenCalledWith(event, handler1);
+    });
+
+    it('re-adds the listener on emitter change', () => {
+      const event = 'test';
+      const useListener = makeUseListenerFunction(event);
+      const handler = jest.fn();
+      const eventEmitter2 = makeEventEmitter();
+      const { rerender, unmount } = renderHook(
+        ({ eventEmitter, handler }) => useListener(eventEmitter, handler),
+        { initialProps: { eventEmitter, handler } }
+      );
+      expect(eventEmitter.on).toHaveBeenCalledWith(event, handler);
+      expect(eventEmitter.off).not.toHaveBeenCalled();
+      jest.clearAllMocks();
+      rerender({ eventEmitter: eventEmitter2, handler });
+      expect(eventEmitter.on).not.toHaveBeenCalled();
+      expect(eventEmitter.off).toHaveBeenCalledWith(event, handler);
+      expect(eventEmitter2.on).toHaveBeenCalledWith(event, handler);
+
+      jest.clearAllMocks();
+      unmount();
+      expect(eventEmitter.on).not.toHaveBeenCalled();
+      expect(eventEmitter.off).not.toHaveBeenCalled();
+      expect(eventEmitter2.on).not.toHaveBeenCalled();
+      expect(eventEmitter2.off).toHaveBeenCalledWith(event, handler);
+    });
+  });
+
+  describe('makeEventFunctions', () => {
+    const event = 'test';
+    const { listen, emit, useListener } = makeEventFunctions(event);
+    const handler = jest.fn();
+
+    it('listen', () => {
+      listen(eventEmitter, handler);
+      expect(eventEmitter.on).toHaveBeenCalledWith(event, handler);
+      expect(eventEmitter.off).not.toHaveBeenCalled();
+    });
+
+    it('emit', () => {
+      const payload = { test: 'test' };
+      emit(eventEmitter, payload);
+      expect(eventEmitter.emit).toHaveBeenCalledWith(event, payload);
+    });
+
+    it('useListener', () => {
+      const { unmount } = renderHook(() => useListener(eventEmitter, handler));
+      expect(eventEmitter.on).toHaveBeenCalledWith(event, handler);
+      expect(eventEmitter.off).not.toHaveBeenCalled();
+      jest.clearAllMocks();
+      unmount();
+      expect(eventEmitter.on).not.toHaveBeenCalledWith(event, handler);
+      expect(eventEmitter.off).toHaveBeenCalledWith(event, handler);
+    });
   });
 });

--- a/packages/golden-layout/src/utils/EventUtils.ts
+++ b/packages/golden-layout/src/utils/EventUtils.ts
@@ -1,0 +1,79 @@
+import EventEmitter from './EventEmitter';
+import { useEffect } from 'react';
+
+export type EventListenerRemover = () => void;
+export type EventListenFunction<TPayload = unknown> = (
+  eventEmitter: EventEmitter,
+  handler: (p: TPayload) => void
+) => EventListenerRemover;
+
+export type EventEmitFunction<TPayload = unknown> = (
+  eventEmitter: EventEmitter,
+  payload: TPayload
+) => void;
+
+export type EventListenerHook<TPayload = unknown> = (
+  eventEmitter: EventEmitter,
+  handler: (p: TPayload) => void
+) => void;
+
+/**
+ * Listen for an event
+ * @param eventEmitter The event emitter to listen to
+ * @param event The event to listen for
+ * @param handler The handler to call when the event is emitted
+ * @returns A function to stop listening for the event
+ */
+export function listenForEvent<TPayload>(
+  eventEmitter: EventEmitter,
+  event: string,
+  handler: (p: TPayload) => void
+): EventListenerRemover {
+  eventEmitter.on(event, handler);
+  return () => {
+    eventEmitter.off(event, handler);
+  };
+}
+
+export function makeListenFunction<TPayload>(
+  event: string
+): EventListenFunction<TPayload> {
+  return (eventEmitter, handler) =>
+    listenForEvent(eventEmitter, event, handler);
+}
+
+export function makeEmitFunction<TPayload>(
+  event: string
+): EventEmitFunction<TPayload> {
+  return (eventEmitter, payload) => {
+    eventEmitter.emit(event, payload);
+  };
+}
+
+export function makeUseListenerFunction<TPayload>(
+  event: string
+): EventListenerHook<TPayload> {
+  return (eventEmitter, handler) => {
+    useEffect(
+      () => listenForEvent(eventEmitter, event, handler),
+      [eventEmitter, handler]
+    );
+  };
+}
+
+/**
+ * Create listener, emitter, and hook functions for an event
+ * @param event Name of the event to create functions for
+ * @returns Listener, Emitter, and Hook functions for the event
+ */
+export function makeEventFunctions<TPayload>(event: string): {
+  listen: EventListenFunction<TPayload>;
+  emit: EventEmitFunction<TPayload>;
+  useListener: EventListenerHook<TPayload>;
+} {
+  return {
+    listen: makeListenFunction<TPayload>(event),
+    emit: makeEmitFunction<TPayload>(event),
+    useListener: makeUseListenerFunction<TPayload>(event),
+  };
+}

--- a/packages/golden-layout/src/utils/index.ts
+++ b/packages/golden-layout/src/utils/index.ts
@@ -6,3 +6,4 @@ export { default as ReactComponentHandler } from './ReactComponentHandler';
 export * from './ConfigMinifier';
 export { default as BubblingEvent } from './BubblingEvent';
 export { default as EventHub } from './EventHub';
+export * from './EventUtils';

--- a/tests/styleguide.spec.ts
+++ b/tests/styleguide.spec.ts
@@ -38,13 +38,14 @@ const sampleSectionIds: string[] = [
   'sample-section-grids-tree',
   'sample-section-grids-iris',
   'sample-section-charts',
+  'sample-section-error-views',
+  'sample-section-xcomponents',
   'sample-section-spectrum-buttons',
   'sample-section-spectrum-collections',
   'sample-section-spectrum-content',
   'sample-section-spectrum-forms',
   'sample-section-spectrum-overlays',
   'sample-section-spectrum-well',
-  'sample-section-error-views',
 ];
 const buttonSectionIds: string[] = [
   'sample-section-buttons-regular',


### PR DESCRIPTION
- Instead of using PanelEvent.OPEN directly and not getting any type safety, add functions for emitting, listening, and a hook to enforce type safety
- Add xcomponents to the styleguide