### PR TITLE
fix: Markdown incorrectly rendering inline code blocks

### DIFF
--- a/packages/dashboard-core-plugins/src/controls/markdown/MarkdownEditor.tsx
+++ b/packages/dashboard-core-plugins/src/controls/markdown/MarkdownEditor.tsx
@@ -13,7 +13,16 @@ interface MarkdownEditorProps {
 }
 
 const renderMarkdown: CodeComponent = props => {
-  const { children, className } = props;
+  const { children, inline, className } = props;
+  if (inline === true) {
+    return (
+      <code>
+        {React.Children.map(children, child =>
+          typeof child === 'string' ? child.trim() : child
+        )}
+      </code>
+    );
+  }
   const language =
     className !== undefined && className?.startsWith('language-')
       ? className.substring(9)

--- a/packages/dashboard-core-plugins/src/panels/MarkdownPanel.scss
+++ b/packages/dashboard-core-plugins/src/panels/MarkdownPanel.scss
@@ -36,7 +36,7 @@ $panel-container-padding: 10px;
   code {
     color: $foreground;
     background: $gray-700;
-    padding: 2px $spacer-2;
+    padding: 0.2em;
     border-radius: $border-radius;
     border: 1px solid $black;
   }


### PR DESCRIPTION
- Fixes #2312
- Tested using a code block from the ticket
![image](https://github.com/user-attachments/assets/11adc367-c421-43a8-aadd-9de146a598ee)
