### PR TITLE
refactor: Require memoizee and memoizeClear calls have a max size

### DIFF
--- a/@types/memoizee/index.d.ts
+++ b/@types/memoizee/index.d.ts
@@ -22,7 +22,7 @@ declare namespace memoizee {
 // eslint-disable-next-line @typescript-eslint/ban-types
 declare function memoizee<F extends Function>(
   f: F,
-  options?: memoizee.Options<F>
+  options: memoizee.Options<F> & { max: number }
 ): F & memoizee.Memoized<F>;
 
 export = memoizee;

--- a/packages/chart/src/FigureChartModel.ts
+++ b/packages/chart/src/FigureChartModel.ts
@@ -405,14 +405,16 @@ class FigureChartModel extends ChartModel {
         }
       }
       return undefined;
-    }
+    },
+    { max: 100 }
   );
 
   getValueTranslator = memoize(
     (columnType: string, formatter: Formatter | undefined) => {
       const timeZone = this.getTimeZone(columnType, formatter);
       return (value: unknown) => this.chartUtils.unwrapValue(value, timeZone);
-    }
+    },
+    { max: 100 }
   );
 
   /** Gets the parser for a value with the provided column type */
@@ -421,7 +423,8 @@ class FigureChartModel extends ChartModel {
       const timeZone = this.getTimeZone(columnType, formatter);
       return (value: unknown) =>
         this.chartUtils.wrapValue(value, columnType, timeZone);
-    }
+    },
+    { max: 100 }
   );
 
   /**
@@ -434,7 +437,8 @@ class FigureChartModel extends ChartModel {
       rangeStart = valueParser(rangeStart);
       rangeEnd = valueParser(rangeEnd);
       return [rangeStart, rangeEnd];
-    }
+    },
+    { max: 100 }
   );
 
   /**
@@ -449,7 +453,8 @@ class FigureChartModel extends ChartModel {
         }
 
         return (range: [unknown, unknown]) => range;
-      }
+      },
+    { max: 100 }
   );
 
   handleDownsampleStart(event: ChartEvent): void {

--- a/packages/code-studio/src/settings/ColumnSpecificSectionContent.tsx
+++ b/packages/code-studio/src/settings/ColumnSpecificSectionContent.tsx
@@ -147,7 +147,9 @@ export class ColumnSpecificSectionContent extends PureComponent<
     return lastFormatRuleIndex;
   }
 
-  getCachedColumnTypeOptions = memoize(() => <ColumnTypeOptions />);
+  getCachedColumnTypeOptions = memoize(() => <ColumnTypeOptions />, {
+    max: 100,
+  });
 
   getCachedDateTimeFormatOptions = memoize(
     (
@@ -168,7 +170,8 @@ export class ColumnSpecificSectionContent extends PureComponent<
           legacyGlobalFormat={legacyGlobalFormat}
         />
       );
-    }
+    },
+    { max: 100 }
   );
 
   handleFormatRuleChange(

--- a/packages/code-studio/src/settings/FormattingSectionContent.tsx
+++ b/packages/code-studio/src/settings/FormattingSectionContent.tsx
@@ -183,7 +183,8 @@ export class FormattingSectionContent extends PureComponent<
           legacyGlobalFormat={legacyGlobalFormat}
         />
       );
-    }
+    },
+    { max: 100 }
   );
 
   queueUpdate(updates: Partial<WorkspaceSettings>): void {

--- a/packages/code-studio/src/styleguide/DraggableLists.tsx
+++ b/packages/code-studio/src/styleguide/DraggableLists.tsx
@@ -162,8 +162,9 @@ class DraggableLists extends Component<
     });
   }
 
-  getSelectionChangeHandler = memoize((listIndex: number) =>
-    this.handleSelectionChange.bind(this, listIndex)
+  getSelectionChangeHandler = memoize(
+    (listIndex: number) => this.handleSelectionChange.bind(this, listIndex),
+    { max: 1000 }
   );
 
   getDraggableList = memoize(
@@ -187,7 +188,8 @@ class DraggableLists extends Component<
         // eslint-disable-next-line react/jsx-props-no-spreading
         {...DRAG_LIST_PROPS[listIndex]}
       />
-    )
+    ),
+    { max: 1000 }
   );
 
   render(): React.ReactElement {

--- a/packages/components/src/AutoCompleteInput.tsx
+++ b/packages/components/src/AutoCompleteInput.tsx
@@ -169,7 +169,8 @@ class AutoCompleteInput extends Component<
       options.filter(
         // supports partial match
         option => option.title.toLowerCase().indexOf(input.toLowerCase()) >= 0
-      )
+      ),
+    { max: 1000 }
   );
 
   // validation needs to be an exact case-sensitve match on value

--- a/packages/components/src/ItemList.tsx
+++ b/packages/components/src/ItemList.tsx
@@ -282,34 +282,40 @@ export class ItemList<T> extends PureComponent<
     { max: ItemList.CACHE_SIZE }
   );
 
-  getOuterElement = memoize((onKeyDown: React.KeyboardEventHandler) => {
-    const component = React.forwardRef<HTMLDivElement>((props, ref) => (
-      // We need to add the tabIndex to make sure it is focusable, otherwise we can't get key events
-      <div
-        ref={ref}
-        tabIndex={-1}
-        onKeyDown={onKeyDown}
-        role="presentation"
-        // eslint-disable-next-line react/jsx-props-no-spreading
-        {...props}
-      />
-    ));
-    component.displayName = 'ItemListOuterElement';
-    return component;
-  });
+  getOuterElement = memoize(
+    (onKeyDown: React.KeyboardEventHandler) => {
+      const component = React.forwardRef<HTMLDivElement>((props, ref) => (
+        // We need to add the tabIndex to make sure it is focusable, otherwise we can't get key events
+        <div
+          ref={ref}
+          tabIndex={-1}
+          onKeyDown={onKeyDown}
+          role="presentation"
+          // eslint-disable-next-line react/jsx-props-no-spreading
+          {...props}
+        />
+      ));
+      component.displayName = 'ItemListOuterElement';
+      return component;
+    },
+    { max: 1000 }
+  );
 
-  getInnerElement = memoize(() => {
-    const component = React.forwardRef<HTMLDivElement>((props, ref) => (
-      <div
-        className="item-list-inner-element"
-        ref={ref}
-        // eslint-disable-next-line react/jsx-props-no-spreading
-        {...props}
-      />
-    ));
-    component.displayName = 'ItemListInnerElement';
-    return component;
-  });
+  getInnerElement = memoize(
+    () => {
+      const component = React.forwardRef<HTMLDivElement>((props, ref) => (
+        <div
+          className="item-list-inner-element"
+          ref={ref}
+          // eslint-disable-next-line react/jsx-props-no-spreading
+          {...props}
+        />
+      ));
+      component.displayName = 'ItemListInnerElement';
+      return component;
+    },
+    { max: 1000 }
+  );
 
   getItemData = memoize(
     (
@@ -320,7 +326,8 @@ export class ItemList<T> extends PureComponent<
       items,
       selectedRanges,
       renderItem,
-    })
+    }),
+    { max: 1000 }
   );
 
   focus(): void {

--- a/packages/dashboard-core-plugins/src/controls/dropdown-filter/DropdownFilter.tsx
+++ b/packages/dashboard-core-plugins/src/controls/dropdown-filter/DropdownFilter.tsx
@@ -232,7 +232,8 @@ export class DropdownFilter extends Component<
       }
 
       return name;
-    }
+    },
+    { max: 1000 }
   );
 
   handleColumnChange(eventTargetValue: string): void {

--- a/packages/dashboard-core-plugins/src/controls/input-filter/InputFilter.tsx
+++ b/packages/dashboard-core-plugins/src/controls/input-filter/InputFilter.tsx
@@ -109,19 +109,22 @@ class InputFilter extends Component<InputFilterProps, InputFilterState> {
 
   inputRef: RefObject<HTMLInputElement>;
 
-  getItemLabel = memoizee((columns: InputFilterColumn[], index: number) => {
-    const { name, type } = columns[index];
+  getItemLabel = memoizee(
+    (columns: InputFilterColumn[], index: number) => {
+      const { name, type } = columns[index];
 
-    if (
-      (index > 0 && columns[index - 1].name === name) ||
-      (index < columns.length - 1 && columns[index + 1].name === name)
-    ) {
-      const shortType = type.substring(type.lastIndexOf('.') + 1);
-      return `${name} (${shortType})`;
-    }
+      if (
+        (index > 0 && columns[index - 1].name === name) ||
+        (index < columns.length - 1 && columns[index + 1].name === name)
+      ) {
+        const shortType = type.substring(type.lastIndexOf('.') + 1);
+        return `${name} (${shortType})`;
+      }
 
-    return name;
-  });
+      return name;
+    },
+    { max: 1000 }
+  );
 
   handleColumnChange(eventTargetValue: string): void {
     const { columns } = this.props;

--- a/packages/dashboard-core-plugins/src/panels/DropdownFilterPanel.tsx
+++ b/packages/dashboard-core-plugins/src/panels/DropdownFilterPanel.tsx
@@ -310,7 +310,8 @@ export class DropdownFilterPanel extends Component<
           ? formatter.getFormattedString(value, type, name)
           : null
       );
-    }
+    },
+    { max: 1000 }
   );
 
   getCoordinateForColumn(): [number, number] | null {
@@ -348,21 +349,25 @@ export class DropdownFilterPanel extends Component<
       const panelId = LayoutUtils.getIdFromPanel(panel);
       log.debug('getCachedPanelLinks', dashboardLinks, panelId);
       return dashboardLinks.filter(link => link.end?.panelId === panelId);
-    }
+    },
+    { max: 1000 }
   );
 
-  getCachedSource = memoize((links: Link[]) => {
-    log.debug('getCachedSource', links);
-    let source: LinkPoint | undefined;
-    if (links.length > 0) {
-      const [link] = links;
-      source = link.start;
-      if (links.length > 1) {
-        log.error('Filter has more that one link', links);
+  getCachedSource = memoize(
+    (links: Link[]) => {
+      log.debug('getCachedSource', links);
+      let source: LinkPoint | undefined;
+      if (links.length > 0) {
+        const [link] = links;
+        source = link.start;
+        if (links.length > 1) {
+          log.error('Filter has more that one link', links);
+        }
       }
-    }
-    return source;
-  });
+      return source;
+    },
+    { max: 1000 }
+  );
 
   getCachedSourceTable = memoize(
     (
@@ -375,7 +380,8 @@ export class DropdownFilterPanel extends Component<
       }
       const { panelId } = source;
       return panelTableMap.get(panelId) ?? null;
-    }
+    },
+    { max: 1000 }
   );
 
   getCachedSourceColumn = memoize(
@@ -390,7 +396,8 @@ export class DropdownFilterPanel extends Component<
             name === source.columnName && type === source.columnType
         ) ?? null
       );
-    }
+    },
+    { max: 1000 }
   );
 
   getSource(links: Link[]): LinkPoint | undefined {

--- a/packages/grid/src/MockTreeGridModel.ts
+++ b/packages/grid/src/MockTreeGridModel.ts
@@ -161,7 +161,8 @@ class MockTreeGridModel extends MockGridModel implements ExpandableGridModel {
       }
 
       return { key, offsetRow };
-    }
+    },
+    { max: 10000 }
   );
 
   getCachedTextForRowHeader = memoizeClear(
@@ -176,7 +177,8 @@ class MockTreeGridModel extends MockGridModel implements ExpandableGridModel {
       }
 
       return `${offsetRow}`;
-    }
+    },
+    { max: 10000 }
   );
 
   getCachedTextForCell = memoizeClear(
@@ -195,7 +197,8 @@ class MockTreeGridModel extends MockGridModel implements ExpandableGridModel {
       }
 
       return `${column},${offsetRow}`;
-    }
+    },
+    { max: 10000 }
   );
 
   getCachedIsRowExpandable = memoizeClear(
@@ -203,7 +206,8 @@ class MockTreeGridModel extends MockGridModel implements ExpandableGridModel {
       const depth = this.getCachedDepthForRow(children, row);
 
       return depth < maxDepth;
-    }
+    },
+    { max: 10000 }
   );
 
   getCachedIsRowExpanded = memoizeClear(
@@ -218,7 +222,8 @@ class MockTreeGridModel extends MockGridModel implements ExpandableGridModel {
       }
 
       return children.has(offsetRow);
-    }
+    },
+    { max: 10000 }
   );
 
   getCachedDepthForRow = memoizeClear(
@@ -233,7 +238,8 @@ class MockTreeGridModel extends MockGridModel implements ExpandableGridModel {
       }
 
       return 0;
-    }
+    },
+    { max: 10000 }
   );
 }
 

--- a/packages/grid/src/memoizeClear.ts
+++ b/packages/grid/src/memoizeClear.ts
@@ -10,7 +10,11 @@ import memoizee from 'memoizee';
  * @param fn The function to memoize
  * @param options The options to set for memoization
  */
-export const memoizeClear: typeof memoizee = (fn, options) => {
+// eslint-disable-next-line @typescript-eslint/ban-types
+export function memoizeClear<F extends Function>(
+  fn: F,
+  options: memoizee.Options<F> & { max: number }
+): F & memoizee.Memoized<F> {
   let isClearingCache = false;
   const memoizedFn = memoizee(fn, {
     ...options,
@@ -25,6 +29,6 @@ export const memoizeClear: typeof memoizee = (fn, options) => {
   });
 
   return memoizedFn;
-};
+}
 
 export default memoizeClear;

--- a/packages/iris-grid/src/IrisGrid.tsx
+++ b/packages/iris-grid/src/IrisGrid.tsx
@@ -1251,7 +1251,8 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
         );
       });
       return aggregationMap;
-    }
+    },
+    { max: 1 }
   );
 
   getOperationMap = memoize(
@@ -1276,7 +1277,8 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
           });
         });
       return operationMap;
-    }
+    },
+    { max: 1 }
   );
 
   getOperationOrder = memoize(
@@ -1285,7 +1287,8 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
         .map((a: Aggregation) => a.operation)
         .filter(
           (o: AggregationOperation) => !AggregationUtils.isRollupOperation(o)
-        )
+        ),
+    { max: 1 }
   );
 
   getCachedFormatColumns = memoize(
@@ -1293,7 +1296,8 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
       dh: typeof DhType,
       columns: readonly DhType.Column[],
       rules: readonly SidebarFormattingRule[]
-    ) => getFormatColumns(dh, columns, rules)
+    ) => getFormatColumns(dh, columns, rules),
+    { max: 1000 }
   );
 
   /**
@@ -1325,7 +1329,8 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
       }
 
       return this.getCachedFormatColumns(dh, columns, rulesParam);
-    }
+    },
+    { max: 1 }
   );
 
   getModelRollupConfig = memoize(
@@ -1338,7 +1343,8 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
         originalColumns,
         config,
         aggregationSettings
-      )
+      ),
+    { max: 1 }
   );
 
   getModelTotalsConfig = memoize(
@@ -1370,7 +1376,8 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
         showOnTop: aggregationSettings.showOnTop,
         defaultOperation: AggregationOperation.SKIP,
       } as UITotalsTableConfig;
-    }
+    },
+    { max: 1 }
   );
 
   getCachedStateOverride = memoize(
@@ -1457,8 +1464,10 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
     { max: 1 }
   );
 
-  getCachedKeyHandlers = memoize((keyHandlers: readonly KeyHandler[]) =>
-    [...keyHandlers, ...this.keyHandlers].sort((a, b) => a.order - b.order)
+  getCachedKeyHandlers = memoize(
+    (keyHandlers: readonly KeyHandler[]) =>
+      [...keyHandlers, ...this.keyHandlers].sort((a, b) => a.order - b.order),
+    { max: 1 }
   );
 
   getKeyHandlers(): readonly KeyHandler[] {
@@ -1469,7 +1478,8 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
   getCachedMouseHandlers = memoize(
     (
       mouseHandlers: readonly GridMouseHandler[]
-    ): readonly GridMouseHandler[] => [...mouseHandlers, ...this.mouseHandlers]
+    ): readonly GridMouseHandler[] => [...mouseHandlers, ...this.mouseHandlers],
+    { max: 1 }
   );
 
   getCachedRenderer = memoize(
@@ -1975,7 +1985,8 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
       const columnSet = new Set([...alwaysFetchColumns, ...floatingColumns]);
 
       return Object.freeze([...columnSet]);
-    }
+    },
+    { max: 1 }
   );
 
   updateFormatter(
@@ -4002,7 +4013,8 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
           </Tooltip>
         </div>
       );
-    }
+    },
+    { max: 1 }
   );
 
   getExpandCellTooltip = memoize(
@@ -4046,34 +4058,38 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
           </Tooltip>
         </div>
       );
-    }
+    },
+    { max: 1 }
   );
 
-  getHoverTooltip = memoize((hoverTooltipProps: CSSProperties): ReactNode => {
-    if (hoverTooltipProps == null) {
-      return null;
-    }
+  getHoverTooltip = memoize(
+    (hoverTooltipProps: CSSProperties): ReactNode => {
+      if (hoverTooltipProps == null) {
+        return null;
+      }
 
-    const { hoverDisplayValue } = this.state;
+      const { hoverDisplayValue } = this.state;
 
-    const wrapperStyle: CSSProperties = {
-      position: 'absolute',
-      ...hoverTooltipProps,
-      pointerEvents: 'none',
-    };
+      const wrapperStyle: CSSProperties = {
+        position: 'absolute',
+        ...hoverTooltipProps,
+        pointerEvents: 'none',
+      };
 
-    const popperOptions: PopperOptions = {
-      placement: 'bottom',
-    };
+      const popperOptions: PopperOptions = {
+        placement: 'bottom',
+      };
 
-    return (
-      <div style={wrapperStyle}>
-        <Tooltip options={popperOptions} ref={this.handleTooltipRef}>
-          <div className="link-hover-tooltip">{hoverDisplayValue}</div>
-        </Tooltip>
-      </div>
-    );
-  });
+      return (
+        <div style={wrapperStyle}>
+          <Tooltip options={popperOptions} ref={this.handleTooltipRef}>
+            <div className="link-hover-tooltip">{hoverDisplayValue}</div>
+          </Tooltip>
+        </div>
+      );
+    },
+    { max: 1 }
+  );
 
   handleGotoRowSelectedRowNumberSubmit(): void {
     const { gotoRow: rowNumber } = this.state;

--- a/packages/iris-grid/src/IrisGridPartitionSelector.tsx
+++ b/packages/iris-grid/src/IrisGridPartitionSelector.tsx
@@ -284,11 +284,13 @@ class IrisGridPartitionSelector extends Component<
 
   getCachedChangeCallback = memoizee(
     (index: number) => (value: unknown) =>
-      this.handlePartitionSelect(index, value)
+      this.handlePartitionSelect(index, value),
+    { max: 100 }
   );
 
   getCachedFormatValueCallback = memoizee(
-    (index: number) => (value: unknown) => this.getDisplayValue(index, value)
+    (index: number) => (value: unknown) => this.getDisplayValue(index, value),
+    { max: 100 }
   );
 
   render(): JSX.Element {

--- a/packages/iris-grid/src/sidebar/RollupRows.tsx
+++ b/packages/iris-grid/src/sidebar/RollupRows.tsx
@@ -412,7 +412,8 @@ class RollupRows extends Component<RollupRowsProps, RollupRowsState> {
         column =>
           RollupRows.isGroupable(column) &&
           groupedColumns.find(name => name === column.name) == null
-      )
+      ),
+    { max: 100 }
   );
 
   getCachedSortedColumns = memoize(
@@ -422,7 +423,8 @@ class RollupRows extends Component<RollupRowsProps, RollupRowsState> {
     ): readonly dh.Column[] =>
       sort == null
         ? [...columns]
-        : TableUtils.sortColumns(columns, sort === RollupRows.SORT.ASCENDING)
+        : TableUtils.sortColumns(columns, sort === RollupRows.SORT.ASCENDING),
+    { max: 100 }
   );
 
   getUngroupedColumns(): readonly dh.Column[] {

--- a/packages/iris-grid/src/sidebar/visibility-ordering-builder/VisibilityOrderingBuilder.tsx
+++ b/packages/iris-grid/src/sidebar/visibility-ordering-builder/VisibilityOrderingBuilder.tsx
@@ -1004,7 +1004,8 @@ class VisibilityOrderingBuilder extends PureComponent<
           handleProps={handleProps}
         />
       );
-    }
+    },
+    { max: 1000 }
   );
 
   getMemoizedFirstMovableIndex = memoize(
@@ -1022,7 +1023,8 @@ class VisibilityOrderingBuilder extends PureComponent<
       }
 
       return null;
-    }
+    },
+    { max: 10 }
   );
 
   /**
@@ -1052,7 +1054,8 @@ class VisibilityOrderingBuilder extends PureComponent<
       }
 
       return null;
-    }
+    },
+    { max: 10 }
   );
 
   /**
@@ -1073,7 +1076,8 @@ class VisibilityOrderingBuilder extends PureComponent<
     ): readonly IrisGridTreeItem[] =>
       getTreeItems(columns, movedColumns, columnHeaderGroups, hiddenColumns, [
         ...selectedColumns.values(),
-      ])
+      ]),
+    { max: 1000 }
   );
 
   /**
@@ -1204,7 +1208,8 @@ class VisibilityOrderingBuilder extends PureComponent<
       }
 
       return elements;
-    }
+    },
+    { max: 10 }
   );
 
   renderImmovableItem = memoize(
@@ -1214,7 +1219,8 @@ class VisibilityOrderingBuilder extends PureComponent<
           <span className="column-name">{columnName}</span>
         </div>
       </div>
-    )
+    ),
+    { max: 1000 }
   );
 
   render(): ReactElement {


### PR DESCRIPTION
Related to #2374 (and might need that change before this can merge). This requires all `memoizee` and `memoizeClear` calls to provide a max cache size. Most of these were small caches most likely, but this should help prevent another issue that is hard to spot since it takes potentially hours to reproduce like DH-18798