### PR TITLE
fix: Remove the session wrapper from the embedded widget app

### DIFF
--- a/packages/embed-widget/src/App.tsx
+++ b/packages/embed-widget/src/App.tsx
@@ -19,11 +19,7 @@ import {
   ShortcutRegistry,
 } from '@deephaven/components'; // Use the loading spinner from the Deephaven components package
 import type { dh } from '@deephaven/jsapi-types';
-import {
-  fetchVariableDefinition,
-  getSessionDetails,
-  loadSessionWrapper,
-} from '@deephaven/jsapi-utils';
+import { fetchVariableDefinition } from '@deephaven/jsapi-utils';
 import Log from '@deephaven/log';
 import { useDashboardPlugins } from '@deephaven/plugin';
 import {
@@ -88,12 +84,6 @@ function App(): JSX.Element {
             throw new Error('Missing URL parameter "name"');
           }
 
-          const sessionDetails = await getSessionDetails();
-          const sessionWrapper = await loadSessionWrapper(
-            api,
-            connection,
-            sessionDetails
-          );
           const storageService = client.getStorageService();
           const layoutStorage = new GrpcLayoutStorage(
             storageService,
@@ -101,7 +91,7 @@ function App(): JSX.Element {
           );
           const workspaceStorage = new LocalWorkspaceStorage(layoutStorage);
           const loadedWorkspace = await workspaceStorage.load({
-            isConsoleAvailable: sessionWrapper !== undefined,
+            isConsoleAvailable: false,
           });
           const {
             data: { settings },


### PR DESCRIPTION
- We creating a new session and getting the session details, even though that was unnecessary for fetching the object itself since we already have a connection
- Just pass `isConsoleAvailable: false` here, since we will never have the console available in the embedded widget scenario
- Should speed up the embed-widget fetch quite a bit
