### PR TITLE
feat: Make rollup group behaviour a setting in the global settings menu

### DIFF
--- a/packages/app-utils/src/storage/LocalWorkspaceStorage.ts
+++ b/packages/app-utils/src/storage/LocalWorkspaceStorage.ts
@@ -56,6 +56,7 @@ export class LocalWorkspaceStorage implements WorkspaceStorage {
       truncateNumbersWithPound: false,
       showEmptyStrings: true,
       showNullStrings: true,
+      showExtraGroupColumn: true,
       defaultNotebookSettings: {
         isMinimapEnabled: false,
       },
@@ -103,6 +104,7 @@ export class LocalWorkspaceStorage implements WorkspaceStorage {
         serverConfigValues,
         'showNullStrings'
       ),
+      showExtraGroupColumn: true,
       defaultNotebookSettings:
         serverConfigValues?.get('isMinimapEnabled') !== undefined
           ? {

--- a/packages/code-studio/src/settings/FormattingSectionContent.tsx
+++ b/packages/code-studio/src/settings/FormattingSectionContent.tsx
@@ -28,6 +28,7 @@ import {
   getTruncateNumbersWithPound,
   getShowEmptyStrings,
   getShowNullStrings,
+  getShowExtraGroupColumn,
   updateSettings as updateSettingsAction,
   RootState,
   WorkspaceSettings,
@@ -56,6 +57,7 @@ interface FormattingSectionContentProps {
   truncateNumbersWithPound: boolean;
   showEmptyStrings: boolean;
   showNullStrings: boolean;
+  showExtraGroupColumn: boolean;
   updateSettings: (settings: Partial<WorkspaceSettings>) => void;
   defaultDecimalFormatOptions: FormatOption;
   defaultIntegerFormatOptions: FormatOption;
@@ -72,6 +74,7 @@ interface FormattingSectionContentState {
   truncateNumbersWithPound: boolean;
   showEmptyStrings: boolean;
   showNullStrings: boolean;
+  showExtraGroupColumn: boolean;
   timestampAtMenuOpen: Date;
 }
 
@@ -113,6 +116,8 @@ export class FormattingSectionContent extends PureComponent<
       this.handleShowEmptyStringsChange.bind(this);
     this.handleShowNullStringsChange =
       this.handleShowNullStringsChange.bind(this);
+    this.handleShowExtraGroupColumnChange =
+      this.handleShowExtraGroupColumnChange.bind(this);
 
     const {
       defaultDateTimeFormat,
@@ -124,6 +129,7 @@ export class FormattingSectionContent extends PureComponent<
       truncateNumbersWithPound,
       showEmptyStrings,
       showNullStrings,
+      showExtraGroupColumn,
     } = props;
 
     this.containerRef = React.createRef();
@@ -139,6 +145,7 @@ export class FormattingSectionContent extends PureComponent<
       truncateNumbersWithPound,
       showEmptyStrings,
       showNullStrings,
+      showExtraGroupColumn,
       timestampAtMenuOpen: new Date(),
     };
   }
@@ -330,6 +337,16 @@ export class FormattingSectionContent extends PureComponent<
     this.queueUpdate(update);
   }
 
+  handleShowExtraGroupColumnChange(): void {
+    const { showExtraGroupColumn } = this.state;
+    const update = {
+      showExtraGroupColumn: !showExtraGroupColumn,
+    };
+    console.log('After updating state constructor', showExtraGroupColumn);
+    this.setState(update);
+    this.queueUpdate(update);
+  }
+
   commitChanges(): void {
     const { updateSettings } = this.props;
     const updates = this.pendingUpdates.reduce(
@@ -356,6 +373,7 @@ export class FormattingSectionContent extends PureComponent<
       truncateNumbersWithPound,
       showEmptyStrings,
       showNullStrings,
+      showExtraGroupColumn,
     } = this.state;
 
     const {
@@ -596,6 +614,23 @@ export class FormattingSectionContent extends PureComponent<
               </Checkbox>
             </div>
           </div>
+
+          <div className="form-row mb-3">
+            <label
+              className="col-form-label col-3"
+              htmlFor="default-integer-format-input"
+            >
+              Rollup
+            </label>
+            <div className="col pr-0 pt-2">
+              <Checkbox
+                checked={showExtraGroupColumn ?? null}
+                onChange={this.handleShowExtraGroupColumnChange}
+              >
+                Show extra &quot;group&quot; column
+              </Checkbox>
+            </div>
+          </div>
         </div>
       </div>
     );
@@ -614,6 +649,7 @@ const mapStateToProps = (
   truncateNumbersWithPound: getTruncateNumbersWithPound(state),
   showEmptyStrings: getShowEmptyStrings(state),
   showNullStrings: getShowNullStrings(state),
+  showExtraGroupColumn: getShowExtraGroupColumn(state),
   timeZone: getTimeZone(state),
   defaults: getDefaultSettings(state),
 });

--- a/packages/iris-grid/src/IrisGrid.tsx
+++ b/packages/iris-grid/src/IrisGrid.tsx
@@ -523,6 +523,7 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
       truncateNumbersWithPound: false,
       showEmptyStrings: true,
       showNullStrings: true,
+      showExtraGroupColumn: true,
       formatter: EMPTY_ARRAY,
       decimalFormatOptions: PropTypes.shape({
         defaultFormatString: PropTypes.string,
@@ -637,6 +638,7 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
     this.truncateNumbersWithPound = false;
     this.showEmptyStrings = true;
     this.showNullStrings = true;
+    this.showExtraGroupColumn = true;
 
     // When the loading scrim started/when it should extend to the end of the screen.
     this.tableSaver = null;
@@ -1022,6 +1024,8 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
   showEmptyStrings: boolean;
 
   showNullStrings: boolean;
+
+  showExtraGroupColumn: boolean;
 
   // When the loading scrim started/when it should extend to the end of the screen.
   loadingScrimStartTime?: number;
@@ -1870,6 +1874,7 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
 
     const showEmptyStrings = settings?.showEmptyStrings ?? true;
     const showNullStrings = settings?.showNullStrings ?? true;
+    const showExtraGroupColumn = settings?.showExtraGroupColumn ?? false;
 
     const isColumnFormatChanged = !deepEqual(
       this.globalColumnFormats,
@@ -1892,6 +1897,8 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
     const isShowEmptyStringsChanged =
       this.showEmptyStrings !== showEmptyStrings;
     const isShowNullStringsChanged = this.showNullStrings !== showNullStrings;
+    const isShowExtraGroupColumnChanged =
+      this.showExtraGroupColumn !== showExtraGroupColumn;
 
     if (
       isColumnFormatChanged ||
@@ -1900,7 +1907,8 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
       isIntegerFormattingChanged ||
       isTruncateNumbersChanged ||
       isShowEmptyStringsChanged ||
-      isShowNullStringsChanged
+      isShowNullStringsChanged ||
+      isShowExtraGroupColumnChanged
     ) {
       this.globalColumnFormats = globalColumnFormats;
       this.dateTimeFormatterOptions = dateTimeFormatterOptions;
@@ -1909,6 +1917,7 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
       this.truncateNumbersWithPound = truncateNumbersWithPound;
       this.showEmptyStrings = showEmptyStrings;
       this.showNullStrings = showNullStrings;
+      this.showExtraGroupColumn = showExtraGroupColumn;
       this.updateFormatter({}, forceUpdate);
 
       if (isDateFormattingChanged && forceUpdate) {
@@ -1977,7 +1986,8 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
       this.integerFormatOptions,
       this.truncateNumbersWithPound,
       this.showEmptyStrings,
-      this.showNullStrings
+      this.showNullStrings,
+      this.showExtraGroupColumn
     );
 
     log.debug('updateFormatter', this.globalColumnFormats, mergedColumnFormats);

--- a/packages/iris-grid/src/IrisGridTreeTableModel.ts
+++ b/packages/iris-grid/src/IrisGridTreeTableModel.ts
@@ -44,8 +44,12 @@ class IrisGridTreeTableModel extends IrisGridTableModelTemplate<
     inputTable: DhType.InputTable | null = null
   ) {
     super(dh, table, formatter, inputTable);
+    console.log(
+      'IrisGridTreeTableModel constructor',
+      this.formatter.showExtraGroupColumn
+    );
     this.virtualColumns =
-      table.groupedColumns.length > 1
+      table.groupedColumns.length > 1 && this.formatter.showExtraGroupColumn
         ? [
             {
               name: '__DH_UI_GROUP__',
@@ -203,10 +207,20 @@ class IrisGridTreeTableModel extends IrisGridTableModelTemplate<
   }
 
   get columns(): DhType.Column[] {
-    return this.getCachedColumns(this.virtualColumns, super.columns);
+    return this.getCachedColumns(
+      // this.formatter.showExtraGroupColumn ? this.virtualColumns : [],
+      this.virtualColumns,
+      super.columns
+    );
   }
 
   get groupedColumns(): readonly DhType.Column[] {
+    // console.log(
+    //   'this.formatter.showExtraGroupColumn',
+    //   this.formatter.showExtraGroupColumn,
+    //   'this.virtualColumns',
+    //   this.virtualColumns
+    // );
     return this.getCachedGroupColumns(
       this.virtualColumns,
       this.table.groupedColumns
@@ -321,14 +335,20 @@ class IrisGridTreeTableModel extends IrisGridTableModelTemplate<
     (
       virtualColumns: readonly DhType.Column[],
       tableColumns: readonly DhType.Column[]
-    ) => [...virtualColumns, ...tableColumns]
+    ) => [
+      ...(this.formatter.showExtraGroupColumn ? virtualColumns : []),
+      ...tableColumns,
+    ]
   );
 
   getCachedGroupColumns = memoize(
     (
       virtualColumns: readonly DhType.Column[],
       tableGroupedColumns: readonly DhType.Column[]
-    ) => [...virtualColumns, ...tableGroupedColumns]
+    ) => [
+      ...(this.formatter.showExtraGroupColumn ? virtualColumns : []),
+      ...tableGroupedColumns,
+    ]
   );
 
   getCachedFilterableColumnSet = memoize(

--- a/packages/jsapi-utils/src/Formatter.ts
+++ b/packages/jsapi-utils/src/Formatter.ts
@@ -86,7 +86,8 @@ export class Formatter {
     >[1],
     truncateNumbersWithPound = false,
     showEmptyStrings = true,
-    showNullStrings = true
+    showNullStrings = true,
+    showExtraGroupColumn = true
   ) {
     // Formatting order:
     // - columnFormatMap[type][name]
@@ -120,6 +121,7 @@ export class Formatter {
 
     this.showEmptyStrings = showEmptyStrings;
     this.showNullStrings = showNullStrings;
+    this.showExtraGroupColumn = showExtraGroupColumn;
   }
 
   defaultColumnFormatter: TableColumnFormatter;
@@ -133,6 +135,8 @@ export class Formatter {
   showEmptyStrings: boolean;
 
   showNullStrings: boolean;
+
+  showExtraGroupColumn: boolean;
 
   /**
    * Gets columnFormatMap indexed by name for a given column type, creates new Map entry if necessary

--- a/packages/jsapi-utils/src/FormatterUtils.test.ts
+++ b/packages/jsapi-utils/src/FormatterUtils.test.ts
@@ -71,6 +71,7 @@ describe('createFormatterFromSettings', () => {
         truncateNumbersWithPound,
         showEmptyStrings,
         showNullStrings,
+        showExtraGroupColumn,
       } = settings ?? {};
 
       const actual = createFormatterFromSettings(dh, settings);
@@ -83,7 +84,8 @@ describe('createFormatterFromSettings', () => {
         defaultIntegerFormatOptions,
         truncateNumbersWithPound,
         showEmptyStrings,
-        showNullStrings
+        showNullStrings,
+        showExtraGroupColumn
       );
       expect(actual).toBeInstanceOf(FormatterActual);
     }

--- a/packages/jsapi-utils/src/FormatterUtils.ts
+++ b/packages/jsapi-utils/src/FormatterUtils.ts
@@ -26,6 +26,7 @@ export function createFormatterFromSettings(
     truncateNumbersWithPound,
     showEmptyStrings,
     showNullStrings,
+    showExtraGroupColumn,
   } = settings ?? {};
 
   return new Formatter(
@@ -36,7 +37,8 @@ export function createFormatterFromSettings(
     defaultIntegerFormatOptions,
     truncateNumbersWithPound,
     showEmptyStrings,
-    showNullStrings
+    showNullStrings,
+    showExtraGroupColumn
   );
 }
 

--- a/packages/jsapi-utils/src/Settings.ts
+++ b/packages/jsapi-utils/src/Settings.ts
@@ -21,6 +21,7 @@ export interface NumberFormatSettings {
   truncateNumbersWithPound?: boolean;
   showEmptyStrings?: boolean;
   showNullStrings?: boolean;
+  showExtraGroupColumn?: boolean;
 }
 
 export interface Settings

--- a/packages/redux/src/selectors.ts
+++ b/packages/redux/src/selectors.ts
@@ -129,6 +129,11 @@ export const getShowNullStrings = <State extends RootState = RootState>(
   store: State
 ): Settings<State>['showNullStrings'] => getSettings(store).showNullStrings;
 
+export const getShowExtraGroupColumn = <State extends RootState = RootState>(
+  store: State
+): Settings<State>['showExtraGroupColumn'] =>
+  getSettings(store).showExtraGroupColumn;
+
 export const getDisableMoveConfirmation = <State extends RootState>(
   store: State
 ): Settings<State>['disableMoveConfirmation'] =>

--- a/packages/redux/src/store.ts
+++ b/packages/redux/src/store.ts
@@ -49,6 +49,7 @@ export interface WorkspaceSettings {
   truncateNumbersWithPound: boolean;
   showEmptyStrings: boolean;
   showNullStrings: boolean;
+  showExtraGroupColumn: boolean;
   disableMoveConfirmation: boolean;
   shortcutOverrides?: {
     windows?: { [id: string]: ValidKeyState };


### PR DESCRIPTION
WIP - Cannot seem to figure out why the "Group" column is still being added when the `showExtraGroupColumn` is set to false