### PR TITLE
fix: Reuse dashboard tabs when reassigning the variable

### DIFF
--- a/packages/code-studio/src/main/AppMainContainer.tsx
+++ b/packages/code-studio/src/main/AppMainContainer.tsx
@@ -524,16 +524,30 @@ export class AppMainContainer extends Component<
     const newId = nanoid();
     const { setDashboardPluginData } = this.props;
     setDashboardPluginData(newId, pluginId, data);
-    this.setState(({ tabs }) => ({
-      tabs: [
-        ...tabs,
-        {
-          key: newId,
-          title,
-        },
-      ],
-      activeTabKey: newId,
-    }));
+    this.setState(({ tabs }) => {
+      const existingTab = tabs.findIndex(
+        ({ title: tabTitle }) => tabTitle === title
+      );
+      if (existingTab !== -1) {
+        // Replace the existing tab
+        return {
+          tabs: tabs.map((tab, index) =>
+            index === existingTab ? { key: newId, title } : tab
+          ),
+          activeTabKey: newId,
+        };
+      }
+      return {
+        tabs: [
+          ...tabs,
+          {
+            key: newId,
+            title,
+          },
+        ],
+        activeTabKey: newId,
+      };
+    });
   }
 
   handleWidgetMenuClick(): void {

--- a/packages/dashboard-core-plugins/src/panels/ConsolePanel.tsx
+++ b/packages/dashboard-core-plugins/src/panels/ConsolePanel.tsx
@@ -14,6 +14,7 @@ import {
 } from '@deephaven/console';
 import {
   type DashboardPanelProps,
+  emitCloseDashboard,
   emitPanelOpen,
   LayoutManagerContext,
   LayoutUtils,
@@ -278,6 +279,8 @@ export class ConsolePanel extends PureComponent<
       if (id != null) {
         const { glEventHub } = this.props;
         glEventHub.emit(PanelEvent.CLOSE, id);
+        // Just emit for all panels since there shouldn't be dashboard and panel name conflicts
+        emitCloseDashboard(glEventHub, title);
       }
     }
   }

--- a/packages/dashboard/src/DashboardEvents.ts
+++ b/packages/dashboard/src/DashboardEvents.ts
@@ -1,6 +1,8 @@
-import type { EventHub } from '@deephaven/golden-layout';
+import { makeEventFunctions } from '@deephaven/golden-layout';
 
 export const CREATE_DASHBOARD = 'CREATE_DASHBOARD';
+
+export const CLOSE_DASHBOARD = 'CLOSE_DASHBOARD';
 
 export interface CreateDashboardPayload<T = unknown> {
   pluginId: string;
@@ -8,28 +10,14 @@ export interface CreateDashboardPayload<T = unknown> {
   data: T;
 }
 
-export function stopListenForCreateDashboard<T = unknown>(
-  eventHub: EventHub,
-  handler: (p: CreateDashboardPayload<T>) => void
-): void {
-  try {
-    eventHub.off(CREATE_DASHBOARD, handler);
-  } catch {
-    // golden-layout throws if the handler is not found. Instead catch it and no-op
-  }
-}
+export const {
+  listen: listenForCreateDashboard,
+  emit: emitCreateDashboard,
+  useListener: useCreateDashboardListener,
+} = makeEventFunctions<[detail: CreateDashboardPayload]>(CREATE_DASHBOARD);
 
-export function listenForCreateDashboard<T = unknown>(
-  eventHub: EventHub,
-  handler: (p: CreateDashboardPayload<T>) => void
-): () => void {
-  eventHub.on(CREATE_DASHBOARD, handler);
-  return () => stopListenForCreateDashboard(eventHub, handler);
-}
-
-export function emitCreateDashboard<T = unknown>(
-  eventHub: EventHub,
-  payload: CreateDashboardPayload<T>
-): void {
-  eventHub.emit(CREATE_DASHBOARD, payload);
-}
+export const {
+  listen: listenForCloseDashboard,
+  emit: emitCloseDashboard,
+  useListener: useCloseDashboardListener,
+} = makeEventFunctions<[title: string]>(CLOSE_DASHBOARD);


### PR DESCRIPTION
Fixes #1971

Tested with this code run 1 line at a time

```python
import deephaven.ui as ui

a = ui.dashboard(ui.text("Hello"))

a = ui.dashboard(ui.text("World"))

a = ui.text("Hello")

a = ui.dashboard(ui.text("Hello"))

del a
```

Also tested dashboards still load in embed-widget. There was a race condition since the `makeUseListenerFunction` hook was using `useEffect`. This caused the event to emit between the event hub being set and the listener being added.