### PR TITLE
feat: Added a 404 status check

### DIFF
--- a/packages/jsapi-nodejs/src/serverUtils.ts
+++ b/packages/jsapi-nodejs/src/serverUtils.ts
@@ -45,6 +45,11 @@ export async function downloadFromURL(
         });
 
         res.on('end', async () => {
+          if (res.statusCode === 404) {
+            reject(new Error(`File not found: "${url}"`));
+            return;
+          }
+
           resolve(file);
         });
       })


### PR DESCRIPTION
In cases of 404 status messages, an html content 404 page was getting saved to disk later showing a non-helpful error to consumers. This should make the problem more explicit.

resolves #2271 