### PR TITLE
refactor: Change TabEvent to object literal, add TabEventMap

### DIFF
--- a/packages/dashboard-core-plugins/src/events/TabEvent.ts
+++ b/packages/dashboard-core-plugins/src/events/TabEvent.ts
@@ -1,15 +1,6 @@
-class TabEvent {
-  static focus = 'TabEvent.focus';
-
-  static blur = 'TabEvent.blur';
-
-  static openPQObject = 'TabEvent.openPQObject';
-
-  static openControl = 'TabEvent.openControl';
-
-  static reload = 'TabEvent.reload';
-
-  static clearAllFilters = 'TabEvent.clearAllFilters';
-}
+const TabEvent = {
+  focus: 'TabEvent.focus',
+  blur: 'TabEvent.blur',
+} as const;
 
 export default TabEvent;

--- a/packages/dashboard-core-plugins/src/events/TabEvent.ts
+++ b/packages/dashboard-core-plugins/src/events/TabEvent.ts
@@ -1,6 +1,6 @@
-const TabEvent = {
+const TabEvent = Object.freeze({
   focus: 'TabEvent.focus',
   blur: 'TabEvent.blur',
-} as const;
+});
 
 export default TabEvent;

--- a/packages/dashboard-core-plugins/src/events/TabEventMap.ts
+++ b/packages/dashboard-core-plugins/src/events/TabEventMap.ts
@@ -1,0 +1,12 @@
+import { ValueOf } from '@deephaven/utils';
+import TabEvent from './TabEvent';
+
+export type TabEventType = ValueOf<typeof TabEvent>;
+
+export interface TabEventMap
+  extends Record<TabEventType, (...args: never[]) => void> {
+  [TabEvent.focus]: () => void;
+  [TabEvent.blur]: () => void;
+}
+
+export default TabEventMap;


### PR DESCRIPTION
Add TabEventMap associating TabEvent types to callback signatures.
Change TabEvent to object literal so it could be used to define TabEventMap.

BREAKING CHANGE: Delete unused event types: `openPQObject`, `openControl`, `reload`, `clearAllFilters`.