### PR TITLE
fix: DH-17599: Fix table name validation - allow hyphens

### DIFF
--- a/packages/utils/src/DbNameValidator.test.ts
+++ b/packages/utils/src/DbNameValidator.test.ts
@@ -3,13 +3,13 @@ import DbNameValidator from './DbNameValidator';
 const TABLE_PREFIX = 'table_';
 const COLUMN_PREFIX = 'column_';
 
-const VALID_TABLE_NAME = '$+@abc123_ABC';
-const INVALID_TABLE_NAME = '%^&abc';
-const CLEANED_INVALID_TABLE_NAME = 'abc';
+const VALID_TABLE_NAME = '$+@abc-123_ABC';
+const INVALID_TABLE_NAME = '%^&ab-c';
+const CLEANED_INVALID_TABLE_NAME = 'ab-c';
 
 const VALID_COL_NAME = 'abc123_ABC';
-const INVALID_COL_NAME = '@abc123_ABC123';
-const CLEANED_INVALID_COL_NAME = 'abc123_ABC123';
+const INVALID_COL_NAME = '@abc123_ABC-123';
+const CLEANED_INVALID_COL_NAME = 'abc123_ABC_123';
 
 const START_WITH_NUM = '123abc';
 const RESERVED_JAVA_WORD = 'return';

--- a/packages/utils/src/DbNameValidator.ts
+++ b/packages/utils/src/DbNameValidator.ts
@@ -85,13 +85,13 @@ function tableNameReplacer(input: string): string {
 class DbNameValidator {
   static legalize = (
     name: string,
-    customReplace: (input: string) => string,
+    replace: (input: string) => string,
     prefix: string,
     regex: RegExp,
     checkReserved: boolean,
     i: number
   ): string => {
-    let legalName = customReplace(name.trim());
+    let legalName = replace(name.trim());
 
     // Add prefix to reserved names
     if (

--- a/packages/utils/src/DbNameValidator.ts
+++ b/packages/utils/src/DbNameValidator.ts
@@ -63,10 +63,20 @@ const JAVA_KEYWORDS = new Set([
 ]);
 
 // From io.deephaven.db.tables.utils.DBNameValidator#STERILE_TABLE_AND_NAMESPACE_REGEX
-const STERILE_TABLE_AND_NAMESPACE_REGEX = /[^a-zA-Z0-9_$+@-]/g;
+const STERILE_TABLE_AND_NAMESPACE_REGEX = /[^a-zA-Z0-9_$\-+@]/g;
 
 // From io.deephaven.db.tables.utils.DBNameValidator#STERILE_COLUMN_AND_QUERY_REGEX
 const STERILE_COLUMN_AND_QUERY_REGEX = /[^A-Za-z0-9_$]/g;
+
+function columnNameReplacer(input: string): string {
+  // Replace all dashes and spaces with underscores
+  return input.replace(/[ -]/g, '_');
+}
+
+function tableNameReplacer(input: string): string {
+  // Replace spaces with underscores
+  return input.replace(/\s/g, '_');
+}
 
 /**
  * Similar to DBNameValidator.java, this class has utilities for validating and legalizing
@@ -75,13 +85,13 @@ const STERILE_COLUMN_AND_QUERY_REGEX = /[^A-Za-z0-9_$]/g;
 class DbNameValidator {
   static legalize = (
     name: string,
+    customReplace: (input: string) => string,
     prefix: string,
     regex: RegExp,
     checkReserved: boolean,
     i: number
   ): string => {
-    // Replace all dashes and spaces with underscores
-    let legalName = name.trim().replace(/[- ]/g, '_');
+    let legalName = customReplace(name.trim());
 
     // Add prefix to reserved names
     if (
@@ -111,6 +121,7 @@ class DbNameValidator {
   static legalizeTableName = (name: string): string =>
     DbNameValidator.legalize(
       name,
+      tableNameReplacer,
       TABLE_PREFIX,
       STERILE_TABLE_AND_NAMESPACE_REGEX,
       false,
@@ -136,6 +147,7 @@ class DbNameValidator {
     // Replace all dashes and spaces with underscores
     DbNameValidator.legalize(
       header,
+      columnNameReplacer,
       COLUMN_PREFIX,
       STERILE_COLUMN_AND_QUERY_REGEX,
       true,


### PR DESCRIPTION
- Updated `STERILE_TABLE_AND_NAMESPACE_REGEX` in `DbNameValidator` to match the Java class and allow hyphens in table names
- Added `replace` arg to `DbNameValidator.legalize` to preserve the existing `legalizeColumnName` behavior - replace spaces and hyphens in column names with underscores.
- Updated unit tests