### PR TITLE
fix: GridMetrics including totals rows in visible rows when scrolled to bottom

### DIFF
--- a/packages/grid/src/GridMetricCalculator.ts
+++ b/packages/grid/src/GridMetricCalculator.ts
@@ -974,8 +974,8 @@ export class GridMetricCalculator {
     let y = 0;
     let row = top;
     const rowHeights = new Map();
-    const { rowCount } = model;
-    while (y < height + topOffset && row < rowCount) {
+    const { rowCount, floatingBottomRowCount } = model;
+    while (y < height + topOffset && row < rowCount - floatingBottomRowCount) {
       const rowHeight = this.getVisibleRowHeight(row, state);
       rowHeights.set(row, rowHeight);
       y += rowHeight;
@@ -1039,8 +1039,11 @@ export class GridMetricCalculator {
     let x = 0;
     let column = left;
     const columnWidths = new Map();
-    const { columnCount } = model;
-    while (x < width + leftOffset && column < columnCount) {
+    const { columnCount, floatingRightColumnCount } = model;
+    while (
+      x < width + leftOffset &&
+      column < columnCount - floatingRightColumnCount
+    ) {
       const columnWidth = this.getVisibleColumnWidth(
         column,
         state,


### PR DESCRIPTION
Noticed this while working on databars. The totals rows are being included in `metrics.visibleRows` when scrolled to the bottom. They were also being duplicated in `allRows`.

1. Create a table such as `t = empty_table(1000).update(["X=ii"])`
2. Add an aggregation
3. Scroll to bottom of the table
4. Log `visibleRows` or `allRows` from `GridMetrics`

Without this change you'll see that the totals row(s) (index 1000+) are included in those arrays when scrolled to the bottom. They are doubled in `allRows`