### PR TITLE
build: Sync package-lock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31679,7 +31679,7 @@
         "@deephaven/utils": "file:../utils",
         "@fortawesome/fontawesome-svg-core": "^6.2.1",
         "@fortawesome/react-fontawesome": "^0.2.0",
-        "@internationalized/date": "*",
+        "@internationalized/date": "^3.5.5",
         "@react-spectrum/theme-default": "^3.5.1",
         "@react-spectrum/utils": "^3.11.5",
         "@react-types/radio": "^3.8.1",


### PR DESCRIPTION
I ran `npm i` to sync package-lock with latest package.json. Fixed a mismatched version number for `@internationalized/date`

fallout from #2170