### PR TITLE
fix: DH-18542: Remove duplicate and invalid ruff quick fixes

### DIFF
--- a/packages/console/src/monaco/MonacoProviders.tsx
+++ b/packages/console/src/monaco/MonacoProviders.tsx
@@ -389,7 +389,14 @@ class MonacoProviders extends PureComponent<
     }));
 
     return {
-      actions: [...fixActions, ...disableLineActions, ...disableGlobalActions],
+      actions: [
+        ...fixActions,
+        ...disableLineActions,
+        ...disableGlobalActions,
+      ].filter(
+        // Remove actions with duplicate titles as they are a diagnostic duplicated for this selection. List should be small
+        (action, i, arr) => arr.find(a => a.title === action.title) === action
+      ),
       dispose: () => {
         /* no-op */
       },

--- a/packages/console/src/monaco/MonacoProviders.tsx
+++ b/packages/console/src/monaco/MonacoProviders.tsx
@@ -251,17 +251,18 @@ class MonacoProviders extends PureComponent<
       };
     }
 
-    const diagnostics = MonacoProviders.getDiagnostics(model)
-      .filter(d => d.code != null) // Syntax errors have no code and can't be fixed/disabled
-      .filter(d => {
-        const diagnosticRange = new monaco.Range(
-          d.location.row,
-          d.location.column,
-          d.end_location.row,
-          d.end_location.column
-        );
-        return diagnosticRange.intersectRanges(range);
-      });
+    const diagnostics = MonacoProviders.getDiagnostics(model).filter(d => {
+      const diagnosticRange = new monaco.Range(
+        d.location.row,
+        d.location.column,
+        d.end_location.row,
+        d.end_location.column
+      );
+      return (
+        d.code != null && // Syntax errors have no code and can't be fixed/disabled
+        diagnosticRange.intersectRanges(range)
+      );
+    });
 
     const fixActions: monaco.languages.CodeAction[] = diagnostics
       .filter(({ fix }) => fix != null)
@@ -274,7 +275,6 @@ class MonacoProviders extends PureComponent<
             title = `Fix ${d.code}`;
           }
         }
-        const b = 4;
         return {
           title,
           id: `fix-${d.code}`,
@@ -314,6 +314,7 @@ class MonacoProviders extends PureComponent<
     const disableLineActions: monaco.languages.CodeAction[] = diagnostics
       .map(d => {
         if (d.code == null) {
+          // The nulls are already filtered out, but TS doesn't know that
           return [];
         }
         const line = model.getLineContent(d.location.row);

--- a/packages/console/src/monaco/MonacoProviders.tsx
+++ b/packages/console/src/monaco/MonacoProviders.tsx
@@ -274,6 +274,7 @@ class MonacoProviders extends PureComponent<
             title = `Fix ${d.code}`;
           }
         }
+        const b = 4;
         return {
           title,
           id: `fix-${d.code}`,
@@ -362,7 +363,11 @@ class MonacoProviders extends PureComponent<
           },
         ];
       })
-      .flat();
+      .flat()
+      .filter(
+        // Remove actions with duplicate titles as you can't disable the same rule on a line twice
+        (action, i, arr) => arr.find(a => a.title === action.title) === action
+      );
 
     const disableGlobalActions: monaco.languages.CodeAction[] = [
       ...seenCodes,
@@ -389,14 +394,7 @@ class MonacoProviders extends PureComponent<
     }));
 
     return {
-      actions: [
-        ...fixActions,
-        ...disableLineActions,
-        ...disableGlobalActions,
-      ].filter(
-        // Remove actions with duplicate titles as they are a diagnostic duplicated for this selection. List should be small
-        (action, i, arr) => arr.find(a => a.title === action.title) === action
-      ),
+      actions: [...fixActions, ...disableLineActions, ...disableGlobalActions],
       dispose: () => {
         /* no-op */
       },


### PR DESCRIPTION
Should remove the invalid quick fixes to disable syntax errors (wouldn't that be nice if you could do that)

Also if there is a duplicate code detected (usually only if you have a selection and use the light bulb instead of the hover quick fix link in the modal), then the "diasble RULE for file" should only appear once. There should also be "disable RULE for line X" and "disable RULE for line Y" instead of just "for line".