### PR TITLE
fix: DH-17851: Fix snapshot error in TreeTable model when selection extends past viewport

### DIFF
--- a/packages/iris-grid/src/IrisGridTreeTableModel.test.ts
+++ b/packages/iris-grid/src/IrisGridTreeTableModel.test.ts
@@ -1,4 +1,8 @@
+import { GridRange } from '@deephaven/grid';
 import dh from '@deephaven/jsapi-shim';
+import { type dh as DhType } from '@deephaven/jsapi-types';
+import { TestUtils } from '@deephaven/test-utils';
+import { act } from 'react-dom/test-utils';
 import IrisGridTestUtils from './IrisGridTestUtils';
 import IrisGridTreeTableModel from './IrisGridTreeTableModel';
 
@@ -103,5 +107,54 @@ describe('IrisGridTreeTableModel values table', () => {
     const model = new IrisGridTreeTableModel(dh, table);
 
     expect(model.isValuesTableAvailable).toBe(true);
+  });
+});
+
+describe('IrisGridTreeTableModel snapshot', () => {
+  it(`doesn't throw if selection extends past the viewport`, async () => {
+    function getLastRegisteredEventHandler(
+      table: DhType.TreeTable,
+      eventName: string
+    ): ((event) => void) | undefined {
+      const { calls } = TestUtils.asMock(table.addEventListener).mock;
+      const [lastCall] = calls.filter(call => call[0] === eventName).slice(-1);
+      return lastCall?.[1];
+    }
+    function mockUpdateEvent(
+      offset: number,
+      rows: DhType.TreeRow[],
+      columns: DhType.Column[]
+    ): CustomEvent {
+      return {
+        detail: {
+          offset,
+          rows,
+          columns,
+        },
+      } as CustomEvent;
+    }
+    const columns = irisGridTestUtils.makeColumns();
+    const table = TestUtils.createMockProxy<DhType.TreeTable>({
+      columns,
+      groupedColumns: columns,
+      size: 100,
+    });
+    const model = new IrisGridTreeTableModel(dh, table);
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    model.addEventListener(IrisGridTreeTableModel.EVENT.UPDATED, () => {});
+    model.setViewport(0, 5, columns);
+    // Trigger update event to populate viewport data in the model
+    const updateEventHandler = getLastRegisteredEventHandler(
+      table,
+      dh.Table.EVENT_UPDATED
+    );
+    const row = irisGridTestUtils.makeRow(0);
+    const event = mockUpdateEvent(0, Array(6).fill(row), columns);
+    act(() => {
+      updateEventHandler?.(event);
+    });
+    // Get the snapshot for rows 2-10 with the viewport at 0-5
+    const snapshot = await model.snapshot([new GridRange(0, 2, 0, 10)]);
+    expect(snapshot.length).toBe(4);
   });
 });

--- a/packages/iris-grid/src/IrisGridTreeTableModel.test.ts
+++ b/packages/iris-grid/src/IrisGridTreeTableModel.test.ts
@@ -154,7 +154,8 @@ describe('IrisGridTreeTableModel snapshot', () => {
       updateEventHandler?.(event);
     });
     // Get the snapshot for rows 2-10 with the viewport at 0-5
-    const snapshot = await model.snapshot([new GridRange(0, 2, 0, 10)]);
-    expect(snapshot.length).toBe(4);
+    await expect(async () => {
+      await model.snapshot([new GridRange(0, 2, 0, 10)]);
+    }).not.toThrow();
   });
 });

--- a/packages/iris-grid/src/IrisGridTreeTableModel.test.ts
+++ b/packages/iris-grid/src/IrisGridTreeTableModel.test.ts
@@ -116,9 +116,10 @@ describe('IrisGridTreeTableModel snapshot', () => {
       table: DhType.TreeTable,
       eventName: string
     ): ((event) => void) | undefined {
-      const { calls } = TestUtils.asMock(table.addEventListener).mock;
-      const [lastCall] = calls.filter(call => call[0] === eventName).slice(-1);
-      return lastCall?.[1];
+      return TestUtils.findLastCall(
+        table.addEventListener,
+        ([name]) => name === eventName
+      )?.[1];
     }
     function mockUpdateEvent(
       offset: number,

--- a/packages/iris-grid/src/IrisGridTreeTableModel.ts
+++ b/packages/iris-grid/src/IrisGridTreeTableModel.ts
@@ -197,9 +197,9 @@ class IrisGridTreeTableModel extends IrisGridTableModelTemplate<
 
     const viewportRange = new GridRange(
       0,
-      this.viewportData?.offset,
+      this.viewportData.offset,
       columns.length,
-      this.viewportData.offset + this.viewportData.rows.length
+      this.viewportData.offset + this.viewportData.rows.length - 1
     );
 
     for (let i = 0; i < ranges.length; i += 1) {


### PR DESCRIPTION
`IrisGridTreeTableModel.snapshot` was attempting to access data outside of the populated `viewportData` array.