### PR TITLE
fix: DH-17861: Fix the warning about IrisGridModelUpdater render not being a pure function

### DIFF
--- a/packages/iris-grid/src/IrisGridModelUpdater.tsx
+++ b/packages/iris-grid/src/IrisGridModelUpdater.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/require-default-props */
 /* eslint-disable no-param-reassign */
-import { useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 import type { dh } from '@deephaven/jsapi-types';
 import { type ModelIndex, type MoveOperation } from '@deephaven/grid';
 import {
@@ -177,18 +177,6 @@ function IrisGridModelUpdater({
     [model, isTotalsAvailable, totalsConfig]
   );
   useOnChange(
-    function updatePendingRowCount() {
-      model.pendingRowCount = pendingRowCount;
-    },
-    [model, pendingRowCount]
-  );
-  useOnChange(
-    function updatePendingDataMap() {
-      model.pendingDataMap = pendingDataMap;
-    },
-    [model, pendingDataMap]
-  );
-  useOnChange(
     function updateFrozenColumns() {
       if (frozenColumns) {
         model.updateFrozenColumns(frozenColumns);
@@ -209,6 +197,20 @@ function IrisGridModelUpdater({
       }
     },
     [model, partitionConfig]
+  );
+  // These setters are whapped in useEffect instead of useOnChange because they fire an event
+  // that potentially causes side effects, violating the rule that render should be a pure function.
+  useEffect(
+    function updatePendingRowCount() {
+      model.pendingRowCount = pendingRowCount;
+    },
+    [model, pendingRowCount]
+  );
+  useEffect(
+    function updatePendingDataMap() {
+      model.pendingDataMap = pendingDataMap;
+    },
+    [model, pendingDataMap]
   );
 
   return null;

--- a/packages/iris-grid/src/IrisGridModelUpdater.tsx
+++ b/packages/iris-grid/src/IrisGridModelUpdater.tsx
@@ -198,7 +198,7 @@ function IrisGridModelUpdater({
     },
     [model, partitionConfig]
   );
-  // These setters are whapped in useEffect instead of useOnChange because they fire an event
+  // These setters are wrapped in useEffect instead of useOnChange because they emit an event
   // that potentially causes side effects, violating the rule that render should be a pure function.
   useEffect(
     function updatePendingRowCount() {


### PR DESCRIPTION
`pendingRowCount` and `pendingDataMap` setters in `IrisGridModelUpdater` were emitting an event in the render cycle, that caused a React warning about the render not being a pure function because the event triggered state update in `IrisGrid`.
Wrap the setters in `useEffect` instead of `useOnChange` so the events are emitted after the render.