### PR TITLE
fix: monaco editor overflowing at certain zoom levels

### DIFF
--- a/packages/console/src/notebook/Editor.scss
+++ b/packages/console/src/notebook/Editor.scss
@@ -5,6 +5,13 @@
     // override default scroll container shadow to match our global shadows
     --vscode-scrollbar-shadow: var(--dh-color-dropshadow);
 
+    // monaco editor sets an inline width in pixels which are rounded up to the nearest pixel.
+    // when zoomed, actual width can be a fractional width, and that rounding up can cause overflow
+    width: 100% !important; // override inline width
+    .overflow-guard {
+      width: 100% !important; // override inline width
+    }
+
     // set font for menus
     font-family: var(--font-family-sans-serif);
     .shadow-root-host {
@@ -20,7 +27,7 @@
 // The classes come from Monaco itself, not core or web-client-ui
 .rendered-markdown.markdown-docs {
   min-width: 12rem;
-  
+
   hr {
     background-color: $text-muted;
     height: 1px;


### PR DESCRIPTION
Container has 1462.86px of space but Monaco is setting itself to 1463px, causing overflow.

May have to play with zoom levels and browser widths to get it to reproduce. For me a 2560 window with 2 levels of zoom reliably reproduced.

![image](https://github.com/user-attachments/assets/15d6bf0a-b269-4853-8aaa-41a8e8b1b988)

Fix by overriding those widths to be 100%. Noticed no behavior differences other than fixing zoom issue.
