### PR TITLE
fix: No context menu item for paste in an input table

### DIFF
--- a/packages/grid/src/Grid.tsx
+++ b/packages/grid/src/Grid.tsx
@@ -1552,6 +1552,10 @@ class Grid extends PureComponent<GridProps, GridState> {
 
       const edits: EditOperation[] = [];
       ranges.forEach(range => {
+        if ((range.startColumn ?? 0) + tableWidth > columnCount) {
+          throw new PasteError('Pasted content would overflow columns.');
+        }
+
         for (let x = 0; x < tableWidth; x += 1) {
           for (let y = 0; y < tableHeight; y += 1) {
             edits.push({

--- a/packages/grid/src/key-handlers/PasteKeyHandler.test.tsx
+++ b/packages/grid/src/key-handlers/PasteKeyHandler.test.tsx
@@ -66,13 +66,13 @@ describe('table parsing', () => {
 
   const TEXT_TABLE_FIREFOX = (
     <>
-      A&nbsp;&nbsp; &nbsp;B&nbsp;&nbsp; &nbsp;C
+      A&nbsp;&nbsp;&nbsp; B&nbsp;&nbsp;&nbsp; C
       <br />
-      1&nbsp;&nbsp; &nbsp;2&nbsp;&nbsp; &nbsp;3
+      1&nbsp;&nbsp;&nbsp; 2&nbsp;&nbsp;&nbsp; 3
     </>
   );
 
-  const SINGLE_ROW_FIREFOX = <>A&nbsp;&nbsp; &nbsp;B&nbsp;&nbsp; &nbsp;C</>;
+  const SINGLE_ROW_FIREFOX = <>A&nbsp;&nbsp;&nbsp; B&nbsp;&nbsp;&nbsp; C</>;
 
   function testTable(jsx: JSX.Element, expectedValue: string[][]) {
     const element = makeElementFromJsx(jsx);

--- a/packages/grid/src/key-handlers/PasteKeyHandler.ts
+++ b/packages/grid/src/key-handlers/PasteKeyHandler.ts
@@ -39,10 +39,9 @@ export function parseValueFromNodes(nodes: NodeListOf<ChildNode>): string[][] {
     if (text.length > 0) {
       // When Chrome pastes a table from text, it preserves the tab characters
       // In Firefox, it breaks it into a combination of non-breaking spaces and spaces
-      result.push(text.split(/\t|\u00a0\u00a0 \u00a0/));
+      result.push(text.split(/\t|\u00a0\u00a0\u00a0/));
     }
   });
-
   return result;
 }
 
@@ -62,7 +61,7 @@ export function parseValueFromElement(
     // If there's only one row and it doesn't contain a tab, then just treat it as a regular value
     const { childNodes } = element;
     const hasTabChar = text.includes('\t');
-    const hasFirefoxTab = text.includes('\u00a0\u00a0 \u00a0');
+    const hasFirefoxTab = text.includes('\u00a0\u00a0\u00a0');
     if (
       hasTabChar &&
       childNodes.length !== 0 &&

--- a/packages/grid/src/key-handlers/PasteKeyHandler.ts
+++ b/packages/grid/src/key-handlers/PasteKeyHandler.ts
@@ -39,7 +39,7 @@ export function parseValueFromNodes(nodes: NodeListOf<ChildNode>): string[][] {
     if (text.length > 0) {
       // When Chrome pastes a table from text, it preserves the tab characters
       // In Firefox, it breaks it into a combination of non-breaking spaces and spaces
-      result.push(text.split(/\t|\u00a0\u00a0\u00a0/));
+      result.push(text.split(/\t|\u00a0\u00a0\u00a0 /));
     }
   });
   return result;
@@ -61,7 +61,7 @@ export function parseValueFromElement(
     // If there's only one row and it doesn't contain a tab, then just treat it as a regular value
     const { childNodes } = element;
     const hasTabChar = text.includes('\t');
-    const hasFirefoxTab = text.includes('\u00a0\u00a0\u00a0');
+    const hasFirefoxTab = text.includes('\u00a0\u00a0\u00a0 ');
     if (
       hasTabChar &&
       childNodes.length !== 0 &&

--- a/packages/iris-grid/src/IrisGrid.tsx
+++ b/packages/iris-grid/src/IrisGrid.tsx
@@ -194,6 +194,7 @@ import {
 import type ColumnHeaderGroup from './ColumnHeaderGroup';
 import { IrisGridThemeContext } from './IrisGridThemeProvider';
 import { isMissingPartitionError } from './MissingPartitionError';
+import { NoPastePermissionModal } from './NoPastePermissionModal';
 
 const log = Log.module('IrisGrid');
 
@@ -442,6 +443,7 @@ export interface IrisGridState {
   toastMessage: JSX.Element | null;
   frozenColumns: readonly ColumnName[];
   showOverflowModal: boolean;
+  showNoPastePermissionModal: boolean;
   overflowText: string;
   overflowButtonTooltipProps: CSSProperties | null;
   expandCellTooltipProps: CSSProperties | null;
@@ -624,6 +626,8 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
     this.handleCrossColumnSearch = this.handleCrossColumnSearch.bind(this);
     this.handleRollupChange = this.handleRollupChange.bind(this);
     this.handleOverflowClose = this.handleOverflowClose.bind(this);
+    this.handleCloseNoPastePermissionModal =
+      this.handleCloseNoPastePermissionModal.bind(this);
     this.getColumnBoundingRect = this.getColumnBoundingRect.bind(this);
     this.handleGotoRowSelectedRowNumberChanged =
       this.handleGotoRowSelectedRowNumberChanged.bind(this);
@@ -870,6 +874,7 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
       toastMessage: null,
       frozenColumns,
       showOverflowModal: false,
+      showNoPastePermissionModal: false,
       overflowText: '',
       overflowButtonTooltipProps: null,
       expandCellTooltipProps: null,
@@ -3853,6 +3858,18 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
     });
   }
 
+  handleOpenNoPastePermissionModal(): void {
+    this.setState({
+      showNoPastePermissionModal: true,
+    });
+  }
+
+  handleCloseNoPastePermissionModal(): void {
+    this.setState({
+      showNoPastePermissionModal: false,
+    });
+  }
+
   getColumnBoundingRect(): DOMRect {
     const { metrics, shownColumnTooltip } = this.state;
     assertNotNull(metrics);
@@ -4273,6 +4290,7 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
       frozenColumns,
       columnHeaderGroups,
       showOverflowModal,
+      showNoPastePermissionModal,
       overflowText,
       overflowButtonTooltipProps,
       expandCellTooltipProps,
@@ -4998,6 +5016,10 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
           </div>
         </SlideTransition>
         <ContextActions actions={this.contextActions} />
+        <NoPastePermissionModal
+          isOpen={showNoPastePermissionModal}
+          handleClose={this.handleCloseNoPastePermissionModal}
+        />
       </div>
     );
   }

--- a/packages/iris-grid/src/IrisGrid.tsx
+++ b/packages/iris-grid/src/IrisGrid.tsx
@@ -444,6 +444,7 @@ export interface IrisGridState {
   frozenColumns: readonly ColumnName[];
   showOverflowModal: boolean;
   showNoPastePermissionModal: boolean;
+  noPastePermissionError: string;
   overflowText: string;
   overflowButtonTooltipProps: CSSProperties | null;
   expandCellTooltipProps: CSSProperties | null;
@@ -875,6 +876,7 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
       frozenColumns,
       showOverflowModal: false,
       showNoPastePermissionModal: false,
+      noPastePermissionError: '',
       overflowText: '',
       overflowButtonTooltipProps: null,
       expandCellTooltipProps: null,
@@ -3858,9 +3860,10 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
     });
   }
 
-  handleOpenNoPastePermissionModal(): void {
+  handleOpenNoPastePermissionModal(errorMessage: string): void {
     this.setState({
       showNoPastePermissionModal: true,
+      noPastePermissionError: errorMessage,
     });
   }
 
@@ -4291,6 +4294,7 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
       columnHeaderGroups,
       showOverflowModal,
       showNoPastePermissionModal,
+      noPastePermissionError,
       overflowText,
       overflowButtonTooltipProps,
       expandCellTooltipProps,
@@ -5018,7 +5022,8 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
         <ContextActions actions={this.contextActions} />
         <NoPastePermissionModal
           isOpen={showNoPastePermissionModal}
-          handleClose={this.handleCloseNoPastePermissionModal}
+          onClose={this.handleCloseNoPastePermissionModal}
+          errorMessage={noPastePermissionError}
         />
       </div>
     );

--- a/packages/iris-grid/src/NoPastePermissionModal.tsx
+++ b/packages/iris-grid/src/NoPastePermissionModal.tsx
@@ -30,7 +30,7 @@ export function NoPastePermissionModal({
       </ModalBody>
       <ModalFooter>
         <Button kind="primary" onClick={handleClose}>
-          Okay
+          Dismiss
         </Button>
       </ModalFooter>
     </Modal>

--- a/packages/iris-grid/src/NoPastePermissionModal.tsx
+++ b/packages/iris-grid/src/NoPastePermissionModal.tsx
@@ -1,0 +1,38 @@
+import {
+  Button,
+  GLOBAL_SHORTCUTS,
+  Modal,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
+} from '@deephaven/components';
+
+export type NoPastePermissionModalProps = {
+  isOpen: boolean;
+  handleClose: () => void;
+};
+
+export function NoPastePermissionModal({
+  isOpen,
+  handleClose,
+}: NoPastePermissionModalProps): JSX.Element {
+  const pasteShortcutText = GLOBAL_SHORTCUTS.PASTE.getDisplayText();
+  return (
+    <Modal isOpen={isOpen} toggle={handleClose} centered>
+      <ModalHeader closeButton={false}>No Paste Permission</ModalHeader>
+      <ModalBody>
+        <p>
+          For security reasons your browser does not allow access to your
+          clipboard on click, or requested clipboard permissions have been
+          denied.
+        </p>
+        <p>You can still use {pasteShortcutText} to paste.</p>
+      </ModalBody>
+      <ModalFooter>
+        <Button kind="primary" onClick={handleClose}>
+          OK
+        </Button>
+      </ModalFooter>
+    </Modal>
+  );
+}

--- a/packages/iris-grid/src/NoPastePermissionModal.tsx
+++ b/packages/iris-grid/src/NoPastePermissionModal.tsx
@@ -9,27 +9,25 @@ import {
 
 export type NoPastePermissionModalProps = {
   isOpen: boolean;
-  handleClose: () => void;
+  onClose: () => void;
+  errorMessage: string;
 };
 
 export function NoPastePermissionModal({
   isOpen,
-  handleClose,
+  onClose,
+  errorMessage,
 }: NoPastePermissionModalProps): JSX.Element {
   const pasteShortcutText = GLOBAL_SHORTCUTS.PASTE.getDisplayText();
   return (
-    <Modal isOpen={isOpen} toggle={handleClose} centered>
+    <Modal isOpen={isOpen} toggle={onClose} centered>
       <ModalHeader closeButton={false}>No Paste Permission</ModalHeader>
       <ModalBody>
-        <p>
-          For security reasons your browser does not allow access to your
-          clipboard on click, or requested clipboard permissions have been
-          denied.
-        </p>
+        <p>{errorMessage}</p>
         <p>You can still use {pasteShortcutText} to paste.</p>
       </ModalBody>
       <ModalFooter>
-        <Button kind="primary" onClick={handleClose}>
+        <Button kind="primary" onClick={onClose}>
           Dismiss
         </Button>
       </ModalFooter>

--- a/packages/iris-grid/src/NoPastePermissionModal.tsx
+++ b/packages/iris-grid/src/NoPastePermissionModal.tsx
@@ -30,7 +30,7 @@ export function NoPastePermissionModal({
       </ModalBody>
       <ModalFooter>
         <Button kind="primary" onClick={handleClose}>
-          OK
+          Okay
         </Button>
       </ModalFooter>
     </Modal>

--- a/packages/iris-grid/src/mousehandlers/IrisGridContextMenuHandler.tsx
+++ b/packages/iris-grid/src/mousehandlers/IrisGridContextMenuHandler.tsx
@@ -45,6 +45,7 @@ import {
   assertNotNaN,
   assertNotNull,
   copyToClipboard,
+  readFromClipboard,
 } from '@deephaven/utils';
 import {
   DateTimeFormatContextMenu,
@@ -476,6 +477,22 @@ class IrisGridContextMenuHandler extends GridMouseHandler {
         },
       });
     }
+
+    actions.push({
+      title: 'Paste',
+      group: IrisGridContextMenuHandler.GROUP_COPY,
+      order: 50,
+      action: async () => {
+        const text = await readFromClipboard();
+        if (text !== null) {
+          const items = text.split('\n').map(row => row.split('\t'));
+          await grid.pasteValue(items);
+        } else {
+          // todo: Bring up a popup
+          console.error('no permissions');
+        }
+      },
+    });
 
     actions.push({
       title: 'View Cell Contents',

--- a/packages/iris-grid/src/mousehandlers/IrisGridContextMenuHandler.tsx
+++ b/packages/iris-grid/src/mousehandlers/IrisGridContextMenuHandler.tsx
@@ -488,8 +488,7 @@ class IrisGridContextMenuHandler extends GridMouseHandler {
           const items = text.split('\n').map(row => row.split('\t'));
           await grid.pasteValue(items);
         } else {
-          // todo: Bring up a popup
-          console.error('no permissions');
+          irisGrid.handleOpenNoPastePermissionModal();
         }
       },
     });

--- a/packages/utils/src/ClipboardUtils.ts
+++ b/packages/utils/src/ClipboardUtils.ts
@@ -51,15 +51,9 @@ export async function readFromClipboard(): Promise<string | null> {
 
   let permissionState = await checkPermission('clipboard-read');
 
-  if (permissionState === 'granted' || permissionState === null) {
-    // Some browsers that don't support permissions seems to have a workaround where
-    // calling readText() shows the native context menu and allows user to hit paste there
-    try {
-      const text = await clipboard.readText();
-      return text;
-    } catch {
-      return null;
-    }
+  if (permissionState === 'granted') {
+    const text = await clipboard.readText();
+    return text;
   }
 
   if (permissionState === 'prompt') {

--- a/packages/utils/src/ClipboardUtils.ts
+++ b/packages/utils/src/ClipboardUtils.ts
@@ -76,14 +76,10 @@ export async function readFromClipboard(): Promise<string> {
         const text = await clipboard.readText();
         return text;
       }
-
-      if (permissionState === 'prompt' || permissionState === 'denied') {
-        // Prompt means user closed out of the previous permission prompt, also treat it as a denial
-        throw new ClipboardPermissionsDeniedError();
-      }
     }
 
-    if (permissionState === 'denied') {
+    if (permissionState === 'prompt' || permissionState === 'denied') {
+      // Prompt means user closed out of the previous permission prompt, also treat it as a denial
       throw new ClipboardPermissionsDeniedError();
     }
   } catch (err: unknown) {

--- a/packages/utils/src/ClipboardUtils.ts
+++ b/packages/utils/src/ClipboardUtils.ts
@@ -1,3 +1,5 @@
+import { checkPermission } from './PermissionUtils';
+
 /**
  * Copy the passed in text to the clipboard.
  * @param text The text to copy
@@ -37,4 +39,49 @@ export function copyToClipboardExecCommand(text: string): void {
   }
 
   if (!result) throw new Error('Unable to execute copy command');
+}
+
+/**
+ * Reads text from the clipboard.
+ * @returns Promise that resolves to text from clipboard as string, or null if permissions are not supported/granted.
+ */
+export async function readFromClipboard(): Promise<string | null> {
+  const { clipboard } = navigator;
+  if (clipboard === undefined) return null;
+
+  let permissionState = await checkPermission('clipboard-read');
+
+  if (permissionState === 'granted' || permissionState === null) {
+    // Some browsers that don't support permissions seems to have a workaround where
+    // calling readText() shows the native context menu and allows user to hit paste there
+    try {
+      const text = await clipboard.readText();
+      return text;
+    } catch {
+      return null;
+    }
+  }
+
+  if (permissionState === 'prompt') {
+    try {
+      // Need to call this to bring up a permission prompt
+      await clipboard.readText();
+    } catch {
+      // Ignore error caused by calling readText() without permissions
+    }
+
+    // Check status again after user has interacted with the permission prompt
+    permissionState = await checkPermission('clipboard-read');
+    if (permissionState === 'granted') {
+      const text = await clipboard.readText();
+      return text;
+    }
+
+    if (permissionState === 'prompt' || permissionState === 'denied') {
+      // Prompt means user closed out of the previous permission prompt, treat it as a denial
+      return null;
+    }
+  }
+
+  return null;
 }

--- a/packages/utils/src/PermissionUtils.test.ts
+++ b/packages/utils/src/PermissionUtils.test.ts
@@ -1,3 +1,4 @@
+import UnsupportedPermissionError from './errors/UnsupportedPermissionError';
 import { checkPermission } from './PermissionUtils';
 
 describe('checkPermission', () => {
@@ -12,21 +13,21 @@ describe('checkPermission', () => {
         },
       });
 
-      const result = await checkPermission('');
-      expect(result).toEqual(state);
+      await expect(checkPermission('')).resolves.toEqual(state);
     }
   );
 
-  it('should return null if permission is unsupported by the browser', async () => {
+  it('should throw error if permission is unsupported by the browser', async () => {
     Object.assign(navigator, {
       permissions: {
         query: jest
           .fn()
-          .mockRejectedValue(new Error('Permission not supported')),
+          .mockRejectedValue(new TypeError('Permission not supported')),
       },
     });
 
-    const result = await checkPermission('');
-    expect(result).toBeNull();
+    await expect(checkPermission('')).rejects.toThrow(
+      UnsupportedPermissionError
+    );
   });
 });

--- a/packages/utils/src/PermissionUtils.test.ts
+++ b/packages/utils/src/PermissionUtils.test.ts
@@ -1,0 +1,32 @@
+import { checkPermission } from './PermissionUtils';
+
+describe('checkPermission', () => {
+  beforeEach(() => jest.resetAllMocks());
+
+  it.each(['granted', 'prompt', 'denied'])(
+    'should return the correct PermissionState for %s permission state',
+    async state => {
+      Object.assign(navigator, {
+        permissions: {
+          query: jest.fn().mockResolvedValue({ state }),
+        },
+      });
+
+      const result = await checkPermission('');
+      expect(result).toEqual(state);
+    }
+  );
+
+  it('should return null if permission is unsupported by the browser', async () => {
+    Object.assign(navigator, {
+      permissions: {
+        query: jest
+          .fn()
+          .mockRejectedValue(new Error('Permission not supported')),
+      },
+    });
+
+    const result = await checkPermission('');
+    expect(result).toBeNull();
+  });
+});

--- a/packages/utils/src/PermissionUtils.ts
+++ b/packages/utils/src/PermissionUtils.ts
@@ -1,19 +1,26 @@
+import UnsupportedPermissionError from './errors/UnsupportedPermissionError';
+
 /**
  * Checks permission to use a particular API from: https://developer.mozilla.org/en-US/docs/Web/API/Permissions_API#permission-aware_apis
  * @param permission The name of the permission
- * @returns PermissionState on success, null if permission is unsupported by browser
+ * @returns Promise that resolves to PermissionState on success, or rejects if permission is unsupported by browser
  */
 // eslint-disable-next-line import/prefer-default-export
 export async function checkPermission(
   permission: string
-): Promise<PermissionState | null> {
+): Promise<PermissionState> {
   try {
     // Typescript doesn't recognize certain permissions as a valid PermissionName
     // https://github.com/microsoft/TypeScript/issues/33923
     const name = permission as PermissionName;
     return (await navigator.permissions.query({ name })).state;
-  } catch (error) {
-    // Permission is unsupported by browser
-    return null;
+  } catch (error: unknown) {
+    // TypeError thrown if retrieving the PermissionDescriptor information failed in some way,
+    // or the permission doesn't exist or is unsupported by the user agent.
+    if (error instanceof TypeError) {
+      throw new UnsupportedPermissionError();
+    }
+
+    throw error;
   }
 }

--- a/packages/utils/src/PermissionUtils.ts
+++ b/packages/utils/src/PermissionUtils.ts
@@ -1,0 +1,19 @@
+/**
+ * Checks permission to use a particular API from: https://developer.mozilla.org/en-US/docs/Web/API/Permissions_API#permission-aware_apis
+ * @param permission The name of the permission
+ * @returns PermissionState on success, null if permission is unsupported by browser
+ */
+// eslint-disable-next-line import/prefer-default-export
+export async function checkPermission(
+  permission: string
+): Promise<PermissionState | null> {
+  try {
+    // Typescript doesn't recognize certain permissions as a valid PermissionName
+    // https://github.com/microsoft/TypeScript/issues/33923
+    const name = permission as PermissionName;
+    return (await navigator.permissions.query({ name })).state;
+  } catch (error) {
+    // Permission is unsupported by browser
+    return null;
+  }
+}

--- a/packages/utils/src/errors/ClipboardPermissionDeniedError.ts
+++ b/packages/utils/src/errors/ClipboardPermissionDeniedError.ts
@@ -1,0 +1,5 @@
+export class ClipboardPermissionsDeniedError extends Error {
+  isClipboardPermissionsDeniedError = true;
+}
+
+export default ClipboardPermissionsDeniedError;

--- a/packages/utils/src/errors/ClipboardUnavailableError.ts
+++ b/packages/utils/src/errors/ClipboardUnavailableError.ts
@@ -1,0 +1,5 @@
+export class ClipboardUnavailableError extends Error {
+  isClipboardUnavailableError = true;
+}
+
+export default ClipboardUnavailableError;

--- a/packages/utils/src/errors/UnsupportedPermissionError.ts
+++ b/packages/utils/src/errors/UnsupportedPermissionError.ts
@@ -1,0 +1,5 @@
+export class UnsupportedPermissionError extends Error {
+  isPermissionUnsupported = true;
+}
+
+export default UnsupportedPermissionError;

--- a/packages/utils/src/errors/index.ts
+++ b/packages/utils/src/errors/index.ts
@@ -1,0 +1,2 @@
+export { default as ClipboardPermissionsDeniedError } from './ClipboardPermissionDeniedError';
+export { default as ClipboardUnavailableError } from './ClipboardUnavailableError';

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -25,3 +25,4 @@ export * from './TypeUtils';
 export { default as InvalidMetadataError } from './InvalidMetadataError';
 export { default as ValidationError } from './ValidationError';
 export * from './UIConstants';
+export * from './errors';


### PR DESCRIPTION
- Added paste as a context menu option in IrisGrid
- Added methods to check for and request clipboard permissions, which are called when clicking paste in context menu
- For browsers that support the `clipboard-read` permission (e.g. Chrome), clicking paste results in the same behaviour as pressing the keyboard shortcut, provided the user has accepted the request for permission 
- For browsers that don't support the `clipboard-read` permission (e.g. Firefox and Safari), a modal is shown to explain the reason and to suggest using the keyboard shortcut instead

Additional related issues fixed
- Show relevant warning when attempting to paste too many columns into input table
- Fixed copy and pasting between Deephaven tables on Firefox. The issue is caused by tabs in pasted content being converted to `&nbsp;&nbsp;&nbsp; ` instead of `&nbsp;&nbsp; &nbsp;` which we were expecting before. Was able to reproduce former behaviour on an older build of Firefox (91.0), meaning this discrepancy is likely caused by an update to Firefox (unsure when exactly)