### PR TITLE
fix: Embed-widget not setting log level on init

### DIFF
--- a/packages/embed-widget/src/index.tsx
+++ b/packages/embed-widget/src/index.tsx
@@ -3,7 +3,13 @@ import ReactDOM from 'react-dom';
 import '@deephaven/components/scss/BaseStyleSheet.scss'; // Do NOT move any lower. This needs to be imported before any other styles
 import { LoadingOverlay, preloadTheme } from '@deephaven/components';
 import { ApiBootstrap } from '@deephaven/jsapi-bootstrap';
+import { logInit } from '@deephaven/log';
 import './index.scss';
+
+logInit(
+  parseInt(import.meta.env.VITE_LOG_LEVEL ?? '2', 10),
+  import.meta.env.VITE_ENABLE_LOG_PROXY === 'true'
+);
 
 preloadTheme();
 


### PR DESCRIPTION
Just something I noticed while debugging https://github.com/deephaven/deephaven-plugins/issues/1039