### PR TITLE
build: Fix e2e tests for builds on v0.85

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -14,7 +14,7 @@ on:
       - 'release/**'
       - 'feature/**'
 env:
-  DHC_VERSION: edge
+  DHC_VERSION: 0.36.1
 
 jobs:
   build:

--- a/tests/docker-scripts/docker-compose.yml
+++ b/tests/docker-scripts/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   dhc-server:
     container_name: dhc-server
-    image: ghcr.io/deephaven/server:${DHC_VERSION:-edge}
+    image: ghcr.io/deephaven/server:${DHC_VERSION:-0.36.1}
     pull_policy: always
     volumes:
       - ./data:/data


### PR DESCRIPTION
- The edge version of deephaven-core installs the latest version of deephaven.ui, which is not compatible with this old version of the UI
- Just pin the e2e tests to an older build of core