### PR TITLE
fix: Partition aware source table UI widget swaps from merge to coalesce

### DIFF
--- a/packages/iris-grid/src/IrisGridProxyModel.ts
+++ b/packages/iris-grid/src/IrisGridProxyModel.ts
@@ -436,10 +436,10 @@ class IrisGridProxyModel extends IrisGridModel implements PartitionedGridModel {
   }
 
   get isPartitionRequired(): boolean {
+    // @ts-expect-error If the original model is not a partitioned model return undefined to make the proxy model also return false in isPartitionedGridModelProvider
     return isPartitionedGridModelProvider(this.originalModel)
       ? this.originalModel.isPartitionRequired
-      : // @ts-expect-error If the original model is not a partitioned model return undefined to make the proxy model also return false in isPartitionedGridModelProvider
-        undefined;
+      : undefined;
   }
 
   get isPartitionAwareSourceTable(): boolean {

--- a/packages/iris-grid/src/IrisGridProxyModel.ts
+++ b/packages/iris-grid/src/IrisGridProxyModel.ts
@@ -436,10 +436,10 @@ class IrisGridProxyModel extends IrisGridModel implements PartitionedGridModel {
   }
 
   get isPartitionRequired(): boolean {
-    // @ts-expect-error If the original model is not a partitioned model return undefined to make the proxy model also return false in isPartitionedGridModelProvider
     return isPartitionedGridModelProvider(this.originalModel)
       ? this.originalModel.isPartitionRequired
-      : undefined;
+      : // @ts-expect-error If the original model is not a partitioned model return undefined to make the proxy model also return false in isPartitionedGridModelProvider
+        undefined;
   }
 
   get formatter(): Formatter {

--- a/packages/iris-grid/src/IrisGridProxyModel.ts
+++ b/packages/iris-grid/src/IrisGridProxyModel.ts
@@ -443,9 +443,10 @@ class IrisGridProxyModel extends IrisGridModel implements PartitionedGridModel {
   }
 
   get isPartitionAwareSourceTable(): boolean {
-    return isPartitionedGridModelProvider(this.originalModel)
-      ? this.originalModel.isPartitionAwareSourceTable
-      : false;
+    return (
+      isPartitionedGridModelProvider(this.originalModel) &&
+      this.originalModel.isPartitionAwareSourceTable
+    );
   }
 
   get formatter(): Formatter {

--- a/packages/iris-grid/src/IrisGridTableModel.ts
+++ b/packages/iris-grid/src/IrisGridTableModel.ts
@@ -37,6 +37,9 @@ class IrisGridTableModel
 
   initialFilters: DhType.FilterCondition[] = [];
 
+  // The initial value for table.isUncoalesced before any transformations (e.g. filter, select)
+  wasUncoalesced: boolean;
+
   /**
    * @param dh JSAPI instance
    * @param table Iris data table to be used in the model
@@ -47,12 +50,14 @@ class IrisGridTableModel
     dh: typeof DhType,
     table: DhType.Table,
     formatter = new Formatter(dh),
-    inputTable: DhType.InputTable | null = null
+    inputTable: DhType.InputTable | null = null,
+    wasUncoalesced = table.isUncoalesced
   ) {
     super(dh, table, formatter, inputTable);
     this.customColumnList = [];
     this.formatColumnList = [];
     this.initialFilters = table.filter;
+    this.wasUncoalesced = wasUncoalesced;
   }
 
   get isExportAvailable(): boolean {
@@ -301,7 +306,7 @@ class IrisGridTableModel
   }
 
   get isPartitionAwareSourceTable(): boolean {
-    return this.isPartitionRequired;
+    return this.wasUncoalesced;
   }
 
   isFilterable(columnIndex: ModelIndex): boolean {

--- a/packages/iris-grid/src/IrisGridTableModel.ts
+++ b/packages/iris-grid/src/IrisGridTableModel.ts
@@ -50,14 +50,13 @@ class IrisGridTableModel
     dh: typeof DhType,
     table: DhType.Table,
     formatter = new Formatter(dh),
-    inputTable: DhType.InputTable | null = null,
-    wasUncoalesced = table.isUncoalesced
+    inputTable: DhType.InputTable | null = null
   ) {
     super(dh, table, formatter, inputTable);
     this.customColumnList = [];
     this.formatColumnList = [];
     this.initialFilters = table.filter;
-    this.wasUncoalesced = wasUncoalesced;
+    this.wasUncoalesced = this.isPartitionRequired;
   }
 
   get isExportAvailable(): boolean {

--- a/packages/iris-grid/src/IrisGridTableModel.ts
+++ b/packages/iris-grid/src/IrisGridTableModel.ts
@@ -37,7 +37,7 @@ class IrisGridTableModel
 
   initialFilters: DhType.FilterCondition[] = [];
 
-  // The initial value for table.isUncoalesced before any transformations (e.g. filter, select)
+  // The initial value for table.isUncoalesced on the source table before any transformations (e.g. filter, select)
   wasUncoalesced: boolean;
 
   /**


### PR DESCRIPTION
- Fixes the observed issue of the partition selector button flipping between Merge and Coalesce depending on which partition view is selected. 
- The original condition for `isPartitionAwareSourceTable` in `IrisGridTableModel.ts` isn't always accurate as `table.isUncoalesced` is only true when no filters have been applied yet. Once a filter is applied, the table is no longer considered uncoalesced but the source table should still have the same property as before.
- Test snippet is linked on the ticket: [DH-19015](https://deephaven.atlassian.net/browse/DH-19015)

[DH-19015]: https://deephaven.atlassian.net/browse/DH-19015?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ