### PR TITLE
fix: allow input table to delete row with null key

### DIFF
--- a/packages/iris-grid/src/IrisGridTableModel.ts
+++ b/packages/iris-grid/src/IrisGridTableModel.ts
@@ -427,11 +427,7 @@ class IrisGridTableModel
       for (let c = 0; c < keyColumns.length; c += 1) {
         const column = keyColumns[c];
         const value = row[c];
-        const filterValue = this.tableUtils.makeFilterRawValue(
-          column.type,
-          value
-        );
-        const filter = column.filter().eq(filterValue);
+        const filter = this.tableUtils.makeNullableEqFilter(column, value);
         columnFilters.push(filter);
       }
       return columnFilters.reduce((agg, curr) => agg?.and(curr) ?? curr);


### PR DESCRIPTION
https://deephaven.atlassian.net/browse/DH-18681

IrisGridTableModel was failing to create a filter on a `null` key. Updated to use the nullable util method.