### PR TITLE
feat: Removed esbuild runtime dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13689,18 +13689,6 @@
         "@esbuild/win32-x64": "0.21.5"
       }
     },
-    "node_modules/esbuild-wasm": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/esbuild-wasm/-/esbuild-wasm-0.24.0.tgz",
-      "integrity": "sha512-xhNn5tL1AhkPg4ft59yXT6FkwKXiPSYyz1IeinJHUJpjvOHOIPvdmFQc0pGdjxlKSbzZc2mNmtVOWAR1EF/JAg==",
-      "dev": true,
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/escalade": {
       "version": "3.1.1",
       "license": "MIT",
@@ -30227,14 +30215,10 @@
       },
       "devDependencies": {
         "@types/node": "^22.7.5",
-        "@types/ws": "^8.5.12",
-        "esbuild-wasm": "^0.24.0"
+        "@types/ws": "^8.5.12"
       },
       "engines": {
         "node": ">=16"
-      },
-      "peerDependencies": {
-        "esbuild-wasm": "^0.24.0"
       }
     },
     "packages/jsapi-nodejs/node_modules/@types/node": {
@@ -32524,7 +32508,6 @@
       "requires": {
         "@types/node": "^22.7.5",
         "@types/ws": "^8.5.12",
-        "esbuild-wasm": "^0.24.0",
         "ws": "^8.18.0"
       },
       "dependencies": {
@@ -41237,12 +41220,6 @@
         "@esbuild/win32-ia32": "0.21.5",
         "@esbuild/win32-x64": "0.21.5"
       }
-    },
-    "esbuild-wasm": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/esbuild-wasm/-/esbuild-wasm-0.24.0.tgz",
-      "integrity": "sha512-xhNn5tL1AhkPg4ft59yXT6FkwKXiPSYyz1IeinJHUJpjvOHOIPvdmFQc0pGdjxlKSbzZc2mNmtVOWAR1EF/JAg==",
-      "dev": true
     },
     "escalade": {
       "version": "3.1.1"

--- a/packages/jsapi-nodejs/package.json
+++ b/packages/jsapi-nodejs/package.json
@@ -25,11 +25,7 @@
   },
   "devDependencies": {
     "@types/node": "^22.7.5",
-    "@types/ws": "^8.5.12",
-    "esbuild-wasm": "^0.24.0"
-  },
-  "peerDependencies": {
-    "esbuild-wasm": "^0.24.0"
+    "@types/ws": "^8.5.12"
   },
   "files": [
     "dist"


### PR DESCRIPTION
DH-18191: Removed esbuild runtime dependency and replaced it with an optional `PostDownloadTransform` function. Files now get downloaded directly to the `serverStorageDir` instead of `target` subdirectory.

BREAKING CHANGES: @deephaven/jsapi-nodejs `loadModules` arguments has changed. Transformation of module types is now the responsibility of the consumer.