### PR TITLE
feat: Ruff updates for DHE support

### DIFF
--- a/__mocks__/@astral-sh/ruff-wasm-web.js
+++ b/__mocks__/@astral-sh/ruff-wasm-web.js
@@ -1,0 +1,3 @@
+const init = jest.fn();
+export const Workspace = jest.fn();
+export default init;

--- a/jest.config.base.cjs
+++ b/jest.config.base.cjs
@@ -65,6 +65,10 @@ module.exports = {
     ),
     // Handle monaco worker files
     '\\.worker.*$': 'identity-obj-proxy',
+    '^@astral-sh/ruff-wasm-web$': path.join(
+      __dirname,
+      './__mocks__/@astral-sh/ruff-wasm-web.js'
+    ),
     // Handle pouchdb modules
     '^pouchdb-browser$': path.join(
       __dirname,

--- a/packages/code-studio/src/settings/EditorSectionContent.tsx
+++ b/packages/code-studio/src/settings/EditorSectionContent.tsx
@@ -1,6 +1,14 @@
 import React, { useCallback, useState } from 'react';
 import { useDispatch } from 'react-redux';
-import { Switch, ActionButton, Icon, Text } from '@deephaven/components';
+import {
+  Switch,
+  ActionButton,
+  Icon,
+  Text,
+  ContextualHelp,
+  Heading,
+  Content,
+} from '@deephaven/components';
 import { useAppSelector } from '@deephaven/dashboard';
 import { getNotebookSettings, updateNotebookSettings } from '@deephaven/redux';
 import { vsSettings } from '@deephaven/icons';
@@ -95,10 +103,23 @@ export function EditorSectionContent(): JSX.Element {
           Enable Minimap
         </Switch>
       </div>
-      <div className="form-row pl-1">
-        <Switch isSelected={formatOnSave} onChange={handleFormatOnSaveChange}>
+      <div className="form-row align-items-center pl-1">
+        <Switch
+          isSelected={formatOnSave}
+          onChange={handleFormatOnSaveChange}
+          margin={0}
+        >
           Format on Save
         </Switch>
+        <ContextualHelp variant="info">
+          <Heading>Format on Save</Heading>
+          <Content>
+            <Text>
+              The Ruff settings control formatting options. Notebooks can be
+              formatted manually using the right-click context menu.
+            </Text>
+          </Content>
+        </ContextualHelp>
       </div>
       <div className="form-row pl-1">
         <Switch

--- a/packages/dashboard-core-plugins/src/ConsolePlugin.tsx
+++ b/packages/dashboard-core-plugins/src/ConsolePlugin.tsx
@@ -1,4 +1,4 @@
-import { MonacoProviders, type ScriptEditor } from '@deephaven/console';
+import { type ScriptEditor } from '@deephaven/console';
 import {
   assertIsDashboardPluginProps,
   type DashboardPluginComponentProps,
@@ -7,15 +7,13 @@ import {
   LayoutUtils,
   type PanelComponent,
   type PanelHydrateFunction,
-  useAppSelector,
   useListener,
   usePanelRegistration,
 } from '@deephaven/dashboard';
 import { FileUtils } from '@deephaven/file-explorer';
 import { type CloseOptions, isComponent } from '@deephaven/golden-layout';
 import Log from '@deephaven/log';
-import { getNotebookSettings } from '@deephaven/redux';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import { nanoid } from 'nanoid';
 import { ConsoleEvent, NotebookEvent } from './events';
@@ -27,6 +25,7 @@ import {
   NotebookPanel,
 } from './panels';
 import { setDashboardConsoleSettings } from './redux';
+import useConfigureRuff from './useConfigureRuff';
 
 const log = Log.module('ConsolePlugin');
 
@@ -76,15 +75,7 @@ export function ConsolePlugin(
     new Map<string, string>()
   );
 
-  const { python: { linter = {} } = {} } = useAppSelector(getNotebookSettings);
-  const { isEnabled: ruffEnabled = false, config: ruffConfig } = linter;
-  useEffect(
-    function setRuffSettings() {
-      MonacoProviders.isRuffEnabled = ruffEnabled;
-      MonacoProviders.setRuffSettings(ruffConfig);
-    },
-    [ruffEnabled, ruffConfig]
-  );
+  useConfigureRuff();
 
   const dispatch = useDispatch();
 

--- a/packages/dashboard-core-plugins/src/index.ts
+++ b/packages/dashboard-core-plugins/src/index.ts
@@ -22,6 +22,7 @@ export { default as ControlType } from './controls/ControlType';
 export { default as LinkerUtils } from './linker/LinkerUtils';
 export type { Link } from './linker/LinkerUtils';
 export { default as ToolType } from './linker/ToolType';
+export * from './useConfigureRuff';
 export * from './useLoadTablePlugin';
 
 export * from './events';

--- a/packages/dashboard-core-plugins/src/panels/NotebookPanel.tsx
+++ b/packages/dashboard-core-plugins/src/panels/NotebookPanel.tsx
@@ -15,7 +15,12 @@ import {
   type DropdownAction,
   LoadingOverlay,
 } from '@deephaven/components';
-import { ScriptEditor, ScriptEditorUtils, SHORTCUTS } from '@deephaven/console';
+import {
+  MonacoUtils,
+  ScriptEditor,
+  ScriptEditorUtils,
+  SHORTCUTS,
+} from '@deephaven/console';
 import {
   type FileStorage,
   FileUtils,
@@ -1005,18 +1010,14 @@ class NotebookPanel extends Component<NotebookPanelProps, NotebookPanelState> {
   }
 
   canFormat(): boolean {
-    return (
-      this.notebook?.editor
-        ?.getAction('editor.action.formatDocument')
-        ?.isSupported() === true
-    );
+    return this.notebook?.editor != null
+      ? MonacoUtils.canFormat(this.notebook.editor)
+      : false;
   }
 
   async handleFormat(): Promise<void> {
-    if (this.canFormat()) {
-      await this.notebook?.editor
-        ?.getAction('editor.action.formatDocument')
-        ?.run();
+    if (this.notebook?.editor != null) {
+      await MonacoUtils.formatDocument(this.notebook.editor);
     }
   }
 
@@ -1321,6 +1322,8 @@ class NotebookPanel extends Component<NotebookPanelProps, NotebookPanelState> {
     ];
 
     const portal = tab?.element.find('.lm_title_before').get(0);
+
+    console.log(this.notebook?.editor);
 
     return (
       <>

--- a/packages/dashboard-core-plugins/src/useConfigureRuff.ts
+++ b/packages/dashboard-core-plugins/src/useConfigureRuff.ts
@@ -1,0 +1,23 @@
+import { useEffect } from 'react';
+import { MonacoProviders } from '@deephaven/console';
+import { useAppSelector } from '@deephaven/dashboard';
+import { getNotebookSettings } from '@deephaven/redux';
+
+/**
+ * Hook to configure Ruff settings in Monaco.
+ * The enabled status and settings are read from redux.
+ * Any changes to the redux values will be applied to the Monaco providers.
+ */
+export function useConfigureRuff(): void {
+  const { python: { linter = {} } = {} } = useAppSelector(getNotebookSettings);
+  const { isEnabled: ruffEnabled = false, config: ruffConfig } = linter;
+  useEffect(
+    function setRuffSettings() {
+      MonacoProviders.isRuffEnabled = ruffEnabled;
+      MonacoProviders.setRuffSettings(ruffConfig); // Also inits Ruff if needed
+    },
+    [ruffEnabled, ruffConfig]
+  );
+}
+
+export default useConfigureRuff;


### PR DESCRIPTION
Support for DH-17923 and also fixes some other edge cases with Ruff.

- Adds a hook for configuring Ruff and keeping it in sync w/ redux settings.
- Fixes a bug where if Ruff was enabled, but there was no user session then quick fixes were shown but linting underlines were not. Changed so Python is always linted if opened since it doesn't require a session to lint.
- Allow passing a default config to the Ruff config editor since DHE can set a custom config as the default via server props
- Added readOnly mode to the Ruff config editor
- Moved some formatting logic into MonacoUtils since DHE implements its own notebook panel. Eventually we should just consume the DHC NotebookPanel in DHE with extensions for PQs and other DHE options