### PR TITLE
fix: Paste option shows when it shouldn't

### DIFF
--- a/packages/iris-grid/src/mousehandlers/IrisGridContextMenuHandler.tsx
+++ b/packages/iris-grid/src/mousehandlers/IrisGridContextMenuHandler.tsx
@@ -482,12 +482,13 @@ class IrisGridContextMenuHandler extends GridMouseHandler {
     }
 
     if (isEditableGridModel(model) && model.isEditable) {
-      // selectedRanges is updated by GridSelectionMouseHandler in the same cycle so can't access it here
+      // selectedRanges is updated by GridSelectionMouseHandler in the same cycle so can't access the updated value here
       // so need to handle cases where a cell is right clicked without highlighting it first
       const canPasteInOriginalRange = selectedRanges.every(range =>
         model.isEditableRange(range)
       );
 
+      // To account for how when a cell outside of a selection is right clicked, that selection gets cleared
       const isCellInOriginalRange = GridRange.containsCell(
         selectedRanges,
         columnIndex,


### PR DESCRIPTION
Useful snippet for testing

```
from deephaven import empty_table, input_table
source = empty_table(10).update(["X = i", "Y = i"])
result = input_table(init_table=source)
```

- The source table is not an input table and now has no option to paste into any cells
- The result table is an input table, and the option to paste will appear only if the current selection can be pasted into