### PR TITLE
ci: Run pr-check action on reopened PRs

### DIFF
--- a/.github/workflows/conventional-pr-check.yml
+++ b/.github/workflows/conventional-pr-check.yml
@@ -4,6 +4,7 @@ on:
   pull_request_target:
     types:
       - opened
+      - reopened
       - edited
       - synchronize
 


### PR DESCRIPTION
Just something I noticed when closing/re-opening the npm audit PR earlier. The pr-check action doesn't run on re-opened PRs, so you have to close/reopen, then edit the PR title to trigger all the actions