### PR TITLE
fix: Update Spectrum Theme for Missing ContextualHelpTrigger Icon

### DIFF
--- a/packages/components/src/theme/theme-spectrum/theme-spectrum-overrides.css
+++ b/packages/components/src/theme/theme-spectrum/theme-spectrum-overrides.css
@@ -9,6 +9,10 @@ label[class*='spectrum-'] {
   margin-bottom: 0;
 }
 
+/*
+* This workaround can be removed when this fix is pulled in
+* https://github.com/adobe/react-spectrum/issues/7571
+*/
 [class*='spectrum-Menu-itemGrid'] svg,
 svg[class*='spectrum-Textfield-validationIcon'] {
   /* set as border-box by reboot, but spectrum expects this to be content-box */

--- a/packages/components/src/theme/theme-spectrum/theme-spectrum-overrides.css
+++ b/packages/components/src/theme/theme-spectrum/theme-spectrum-overrides.css
@@ -9,6 +9,12 @@ label[class*='spectrum-'] {
   margin-bottom: 0;
 }
 
+[class*='spectrum-Menu-itemGrid'] svg,
+svg[class*='spectrum-Textfield-validationIcon'] {
+  /* set as border-box by reboot, but spectrum expects this to be content-box */
+  box-sizing: content-box;
+}
+
 svg[class*='spectrum-Textfield-validationIcon'] {
   /* set as border-box by reboot, but spectrum expects this to be content-box */
   box-sizing: content-box;


### PR DESCRIPTION
This is for `ui.menu`
https://deephaven.atlassian.net/browse/DH-18089
The ContexualHelpTrigger icon does not display because incorrect box-sizing.