### PR TITLE
fix: Don't change console history if Shift held down

### DIFF
--- a/packages/console/src/ConsoleInput.tsx
+++ b/packages/console/src/ConsoleInput.tsx
@@ -224,43 +224,44 @@ export class ConsoleInput extends PureComponent<
       const position = commandEditor?.getPosition();
       assertNotNull(position);
       const { lineNumber } = position;
-      if (
-        keyEvent.code === 'ArrowUp' &&
-        !this.isSuggestionMenuPopulated() &&
-        lineNumber === 1
-      ) {
-        if (commandHistoryIndex != null) {
-          this.loadCommand(commandHistoryIndex + 1);
-        } else {
-          this.loadCommand(0);
-        }
-
-        this.focusStart();
-        keyEvent.stopPropagation();
-        keyEvent.preventDefault();
-
-        return;
-      }
-
-      if (
-        keyEvent.code === 'ArrowDown' &&
-        !this.isSuggestionMenuPopulated() &&
-        lineNumber === model?.getLineCount()
-      ) {
-        if (commandHistoryIndex != null && commandHistoryIndex > 0) {
-          this.loadCommand(commandHistoryIndex - 1);
-        } else {
-          this.loadCommand(null);
-        }
-
-        this.focusEnd();
-        keyEvent.stopPropagation();
-        keyEvent.preventDefault();
-
-        return;
-      }
 
       if (!keyEvent.altKey && !keyEvent.shiftKey && !keyEvent.metaKey) {
+        if (
+          keyEvent.code === 'ArrowUp' &&
+          !this.isSuggestionMenuPopulated() &&
+          lineNumber === 1
+        ) {
+          if (commandHistoryIndex != null) {
+            this.loadCommand(commandHistoryIndex + 1);
+          } else {
+            this.loadCommand(0);
+          }
+
+          this.focusStart();
+          keyEvent.stopPropagation();
+          keyEvent.preventDefault();
+
+          return;
+        }
+
+        if (
+          keyEvent.code === 'ArrowDown' &&
+          !this.isSuggestionMenuPopulated() &&
+          lineNumber === model?.getLineCount()
+        ) {
+          if (commandHistoryIndex != null && commandHistoryIndex > 0) {
+            this.loadCommand(commandHistoryIndex - 1);
+          } else {
+            this.loadCommand(null);
+          }
+
+          this.focusEnd();
+          keyEvent.stopPropagation();
+          keyEvent.preventDefault();
+
+          return;
+        }
+
         if (
           keyEvent.keyCode === monaco.KeyCode.Enter &&
           !this.isSuggestionMenuPopulated()


### PR DESCRIPTION
- If a modifier key was held down to select text in a console input and you were pressing up/down, you would change history items and it was very annoying
