### PR TITLE
fix: makeEventFunctions take an array of parameters

### DIFF
--- a/packages/dashboard/src/PanelEvent.ts
+++ b/packages/dashboard/src/PanelEvent.ts
@@ -76,7 +76,7 @@ export const {
   listen: listenForPanelOpen,
   emit: emitPanelOpen,
   useListener: usePanelOpenListener,
-} = makeEventFunctions<PanelOpenEventDetail>(PanelEvent.OPEN);
+} = makeEventFunctions<[PanelOpenEventDetail]>(PanelEvent.OPEN);
 
 // TODO (#2147): Add the rest of the event functions here. Need to create the correct types for all of them.
 

--- a/packages/dashboard/src/PanelEvent.ts
+++ b/packages/dashboard/src/PanelEvent.ts
@@ -76,7 +76,7 @@ export const {
   listen: listenForPanelOpen,
   emit: emitPanelOpen,
   useListener: usePanelOpenListener,
-} = makeEventFunctions<[PanelOpenEventDetail]>(PanelEvent.OPEN);
+} = makeEventFunctions<[detail: PanelOpenEventDetail]>(PanelEvent.OPEN);
 
 // TODO (#2147): Add the rest of the event functions here. Need to create the correct types for all of them.
 

--- a/packages/golden-layout/src/utils/EventUtils.ts
+++ b/packages/golden-layout/src/utils/EventUtils.ts
@@ -1,20 +1,23 @@
 import { useEffect } from 'react';
 import EventEmitter from './EventEmitter';
 
+export type EventHandlerFunction<P = []> = (
+  ...parameters: P extends unknown[] ? P : [P]
+) => void;
 export type EventListenerRemover = () => void;
-export type EventListenFunction<TParameters extends unknown[] = []> = (
+export type EventListenFunction<TParameters = []> = (
   eventEmitter: EventEmitter,
-  handler: (...parameters: TParameters) => void
+  handler: EventHandlerFunction<TParameters>
 ) => EventListenerRemover;
 
-export type EventEmitFunction<TParameters extends unknown[] = []> = (
+export type EventEmitFunction<TParameters = []> = (
   eventEmitter: EventEmitter,
-  ...parameters: TParameters
+  ...parameters: TParameters extends unknown[] ? TParameters : [TParameters]
 ) => void;
 
-export type EventListenerHook<TParameters extends unknown[] = []> = (
+export type EventListenerHook<TParameters = []> = (
   eventEmitter: EventEmitter,
-  handler: (...parameters: TParameters) => void
+  handler: EventHandlerFunction<TParameters>
 ) => void;
 
 /**
@@ -24,10 +27,10 @@ export type EventListenerHook<TParameters extends unknown[] = []> = (
  * @param handler The handler to call when the event is emitted
  * @returns A function to stop listening for the event
  */
-export function listenForEvent<TParameters extends unknown[]>(
+export function listenForEvent<TParameters>(
   eventEmitter: EventEmitter,
   event: string,
-  handler: (...p: TParameters) => void
+  handler: EventHandlerFunction<TParameters>
 ): EventListenerRemover {
   eventEmitter.on(event, handler);
   return () => {
@@ -35,14 +38,14 @@ export function listenForEvent<TParameters extends unknown[]>(
   };
 }
 
-export function makeListenFunction<TParameters extends unknown[]>(
+export function makeListenFunction<TParameters>(
   event: string
 ): EventListenFunction<TParameters> {
   return (eventEmitter, handler) =>
     listenForEvent(eventEmitter, event, handler);
 }
 
-export function makeEmitFunction<TParameters extends unknown[]>(
+export function makeEmitFunction<TParameters>(
   event: string
 ): EventEmitFunction<TParameters> {
   return (eventEmitter, ...parameters) => {
@@ -50,7 +53,7 @@ export function makeEmitFunction<TParameters extends unknown[]>(
   };
 }
 
-export function makeUseListenerFunction<TParameters extends unknown[]>(
+export function makeUseListenerFunction<TParameters>(
   event: string
 ): EventListenerHook<TParameters> {
   return (eventEmitter, handler) => {
@@ -66,9 +69,7 @@ export function makeUseListenerFunction<TParameters extends unknown[]>(
  * @param event Name of the event to create functions for
  * @returns Listener, Emitter, and Hook functions for the event
  */
-export function makeEventFunctions<TParameters extends unknown[]>(
-  event: string
-): {
+export function makeEventFunctions<TParameters>(event: string): {
   listen: EventListenFunction<TParameters>;
   emit: EventEmitFunction<TParameters>;
   useListener: EventListenerHook<TParameters>;

--- a/packages/golden-layout/src/utils/EventUtils.ts
+++ b/packages/golden-layout/src/utils/EventUtils.ts
@@ -1,9 +1,9 @@
 import { useEffect } from 'react';
 import EventEmitter from './EventEmitter';
 
-export type EventHandlerFunction<P = []> = (
-  ...parameters: P extends unknown[] ? P : [P]
-) => void;
+type AsArray<P> = P extends unknown[] ? P : [P];
+
+export type EventHandlerFunction<P = []> = (...parameters: AsArray<P>) => void;
 export type EventListenerRemover = () => void;
 export type EventListenFunction<TParameters = []> = (
   eventEmitter: EventEmitter,
@@ -12,7 +12,7 @@ export type EventListenFunction<TParameters = []> = (
 
 export type EventEmitFunction<TParameters = []> = (
   eventEmitter: EventEmitter,
-  ...parameters: TParameters extends unknown[] ? TParameters : [TParameters]
+  ...parameters: AsArray<TParameters>
 ) => void;
 
 export type EventListenerHook<TParameters = []> = (

--- a/packages/golden-layout/src/utils/EventUtils.ts
+++ b/packages/golden-layout/src/utils/EventUtils.ts
@@ -1,20 +1,20 @@
-import EventEmitter from './EventEmitter';
 import { useEffect } from 'react';
+import EventEmitter from './EventEmitter';
 
 export type EventListenerRemover = () => void;
-export type EventListenFunction<TPayload = unknown> = (
+export type EventListenFunction<TParameters extends unknown[] = []> = (
   eventEmitter: EventEmitter,
-  handler: (p: TPayload) => void
+  handler: (...parameters: TParameters) => void
 ) => EventListenerRemover;
 
-export type EventEmitFunction<TPayload = unknown> = (
+export type EventEmitFunction<TParameters extends unknown[] = []> = (
   eventEmitter: EventEmitter,
-  payload: TPayload
+  ...parameters: TParameters
 ) => void;
 
-export type EventListenerHook<TPayload = unknown> = (
+export type EventListenerHook<TParameters extends unknown[] = []> = (
   eventEmitter: EventEmitter,
-  handler: (p: TPayload) => void
+  handler: (...parameters: TParameters) => void
 ) => void;
 
 /**
@@ -24,10 +24,10 @@ export type EventListenerHook<TPayload = unknown> = (
  * @param handler The handler to call when the event is emitted
  * @returns A function to stop listening for the event
  */
-export function listenForEvent<TPayload>(
+export function listenForEvent<TParameters extends unknown[]>(
   eventEmitter: EventEmitter,
   event: string,
-  handler: (p: TPayload) => void
+  handler: (...p: TParameters) => void
 ): EventListenerRemover {
   eventEmitter.on(event, handler);
   return () => {
@@ -35,24 +35,24 @@ export function listenForEvent<TPayload>(
   };
 }
 
-export function makeListenFunction<TPayload>(
+export function makeListenFunction<TParameters extends unknown[]>(
   event: string
-): EventListenFunction<TPayload> {
+): EventListenFunction<TParameters> {
   return (eventEmitter, handler) =>
     listenForEvent(eventEmitter, event, handler);
 }
 
-export function makeEmitFunction<TPayload>(
+export function makeEmitFunction<TParameters extends unknown[]>(
   event: string
-): EventEmitFunction<TPayload> {
-  return (eventEmitter, payload) => {
-    eventEmitter.emit(event, payload);
+): EventEmitFunction<TParameters> {
+  return (eventEmitter, ...parameters) => {
+    eventEmitter.emit(event, ...parameters);
   };
 }
 
-export function makeUseListenerFunction<TPayload>(
+export function makeUseListenerFunction<TParameters extends unknown[]>(
   event: string
-): EventListenerHook<TPayload> {
+): EventListenerHook<TParameters> {
   return (eventEmitter, handler) => {
     useEffect(
       () => listenForEvent(eventEmitter, event, handler),
@@ -66,14 +66,16 @@ export function makeUseListenerFunction<TPayload>(
  * @param event Name of the event to create functions for
  * @returns Listener, Emitter, and Hook functions for the event
  */
-export function makeEventFunctions<TPayload>(event: string): {
-  listen: EventListenFunction<TPayload>;
-  emit: EventEmitFunction<TPayload>;
-  useListener: EventListenerHook<TPayload>;
+export function makeEventFunctions<TParameters extends unknown[]>(
+  event: string
+): {
+  listen: EventListenFunction<TParameters>;
+  emit: EventEmitFunction<TParameters>;
+  useListener: EventListenerHook<TParameters>;
 } {
   return {
-    listen: makeListenFunction<TPayload>(event),
-    emit: makeEmitFunction<TPayload>(event),
-    useListener: makeUseListenerFunction<TPayload>(event),
+    listen: makeListenFunction<TParameters>(event),
+    emit: makeEmitFunction<TParameters>(event),
+    useListener: makeUseListenerFunction<TParameters>(event),
   };
 }

--- a/packages/golden-layout/src/utils/EventUtils.ts
+++ b/packages/golden-layout/src/utils/EventUtils.ts
@@ -27,7 +27,7 @@ export type EventListenerHook<TParameters = []> = (
  * @param handler The handler to call when the event is emitted
  * @returns A function to stop listening for the event
  */
-export function listenForEvent<TParameters>(
+export function listenForEvent<TParameters = []>(
   eventEmitter: EventEmitter,
   event: string,
   handler: EventHandlerFunction<TParameters>
@@ -38,14 +38,14 @@ export function listenForEvent<TParameters>(
   };
 }
 
-export function makeListenFunction<TParameters>(
+export function makeListenFunction<TParameters = []>(
   event: string
 ): EventListenFunction<TParameters> {
   return (eventEmitter, handler) =>
     listenForEvent(eventEmitter, event, handler);
 }
 
-export function makeEmitFunction<TParameters>(
+export function makeEmitFunction<TParameters = []>(
   event: string
 ): EventEmitFunction<TParameters> {
   return (eventEmitter, ...parameters) => {
@@ -53,7 +53,7 @@ export function makeEmitFunction<TParameters>(
   };
 }
 
-export function makeUseListenerFunction<TParameters>(
+export function makeUseListenerFunction<TParameters = []>(
   event: string
 ): EventListenerHook<TParameters> {
   return (eventEmitter, handler) => {
@@ -69,7 +69,9 @@ export function makeUseListenerFunction<TParameters>(
  * @param event Name of the event to create functions for
  * @returns Listener, Emitter, and Hook functions for the event
  */
-export function makeEventFunctions<TParameters>(event: string): {
+export function makeEventFunctions<TParameters = []>(
+  event: string
+): {
   listen: EventListenFunction<TParameters>;
   emit: EventEmitFunction<TParameters>;
   useListener: EventListenerHook<TParameters>;


### PR DESCRIPTION
- Previously every emit required exactly one parameter, which is not the case
- Allow zero or more parameters
