### PR TITLE
fix: Enabled @typescript-eslint/return-await rule and fixed offending code

### DIFF
--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -96,6 +96,10 @@ module.exports = {
         '@typescript-eslint/default-param-last': ['error'],
         '@typescript-eslint/explicit-module-boundary-types': 'error',
         '@typescript-eslint/method-signature-style': 'error',
+        // `no-return-await` needs to be disabled when enabling `@typescript-eslint/return-await`
+        // to avoid incorrectly reporting errors
+        'no-return-await': 'off',
+        '@typescript-eslint/return-await': 'error',
       },
     },
     {

--- a/packages/iris-grid/src/IrisGridTableModelTemplate.ts
+++ b/packages/iris-grid/src/IrisGridTableModelTemplate.ts
@@ -1528,7 +1528,9 @@ class IrisGridTableModelTemplate<
       table = await this.table.copy();
       table.applyFilter([]);
       table.applySort([]);
-      return table.selectDistinct(Array.isArray(columns) ? columns : [columns]);
+      return await table.selectDistinct(
+        Array.isArray(columns) ? columns : [columns]
+      );
     } finally {
       if (table != null) {
         table.close();

--- a/packages/utils/src/ClipboardUtils.test.ts
+++ b/packages/utils/src/ClipboardUtils.test.ts
@@ -10,7 +10,7 @@ describe('Clipboard', () => {
       Object.assign(navigator, {
         clipboard: {
           // eslint-disable-next-line @typescript-eslint/no-empty-function
-          writeText: () => {},
+          writeText: async () => {},
         },
       });
       jest.spyOn(navigator.clipboard, 'writeText');
@@ -22,7 +22,7 @@ describe('Clipboard', () => {
     it('should call copyToClipboardExecCommand if writeText fails', async () => {
       Object.assign(navigator, {
         clipboard: {
-          writeText: () => {
+          writeText: async () => {
             throw new Error('Could not write text');
           },
         },

--- a/packages/utils/src/ClipboardUtils.ts
+++ b/packages/utils/src/ClipboardUtils.ts
@@ -9,7 +9,8 @@ export async function copyToClipboard(text: string): Promise<void> {
     try {
       return await navigator.clipboard.writeText(text);
     } catch {
-      // Ignore error
+      // Ignore error. Fallback to `copyToClipboardExecCommand` same as when
+      // clipboard is not available.
     }
   }
   copyToClipboardExecCommand(text);

--- a/packages/utils/src/ClipboardUtils.ts
+++ b/packages/utils/src/ClipboardUtils.ts
@@ -7,9 +7,9 @@ export async function copyToClipboard(text: string): Promise<void> {
   const { clipboard } = navigator;
   if (clipboard !== undefined) {
     try {
-      return navigator.clipboard.writeText(text);
+      return await navigator.clipboard.writeText(text);
     } catch {
-      return copyToClipboardExecCommand(text);
+      // Ignore error
     }
   }
   copyToClipboardExecCommand(text);

--- a/packages/utils/src/ClipboardUtils.ts
+++ b/packages/utils/src/ClipboardUtils.ts
@@ -9,8 +9,8 @@ export async function copyToClipboard(text: string): Promise<void> {
     try {
       return await navigator.clipboard.writeText(text);
     } catch {
-      // Ignore error. Fallback to `copyToClipboardExecCommand` same as when
-      // clipboard is not available.
+      // Ignore error. Fallback to `copyToClipboardExecCommand` below
+      // (same as when clipboard is not available).
     }
   }
   copyToClipboardExecCommand(text);


### PR DESCRIPTION
Enabled `@typescript-eslint/return-await` eslint rule and fixed offending code.

fixes #2154

BREAKING CHANGE: Fix any try / catch blocks that return non-awaited Promises