### PR TITLE
fix: ChartBuilderPlugin fixes for charts built from PPQs in Enterprise

### DIFF
--- a/packages/app-utils/src/components/AppDashboards.tsx
+++ b/packages/app-utils/src/components/AppDashboards.tsx
@@ -5,10 +5,7 @@ import {
   DehydratedDashboardPanelProps,
   LazyDashboard,
 } from '@deephaven/dashboard';
-import {
-  sanitizeVariableDescriptor,
-  useObjectFetcher,
-} from '@deephaven/jsapi-bootstrap';
+import { useObjectFetcher } from '@deephaven/jsapi-bootstrap';
 import LayoutManager, {
   ItemConfig,
   Settings as LayoutSettings,
@@ -44,9 +41,8 @@ export function AppDashboards({
       const { metadata } = hydrateProps;
       try {
         if (metadata != null) {
-          const widget = sanitizeVariableDescriptor(metadata);
           return {
-            fetch: async () => fetchObject(widget),
+            fetch: async () => fetchObject(metadata),
             ...hydrateProps,
             localDashboardId: id,
           };

--- a/packages/dashboard-core-plugins/src/ChartBuilderPlugin.tsx
+++ b/packages/dashboard-core-plugins/src/ChartBuilderPlugin.tsx
@@ -1,17 +1,11 @@
 import { useCallback } from 'react';
-import {
-  ChartModel,
-  ChartModelFactory,
-  ChartModelSettings,
-  ChartUtils,
-} from '@deephaven/chart';
+import { ChartModelSettings, ChartUtils } from '@deephaven/chart';
 import {
   assertIsDashboardPluginProps,
   DashboardPluginComponentProps,
   LayoutUtils,
   useListener,
 } from '@deephaven/dashboard';
-import { useApi } from '@deephaven/jsapi-bootstrap';
 import type { dh } from '@deephaven/jsapi-types';
 import { nanoid } from 'nanoid';
 import { IrisGridEvent } from './events';

--- a/packages/dashboard-core-plugins/src/ChartBuilderPlugin.tsx
+++ b/packages/dashboard-core-plugins/src/ChartBuilderPlugin.tsx
@@ -28,7 +28,6 @@ export function ChartBuilderPlugin(
 ): JSX.Element | null {
   assertIsDashboardPluginProps(props);
   const { id, layout } = props;
-  const dh = useApi();
 
   const handleCreateChart = useCallback(
     ({
@@ -45,8 +44,7 @@ export function ChartBuilderPlugin(
       table: dh.Table;
     }) => {
       const { settings } = metadata;
-      const makeModel = (): Promise<ChartModel> =>
-        ChartModelFactory.makeModelFromSettings(dh, settings, table);
+      const fetchTable = async () => table;
       const title = ChartUtils.titleFromSettings(settings);
 
       const config = {
@@ -56,7 +54,7 @@ export function ChartBuilderPlugin(
           localDashboardId: id,
           id: panelId,
           metadata,
-          makeModel,
+          fetch: fetchTable,
         },
         title,
         id: panelId,
@@ -65,7 +63,7 @@ export function ChartBuilderPlugin(
       const { root } = layout;
       LayoutUtils.openComponent({ root, config });
     },
-    [dh, id, layout]
+    [id, layout]
   );
 
   useListener(layout.eventHub, IrisGridEvent.CREATE_CHART, handleCreateChart);

--- a/packages/dashboard-core-plugins/src/ChartPanelPlugin.tsx
+++ b/packages/dashboard-core-plugins/src/ChartPanelPlugin.tsx
@@ -50,7 +50,7 @@ async function createChartModel(
     }
   }
 
-  if (tableName != null) {
+  if (tableName != null && tableName !== '') {
     const table = (await panelFetch()) as DhType.Table;
     new IrisGridUtils(dh).applyTableSettings(
       table,

--- a/packages/dashboard-core-plugins/src/panels/ChartPanel.tsx
+++ b/packages/dashboard-core-plugins/src/panels/ChartPanel.tsx
@@ -6,6 +6,7 @@ import debounce from 'lodash.debounce';
 import {
   Chart,
   ChartModel,
+  ChartModelFactory,
   ChartModelSettings,
   ChartUtils,
   FilterMap,
@@ -648,12 +649,8 @@ export class ChartPanel extends Component<ChartPanelProps, ChartPanelState> {
       const { settings } = metadata;
       this.pending
         .add(
-          dh.plot.Figure.create(
-            new ChartUtils(dh).makeFigureSettings(
-              settings,
-              source
-            ) as unknown as dh.plot.FigureDescriptor
-          )
+          ChartModelFactory.makeFigureFromSettings(dh, settings, source),
+          resolved => resolved.close()
         )
         .then(figure => {
           if (isFigureChartModel(model)) {

--- a/packages/dashboard-core-plugins/src/panels/ChartPanel.tsx
+++ b/packages/dashboard-core-plugins/src/panels/ChartPanel.tsx
@@ -8,7 +8,6 @@ import {
   ChartModel,
   ChartModelFactory,
   ChartModelSettings,
-  ChartUtils,
   FilterMap,
   isFigureChartModel,
 } from '@deephaven/chart';

--- a/packages/dashboard-core-plugins/src/panels/WidgetPanel.tsx
+++ b/packages/dashboard-core-plugins/src/panels/WidgetPanel.tsx
@@ -1,47 +1,15 @@
-import React, { PureComponent, ReactElement, ReactNode } from 'react';
+import React, { PureComponent, ReactElement } from 'react';
 import classNames from 'classnames';
 import memoize from 'memoize-one';
-import { PanelComponent } from '@deephaven/dashboard';
-import type { Container, EventEmitter } from '@deephaven/golden-layout';
 import { ContextActions, createXComponent } from '@deephaven/components';
 import { copyToClipboard } from '@deephaven/utils';
 import Panel from './Panel';
 import WidgetPanelTooltip from './WidgetPanelTooltip';
 import './WidgetPanel.scss';
-import { WidgetPanelDescriptor } from './WidgetPanelTypes';
-
-type WidgetPanelProps = {
-  children: ReactNode;
-
-  descriptor: WidgetPanelDescriptor;
-  componentPanel?: PanelComponent;
-
-  glContainer: Container;
-  glEventHub: EventEmitter;
-
-  className?: string;
-  errorMessage?: string;
-  isClonable?: boolean;
-  isDisconnected?: boolean;
-  isLoading?: boolean;
-  isLoaded?: boolean;
-  isRenamable?: boolean;
-  showTabTooltip?: boolean;
-
-  renderTabTooltip?: () => ReactNode;
-
-  onFocus?: () => void;
-  onBlur?: () => void;
-  onHide?: () => void;
-  onClearAllFilters?: () => void;
-  onResize?: () => void;
-  onSessionClose?: (...args: unknown[]) => void;
-  onSessionOpen?: (...args: unknown[]) => void;
-  onShow?: () => void;
-  onTabBlur?: () => void;
-  onTabFocus?: () => void;
-  onTabClicked?: () => void;
-};
+import {
+  InnerWidgetPanelProps,
+  WidgetPanelDescriptor,
+} from './WidgetPanelTypes';
 
 interface WidgetPanelState {
   isClientDisconnected: boolean;
@@ -53,7 +21,10 @@ interface WidgetPanelState {
 /**
  * Widget panel component that has a loading spinner and displays an error message when set
  */
-class WidgetPanel extends PureComponent<WidgetPanelProps, WidgetPanelState> {
+class WidgetPanel extends PureComponent<
+  InnerWidgetPanelProps,
+  WidgetPanelState
+> {
   static defaultProps = {
     className: '',
     isClonable: true,
@@ -64,7 +35,7 @@ class WidgetPanel extends PureComponent<WidgetPanelProps, WidgetPanelState> {
     showTabTooltip: true,
   };
 
-  constructor(props: WidgetPanelProps) {
+  constructor(props: InnerWidgetPanelProps) {
     super(props);
 
     this.handleSessionClosed = this.handleSessionClosed.bind(this);

--- a/packages/dashboard-core-plugins/src/panels/WidgetPanelTypes.ts
+++ b/packages/dashboard-core-plugins/src/panels/WidgetPanelTypes.ts
@@ -1,4 +1,6 @@
 import { ReactNode } from 'react';
+import { PanelComponent } from '@deephaven/dashboard';
+import type { Container, EventEmitter } from '@deephaven/golden-layout';
 
 export type WidgetPanelDescriptor = {
   /** Type of the widget. */
@@ -23,4 +25,37 @@ export type WidgetPanelTooltipProps = {
 
   /** Children to render within this tooltip */
   children?: ReactNode;
+};
+
+export type InnerWidgetPanelProps = {
+  children: ReactNode;
+
+  descriptor: WidgetPanelDescriptor;
+  componentPanel?: PanelComponent;
+
+  glContainer: Container;
+  glEventHub: EventEmitter;
+
+  className?: string;
+  errorMessage?: string;
+  isClonable?: boolean;
+  isDisconnected?: boolean;
+  isLoading?: boolean;
+  isLoaded?: boolean;
+  isRenamable?: boolean;
+  showTabTooltip?: boolean;
+
+  renderTabTooltip?: () => ReactNode;
+
+  onFocus?: () => void;
+  onBlur?: () => void;
+  onHide?: () => void;
+  onClearAllFilters?: () => void;
+  onResize?: () => void;
+  onSessionClose?: (...args: unknown[]) => void;
+  onSessionOpen?: (...args: unknown[]) => void;
+  onShow?: () => void;
+  onTabBlur?: () => void;
+  onTabFocus?: () => void;
+  onTabClicked?: () => void;
 };


### PR DESCRIPTION
- Don't sanitize the descriptor in `AppDashboards` - the descriptor gets sanitized within the objectFetcher itself
  - By sanitizing too early, we lose metadata needed to load an object
- ChartPanelPlugin uses the `panelFetch` to get the underlying object
  - In cases of a `ParameterizedQuery` on Enterprise, we only have the result of the `ParameterizedQuery` run in the `ParameterizedQueryPanel`
    - Aside, if we're looking at improving `ParameterizedQuery` support, we should complete DH-15760 (which would be breaking an internal API)
- Use correct API when fetching a Chart object