### PR TITLE
refactor: Moved NewTableColumnTypes to jsapi-utils

### DIFF
--- a/packages/console/package.json
+++ b/packages/console/package.json
@@ -29,6 +29,7 @@
     "@deephaven/icons": "file:../icons",
     "@deephaven/jsapi-bootstrap": "file:../jsapi-bootstrap",
     "@deephaven/jsapi-types": "^1.0.0-dev0.34.0",
+    "@deephaven/jsapi-utils": "file:../jsapi-utils",
     "@deephaven/log": "file:../log",
     "@deephaven/react-hooks": "file:../react-hooks",
     "@deephaven/storage": "file:../storage",

--- a/packages/console/src/csv/CsvTypeParser.ts
+++ b/packages/console/src/csv/CsvTypeParser.ts
@@ -7,7 +7,7 @@ import Papa, {
 } from 'papaparse';
 // Intentionally using isNaN rather than Number.isNaN
 /* eslint-disable no-restricted-globals */
-import NewTableColumnTypes from './NewTableColumnTypes';
+import { NewTableColumnTypes } from '@deephaven/jsapi-utils';
 import makeZipStreamHelper from './ZipStreamHelper';
 
 // Initially column types start as unknown

--- a/packages/console/src/index.ts
+++ b/packages/console/src/index.ts
@@ -16,4 +16,3 @@ export * from './console-history';
 export * from './monaco';
 export { default as LogView } from './log/LogView';
 export { default as HeapUsage } from './HeapUsage';
-export { default as NewTableColumnTypes } from './csv/NewTableColumnTypes';

--- a/packages/console/tsconfig.json
+++ b/packages/console/tsconfig.json
@@ -11,6 +11,7 @@
     { "path": "../components" },
     { "path": "../jsapi-bootstrap" },
     { "path": "../jsapi-shim" },
+    { "path": "../jsapi-utils" },
     { "path": "../log" },
     { "path": "../storage" },
     { "path": "../test-utils" },

--- a/packages/jsapi-utils/src/NewTableColumnTypes.ts
+++ b/packages/jsapi-utils/src/NewTableColumnTypes.ts
@@ -1,7 +1,7 @@
 /**
  * Valid column types to be used for a call to newTable.
  */
-class NewTableColumnTypes {
+export class NewTableColumnTypes {
   static INTEGER = 'int';
 
   static LONG = 'long';

--- a/packages/jsapi-utils/src/index.ts
+++ b/packages/jsapi-utils/src/index.ts
@@ -6,6 +6,7 @@ export * from './Formatter';
 export { default as FormatterUtils } from './FormatterUtils';
 export * from './FormatterUtils';
 export * from './MessageUtils';
+export * from './NewTableColumnTypes';
 export * from './NoConsolesError';
 export * from './SessionUtils';
 export * from './Settings';


### PR DESCRIPTION
Moved `NewTableColumnTypes` to jsapi-utils

resolves #2239 