### PR TITLE
fix: Don't use HTML in panel titles, treat as text

### DIFF
--- a/packages/golden-layout/src/controls/DragProxy.ts
+++ b/packages/golden-layout/src/controls/DragProxy.ts
@@ -90,7 +90,7 @@ export default class DragProxy extends EventEmitter {
       'title',
       stripTags(this._contentItem.config.title ?? '')
     );
-    this.element.find('.lm_title').html(this._contentItem.config.title ?? '');
+    this.element.find('.lm_title').text(this._contentItem.config.title ?? '');
     this.childElementContainer = this.element.find('.lm_content');
     this.childElementContainer.append(contentItem.element);
 

--- a/packages/golden-layout/src/controls/Tab.ts
+++ b/packages/golden-layout/src/controls/Tab.ts
@@ -99,7 +99,7 @@ export default class Tab {
   setTitle(title = '') {
     // Disabling for illumon project, we want to manage our own tooltips
     // this.element.attr( 'title', lm.utils.stripTags( title ) );
-    this.titleElement.html(title);
+    this.titleElement.text(title);
   }
 
   /**

--- a/packages/golden-layout/test/title-tests.js
+++ b/packages/golden-layout/test/title-tests.js
@@ -71,7 +71,6 @@ describe('content items are abled to to emit events that bubble up the tree', fu
     expect(stack.header.tabs[0].element.find('.lm_title').text()).toBe(
       'title <b>with</b> html'
     );
-    // expect( stack.header.tabs[ 0 ].element.attr( 'title' ) ).toBe( 'title with html' );
   });
 
   it('destroys the layout', function () {

--- a/packages/golden-layout/test/title-tests.js
+++ b/packages/golden-layout/test/title-tests.js
@@ -66,10 +66,10 @@ describe('content items are abled to to emit events that bubble up the tree', fu
   it('supports html in title', function () {
     itemWithTitle.container.setTitle('title <b>with</b> html');
     expect(stack.header.tabs[0].element.find('.lm_title').html()).toBe(
-      'title <b>with</b> html'
+      'title &lt;b&gt;with&lt;/b&gt; html'
     );
     expect(stack.header.tabs[0].element.find('.lm_title').text()).toBe(
-      'title with html'
+      'title <b>with</b> html'
     );
     // expect( stack.header.tabs[ 0 ].element.attr( 'title' ) ).toBe( 'title with html' );
   });


### PR DESCRIPTION
- Golden Layout was setting the title in panel titles with `.html()` method, which allows remote code execution, and potentially could craft a notebook with a malicious name that could run arbitrary JS
- Instead just use `.text` and treat it like text, as we should.
- Tested on DHC - created a notebook with the name `<img src=q onerror=prompt(1)>.py`. It now appears correctly as text and does not pop up an alert message. Also verified that title still appears in italics when in "preview" mode.
- Fixes DH-18645