### PR TITLE
fix: DH-18279: fix one click titles

### DIFF
--- a/packages/chart/src/FigureChartModel.test.ts
+++ b/packages/chart/src/FigureChartModel.test.ts
@@ -140,6 +140,21 @@ it('handles colors on bar charts properly', () => {
   ]);
 });
 
+it('updates the title correctly', () => {
+  const figure = chartTestUtils.makeFigure();
+  const model = new FigureChartModel(dh, figure);
+  const mockSubscribe = jest.fn();
+  model.subscribe(mockSubscribe);
+
+  model.setTitle('New Title');
+  expect(mockSubscribe).toHaveBeenCalledTimes(1);
+  expect(mockSubscribe).toHaveBeenCalledWith(
+    expect.objectContaining({
+      type: FigureChartModel.EVENT_LAYOUT_UPDATED,
+    })
+  );
+});
+
 describe('axis transform tests', () => {
   it('handles log x-axis properly', () => {
     const xAxis = chartTestUtils.makeAxis({

--- a/packages/chart/src/FigureChartModel.test.ts
+++ b/packages/chart/src/FigureChartModel.test.ts
@@ -151,6 +151,7 @@ it('updates the title correctly', () => {
   expect(mockSubscribe).toHaveBeenCalledWith(
     expect.objectContaining({
       type: FigureChartModel.EVENT_LAYOUT_UPDATED,
+      detail: { title: { text: 'New Title', pad: { t: 8 } } },
     })
   );
 });

--- a/packages/chart/src/FigureChartModel.ts
+++ b/packages/chart/src/FigureChartModel.ts
@@ -625,6 +625,8 @@ class FigureChartModel extends ChartModel {
         ChartUtils.DEFAULT_TITLE_PADDING.t +
         subtitleCount * ChartUtils.SUBTITLE_LINE_HEIGHT * 0.5;
     }
+
+    this.fireLayoutUpdated({ title: this.layout.title });
   }
 
   getPlotWidth(): number {


### PR DESCRIPTION
Example from [DH-18279](https://deephaven.atlassian.net/browse/DH-18279)
```
import deephaven.plot.express as dx
from deephaven.plot.figure import Figure
from deephaven.plot.selectable_dataset import one_click

stocks = dx.data.stocks()

one_click = Figure().plot_xy(series_name="Stock Prices", t=one_click(stocks, ["Sym"]), x="Timestamp", y="Price").show()
```
Title now updates as the input filter is updated

[DH-18279]: https://deephaven.atlassian.net/browse/DH-18279?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ