### PR TITLE
feat: Allow wildcards for logs blacklist

### DIFF
--- a/packages/log/src/LogExport.test.ts
+++ b/packages/log/src/LogExport.test.ts
@@ -87,4 +87,94 @@ describe('getReduxDataString', () => {
     );
     expect(result).toBe(expected);
   });
+
+  it('should handle wildcards in blacklist paths', () => {
+    const reduxData = {
+      key1: 'not blacklisted',
+      key2: {
+        keyA: {
+          key1: 'blacklisted',
+        },
+        keyB: {
+          key1: 'blacklisted',
+        },
+        keyC: {
+          key1: 'blacklisted',
+        },
+      },
+    };
+    const result = getReduxDataString(reduxData, [['key2', '*', 'key1']]);
+    const expected = JSON.stringify(
+      {
+        key1: 'not blacklisted',
+        key2: {
+          keyA: {},
+          keyB: {},
+          keyC: {},
+        },
+      },
+      null,
+      2
+    );
+    expect(result).toBe(expected);
+  });
+
+  it('should handle nested wildcards in blacklist paths', () => {
+    const reduxData = {
+      key1: 'not blacklisted',
+      key2: {
+        keyA: {
+          key1: 'blacklisted',
+          key2: {
+            key3: 'blacklisted',
+          },
+        },
+        keyB: {
+          key1: 'blacklisted',
+          key2: {
+            key3: 'blacklisted',
+            key4: 'blacklisted',
+          },
+        },
+      },
+    };
+    const result = getReduxDataString(reduxData, [['key2', '*', '*']]);
+    const expected = JSON.stringify(
+      {
+        key1: 'not blacklisted',
+        key2: {
+          keyA: {},
+          keyB: {},
+        },
+      },
+      null,
+      2
+    );
+    expect(result).toBe(expected);
+  });
+
+  it('should handle wildcard blacklist paths with no matches', () => {
+    const reduxData = {
+      key1: 'not blacklisted',
+      key2: {
+        keyA: {
+          key1: 'not blacklisted',
+          key2: {
+            key3: 'not blacklisted',
+          },
+        },
+      },
+    };
+    const result = getReduxDataString(reduxData, [['*', '*', '*', '*', '*']]); // Matching more than the depth of the object
+    const expected = JSON.stringify(reduxData, null, 2);
+    expect(result).toBe(expected);
+  });
+
+  it('root wildcard should blacklist all', () => {
+    const reduxData = {
+      key1: 'should not be blacklisted',
+    };
+    const result = getReduxDataString(reduxData, [['*']]);
+    expect(result).toBe('{}');
+  });
 });

--- a/packages/log/src/LogExport.ts
+++ b/packages/log/src/LogExport.ts
@@ -3,6 +3,7 @@ import type LogHistory from './LogHistory';
 
 // List of objects to blacklist
 // '' represents the root object
+// * represents a wildcard key
 export const DEFAULT_PATH_BLACKLIST: string[][] = [
   ['api'],
   ['client'],
@@ -43,7 +44,9 @@ function isOnBlackList(currPath: string[], blacklist: string[][]): boolean {
   for (let i = 0; i < blacklist.length; i += 1) {
     if (
       currPath.length === blacklist[i].length &&
-      currPath.every((v, index) => v === blacklist[i][index])
+      currPath.every(
+        (v, index) => blacklist[i][index] === '*' || v === blacklist[i][index]
+      )
     ) {
       // blacklist match
       return true;
@@ -150,7 +153,7 @@ function formatDate(date: Date): string {
  * @param logHistory Log history to include in the console.txt file
  * @param metadata Additional metadata to include in the metadata.json file
  * @param reduxData Redux data to include in the redux.json file
- * @param blacklist List of JSON paths to blacklist in redux data. A JSON path is a list representing the path to that value (e.g. client.data would be `['client', 'data']`)
+ * @param blacklist List of JSON paths to blacklist in redux data. A JSON path is a list representing the path to that value (e.g. client.data would be `['client', 'data']`). Wildcards (*) are accepted in the path.
  * @param fileNamePrefix The zip file name without the .zip extension. Ex: test will be saved as test.zip
  * @returns A promise that resolves successfully if the log archive is created and downloaded successfully, rejected if there's an error
  */

--- a/packages/log/src/LogExport.ts
+++ b/packages/log/src/LogExport.ts
@@ -7,7 +7,7 @@ import type LogHistory from './LogHistory';
 export const DEFAULT_PATH_BLACKLIST: string[][] = [
   ['api'],
   ['client'],
-  ['dashboardData', 'default', 'connection'],
+  ['dashboardData', '*', 'connection'],
   ['dashboardData', '*', 'sessionWrapper'],
   ['layoutStorage'],
   ['storage'],

--- a/packages/log/src/LogExport.ts
+++ b/packages/log/src/LogExport.ts
@@ -8,7 +8,7 @@ export const DEFAULT_PATH_BLACKLIST: string[][] = [
   ['api'],
   ['client'],
   ['dashboardData', 'default', 'connection'],
-  ['dashboardData', 'default', 'sessionWrapper', 'dh'],
+  ['dashboardData', '*', 'sessionWrapper'],
   ['layoutStorage'],
   ['storage'],
 ];


### PR DESCRIPTION
- Wildcards are now accepted for logs blacklist JSON paths (e.g. `dashboardData.*.sessionWrapper`)
- Updated default blacklist to remove the `sessionWrapper` from any dashboard under `dashboardData`
- This technically removes the ability to look for a `*` literal path and an escape could be added for that case, but it seems like an extreme edge case to handle. 