### PR TITLE
fix: Combobox exported type error

### DIFF
--- a/packages/components/src/spectrum/comboBox/ComboBox.tsx
+++ b/packages/components/src/spectrum/comboBox/ComboBox.tsx
@@ -10,7 +10,7 @@ import type { NormalizedItem } from '../utils';
 import { type PickerPropsT, usePickerProps } from '../picker';
 
 export type ComboBoxProps = PickerPropsT<SpectrumComboBoxProps<NormalizedItem>>;
-export { type MenuTriggerAction } from '@react-types/combobox';
+export type { MenuTriggerAction } from '@react-types/combobox';
 export { SpectrumComboBox };
 
 export const ComboBox = React.forwardRef(function ComboBox(


### PR DESCRIPTION
- Was receiving an error on running `npm start`: [ERROR] Failed to resolve entry for package "@react-types/combobox". The package may have incorrect main/module/exports specified in its package.json. [plugin vite:dep-scan]
- Seemed to be an issue with how we exported the type. An issue has been filed with esbuild: https://github.com/evanw/esbuild/issues/4054
- Just change the export so that we avoid this issue. Tested by running `npm start` again
