### PR TITLE
feat: Add chart event for title change (#2352)

### DIFF
--- a/packages/chart/src/Chart.tsx
+++ b/packages/chart/src/Chart.tsx
@@ -525,6 +525,14 @@ class Chart extends Component<ChartProps, ChartState> {
         this.setState({ shownBlocker: null });
         break;
       }
+      case ChartModel.EVENT_LAYOUT_UPDATED: {
+        const newLayout = detail as Partial<Layout>;
+        this.setState(({ layout, revision }) => ({
+          layout: { ...layout, ...newLayout },
+          revision: revision + 1,
+        }));
+        break;
+      }
       default:
         log.debug('Unknown event type', type, event);
     }

--- a/packages/chart/src/ChartModel.ts
+++ b/packages/chart/src/ChartModel.ts
@@ -41,6 +41,8 @@ class ChartModel {
 
   static EVENT_BLOCKER_CLEAR = 'ChartModel.EVENT_BLOCKER_CLEAR';
 
+  static EVENT_LAYOUT_UPDATED = 'ChartModel.EVENT_LAYOUT_UPDATED';
+
   constructor(dh: typeof DhType) {
     this.dh = dh;
     this.listeners = [];
@@ -195,6 +197,12 @@ class ChartModel {
 
   fireBlockerClear(): void {
     this.fireEvent(new CustomEvent(ChartModel.EVENT_BLOCKER_CLEAR));
+  }
+
+  fireLayoutUpdated(detail: Partial<Layout>): void {
+    this.fireEvent(
+      new CustomEvent(ChartModel.EVENT_LAYOUT_UPDATED, { detail })
+    );
   }
 }
 


### PR DESCRIPTION
These are for https://github.com/deephaven/deephaven-plugins/pull/1088

Currently the layout is only set once, but with indicator it may change, although specifically the title, so I added an event for that. Not sure if it's the best approach.