### PR TITLE
feat: Set selected theme via query string param

### DIFF
--- a/packages/components/src/theme/ThemeModel.ts
+++ b/packages/components/src/theme/ThemeModel.ts
@@ -43,7 +43,7 @@ export type ThemeIconsRequiringManualColorChanges =
 
 export const DEFAULT_DARK_THEME_KEY = 'default-dark' satisfies BaseThemeKey;
 export const DEFAULT_LIGHT_THEME_KEY = 'default-light' satisfies BaseThemeKey;
-export const THEME_KEY_OVERRIDE_QUERY_PARAM = 'themeKey';
+export const THEME_KEY_OVERRIDE_QUERY_PARAM = 'theme';
 
 // Hex versions of some of the default dark theme color palette needed for
 // preload defaults.

--- a/packages/components/src/theme/ThemeModel.ts
+++ b/packages/components/src/theme/ThemeModel.ts
@@ -43,6 +43,7 @@ export type ThemeIconsRequiringManualColorChanges =
 
 export const DEFAULT_DARK_THEME_KEY = 'default-dark' satisfies BaseThemeKey;
 export const DEFAULT_LIGHT_THEME_KEY = 'default-light' satisfies BaseThemeKey;
+export const THEME_KEY_OVERRIDE_QUERY_PARAM = 'themeKey';
 
 // Hex versions of some of the default dark theme color palette needed for
 // preload defaults.

--- a/packages/components/src/theme/ThemeProvider.test.tsx
+++ b/packages/components/src/theme/ThemeProvider.test.tsx
@@ -60,7 +60,7 @@ describe('ThemeProvider', () => {
   });
 
   it.each([null, customThemes])(
-    'should load themes based on default selected theme key: %o',
+    'should load themes based on default selected theme key. customThemes: %o',
     themes => {
       const component = render(
         <ThemeProvider themes={themes}>

--- a/packages/components/src/theme/ThemeProvider.test.tsx
+++ b/packages/components/src/theme/ThemeProvider.test.tsx
@@ -79,7 +79,16 @@ describe('ThemeProvider', () => {
     'should load themes based on override, preload data or default: %o, %s, %s',
     (themes, preloadData, overrideKey) => {
       asMock(getThemeKeyOverride).mockReturnValue(overrideKey);
-      asMock(getThemePreloadData).mockReturnValue(preloadData);
+
+      if (overrideKey == null) {
+        asMock(getThemePreloadData).mockReturnValue(preloadData);
+      } else {
+        asMock(getThemePreloadData).mockImplementation(() => {
+          throw new Error(
+            'getThemePreloadData should not be called when overrideKey is set'
+          );
+        });
+      }
 
       const component = render(
         <ThemeProvider themes={themes}>

--- a/packages/components/src/theme/ThemeProvider.test.tsx
+++ b/packages/components/src/theme/ThemeProvider.test.tsx
@@ -31,7 +31,10 @@ jest.mock('./ThemeUtils', () => {
   };
 });
 
-const customThemes = [{ themeKey: 'themeA' }] as [ThemeData];
+const customThemes = [
+  { themeKey: 'themeA' },
+  { themeKey: 'themeOverrideKey' },
+] as ThemeData[];
 const preloadA: ThemePreloadData = { themeKey: 'themeA' };
 
 beforeEach(() => {
@@ -73,7 +76,7 @@ describe('ThemeProvider', () => {
     [customThemes, null, 'themeOverrideKey'],
     [customThemes, preloadA, 'themeOverrideKey'],
   ] as const)(
-    'should load themes based on override, preload data or default: %s, %s, %s',
+    'should load themes based on override, preload data or default: %o, %s, %s',
     (themes, preloadData, overrideKey) => {
       asMock(getThemeKeyOverride).mockReturnValue(overrideKey);
       asMock(getThemePreloadData).mockReturnValue(preloadData);
@@ -114,7 +117,7 @@ describe('ThemeProvider', () => {
     [customThemes, null],
     [customThemes, preloadA],
   ] as const)(
-    'should set preload data when active themes change: %s, %s',
+    'should set preload data when active themes change: %o, %s',
     (themes, preloadData) => {
       asMock(getThemePreloadData).mockReturnValue(preloadData);
 
@@ -135,7 +138,7 @@ describe('ThemeProvider', () => {
     }
   );
 
-  describe.each([null, customThemes])('setSelectedThemeKey: %s', themes => {
+  describe.each([null, customThemes])('setSelectedThemeKey: %o', themes => {
     it.each([DEFAULT_LIGHT_THEME_KEY, customThemes[0].themeKey])(
       'should change selected theme: %s',
       themeKey => {

--- a/packages/components/src/theme/ThemeProvider.tsx
+++ b/packages/components/src/theme/ThemeProvider.tsx
@@ -1,18 +1,13 @@
 import { createContext, ReactNode, useEffect, useMemo, useState } from 'react';
 import Log from '@deephaven/log';
-import {
-  DEFAULT_DARK_THEME_KEY,
-  DEFAULT_PRELOAD_DATA_VARIABLES,
-  ThemeData,
-} from './ThemeModel';
+import { DEFAULT_PRELOAD_DATA_VARIABLES, ThemeData } from './ThemeModel';
 import {
   calculatePreloadStyleContent,
   getActiveThemes,
   getDefaultBaseThemes,
-  getThemePreloadData,
   setThemePreloadData,
   overrideSVGFillColors,
-  getThemeKeyOverride,
+  getDefaultSelectedThemeKey,
 } from './ThemeUtils';
 import { SpectrumThemeProvider } from './SpectrumThemeProvider';
 import './theme-svg.scss';
@@ -48,13 +43,8 @@ export function ThemeProvider({
 
   const [value, setValue] = useState<ThemeContextValue | null>(null);
 
-  const themeKeyOverride = useMemo(() => getThemeKeyOverride(), []);
-
   const [selectedThemeKey, setSelectedThemeKey] = useState<string>(
-    () =>
-      themeKeyOverride ??
-      getThemePreloadData()?.themeKey ??
-      DEFAULT_DARK_THEME_KEY
+    getDefaultSelectedThemeKey
   );
 
   // Calculate active themes once a non-null themes array is provided.

--- a/packages/components/src/theme/ThemeProvider.tsx
+++ b/packages/components/src/theme/ThemeProvider.tsx
@@ -12,6 +12,7 @@ import {
   getThemePreloadData,
   setThemePreloadData,
   overrideSVGFillColors,
+  getThemeKeyOverride,
 } from './ThemeUtils';
 import { SpectrumThemeProvider } from './SpectrumThemeProvider';
 import './theme-svg.scss';
@@ -47,8 +48,13 @@ export function ThemeProvider({
 
   const [value, setValue] = useState<ThemeContextValue | null>(null);
 
+  const themeKeyOverride = useMemo(() => getThemeKeyOverride(), []);
+
   const [selectedThemeKey, setSelectedThemeKey] = useState<string>(
-    () => getThemePreloadData()?.themeKey ?? DEFAULT_DARK_THEME_KEY
+    () =>
+      themeKeyOverride ??
+      getThemePreloadData()?.themeKey ??
+      DEFAULT_DARK_THEME_KEY
   );
 
   // Calculate active themes once a non-null themes array is provided.

--- a/packages/components/src/theme/ThemeUtils.test.ts
+++ b/packages/components/src/theme/ThemeUtils.test.ts
@@ -10,6 +10,7 @@ import {
   ThemePreloadColorVariable,
   ThemeRegistrationData,
   THEME_CACHE_LOCAL_STORAGE_KEY,
+  THEME_KEY_OVERRIDE_QUERY_PARAM,
 } from './ThemeModel';
 import {
   calculatePreloadStyleContent,
@@ -17,6 +18,7 @@ import {
   extractDistinctCssVariableExpressions,
   getActiveThemes,
   getDefaultBaseThemes,
+  getDefaultSelectedThemeKey,
   getExpressionRanges,
   getThemeKey,
   getThemePreloadData,
@@ -237,6 +239,44 @@ describe('getActiveThemes', () => {
     );
     expect(actual).toEqual([mockTheme.base, mockTheme.custom]);
   });
+});
+
+describe('getDefaultSelectedThemeKey', () => {
+  const origLocation = window.location;
+
+  beforeEach(() => {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    delete window.location;
+    window.location = {
+      search: '',
+    } as unknown as Location;
+  });
+
+  afterEach(() => {
+    window.location = origLocation;
+  });
+
+  it.each([
+    ['overrideKey', 'preloadKey', 'overrideKey'],
+    [undefined, 'preloadKey', 'preloadKey'],
+    [undefined, undefined, DEFAULT_DARK_THEME_KEY],
+  ])(
+    'should coalesce overide key -> preload key -> default key: %s, %s, %s',
+    (overrideKey, preloadKey, expected) => {
+      if (overrideKey != null) {
+        window.location.search = `?${THEME_KEY_OVERRIDE_QUERY_PARAM}=${overrideKey}`;
+      }
+
+      localStorage.setItem(
+        THEME_CACHE_LOCAL_STORAGE_KEY,
+        JSON.stringify({ themeKey: preloadKey })
+      );
+
+      const actual = getDefaultSelectedThemeKey();
+      expect(actual).toEqual(expected);
+    }
+  );
 });
 
 describe('getExpressionRanges', () => {

--- a/packages/components/src/theme/ThemeUtils.ts
+++ b/packages/components/src/theme/ThemeUtils.ts
@@ -180,6 +180,21 @@ export function getDefaultBaseThemes(): ThemeData[] {
 }
 
 /**
+ * Get the default selected theme key. Precedence is:
+ * 1. Theme key override query parameter
+ * 2. Theme key from preload data
+ * 3. Default dark theme key
+ * @returns The default selected theme key
+ */
+export function getDefaultSelectedThemeKey(): string {
+  return (
+    getThemeKeyOverride() ??
+    getThemePreloadData()?.themeKey ??
+    DEFAULT_DARK_THEME_KEY
+  );
+}
+
+/**
  * A theme key override can be set via a query parameter to force a specific
  * theme selection. Useful for embedded widget scenarios that don't expose the
  * theme selector.

--- a/packages/components/src/theme/ThemeUtils.ts
+++ b/packages/components/src/theme/ThemeUtils.ts
@@ -15,6 +15,7 @@ import {
   SVG_ICON_MANUAL_COLOR_MAP,
   ThemeCssVariableName,
   ThemeIconsRequiringManualColorChanges,
+  THEME_KEY_OVERRIDE_QUERY_PARAM,
 } from './ThemeModel';
 
 const log = Log.module('ThemeUtils');
@@ -176,6 +177,16 @@ export function getDefaultBaseThemes(): ThemeData[] {
       styleContent: themeLight,
     },
   ];
+}
+
+/**
+ * A theme key override can be set via a query parameter to force a specific
+ * theme selection. Useful for embedded widget scenarios that don't expose the
+ * theme selector.
+ */
+export function getThemeKeyOverride(): string | null {
+  const searchParams = new URLSearchParams(window.location.search);
+  return searchParams.get(THEME_KEY_OVERRIDE_QUERY_PARAM);
 }
 
 /**

--- a/packages/components/src/theme/__snapshots__/ThemeProvider.test.tsx.snap
+++ b/packages/components/src/theme/__snapshots__/ThemeProvider.test.tsx.snap
@@ -99,7 +99,7 @@ exports[`ThemeProvider setSelectedThemeKey: null should change selected theme: t
 </body>
 `;
 
-exports[`ThemeProvider should load themes based on default selected theme key: [
+exports[`ThemeProvider should load themes based on default selected theme key. customThemes: [
   { themeKey: 'themeA' },
   { themeKey: 'mockDefaultSelectedThemeKey' },
   [length]: 2
@@ -133,7 +133,7 @@ exports[`ThemeProvider should load themes based on default selected theme key: [
 </body>
 `;
 
-exports[`ThemeProvider should load themes based on default selected theme key: null 1`] = `
+exports[`ThemeProvider should load themes based on default selected theme key. customThemes: null 1`] = `
 <body>
   <div>
     <div

--- a/packages/components/src/theme/__snapshots__/ThemeProvider.test.tsx.snap
+++ b/packages/components/src/theme/__snapshots__/ThemeProvider.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`ThemeProvider setSelectedThemeKey: [
   { themeKey: 'themeA' },
-  { themeKey: 'themeOverrideKey' },
+  { themeKey: 'mockDefaultSelectedThemeKey' },
   [length]: 2
 ] should change selected theme: default-light 1`] = `
 <body>
@@ -33,7 +33,7 @@ exports[`ThemeProvider setSelectedThemeKey: [
 
 exports[`ThemeProvider setSelectedThemeKey: [
   { themeKey: 'themeA' },
-  { themeKey: 'themeOverrideKey' },
+  { themeKey: 'mockDefaultSelectedThemeKey' },
   [length]: 2
 ] should change selected theme: themeA 1`] = `
 <body>
@@ -99,11 +99,11 @@ exports[`ThemeProvider setSelectedThemeKey: null should change selected theme: t
 </body>
 `;
 
-exports[`ThemeProvider should load themes based on override, preload data or default: [
+exports[`ThemeProvider should load themes based on default selected theme key: [
   { themeKey: 'themeA' },
-  { themeKey: 'themeOverrideKey' },
+  { themeKey: 'mockDefaultSelectedThemeKey' },
   [length]: 2
-], { themeKey: 'themeA' }, null 1`] = `
+] 1`] = `
 <body>
   <div>
     <style
@@ -117,7 +117,7 @@ exports[`ThemeProvider should load themes based on override, preload data or def
 ./theme-dark-components.css?raw
     </style>
     <style
-      data-theme-key="themeA"
+      data-theme-key="mockDefaultSelectedThemeKey"
     />
     <div
       class="spectrum-theme-provider JuTe6q_spectrum _5QszkG_spectrum _5QszkG_i18nFontFamily PFjRbG_spectrum--light theme-spectrum-palette theme-spectrum-alias HAZavG_spectrum--large zA6MfG_spectrum zA6MfG_spectrum--dark zA6MfG_spectrum--darkest zA6MfG_spectrum--large zA6MfG_spectrum--light zA6MfG_spectrum--lightest zA6MfG_spectrum--medium"
@@ -133,157 +133,7 @@ exports[`ThemeProvider should load themes based on override, preload data or def
 </body>
 `;
 
-exports[`ThemeProvider should load themes based on override, preload data or default: [
-  { themeKey: 'themeA' },
-  { themeKey: 'themeOverrideKey' },
-  [length]: 2
-], { themeKey: 'themeA' }, themeOverrideKey 1`] = `
-<body>
-  <div>
-    <style
-      data-theme-key="default-dark"
-    >
-      ./theme-dark-palette.css?raw
-./theme-dark-semantic.css?raw
-./theme-dark-semantic-chart.css?raw
-./theme-dark-semantic-editor.css?raw
-./theme-dark-semantic-grid.css?raw
-./theme-dark-components.css?raw
-    </style>
-    <style
-      data-theme-key="themeOverrideKey"
-    />
-    <div
-      class="spectrum-theme-provider JuTe6q_spectrum _5QszkG_spectrum _5QszkG_i18nFontFamily PFjRbG_spectrum--light theme-spectrum-palette theme-spectrum-alias HAZavG_spectrum--large zA6MfG_spectrum zA6MfG_spectrum--dark zA6MfG_spectrum--darkest zA6MfG_spectrum--large zA6MfG_spectrum--light zA6MfG_spectrum--lightest zA6MfG_spectrum--medium"
-      dir="ltr"
-      lang="en-US"
-      style="isolation: isolate; color-scheme: light;"
-    >
-      <div>
-        Child
-      </div>
-    </div>
-  </div>
-</body>
-`;
-
-exports[`ThemeProvider should load themes based on override, preload data or default: [
-  { themeKey: 'themeA' },
-  { themeKey: 'themeOverrideKey' },
-  [length]: 2
-], null, null 1`] = `
-<body>
-  <div>
-    <style
-      data-theme-key="default-dark"
-    >
-      ./theme-dark-palette.css?raw
-./theme-dark-semantic.css?raw
-./theme-dark-semantic-chart.css?raw
-./theme-dark-semantic-editor.css?raw
-./theme-dark-semantic-grid.css?raw
-./theme-dark-components.css?raw
-    </style>
-    <div
-      class="spectrum-theme-provider JuTe6q_spectrum _5QszkG_spectrum _5QszkG_i18nFontFamily PFjRbG_spectrum--light theme-spectrum-palette theme-spectrum-alias HAZavG_spectrum--large zA6MfG_spectrum zA6MfG_spectrum--dark zA6MfG_spectrum--darkest zA6MfG_spectrum--large zA6MfG_spectrum--light zA6MfG_spectrum--lightest zA6MfG_spectrum--medium"
-      dir="ltr"
-      lang="en-US"
-      style="isolation: isolate; color-scheme: light;"
-    >
-      <div>
-        Child
-      </div>
-    </div>
-  </div>
-</body>
-`;
-
-exports[`ThemeProvider should load themes based on override, preload data or default: [
-  { themeKey: 'themeA' },
-  { themeKey: 'themeOverrideKey' },
-  [length]: 2
-], null, themeOverrideKey 1`] = `
-<body>
-  <div>
-    <style
-      data-theme-key="default-dark"
-    >
-      ./theme-dark-palette.css?raw
-./theme-dark-semantic.css?raw
-./theme-dark-semantic-chart.css?raw
-./theme-dark-semantic-editor.css?raw
-./theme-dark-semantic-grid.css?raw
-./theme-dark-components.css?raw
-    </style>
-    <style
-      data-theme-key="themeOverrideKey"
-    />
-    <div
-      class="spectrum-theme-provider JuTe6q_spectrum _5QszkG_spectrum _5QszkG_i18nFontFamily PFjRbG_spectrum--light theme-spectrum-palette theme-spectrum-alias HAZavG_spectrum--large zA6MfG_spectrum zA6MfG_spectrum--dark zA6MfG_spectrum--darkest zA6MfG_spectrum--large zA6MfG_spectrum--light zA6MfG_spectrum--lightest zA6MfG_spectrum--medium"
-      dir="ltr"
-      lang="en-US"
-      style="isolation: isolate; color-scheme: light;"
-    >
-      <div>
-        Child
-      </div>
-    </div>
-  </div>
-</body>
-`;
-
-exports[`ThemeProvider should load themes based on override, preload data or default: null, { themeKey: 'themeA' }, null 1`] = `
-<body>
-  <div>
-    <div
-      class="spectrum-theme-provider JuTe6q_spectrum _5QszkG_spectrum _5QszkG_i18nFontFamily PFjRbG_spectrum--light theme-spectrum-palette theme-spectrum-alias HAZavG_spectrum--large zA6MfG_spectrum zA6MfG_spectrum--dark zA6MfG_spectrum--darkest zA6MfG_spectrum--large zA6MfG_spectrum--light zA6MfG_spectrum--lightest zA6MfG_spectrum--medium"
-      dir="ltr"
-      lang="en-US"
-      style="isolation: isolate; color-scheme: light;"
-    >
-      <div>
-        Child
-      </div>
-    </div>
-  </div>
-</body>
-`;
-
-exports[`ThemeProvider should load themes based on override, preload data or default: null, { themeKey: 'themeA' }, themeOverrideKey 1`] = `
-<body>
-  <div>
-    <div
-      class="spectrum-theme-provider JuTe6q_spectrum _5QszkG_spectrum _5QszkG_i18nFontFamily PFjRbG_spectrum--light theme-spectrum-palette theme-spectrum-alias HAZavG_spectrum--large zA6MfG_spectrum zA6MfG_spectrum--dark zA6MfG_spectrum--darkest zA6MfG_spectrum--large zA6MfG_spectrum--light zA6MfG_spectrum--lightest zA6MfG_spectrum--medium"
-      dir="ltr"
-      lang="en-US"
-      style="isolation: isolate; color-scheme: light;"
-    >
-      <div>
-        Child
-      </div>
-    </div>
-  </div>
-</body>
-`;
-
-exports[`ThemeProvider should load themes based on override, preload data or default: null, null, null 1`] = `
-<body>
-  <div>
-    <div
-      class="spectrum-theme-provider JuTe6q_spectrum _5QszkG_spectrum _5QszkG_i18nFontFamily PFjRbG_spectrum--light theme-spectrum-palette theme-spectrum-alias HAZavG_spectrum--large zA6MfG_spectrum zA6MfG_spectrum--dark zA6MfG_spectrum--darkest zA6MfG_spectrum--large zA6MfG_spectrum--light zA6MfG_spectrum--lightest zA6MfG_spectrum--medium"
-      dir="ltr"
-      lang="en-US"
-      style="isolation: isolate; color-scheme: light;"
-    >
-      <div>
-        Child
-      </div>
-    </div>
-  </div>
-</body>
-`;
-
-exports[`ThemeProvider should load themes based on override, preload data or default: null, null, themeOverrideKey 1`] = `
+exports[`ThemeProvider should load themes based on default selected theme key: null 1`] = `
 <body>
   <div>
     <div

--- a/packages/components/src/theme/__snapshots__/ThemeProvider.test.tsx.snap
+++ b/packages/components/src/theme/__snapshots__/ThemeProvider.test.tsx.snap
@@ -1,6 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ThemeProvider setSelectedThemeKey: [ [Object] ] should change selected theme: default-light 1`] = `
+exports[`ThemeProvider setSelectedThemeKey: [
+  { themeKey: 'themeA' },
+  { themeKey: 'themeOverrideKey' },
+  [length]: 2
+] should change selected theme: default-light 1`] = `
 <body>
   <div>
     <style
@@ -27,7 +31,11 @@ exports[`ThemeProvider setSelectedThemeKey: [ [Object] ] should change selected 
 </body>
 `;
 
-exports[`ThemeProvider setSelectedThemeKey: [ [Object] ] should change selected theme: themeA 1`] = `
+exports[`ThemeProvider setSelectedThemeKey: [
+  { themeKey: 'themeA' },
+  { themeKey: 'themeOverrideKey' },
+  [length]: 2
+] should change selected theme: themeA 1`] = `
 <body>
   <div>
     <style
@@ -91,7 +99,11 @@ exports[`ThemeProvider setSelectedThemeKey: null should change selected theme: t
 </body>
 `;
 
-exports[`ThemeProvider should load themes based on override, preload data or default: [ [Object] ], { themeKey: 'themeA' }, null 1`] = `
+exports[`ThemeProvider should load themes based on override, preload data or default: [
+  { themeKey: 'themeA' },
+  { themeKey: 'themeOverrideKey' },
+  [length]: 2
+], { themeKey: 'themeA' }, null 1`] = `
 <body>
   <div>
     <style
@@ -121,7 +133,45 @@ exports[`ThemeProvider should load themes based on override, preload data or def
 </body>
 `;
 
-exports[`ThemeProvider should load themes based on override, preload data or default: [ [Object] ], { themeKey: 'themeA' }, themeOverrideKey 1`] = `
+exports[`ThemeProvider should load themes based on override, preload data or default: [
+  { themeKey: 'themeA' },
+  { themeKey: 'themeOverrideKey' },
+  [length]: 2
+], { themeKey: 'themeA' }, themeOverrideKey 1`] = `
+<body>
+  <div>
+    <style
+      data-theme-key="default-dark"
+    >
+      ./theme-dark-palette.css?raw
+./theme-dark-semantic.css?raw
+./theme-dark-semantic-chart.css?raw
+./theme-dark-semantic-editor.css?raw
+./theme-dark-semantic-grid.css?raw
+./theme-dark-components.css?raw
+    </style>
+    <style
+      data-theme-key="themeOverrideKey"
+    />
+    <div
+      class="spectrum-theme-provider JuTe6q_spectrum _5QszkG_spectrum _5QszkG_i18nFontFamily PFjRbG_spectrum--light theme-spectrum-palette theme-spectrum-alias HAZavG_spectrum--large zA6MfG_spectrum zA6MfG_spectrum--dark zA6MfG_spectrum--darkest zA6MfG_spectrum--large zA6MfG_spectrum--light zA6MfG_spectrum--lightest zA6MfG_spectrum--medium"
+      dir="ltr"
+      lang="en-US"
+      style="isolation: isolate; color-scheme: light;"
+    >
+      <div>
+        Child
+      </div>
+    </div>
+  </div>
+</body>
+`;
+
+exports[`ThemeProvider should load themes based on override, preload data or default: [
+  { themeKey: 'themeA' },
+  { themeKey: 'themeOverrideKey' },
+  [length]: 2
+], null, null 1`] = `
 <body>
   <div>
     <style
@@ -148,7 +198,11 @@ exports[`ThemeProvider should load themes based on override, preload data or def
 </body>
 `;
 
-exports[`ThemeProvider should load themes based on override, preload data or default: [ [Object] ], null, null 1`] = `
+exports[`ThemeProvider should load themes based on override, preload data or default: [
+  { themeKey: 'themeA' },
+  { themeKey: 'themeOverrideKey' },
+  [length]: 2
+], null, themeOverrideKey 1`] = `
 <body>
   <div>
     <style
@@ -161,33 +215,9 @@ exports[`ThemeProvider should load themes based on override, preload data or def
 ./theme-dark-semantic-grid.css?raw
 ./theme-dark-components.css?raw
     </style>
-    <div
-      class="spectrum-theme-provider JuTe6q_spectrum _5QszkG_spectrum _5QszkG_i18nFontFamily PFjRbG_spectrum--light theme-spectrum-palette theme-spectrum-alias HAZavG_spectrum--large zA6MfG_spectrum zA6MfG_spectrum--dark zA6MfG_spectrum--darkest zA6MfG_spectrum--large zA6MfG_spectrum--light zA6MfG_spectrum--lightest zA6MfG_spectrum--medium"
-      dir="ltr"
-      lang="en-US"
-      style="isolation: isolate; color-scheme: light;"
-    >
-      <div>
-        Child
-      </div>
-    </div>
-  </div>
-</body>
-`;
-
-exports[`ThemeProvider should load themes based on override, preload data or default: [ [Object] ], null, themeOverrideKey 1`] = `
-<body>
-  <div>
     <style
-      data-theme-key="default-dark"
-    >
-      ./theme-dark-palette.css?raw
-./theme-dark-semantic.css?raw
-./theme-dark-semantic-chart.css?raw
-./theme-dark-semantic-editor.css?raw
-./theme-dark-semantic-grid.css?raw
-./theme-dark-components.css?raw
-    </style>
+      data-theme-key="themeOverrideKey"
+    />
     <div
       class="spectrum-theme-provider JuTe6q_spectrum _5QszkG_spectrum _5QszkG_i18nFontFamily PFjRbG_spectrum--light theme-spectrum-palette theme-spectrum-alias HAZavG_spectrum--large zA6MfG_spectrum zA6MfG_spectrum--dark zA6MfG_spectrum--darkest zA6MfG_spectrum--large zA6MfG_spectrum--light zA6MfG_spectrum--lightest zA6MfG_spectrum--medium"
       dir="ltr"

--- a/packages/components/src/theme/__snapshots__/ThemeProvider.test.tsx.snap
+++ b/packages/components/src/theme/__snapshots__/ThemeProvider.test.tsx.snap
@@ -91,7 +91,7 @@ exports[`ThemeProvider setSelectedThemeKey: null should change selected theme: t
 </body>
 `;
 
-exports[`ThemeProvider should load themes based on preload data or default: [ [Object] ], { themeKey: 'themeA' } 1`] = `
+exports[`ThemeProvider should load themes based on override, preload data or default: [ [Object] ], { themeKey: 'themeA' }, null 1`] = `
 <body>
   <div>
     <style
@@ -121,7 +121,7 @@ exports[`ThemeProvider should load themes based on preload data or default: [ [O
 </body>
 `;
 
-exports[`ThemeProvider should load themes based on preload data or default: [ [Object] ], null 1`] = `
+exports[`ThemeProvider should load themes based on override, preload data or default: [ [Object] ], { themeKey: 'themeA' }, themeOverrideKey 1`] = `
 <body>
   <div>
     <style
@@ -148,7 +148,61 @@ exports[`ThemeProvider should load themes based on preload data or default: [ [O
 </body>
 `;
 
-exports[`ThemeProvider should load themes based on preload data or default: null, { themeKey: 'themeA' } 1`] = `
+exports[`ThemeProvider should load themes based on override, preload data or default: [ [Object] ], null, null 1`] = `
+<body>
+  <div>
+    <style
+      data-theme-key="default-dark"
+    >
+      ./theme-dark-palette.css?raw
+./theme-dark-semantic.css?raw
+./theme-dark-semantic-chart.css?raw
+./theme-dark-semantic-editor.css?raw
+./theme-dark-semantic-grid.css?raw
+./theme-dark-components.css?raw
+    </style>
+    <div
+      class="spectrum-theme-provider JuTe6q_spectrum _5QszkG_spectrum _5QszkG_i18nFontFamily PFjRbG_spectrum--light theme-spectrum-palette theme-spectrum-alias HAZavG_spectrum--large zA6MfG_spectrum zA6MfG_spectrum--dark zA6MfG_spectrum--darkest zA6MfG_spectrum--large zA6MfG_spectrum--light zA6MfG_spectrum--lightest zA6MfG_spectrum--medium"
+      dir="ltr"
+      lang="en-US"
+      style="isolation: isolate; color-scheme: light;"
+    >
+      <div>
+        Child
+      </div>
+    </div>
+  </div>
+</body>
+`;
+
+exports[`ThemeProvider should load themes based on override, preload data or default: [ [Object] ], null, themeOverrideKey 1`] = `
+<body>
+  <div>
+    <style
+      data-theme-key="default-dark"
+    >
+      ./theme-dark-palette.css?raw
+./theme-dark-semantic.css?raw
+./theme-dark-semantic-chart.css?raw
+./theme-dark-semantic-editor.css?raw
+./theme-dark-semantic-grid.css?raw
+./theme-dark-components.css?raw
+    </style>
+    <div
+      class="spectrum-theme-provider JuTe6q_spectrum _5QszkG_spectrum _5QszkG_i18nFontFamily PFjRbG_spectrum--light theme-spectrum-palette theme-spectrum-alias HAZavG_spectrum--large zA6MfG_spectrum zA6MfG_spectrum--dark zA6MfG_spectrum--darkest zA6MfG_spectrum--large zA6MfG_spectrum--light zA6MfG_spectrum--lightest zA6MfG_spectrum--medium"
+      dir="ltr"
+      lang="en-US"
+      style="isolation: isolate; color-scheme: light;"
+    >
+      <div>
+        Child
+      </div>
+    </div>
+  </div>
+</body>
+`;
+
+exports[`ThemeProvider should load themes based on override, preload data or default: null, { themeKey: 'themeA' }, null 1`] = `
 <body>
   <div>
     <div
@@ -165,7 +219,41 @@ exports[`ThemeProvider should load themes based on preload data or default: null
 </body>
 `;
 
-exports[`ThemeProvider should load themes based on preload data or default: null, null 1`] = `
+exports[`ThemeProvider should load themes based on override, preload data or default: null, { themeKey: 'themeA' }, themeOverrideKey 1`] = `
+<body>
+  <div>
+    <div
+      class="spectrum-theme-provider JuTe6q_spectrum _5QszkG_spectrum _5QszkG_i18nFontFamily PFjRbG_spectrum--light theme-spectrum-palette theme-spectrum-alias HAZavG_spectrum--large zA6MfG_spectrum zA6MfG_spectrum--dark zA6MfG_spectrum--darkest zA6MfG_spectrum--large zA6MfG_spectrum--light zA6MfG_spectrum--lightest zA6MfG_spectrum--medium"
+      dir="ltr"
+      lang="en-US"
+      style="isolation: isolate; color-scheme: light;"
+    >
+      <div>
+        Child
+      </div>
+    </div>
+  </div>
+</body>
+`;
+
+exports[`ThemeProvider should load themes based on override, preload data or default: null, null, null 1`] = `
+<body>
+  <div>
+    <div
+      class="spectrum-theme-provider JuTe6q_spectrum _5QszkG_spectrum _5QszkG_i18nFontFamily PFjRbG_spectrum--light theme-spectrum-palette theme-spectrum-alias HAZavG_spectrum--large zA6MfG_spectrum zA6MfG_spectrum--dark zA6MfG_spectrum--darkest zA6MfG_spectrum--large zA6MfG_spectrum--light zA6MfG_spectrum--lightest zA6MfG_spectrum--medium"
+      dir="ltr"
+      lang="en-US"
+      style="isolation: isolate; color-scheme: light;"
+    >
+      <div>
+        Child
+      </div>
+    </div>
+  </div>
+</body>
+`;
+
+exports[`ThemeProvider should load themes based on override, preload data or default: null, null, themeOverrideKey 1`] = `
 <body>
   <div>
     <div


### PR DESCRIPTION
Allow setting selected theme via a `themeKey` query string param.

Can test by passing `themeKey=default-light` and `themeKey=default-dark` as query string params.

resolves #2203