### PR TITLE
fix: Invalid import in @deephaven/components for webpack

### DIFF
--- a/packages/components/src/transitions/FadeTransition.tsx
+++ b/packages/components/src/transitions/FadeTransition.tsx
@@ -1,7 +1,6 @@
-import CSSTransition, {
-  CSSTransitionProps,
-} from 'react-transition-group/CSSTransition';
-import { EndHandler } from 'react-transition-group/Transition';
+import { CSSTransition } from 'react-transition-group';
+import type { CSSTransitionProps } from 'react-transition-group/CSSTransition';
+import type { EndHandler } from 'react-transition-group/Transition';
 import classNames from 'classnames';
 import ThemeExport from '../ThemeExport';
 

--- a/packages/components/src/transitions/SlideTransition.tsx
+++ b/packages/components/src/transitions/SlideTransition.tsx
@@ -1,9 +1,8 @@
 // SlideTransition class uses CSSTransition with slide-left and slide-right classNames, depending on the prop direction. The transition is 250ms long.
 //
-import CSSTransition, {
-  CSSTransitionProps,
-} from 'react-transition-group/CSSTransition';
-import { EndHandler } from 'react-transition-group/Transition';
+import { CSSTransition } from 'react-transition-group';
+import type { CSSTransitionProps } from 'react-transition-group/CSSTransition';
+import type { EndHandler } from 'react-transition-group/Transition';
 
 import classNames from 'classnames';
 import ThemeExport from '../ThemeExport';


### PR DESCRIPTION
Fixes #2192

Tested by following steps in the ticket. Created a react app w/ `create-react-app` and installed `@deephaven/components@0.91.1-webpack-fix.0` (alpha build from this PR). It properly started without webpack errors.