### PR TITLE
fix: Cherry-pick DH-17537: Fix Advanced Filter dialog not showing the values list on tree tables

### DIFF
--- a/packages/iris-grid/src/IrisGridModel.test.ts
+++ b/packages/iris-grid/src/IrisGridModel.test.ts
@@ -150,6 +150,16 @@ it('updates the model correctly when adding and removing a rollup config', async
   expect(table.rollup).not.toHaveBeenCalled();
 });
 
+it('isRollupAvailable checks if the rollup method is defined', async () => {
+  const table = irisGridTestUtils.makeTable();
+
+  const mock = jest.fn();
+  table.rollup = mock;
+  const model = irisGridTestUtils.makeModel(table);
+
+  expect(model.isRollupAvailable).toBe(true);
+});
+
 it('closes the table correctly when the model is closed', () => {
   const table = irisGridTestUtils.makeTable();
   table.close = jest.fn();

--- a/packages/iris-grid/src/IrisGridTableModel.ts
+++ b/packages/iris-grid/src/IrisGridTableModel.ts
@@ -59,10 +59,6 @@ class IrisGridTableModel
     return this.table.getColumnStatistics != null;
   }
 
-  get isValuesTableAvailable(): boolean {
-    return this.table.selectDistinct != null && this.table.copy != null;
-  }
-
   get isRollupAvailable(): boolean {
     return this.table.rollup != null;
   }

--- a/packages/iris-grid/src/IrisGridTableModelTemplate.ts
+++ b/packages/iris-grid/src/IrisGridTableModelTemplate.ts
@@ -445,6 +445,10 @@ class IrisGridTableModelTemplate<
       : 0;
   }
 
+  get isValuesTableAvailable(): boolean {
+    return this.table.selectDistinct != null && this.table.copy != null;
+  }
+
   get isChartBuilderAvailable(): boolean {
     return true;
   }

--- a/packages/iris-grid/src/IrisGridTreeTableModel.test.ts
+++ b/packages/iris-grid/src/IrisGridTreeTableModel.test.ts
@@ -26,6 +26,23 @@ describe('IrisGridTreeTableModel virtual columns', () => {
       expect(model.columns).toEqual(expected);
     }
   );
+
+  test.each([
+    ['filter', 'Filter'],
+    ['sort', 'Sort'],
+    ['formatColor', 'Color'],
+    ['get', 'get'],
+    ['getFormat', 'getFormat'],
+    ['formatNumber', 'formatNumber'],
+    ['formatDate', 'formatDate'],
+  ])('virtual column method %s is not implemented', (method, displayName) => {
+    const groupedColumns = columns.slice(0, 2);
+    const table = irisGridTestUtils.makeTreeTable(columns, groupedColumns);
+    const model = new IrisGridTreeTableModel(dh, table);
+    expect(() => model.columns[0][method]()).toThrow(
+      new Error(`${displayName} not implemented for virtual column`)
+    );
+  });
 });
 
 describe('IrisGridTreeTableModel layoutHints', () => {
@@ -70,5 +87,15 @@ describe('IrisGridTreeTableModel layoutHints', () => {
     const model = new IrisGridTreeTableModel(dh, table);
 
     expect(model.layoutHints).toEqual(undefined);
+  });
+});
+
+describe('IrisGridTreeTableModel values table', () => {
+  it('is available for tree tables', () => {
+    const columns = irisGridTestUtils.makeColumns();
+    const table = irisGridTestUtils.makeTreeTable(columns, columns, 100, []);
+    const model = new IrisGridTreeTableModel(dh, table);
+
+    expect(model.isValuesTableAvailable).toBe(true);
   });
 });

--- a/packages/iris-grid/src/IrisGridTreeTableModel.ts
+++ b/packages/iris-grid/src/IrisGridTreeTableModel.ts
@@ -61,7 +61,7 @@ class IrisGridTreeTableModel extends IrisGridTableModelTemplate<
                 throw new Error('Filter not implemented for virtual column');
               },
               sort: () => {
-                throw new Error('Sort not implemented virtual column');
+                throw new Error('Sort not implemented for virtual column');
               },
               formatColor: () => {
                 throw new Error('Color not implemented for virtual column');


### PR DESCRIPTION
Move `isValuesTableAvailable` getter from `IrisGridTableModel` to
`IrisGridTableModelTemplate` to make it availalbe in tree table model.
Fixes DH-17537 in enterprise.

Note, this doesn't fix the issue with Advanced Filter on tree tables in
Community. JSAPI throws an exception on a `treeTable.copy` call.

```
[AdvancedFilterCreator] Unable to open values table Error: java.lang.UnsupportedOperationException: reexport
    at UnsupportedOperationException_0.createError (dh-core.js:1383:10)
    at UnsupportedOperationException_0.initializeBackingError (dh-core.js:1409:46)
    at UnsupportedOperationException_0.Throwable_0 (dh-core.js:1348:8)
    at UnsupportedOperationException_0.Exception_1 (dh-core.js:1433:18)
    at UnsupportedOperationException_0.RuntimeException_1 (dh-core.js:1446:18)
    at new UnsupportedOperationException_0 (dh-core.js:35418:25)
    at Object.lambda$56 (dh-core.js:24457:14)
    at JsTreeTable$lambda$56$Type.fetch_25 [as fetch_1] (dh-core.js:25453:10)
    at Object.$lambda$32_0 (dh-core.js:31972:23)
    at ClientTableState$lambda$32$Type.accept_90 [as accept] (dh-core.js:32707:9)
    at Function.onInvoke_2 (dh-core.js:5068:12)
    at lambda (dh-core.js:174:22)
    at new Promise (<anonymous>)
    at Object.$refetch_2 (dh-core.js:32098:13)
    at JsTreeTable.copy_1 [as copy] (dh-core.js:24514:16)
    at Proxy.valuesTable (IrisGridTableModelTemplate.ts:1519:32)
    at AdvancedFilterCreator.initValuesTable (AdvancedFilterCreator.tsx:212:13)
```

Filed an issue in Core:
https://github.com/deephaven/deephaven-core/issues/6097