### PR TITLE
refactor: Change iris-grid reverseType to reverse and deprecate reverseType

### DIFF
--- a/packages/dashboard-core-plugins/src/panels/IrisGridPanel.tsx
+++ b/packages/dashboard-core-plugins/src/panels/IrisGridPanel.tsx
@@ -48,8 +48,6 @@ import {
 import {
   type AdvancedFilterOptions,
   type FormattingRule,
-  type ReverseType,
-  TableUtils,
 } from '@deephaven/jsapi-utils';
 import Log from '@deephaven/log';
 import {
@@ -178,7 +176,7 @@ interface IrisGridPanelState {
   sorts: readonly dh.Sort[];
   userColumnWidths: ModelSizeMap;
   userRowHeights: ModelSizeMap;
-  reverseType: ReverseType;
+  reverse: boolean;
   movedColumns: readonly MoveOperation[];
   movedRows: readonly MoveOperation[];
   isSelectingPartition: boolean;
@@ -288,7 +286,7 @@ export class IrisGridPanel extends PureComponent<
       sorts: [],
       userColumnWidths: new Map(),
       userRowHeights: new Map(),
-      reverseType: TableUtils.REVERSE_TYPE.NONE,
+      reverse: false,
       movedColumns: [],
       movedRows: [],
       isSelectingPartition: false,
@@ -471,7 +469,7 @@ export class IrisGridPanel extends PureComponent<
       isFilterBarShown: boolean,
       quickFilters: ReadonlyQuickFilterMap,
       customColumns: readonly ColumnName[],
-      reverseType: ReverseType,
+      reverse: boolean,
       rollupConfig: UIRollupConfig | undefined,
       showSearchBar: boolean,
       searchValue: string,
@@ -499,7 +497,7 @@ export class IrisGridPanel extends PureComponent<
         },
         quickFilters,
         customColumns,
-        reverseType,
+        reverse,
         rollupConfig,
         showSearchBar,
         searchValue,
@@ -1053,7 +1051,7 @@ export class IrisGridPanel extends PureComponent<
         customColumnFormatMap,
         isFilterBarShown,
         quickFilters,
-        reverseType,
+        reverse,
         rollupConfig,
         aggregationSettings,
         sorts,
@@ -1091,7 +1089,7 @@ export class IrisGridPanel extends PureComponent<
         movedRows,
         partitions,
         quickFilters,
-        reverseType,
+        reverse,
         rollupConfig,
         aggregationSettings,
         sorts,
@@ -1132,7 +1130,7 @@ export class IrisGridPanel extends PureComponent<
       isFilterBarShown,
       quickFilters,
       customColumns,
-      reverseType,
+      reverse,
       rollupConfig,
       showSearchBar,
       searchValue,
@@ -1169,7 +1167,7 @@ export class IrisGridPanel extends PureComponent<
         isFilterBarShown,
         quickFilters,
         customColumns,
-        reverseType,
+        reverse,
         rollupConfig,
         showSearchBar,
         searchValue,
@@ -1248,7 +1246,7 @@ export class IrisGridPanel extends PureComponent<
       partitions,
       partitionConfig,
       quickFilters,
-      reverseType,
+      reverse,
       rollupConfig,
       sorts,
       userColumnWidths,
@@ -1328,7 +1326,7 @@ export class IrisGridPanel extends PureComponent<
             partitions={partitions}
             partitionConfig={partitionConfig}
             quickFilters={quickFilters}
-            reverseType={reverseType}
+            reverse={reverse}
             rollupConfig={rollupConfig}
             settings={settings}
             sorts={sorts}

--- a/packages/iris-grid/src/IrisGrid.tsx
+++ b/packages/iris-grid/src/IrisGrid.tsx
@@ -301,7 +301,7 @@ export interface IrisGridProps {
   sorts: readonly DhType.Sort[];
 
   /** @deprecated use `reverse` instead */
-  reverseType: ReverseType;
+  reverseType?: ReverseType;
   reverse: boolean;
   quickFilters: ReadonlyQuickFilterMap | null;
   customColumns: readonly ColumnName[];
@@ -498,7 +498,6 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
     quickFilters: EMPTY_MAP,
     selectDistinctColumns: EMPTY_ARRAY,
     sorts: EMPTY_ARRAY,
-    reverseType: TableUtils.REVERSE_TYPE.NONE,
     reverse: false,
     customColumns: EMPTY_ARRAY,
     aggregationSettings: DEFAULT_AGGREGATION_SETTINGS,

--- a/packages/iris-grid/src/IrisGrid.tsx
+++ b/packages/iris-grid/src/IrisGrid.tsx
@@ -219,7 +219,7 @@ function isEmptyConfig({
   aggregationSettings,
   customColumns,
   quickFilters,
-  reverseType,
+  reverse,
   rollupConfig,
   searchFilter,
   selectDistinctColumns,
@@ -229,7 +229,7 @@ function isEmptyConfig({
   aggregationSettings: AggregationSettings;
   customColumns: readonly ColumnName[];
   quickFilters: ReadonlyQuickFilterMap;
-  reverseType: ReverseType;
+  reverse: boolean;
   rollupConfig?: UIRollupConfig;
   searchFilter?: DhType.FilterCondition;
   selectDistinctColumns: readonly ColumnName[];
@@ -240,7 +240,7 @@ function isEmptyConfig({
     aggregationSettings.aggregations.length === 0 &&
     customColumns.length === 0 &&
     quickFilters.size === 0 &&
-    reverseType === TableUtils.REVERSE_TYPE.NONE &&
+    !reverse &&
     rollupConfig == null &&
     searchFilter == null &&
     selectDistinctColumns.length === 0 &&
@@ -299,7 +299,10 @@ export interface IrisGridProps {
   partitions?: (string | null)[];
   partitionConfig?: PartitionConfig;
   sorts: readonly DhType.Sort[];
+
+  /** @deprecated use `reverse` instead */
   reverseType: ReverseType;
+  reverse: boolean;
   quickFilters: ReadonlyQuickFilterMap | null;
   customColumns: readonly ColumnName[];
   selectDistinctColumns: readonly ColumnName[];
@@ -378,7 +381,7 @@ export interface IrisGridState {
   hoverAdvancedFilter: number | null;
 
   sorts: readonly DhType.Sort[];
-  reverseType: ReverseType;
+  reverse: boolean;
   customColumns: readonly ColumnName[];
   selectDistinctColumns: readonly ColumnName[];
 
@@ -496,6 +499,7 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
     selectDistinctColumns: EMPTY_ARRAY,
     sorts: EMPTY_ARRAY,
     reverseType: TableUtils.REVERSE_TYPE.NONE,
+    reverse: false,
     customColumns: EMPTY_ARRAY,
     aggregationSettings: DEFAULT_AGGREGATION_SETTINGS,
     rollupConfig: undefined,
@@ -806,7 +810,7 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
       shownAdvancedFilter: null,
       hoverAdvancedFilter: null,
       sorts: [],
-      reverseType: TableUtils.REVERSE_TYPE.NONE,
+      reverse: false,
       customColumns: [],
       selectDistinctColumns,
 
@@ -1004,7 +1008,7 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
     | 'aggregationSettings'
     | 'customColumns'
     | 'quickFilters'
-    | 'reverseType'
+    | 'reverse'
     | 'rollupConfig'
     | 'searchFilter'
     | 'selectDistinctColumns'
@@ -1372,10 +1376,10 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
       quickFilters: ReadonlyQuickFilterMap,
       advancedFilters: ReadonlyAdvancedFilterMap,
       sorts: readonly DhType.Sort[],
-      reverseType: ReverseType,
+      reverse: boolean,
       rollupConfig: UIRollupConfig | undefined,
       isMenuShown: boolean
-    ) => ({
+    ): Partial<IrisGridState & IrisGridProps> => ({
       hoverSelectColumn,
       isFilterBarShown,
       isSelectingColumn,
@@ -1383,7 +1387,7 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
       quickFilters,
       advancedFilters,
       sorts,
-      reverseType,
+      reverse,
       rollupConfig,
       isMenuShown,
     }),
@@ -2026,6 +2030,7 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
       inputFilters,
       sorts,
       model,
+      reverse,
       reverseType,
       customColumns,
       searchValue,
@@ -2053,7 +2058,7 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
 
     this.setState({
       sorts,
-      reverseType,
+      reverse: reverse || reverseType === TableUtils.REVERSE_TYPE.POST_SORT,
       customColumns,
       isReady: true,
       searchFilter,
@@ -2292,7 +2297,7 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
         aggregationSettings,
         customColumns,
         quickFilters,
-        reverseType,
+        reverse,
         rollupConfig,
         searchFilter,
         selectDistinctColumns,
@@ -2305,7 +2310,7 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
         aggregationSettings,
         customColumns,
         quickFilters,
-        reverseType,
+        reverse,
         rollupConfig,
         searchFilter,
         selectDistinctColumns,
@@ -2318,7 +2323,7 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
         aggregationSettings: DEFAULT_AGGREGATION_SETTINGS,
         customColumns: [],
         quickFilters: new Map(),
-        reverseType: TableUtils.REVERSE_TYPE.NONE,
+        reverse: false,
         rollupConfig: undefined,
         selectDistinctColumns: [],
         sorts: [],
@@ -2700,9 +2705,9 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
     this.grid?.forceUpdate();
   }
 
-  reverse(reverseType: ReverseType): void {
+  reverse(reverse: boolean): void {
     this.startLoading('Reversing...');
-    this.setState({ reverseType });
+    this.setState({ reverse });
     this.grid?.forceUpdate();
   }
 
@@ -3136,7 +3141,7 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
       aggregationSettings,
       customColumns,
       quickFilters,
-      reverseType,
+      reverse,
       rollupConfig,
       searchFilter,
       selectDistinctColumns,
@@ -3148,7 +3153,7 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
       aggregationSettings,
       customColumns,
       quickFilters,
-      reverseType,
+      reverse,
       rollupConfig,
       searchFilter,
       selectDistinctColumns,
@@ -3507,7 +3512,7 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
       movedColumns: [],
       frozenColumns: [],
       sorts: [],
-      reverseType: TableUtils.REVERSE_TYPE.NONE,
+      reverse: false,
       selectDistinctColumns: [],
     });
   }
@@ -3530,7 +3535,7 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
       selectDistinctColumns: columnNames,
       movedColumns: [],
       sorts: [],
-      reverseType: TableUtils.REVERSE_TYPE.NONE,
+      reverse: false,
     });
   }
 
@@ -4248,7 +4253,7 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
       conditionalFormatEditIndex,
 
       sorts,
-      reverseType,
+      reverse,
       customColumns,
 
       selectedRanges,
@@ -4311,7 +4316,7 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
       quickFilters,
       advancedFilters,
       sorts,
-      reverseType,
+      reverse,
       rollupConfig,
       isMenuShown
     );
@@ -4830,7 +4835,7 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
                 filter={filter}
                 formatter={formatter}
                 sorts={sorts}
-                reverseType={reverseType}
+                reverse={reverse}
                 movedColumns={movedColumns}
                 customColumns={customColumns}
                 hiddenColumns={hiddenColumns}

--- a/packages/iris-grid/src/IrisGridMetricCalculator.ts
+++ b/packages/iris-grid/src/IrisGridMetricCalculator.ts
@@ -1,7 +1,6 @@
 import { GridMetricCalculator, type ModelSizeMap } from '@deephaven/grid';
 import type { GridMetricState } from '@deephaven/grid';
 import type { dh } from '@deephaven/jsapi-types';
-import { TableUtils } from '@deephaven/jsapi-utils';
 import type IrisGridModel from './IrisGridModel';
 import { type IrisGridThemeType } from './IrisGridTheme';
 
@@ -18,7 +17,7 @@ export interface IrisGridMetricState extends GridMetricState {
     { text: string; filter: dh.FilterCondition | null }
   >;
   sorts: dh.Sort[];
-  reverseType: string;
+  reverse: boolean;
 }
 
 /**
@@ -34,7 +33,7 @@ export class IrisGridMetricCalculator extends GridMetricCalculator {
       advancedFilters,
       quickFilters,
       sorts,
-      reverseType,
+      reverse,
     } = state;
     if (isFilterBarShown) {
       gridY += theme.filterBarHeight;
@@ -44,11 +43,7 @@ export class IrisGridMetricCalculator extends GridMetricCalculator {
     ) {
       gridY += theme.filterBarCollapsedHeight;
     }
-    if (
-      reverseType !== TableUtils.REVERSE_TYPE.NONE &&
-      sorts != null &&
-      sorts.length > 0
-    ) {
+    if (reverse && sorts != null && sorts.length > 0) {
       gridY += theme.reverseHeaderBarHeight;
     }
 

--- a/packages/iris-grid/src/IrisGridModelUpdater.tsx
+++ b/packages/iris-grid/src/IrisGridModelUpdater.tsx
@@ -3,11 +3,7 @@
 import { useEffect, useMemo } from 'react';
 import type { dh } from '@deephaven/jsapi-types';
 import { type ModelIndex, type MoveOperation } from '@deephaven/grid';
-import {
-  type Formatter,
-  type ReverseType,
-  TableUtils,
-} from '@deephaven/jsapi-utils';
+import { type Formatter } from '@deephaven/jsapi-utils';
 import { EMPTY_ARRAY, EMPTY_MAP } from '@deephaven/utils';
 import { useOnChange } from '@deephaven/react-hooks';
 import IrisGridUtils from './IrisGridUtils';
@@ -34,7 +30,7 @@ interface IrisGridModelUpdaterProps {
   right: number | null;
   filter: readonly dh.FilterCondition[];
   sorts: readonly dh.Sort[];
-  reverseType?: ReverseType;
+  reverse?: boolean;
   customColumns: readonly ColumnName[];
   movedColumns: readonly MoveOperation[];
   hiddenColumns: readonly ModelIndex[];
@@ -63,7 +59,7 @@ function IrisGridModelUpdater({
   right,
   filter,
   formatter,
-  reverseType = TableUtils.REVERSE_TYPE.NONE,
+  reverse = false,
   sorts,
   customColumns,
   movedColumns,
@@ -117,12 +113,12 @@ function IrisGridModelUpdater({
   useOnChange(
     function updateSorts() {
       const sortsForModel = [...sorts];
-      if (reverseType !== TableUtils.REVERSE_TYPE.NONE) {
+      if (reverse) {
         sortsForModel.push(model.dh.Table.reverse());
       }
       model.sort = sortsForModel;
     },
-    [model, sorts, reverseType]
+    [model, sorts, reverse]
   );
   useOnChange(
     function updateFormatter() {

--- a/packages/iris-grid/src/IrisGridRenderer.ts
+++ b/packages/iris-grid/src/IrisGridRenderer.ts
@@ -12,7 +12,7 @@ import {
   type VisibleIndex,
 } from '@deephaven/grid';
 import type { dh } from '@deephaven/jsapi-types';
-import { TableUtils, type ReverseType } from '@deephaven/jsapi-utils';
+import { TableUtils } from '@deephaven/jsapi-utils';
 import { assertNotNull, getOrThrow } from '@deephaven/utils';
 import {
   type ReadonlyAdvancedFilterMap,
@@ -42,7 +42,7 @@ export type IrisGridRenderState = GridRenderState & {
   hoverSelectColumn: GridRangeIndex;
   isSelectingColumn: boolean;
   loadingScrimProgress: number;
-  reverseType: ReverseType;
+  reverse: boolean;
   isFilterBarShown: boolean;
   advancedFilters: ReadonlyAdvancedFilterMap;
   quickFilters: ReadonlyQuickFilterMap;
@@ -352,7 +352,7 @@ export class IrisGridRenderer extends GridRenderer {
   ): void {
     super.drawColumnHeaders(context, state);
 
-    const { theme, metrics, model, reverseType } = state;
+    const { theme, metrics, model, reverse } = state;
     const { columnHeaderHeight } = metrics;
 
     this.drawFilterHeaders(context, state);
@@ -364,10 +364,8 @@ export class IrisGridRenderer extends GridRenderer {
     const { sort } = model;
     // if there is only one sort bar, it is interior to the header to save space
     if (sort.length === 1) {
-      const hasReverse = reverseType !== TableUtils.REVERSE_TYPE.NONE;
-
       let color;
-      if (hasReverse) {
+      if (reverse) {
         color = theme.headerReverseBarColor;
       } else {
         color = theme.headerSortBarColor;
@@ -376,15 +374,12 @@ export class IrisGridRenderer extends GridRenderer {
         context,
         state,
         color,
-        hasReverse ? theme.reverseHeaderBarHeight : theme.sortHeaderBarHeight
+        reverse ? theme.reverseHeaderBarHeight : theme.sortHeaderBarHeight
       );
     } else if (sort.length > 1) {
       // if there's multiple bars, the sort is interior to header
       // and the reverse claims space in the table
-      if (
-        // has table reverse
-        reverseType !== TableUtils.REVERSE_TYPE.NONE
-      ) {
+      if (reverse) {
         this.drawHeaderBar(
           context,
           state,

--- a/packages/iris-grid/src/IrisGridUtils.ts
+++ b/packages/iris-grid/src/IrisGridUtils.ts
@@ -1668,7 +1668,7 @@ class IrisGridUtils {
           return null;
         })
         // If we can't find the column any more, it's null, filter it out
-        // If the item is a reverse sort item, filter it out - it will get applied with the `reverseType` property
+        // If the item is a reverse sort item, filter it out - it will get applied with the `reverse` property
         // This should only happen when loading a legacy dashboard
         .filter(
           item =>

--- a/packages/iris-grid/src/IrisGridUtils.ts
+++ b/packages/iris-grid/src/IrisGridUtils.ts
@@ -61,7 +61,7 @@ type HydratedIrisGridState = Pick<
   | 'isFilterBarShown'
   | 'quickFilters'
   | 'customColumns'
-  | 'reverseType'
+  | 'reverse'
   | 'rollupConfig'
   | 'showSearchBar'
   | 'searchValue'
@@ -135,7 +135,9 @@ export interface DehydratedIrisGridState {
   userRowHeights: readonly DehydratedUserRowHeight[];
   customColumns: readonly ColumnName[];
   conditionalFormats: readonly SidebarFormattingRule[];
-  reverseType: ReverseType;
+  /** @deprecated use `reverse` instead. Can be removed after DHE sanluis release */
+  reverseType?: ReverseType;
+  reverse: boolean;
   rollupConfig?: UIRollupConfig;
   showSearchBar: boolean;
   searchValue: string;
@@ -1177,7 +1179,7 @@ class IrisGridUtils {
       quickFilters,
       customColumns,
       conditionalFormats = EMPTY_ARRAY,
-      reverseType,
+      reverse,
       rollupConfig = undefined,
       showSearchBar,
       searchValue,
@@ -1216,7 +1218,7 @@ class IrisGridUtils {
       userRowHeights: [...userRowHeights],
       customColumns: [...customColumns],
       conditionalFormats: [...conditionalFormats],
-      reverseType,
+      reverse,
       rollupConfig,
       showSearchBar,
       searchValue,
@@ -1261,6 +1263,7 @@ class IrisGridUtils {
       userColumnWidths,
       userRowHeights,
       reverseType,
+      reverse,
       rollupConfig = undefined,
       showSearchBar,
       searchValue,
@@ -1315,7 +1318,7 @@ class IrisGridUtils {
       customColumns,
       conditionalFormats,
       userRowHeights: new Map(userRowHeights),
-      reverseType,
+      reverse: reverseType === TableUtils.REVERSE_TYPE.POST_SORT || reverse,
       rollupConfig,
       showSearchBar,
       searchValue,

--- a/packages/iris-grid/src/key-handlers/ReverseKeyHandler.ts
+++ b/packages/iris-grid/src/key-handlers/ReverseKeyHandler.ts
@@ -1,6 +1,5 @@
 import { type KeyboardEvent } from 'react';
 import { KeyHandler } from '@deephaven/grid';
-import { TableUtils } from '@deephaven/jsapi-utils';
 import type IrisGrid from '../IrisGrid';
 import IrisGridShortcuts from '../IrisGridShortcuts';
 
@@ -18,12 +17,8 @@ class ReverseKeyHandler extends KeyHandler {
       if (!this.irisGrid.isReversible()) {
         return false;
       }
-      const { reverseType } = this.irisGrid.state;
-      if (reverseType === TableUtils.REVERSE_TYPE.NONE) {
-        this.irisGrid.reverse(TableUtils.REVERSE_TYPE.POST_SORT);
-      } else {
-        this.irisGrid.reverse(TableUtils.REVERSE_TYPE.NONE);
-      }
+      const { reverse } = this.irisGrid.state;
+      this.irisGrid.reverse(!reverse);
       return true;
     }
     return false;

--- a/packages/iris-grid/src/mousehandlers/IrisGridContextMenuHandler.tsx
+++ b/packages/iris-grid/src/mousehandlers/IrisGridContextMenuHandler.tsx
@@ -188,13 +188,8 @@ class IrisGridContextMenuHandler extends GridMouseHandler {
 
     const actions = [] as ContextAction[];
 
-    const {
-      metrics,
-      reverseType,
-      quickFilters,
-      advancedFilters,
-      searchFilter,
-    } = irisGrid.state;
+    const { metrics, reverse, quickFilters, advancedFilters, searchFilter } =
+      irisGrid.state;
     const theme = irisGrid.getTheme();
     assertNotNull(metrics);
     const {
@@ -206,7 +201,6 @@ class IrisGridContextMenuHandler extends GridMouseHandler {
 
     const modelSort = model.sort;
     const columnSort = TableUtils.getSortForColumn(modelSort, column.name);
-    const hasReverse = reverseType !== TableUtils.REVERSE_TYPE.NONE;
     const { userColumnWidths } = metrics;
     const isColumnHidden = [...userColumnWidths.values()].some(
       columnWidth => columnWidth === 0
@@ -301,8 +295,8 @@ class IrisGridContextMenuHandler extends GridMouseHandler {
        * */
       disabled:
         (columnSort && modelSort.length === 1) ||
-        (hasReverse && modelSort.length === 1) ||
-        (columnSort && hasReverse && modelSort.length === 2) ||
+        (reverse && modelSort.length === 1) ||
+        (columnSort && reverse && modelSort.length === 2) ||
         modelSort.length === 0 ||
         !isColumnSortable,
       group: IrisGridContextMenuHandler.GROUP_SORT,
@@ -313,7 +307,7 @@ class IrisGridContextMenuHandler extends GridMouseHandler {
       title: 'Clear Table Sorting',
       disabled:
         // reverse is a type of sort, but special and needs to be exluded despite being part of model.sort
-        modelSort.length === 0 || (hasReverse && modelSort.length === 1),
+        modelSort.length === 0 || (reverse && modelSort.length === 1),
       group: IrisGridContextMenuHandler.GROUP_SORT,
       action: () => {
         this.irisGrid.sortColumn(
@@ -324,10 +318,7 @@ class IrisGridContextMenuHandler extends GridMouseHandler {
       order: 30,
     });
     actions.push({
-      title:
-        reverseType === TableUtils.REVERSE_TYPE.NONE
-          ? 'Reverse Table'
-          : 'Clear Reverse Table',
+      title: reverse ? 'Clear Reverse Table' : 'Reverse Table',
       icon: vsRemove,
       iconColor: contextMenuReverseIconColor,
       group: IrisGridContextMenuHandler.GROUP_SORT,
@@ -336,11 +327,7 @@ class IrisGridContextMenuHandler extends GridMouseHandler {
       // this just displays the shortcut, the actual listener is in irisgrid handleKeyDown
       shortcut: SHORTCUTS.TABLE.REVERSE,
       action: () => {
-        if (reverseType === TableUtils.REVERSE_TYPE.NONE) {
-          this.irisGrid.reverse(TableUtils.REVERSE_TYPE.POST_SORT);
-        } else {
-          this.irisGrid.reverse(TableUtils.REVERSE_TYPE.NONE);
-        }
+        this.irisGrid.reverse(!reverse);
       },
     });
     actions.push({


### PR DESCRIPTION
Fixes #2149 

This shouldn't be breaking. `reverseType` prop is deprecated, but still accepted. `reverseType` in saved states will be changed into `reverse` and then dropped from the saved state.

Tested this by exporting a layout with a table with reverse from the current DHC release. Then imported the layout to my dev UI and checked the reverse persisted.