### PR TITLE
fix: improve color contrast of editor find in dark mode

### DIFF
--- a/packages/components/src/theme/theme-dark/theme-dark-semantic-editor.css
+++ b/packages/components/src/theme/theme-dark/theme-dark-semantic-editor.css
@@ -59,8 +59,10 @@
   /* Find */
   --dh-color-editor-find-bg: var(--dh-color-gray-200);
   --dh-color-editor-find-match-bg: var(--dh-color-highlight-selected);
-  --dh-color-editor-find-match-highlight-bg: var(
-    --dh-color-highlight-selected-hover
+  --dh-color-editor-find-match-highlight-bg: color-mix(
+    in srgb,
+    var(--dh-color-orange-800) 35%,
+    transparent
   );
   --dh-color-editor-find-option-active-bg: var(--dh-color-accent-700);
   --dh-color-editor-find-option-active-fg: var(--dh-color-gray-900);


### PR DESCRIPTION
User reported editor find contrast in dark mode was bad. Changed color for semantic editor highlight in dark mode to an orange similar to what monokai uses for find in vs code. Confirmed existing color in light mode was fine.

Before:
![image](https://github.com/user-attachments/assets/6253e838-ad85-4491-82a4-6c7d865cb0a2)

After:
![image](https://github.com/user-attachments/assets/b9630774-f2f9-4c30-8c71-07d4fcb2abc7)

