### PR TITLE
fix: error when edited cell is out of grid viewport

### DIFF
--- a/packages/grid/src/Grid.tsx
+++ b/packages/grid/src/Grid.tsx
@@ -2167,15 +2167,25 @@ class Grid extends PureComponent<GridProps, GridState> {
           }
         : { opacity: 0 };
 
-    const modelColumn = this.getModelColumn(column);
-    const modelRow = this.getModelRow(row);
+    let modelColumn;
+    let modelRow;
+    try {
+      modelColumn = this.getModelColumn(column);
+      modelRow = this.getModelRow(row);
+    } catch (e) {
+      // eslint-disable-next-line no-console
+      return null;
+    }
     const inputStyle: CSSProperties | undefined =
       modelColumn != null && modelRow != null
         ? {
             textAlign: model.textAlignForCell(modelColumn, modelRow),
           }
         : undefined;
-    const isValid = model.isValidForCell(modelColumn, modelRow, value);
+    const isValid =
+      modelColumn != null && modelRow != null
+        ? model.isValidForCell(modelColumn, modelRow, value)
+        : false;
 
     return (
       <div style={wrapperStyle}>

--- a/packages/grid/src/Grid.tsx
+++ b/packages/grid/src/Grid.tsx
@@ -2173,7 +2173,6 @@ class Grid extends PureComponent<GridProps, GridState> {
       modelColumn = this.getModelColumn(column);
       modelRow = this.getModelRow(row);
     } catch (e) {
-      // eslint-disable-next-line no-console
       return null;
     }
     const inputStyle: CSSProperties | undefined =

--- a/packages/iris-grid/src/IrisGrid.tsx
+++ b/packages/iris-grid/src/IrisGrid.tsx
@@ -1487,9 +1487,6 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
     return columnIndex != null ? modelColumns.get(columnIndex) : null;
   }
 
-  // the error is switching between row and column being defined
-  // this is because the metrics does not include the value?
-
   getModelRow(rowIndex: GridRangeIndex): ModelIndex | null | undefined {
     const { metrics } = this.state;
     assertNotNull(metrics);

--- a/packages/iris-grid/src/IrisGrid.tsx
+++ b/packages/iris-grid/src/IrisGrid.tsx
@@ -1487,6 +1487,9 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
     return columnIndex != null ? modelColumns.get(columnIndex) : null;
   }
 
+  // the error is switching between row and column being defined
+  // this is because the metrics does not include the value?
+
   getModelRow(rowIndex: GridRangeIndex): ModelIndex | null | undefined {
     const { metrics } = this.state;
     assertNotNull(metrics);


### PR DESCRIPTION
Resolves #2087 

**Steps Moving Forward:**
- Clarify whether we want to be able to **handle edits that are not in the current viewport** -- with my understanding, this will mean we will have to load in more grid data, which does not seem overly valuable (in terms of the efficiency tradeoff) since we are dealing with an improbable edge case where the user begins to edit in the viewport, continues editing outside of the viewport where the cell originally was, and then wants to commit those changes outside as well

** A better solution for the edge case above IMO  is to **create a new enhancement ticket** where we attempt to have the editing cell be floating/sticky in the grid viewport, similar to how it is done on Google Sheets **

**_Ticket Created:_** https://github.com/deephaven/web-client-ui/issues/2153

<img width="276" alt="Screenshot 2024-07-16 at 10 37 02 AM" src="https://github.com/user-attachments/assets/a5dd6e6e-5f91-4625-b225-ddfc46d5ea89">
