### PR TITLE
refactor: DH-14692 Stop exporting client from support logs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30041,7 +30041,8 @@
       "version": "0.85.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "event-target-shim": "^6.0.2"
+        "event-target-shim": "^6.0.2",
+        "jszip": "^3.10.1"
       },
       "engines": {
         "node": ">=16"
@@ -32241,7 +32242,8 @@
     "@deephaven/log": {
       "version": "file:packages/log",
       "requires": {
-        "event-target-shim": "^6.0.2"
+        "event-target-shim": "^6.0.2",
+        "jszip": "^3.10.1"
       }
     },
     "@deephaven/mocks": {

--- a/packages/code-studio/src/index.tsx
+++ b/packages/code-studio/src/index.tsx
@@ -5,9 +5,12 @@ import { Provider } from 'react-redux';
 import { LoadingOverlay, preloadTheme } from '@deephaven/components';
 import { ApiBootstrap } from '@deephaven/jsapi-bootstrap';
 import { store } from '@deephaven/redux';
-import logInit from './log/LogInit';
+import { logInit } from '@deephaven/log';
 
-logInit();
+logInit(
+  parseInt(import.meta.env.VITE_LOG_LEVEL ?? '', 10),
+  import.meta.env.VITE_ENABLE_LOG_PROXY === 'true'
+);
 
 preloadTheme();
 

--- a/packages/code-studio/src/settings/SettingsMenu.tsx
+++ b/packages/code-studio/src/settings/SettingsMenu.tsx
@@ -18,18 +18,18 @@ import {
   Logo,
   Tooltip,
 } from '@deephaven/components';
-import { ServerConfigValues, User } from '@deephaven/redux';
+import { ServerConfigValues, User, store } from '@deephaven/redux';
 import {
   BROADCAST_CHANNEL_NAME,
   BROADCAST_LOGOUT_MESSAGE,
   makeMessage,
 } from '@deephaven/jsapi-utils';
 import { PluginModuleMap } from '@deephaven/plugin';
+import { exportLogs, logHistory } from '@deephaven/log';
 import FormattingSectionContent from './FormattingSectionContent';
 import LegalNotice from './LegalNotice';
 import SettingsMenuSection from './SettingsMenuSection';
 import ShortcutSectionContent from './ShortcutsSectionContent';
-import { exportLogs } from '../log/LogExport';
 import './SettingsMenu.scss';
 import ColumnSpecificSectionContent from './ColumnSpecificSectionContent';
 import {
@@ -134,10 +134,16 @@ export class SettingsMenu extends Component<
   handleExportSupportLogs(): void {
     const { serverConfigValues, pluginData } = this.props;
     const pluginInfo = getFormattedPluginInfo(pluginData);
-    exportLogs(undefined, {
-      ...Object.fromEntries(serverConfigValues),
-      pluginInfo,
-    });
+    exportLogs(
+      logHistory,
+      {
+        uiVersion: import.meta.env.npm_package_version,
+        userAgent: navigator.userAgent,
+        ...Object.fromEntries(serverConfigValues),
+        pluginInfo,
+      },
+      store.getState()
+    );
   }
 
   render(): ReactElement {

--- a/packages/log/package.json
+++ b/packages/log/package.json
@@ -21,7 +21,8 @@
     "build:babel": "babel ./src --out-dir ./dist --extensions \".ts,.tsx,.js,.jsx\" --source-maps --root-mode upward"
   },
   "dependencies": {
-    "event-target-shim": "^6.0.2"
+    "event-target-shim": "^6.0.2",
+    "jszip": "^3.10.1"
   },
   "files": [
     "dist"

--- a/packages/log/src/LogExport.test.ts
+++ b/packages/log/src/LogExport.test.ts
@@ -1,0 +1,90 @@
+import { getReduxDataString } from './LogExport';
+
+describe('getReduxDataString', () => {
+  it('should return a JSON string of the redux data', () => {
+    const reduxData = {
+      key1: 'value1',
+      key2: 2,
+      key3: true,
+    };
+    const result = getReduxDataString(reduxData);
+    const expected = JSON.stringify(reduxData, null, 2);
+    expect(result).toBe(expected);
+  });
+
+  it('should handle circular references', () => {
+    const reduxData: Record<string, unknown> = {
+      key1: 'value1',
+    };
+    reduxData.key2 = reduxData;
+    const result = getReduxDataString(reduxData);
+    const expected = JSON.stringify(
+      {
+        key1: 'value1',
+        key2: 'Circular ref to root',
+      },
+      null,
+      2
+    );
+    expect(result).toBe(expected);
+  });
+
+  it('should handle BigInt values', () => {
+    const reduxData = {
+      key1: BigInt('12345678901234567890'),
+    };
+    const result = getReduxDataString(reduxData);
+    const expected = JSON.stringify(
+      {
+        key1: '12345678901234567890',
+      },
+      null,
+      2
+    );
+    expect(result).toBe(expected);
+  });
+
+  it('should apply blacklist paths', () => {
+    const reduxData = {
+      key1: 'should be blacklisted',
+      key2: {
+        'key2.1': 'should also be blacklisted',
+      },
+      key3: 'value',
+    };
+    const result = getReduxDataString(reduxData, [
+      ['key1'],
+      ['key2', 'key2.1'],
+    ]);
+    const expected = JSON.stringify(
+      {
+        key2: {},
+        key3: 'value',
+      },
+      null,
+      2
+    );
+    expect(result).toBe(expected);
+  });
+
+  it('should stringify Maps', () => {
+    const reduxData = {
+      key1: new Map([
+        ['key1.1', 'value1.1'],
+        ['key1.2', 'value1.2'],
+      ]),
+    };
+    const result = getReduxDataString(reduxData);
+    const expected = JSON.stringify(
+      {
+        key1: [
+          ['key1.1', 'value1.1'],
+          ['key1.2', 'value1.2'],
+        ],
+      },
+      null,
+      2
+    );
+    expect(result).toBe(expected);
+  });
+});

--- a/packages/log/src/LogInit.ts
+++ b/packages/log/src/LogInit.ts
@@ -1,4 +1,7 @@
-import { LogProxy, LogHistory, Logger, Log } from '@deephaven/log';
+import Log from './Log';
+import type Logger from './Logger';
+import LogHistory from './LogHistory';
+import LogProxy from './LogProxy';
 
 declare global {
   interface Window {
@@ -11,10 +14,10 @@ declare global {
 export const logProxy = new LogProxy();
 export const logHistory = new LogHistory(logProxy);
 
-export default function logInit(): void {
-  Log.setLogLevel(parseInt(import.meta.env.VITE_LOG_LEVEL ?? '', 10));
+export function logInit(logLevel = 2, enableProxy = true): void {
+  Log.setLogLevel(logLevel);
 
-  if (import.meta.env.VITE_ENABLE_LOG_PROXY === 'true') {
+  if (enableProxy) {
     logProxy.enable();
     logHistory.enable();
   }
@@ -26,3 +29,5 @@ export default function logInit(): void {
     window.DHLogHistory = logHistory;
   }
 }
+
+export default logInit;

--- a/packages/log/src/index.ts
+++ b/packages/log/src/index.ts
@@ -6,3 +6,5 @@ export { default as Logger } from './Logger';
 export { default as LogHistory } from './LogHistory';
 export { default as LogProxy } from './LogProxy';
 export { default as LoggerLevel } from './LoggerLevel';
+export * from './LogExport';
+export * from './LogInit';


### PR DESCRIPTION
Cherry-pick #2279 
- Move `exportLogs` and `logInit` to the `log` package so they could be reused in Enterprise
- Remove `@deephaven/redux` and `@deephaven/jsapi-shim` dependencies from `LogExport.ts`
- Serialize Maps in redux data
- Unit tests for `getReduxDataString`