### PR TITLE
fix: Table plugins - pass through deprecated props

### DIFF
--- a/packages/dashboard-core-plugins/src/panels/IrisGridPanel.tsx
+++ b/packages/dashboard-core-plugins/src/panels/IrisGridPanel.tsx
@@ -423,7 +423,6 @@ export class IrisGridPanel extends PureComponent<
       }
 
       // TODO #2093: Find a better way to handle deprecated panel prop
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const deprecatedProps = {
         panel: this,
       };
@@ -440,6 +439,8 @@ export class IrisGridPanel extends PureComponent<
             selectedRanges={this.irisGrid.current?.state.selectedRanges}
             onStateChange={this.handlePluginStateChange}
             pluginState={pluginState}
+            // eslint-disable-next-line react/jsx-props-no-spreading
+            {...deprecatedProps}
           />
         </div>
       );


### PR DESCRIPTION
- Deprecated props were not being passed through at all to the plugins
- We need to continue to pass through the deprecated props until we have a replacement
- Partial #2274 