### PR TITLE
fix: Long dashboard titles overflow the navbar tab

### DIFF
--- a/packages/components/src/navigation/NavTab.tsx
+++ b/packages/components/src/navigation/NavTab.tsx
@@ -93,7 +93,7 @@ const NavTab = memo(
               }}
             >
               {iconElem}
-              {title}
+              <span className="btn-nav-tab-title">{title}</span>
               {isClosable && (
                 <Button
                   kind="ghost"

--- a/packages/components/src/navigation/NavTab.tsx
+++ b/packages/components/src/navigation/NavTab.tsx
@@ -7,6 +7,7 @@ import type { NavTabItem } from './NavTabList';
 import Button from '../Button';
 import ContextActions from '../context-actions/ContextActions';
 import { type ResolvableContextAction } from '../context-actions';
+import { Tooltip } from '../popper';
 
 interface NavTabProps {
   tab: NavTabItem;
@@ -93,7 +94,10 @@ const NavTab = memo(
               }}
             >
               {iconElem}
-              <span className="btn-nav-tab-title">{title}</span>
+              <span className="btn-nav-tab-title">
+                {title}
+                <Tooltip>{title}</Tooltip>
+              </span>
               {isClosable && (
                 <Button
                   kind="ghost"

--- a/packages/components/src/navigation/NavTabList.scss
+++ b/packages/components/src/navigation/NavTabList.scss
@@ -42,12 +42,16 @@ $tab-control-btn-offset: -8px;
       overflow: hidden;
       padding: 0 $tab-link-side-padding;
       position: relative;
-      text-overflow: ellipsis;
       user-select: none;
-      white-space: nowrap;
       flex-shrink: 0;
       background: none;
       background-clip: padding-box;
+
+      .btn-nav-tab-title {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
 
       .btn-nav-tab-close {
         position: absolute;


### PR DESCRIPTION
- Moved the title into its own element in the navbar tab so that `text-overflow: ellipsis` would work properly. 
- Tested by creating dashboards with both long and short titles to confirm that long titles are truncated with ellipses, and short titles display in the same way as before.