### PR TITLE
fix: DH-19010: Delete closed http2 sessions from the cache

### DIFF
--- a/packages/jsapi-nodejs/src/NodeHttp2gRPCTransport.ts
+++ b/packages/jsapi-nodejs/src/NodeHttp2gRPCTransport.ts
@@ -56,9 +56,16 @@ export class NodeHttp2gRPCTransport implements GrpcTransport {
 
       if (!NodeHttp2gRPCTransport.sessionMap.has(origin)) {
         const session = http2.connect(origin);
+
         session.on('error', err => {
           NodeHttp2gRPCTransport.logMessage('error', 'Session error', err);
         });
+
+        session.on('close', () => {
+          NodeHttp2gRPCTransport.logMessage('debug', 'Session closed');
+          NodeHttp2gRPCTransport.sessionMap.delete(origin);
+        });
+
         NodeHttp2gRPCTransport.sessionMap.set(origin, session);
       }
 


### PR DESCRIPTION
DH-19010: Delete closed http2 sessions from the cache. This ensures new sessions get created on next request since closed sessions cannot be re-used.

Note that this is currently only used by the VS Code extension. I tested it locally, but final testing will happen as part of the PR that updates DH packages to use this change.