### PR TITLE
fix: Console history scroll not always sticking to bottom

### DIFF
--- a/packages/console/src/Console.tsx
+++ b/packages/console/src/Console.tsx
@@ -649,7 +649,7 @@ export class Console extends PureComponent<ConsoleProps, ConsoleState> {
     }
 
     window.requestAnimationFrame(() => {
-      pane.scrollTop = pane.scrollHeight;
+      pane.scrollTo({ top: pane.scrollHeight });
     });
   }
 

--- a/packages/console/src/Console.tsx
+++ b/packages/console/src/Console.tsx
@@ -377,6 +377,7 @@ export class Console extends PureComponent<ConsoleProps, ConsoleState> {
       return;
     }
 
+    this.scrollConsoleHistoryToBottom();
     this.updateHistory(result, newHistoryItem);
     this.updateKnownObjects(newHistoryItem);
     this.updateWorkspaceHistoryItem(


### PR DESCRIPTION
- Cherry-pick of: console scrolls on 1st code block run (#2275)
- Cherry-pick of: Console does not scroll to bottom when code run from notebook (#2114)
- Tested by running a large block of code