### PR TITLE
fix: DH-18798 - token cache growing unbounded (#2374)

### DIFF
--- a/packages/grid/src/GridModel.ts
+++ b/packages/grid/src/GridModel.ts
@@ -225,7 +225,8 @@ abstract class GridModel<
       const contentToCheckForLinks = text.substring(0, lengthOfContent);
 
       return GridUtils.findTokensWithProtocolInText(contentToCheckForLinks);
-    }
+    },
+    { max: 10000 }
   );
 
   renderTypeForCell(column: ModelIndex, row: ModelIndex): CellRenderType {


### PR DESCRIPTION
Cherry picking back.

This adds a cache for the token cache. I tested this was actually causing the issue by adding some code to the cell renderer to prefill the cache to 1 million items. It hung around 200k without the max. With max it prefills just fine (cleaning out every 10k) and doesn't hinder performance.