### PR TITLE
fix: Fix Type in Spectrum Modal Overlay Background Color

### DIFF
--- a/packages/components/src/theme/theme-spectrum/theme-spectrum-alias.module.css
+++ b/packages/components/src/theme/theme-spectrum/theme-spectrum-alias.module.css
@@ -41,7 +41,7 @@
   /* Shadows / Overlays */
   --spectrum-alias-dropshadow-color: var(--dh-color-dropshadow);
   --spectrum-alias-background-color-modal-overlay: var(
-    --dh-color-modal-overlay-bg
+    --dh-color-overlay-modal-bg
   );
   --spectrum-alias-background-color-hover-overlay: var(
     --dh-color-overlay-hover-bg


### PR DESCRIPTION
closes https://github.com/deephaven/web-client-ui/issues/2266