### PR TITLE
refactor: Cherry-pick latest log export changes into v0.78

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29689,7 +29689,8 @@
       "version": "0.78.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "event-target-shim": "^6.0.2"
+        "event-target-shim": "^6.0.2",
+        "jszip": "^3.10.1"
       },
       "engines": {
         "node": ">=16"
@@ -31879,7 +31880,8 @@
     "@deephaven/log": {
       "version": "file:packages/log",
       "requires": {
-        "event-target-shim": "^6.0.2"
+        "event-target-shim": "^6.0.2",
+        "jszip": "^3.10.1"
       }
     },
     "@deephaven/mocks": {

--- a/packages/code-studio/src/index.tsx
+++ b/packages/code-studio/src/index.tsx
@@ -3,9 +3,12 @@ import ReactDOM from 'react-dom';
 import '@deephaven/components/scss/BaseStyleSheet.scss';
 import { LoadingOverlay, preloadTheme } from '@deephaven/components';
 import { ApiBootstrap } from '@deephaven/jsapi-bootstrap';
-import logInit from './log/LogInit';
+import { logInit } from '@deephaven/log';
 
-logInit();
+logInit(
+  parseInt(import.meta.env.VITE_LOG_LEVEL ?? '', 10),
+  import.meta.env.VITE_ENABLE_LOG_PROXY === 'true'
+);
 
 preloadTheme();
 

--- a/packages/code-studio/src/settings/SettingsMenu.tsx
+++ b/packages/code-studio/src/settings/SettingsMenu.tsx
@@ -20,7 +20,7 @@ import {
   ThemePicker,
   Tooltip,
 } from '@deephaven/components';
-import { ServerConfigValues, User } from '@deephaven/redux';
+import { type ServerConfigValues, type User, store } from '@deephaven/redux';
 import {
   BROADCAST_CHANNEL_NAME,
   BROADCAST_LOGOUT_MESSAGE,
@@ -28,11 +28,11 @@ import {
 } from '@deephaven/jsapi-utils';
 import { assertNotNull } from '@deephaven/utils';
 import { PluginModuleMap } from '@deephaven/plugin';
+import { exportLogs, logHistory } from '@deephaven/log';
 import FormattingSectionContent from './FormattingSectionContent';
 import LegalNotice from './LegalNotice';
 import SettingsMenuSection from './SettingsMenuSection';
 import ShortcutSectionContent from './ShortcutsSectionContent';
-import { exportLogs } from '../log/LogExport';
 import './SettingsMenu.scss';
 import ColumnSpecificSectionContent from './ColumnSpecificSectionContent';
 import {
@@ -136,10 +136,16 @@ export class SettingsMenu extends Component<
   handleExportSupportLogs(): void {
     const { serverConfigValues, pluginData } = this.props;
     const pluginInfo = getFormattedPluginInfo(pluginData);
-    exportLogs(undefined, {
-      ...Object.fromEntries(serverConfigValues),
-      pluginInfo,
-    });
+    exportLogs(
+      logHistory,
+      {
+        uiVersion: import.meta.env.npm_package_version,
+        userAgent: navigator.userAgent,
+        ...Object.fromEntries(serverConfigValues),
+        pluginInfo,
+      },
+      store.getState()
+    );
   }
 
   render(): ReactElement {

--- a/packages/log/package.json
+++ b/packages/log/package.json
@@ -21,7 +21,8 @@
     "build:babel": "babel ./src --out-dir ./dist --extensions \".ts,.tsx,.js,.jsx\" --source-maps --root-mode upward"
   },
   "dependencies": {
-    "event-target-shim": "^6.0.2"
+    "event-target-shim": "^6.0.2",
+    "jszip": "^3.10.1"
   },
   "files": [
     "dist"

--- a/packages/log/src/LogExport.test.ts
+++ b/packages/log/src/LogExport.test.ts
@@ -87,4 +87,94 @@ describe('getReduxDataString', () => {
     );
     expect(result).toBe(expected);
   });
+
+  it('should handle wildcards in blacklist paths', () => {
+    const reduxData = {
+      key1: 'not blacklisted',
+      key2: {
+        keyA: {
+          key1: 'blacklisted',
+        },
+        keyB: {
+          key1: 'blacklisted',
+        },
+        keyC: {
+          key1: 'blacklisted',
+        },
+      },
+    };
+    const result = getReduxDataString(reduxData, [['key2', '*', 'key1']]);
+    const expected = JSON.stringify(
+      {
+        key1: 'not blacklisted',
+        key2: {
+          keyA: {},
+          keyB: {},
+          keyC: {},
+        },
+      },
+      null,
+      2
+    );
+    expect(result).toBe(expected);
+  });
+
+  it('should handle nested wildcards in blacklist paths', () => {
+    const reduxData = {
+      key1: 'not blacklisted',
+      key2: {
+        keyA: {
+          key1: 'blacklisted',
+          key2: {
+            key3: 'blacklisted',
+          },
+        },
+        keyB: {
+          key1: 'blacklisted',
+          key2: {
+            key3: 'blacklisted',
+            key4: 'blacklisted',
+          },
+        },
+      },
+    };
+    const result = getReduxDataString(reduxData, [['key2', '*', '*']]);
+    const expected = JSON.stringify(
+      {
+        key1: 'not blacklisted',
+        key2: {
+          keyA: {},
+          keyB: {},
+        },
+      },
+      null,
+      2
+    );
+    expect(result).toBe(expected);
+  });
+
+  it('should handle wildcard blacklist paths with no matches', () => {
+    const reduxData = {
+      key1: 'not blacklisted',
+      key2: {
+        keyA: {
+          key1: 'not blacklisted',
+          key2: {
+            key3: 'not blacklisted',
+          },
+        },
+      },
+    };
+    const result = getReduxDataString(reduxData, [['*', '*', '*', '*', '*']]); // Matching more than the depth of the object
+    const expected = JSON.stringify(reduxData, null, 2);
+    expect(result).toBe(expected);
+  });
+
+  it('root wildcard should blacklist all', () => {
+    const reduxData = {
+      key1: 'should not be blacklisted',
+    };
+    const result = getReduxDataString(reduxData, [['*']]);
+    expect(result).toBe('{}');
+  });
 });

--- a/packages/log/src/LogExport.test.ts
+++ b/packages/log/src/LogExport.test.ts
@@ -1,0 +1,90 @@
+import { getReduxDataString } from './LogExport';
+
+describe('getReduxDataString', () => {
+  it('should return a JSON string of the redux data', () => {
+    const reduxData = {
+      key1: 'value1',
+      key2: 2,
+      key3: true,
+    };
+    const result = getReduxDataString(reduxData);
+    const expected = JSON.stringify(reduxData, null, 2);
+    expect(result).toBe(expected);
+  });
+
+  it('should handle circular references', () => {
+    const reduxData: Record<string, unknown> = {
+      key1: 'value1',
+    };
+    reduxData.key2 = reduxData;
+    const result = getReduxDataString(reduxData);
+    const expected = JSON.stringify(
+      {
+        key1: 'value1',
+        key2: 'Circular ref to root',
+      },
+      null,
+      2
+    );
+    expect(result).toBe(expected);
+  });
+
+  it('should handle BigInt values', () => {
+    const reduxData = {
+      key1: BigInt('12345678901234567890'),
+    };
+    const result = getReduxDataString(reduxData);
+    const expected = JSON.stringify(
+      {
+        key1: '12345678901234567890',
+      },
+      null,
+      2
+    );
+    expect(result).toBe(expected);
+  });
+
+  it('should apply blacklist paths', () => {
+    const reduxData = {
+      key1: 'should be blacklisted',
+      key2: {
+        'key2.1': 'should also be blacklisted',
+      },
+      key3: 'value',
+    };
+    const result = getReduxDataString(reduxData, [
+      ['key1'],
+      ['key2', 'key2.1'],
+    ]);
+    const expected = JSON.stringify(
+      {
+        key2: {},
+        key3: 'value',
+      },
+      null,
+      2
+    );
+    expect(result).toBe(expected);
+  });
+
+  it('should stringify Maps', () => {
+    const reduxData = {
+      key1: new Map([
+        ['key1.1', 'value1.1'],
+        ['key1.2', 'value1.2'],
+      ]),
+    };
+    const result = getReduxDataString(reduxData);
+    const expected = JSON.stringify(
+      {
+        key1: [
+          ['key1.1', 'value1.1'],
+          ['key1.2', 'value1.2'],
+        ],
+      },
+      null,
+      2
+    );
+    expect(result).toBe(expected);
+  });
+});

--- a/packages/log/src/LogExport.ts
+++ b/packages/log/src/LogExport.ts
@@ -3,11 +3,12 @@ import type LogHistory from './LogHistory';
 
 // List of objects to blacklist
 // '' represents the root object
+// * represents a wildcard key
 export const DEFAULT_PATH_BLACKLIST: string[][] = [
   ['api'],
   ['client'],
-  ['dashboardData', 'default', 'connection'],
-  ['dashboardData', 'default', 'sessionWrapper', 'dh'],
+  ['dashboardData', '*', 'connection'],
+  ['dashboardData', '*', 'sessionWrapper'],
   ['layoutStorage'],
   ['storage'],
 ];
@@ -43,7 +44,9 @@ function isOnBlackList(currPath: string[], blacklist: string[][]): boolean {
   for (let i = 0; i < blacklist.length; i += 1) {
     if (
       currPath.length === blacklist[i].length &&
-      currPath.every((v, index) => v === blacklist[i][index])
+      currPath.every(
+        (v, index) => blacklist[i][index] === '*' || v === blacklist[i][index]
+      )
     ) {
       // blacklist match
       return true;
@@ -150,7 +153,7 @@ function formatDate(date: Date): string {
  * @param logHistory Log history to include in the console.txt file
  * @param metadata Additional metadata to include in the metadata.json file
  * @param reduxData Redux data to include in the redux.json file
- * @param blacklist List of JSON paths to blacklist in redux data. A JSON path is a list representing the path to that value (e.g. client.data would be `['client', 'data']`)
+ * @param blacklist List of JSON paths to blacklist in redux data. A JSON path is a list representing the path to that value (e.g. client.data would be `['client', 'data']`). Wildcards (*) are accepted in the path.
  * @param fileNamePrefix The zip file name without the .zip extension. Ex: test will be saved as test.zip
  * @returns A promise that resolves successfully if the log archive is created and downloaded successfully, rejected if there's an error
  */

--- a/packages/log/src/LogInit.ts
+++ b/packages/log/src/LogInit.ts
@@ -11,10 +11,10 @@ declare global {
 export const logProxy = new LogProxy();
 export const logHistory = new LogHistory(logProxy);
 
-export default function logInit(): void {
-  Log.setLogLevel(parseInt(import.meta.env.VITE_LOG_LEVEL ?? '', 10));
+export function logInit(logLevel = 2, enableProxy = true): void {
+  Log.setLogLevel(logLevel);
 
-  if (import.meta.env.VITE_ENABLE_LOG_PROXY === 'true') {
+  if (enableProxy) {
     logProxy.enable();
     logHistory.enable();
   }
@@ -26,3 +26,5 @@ export default function logInit(): void {
     window.DHLogHistory = logHistory;
   }
 }
+
+export default logInit;

--- a/packages/log/src/LogInit.ts
+++ b/packages/log/src/LogInit.ts
@@ -1,4 +1,7 @@
-import { LogProxy, LogHistory, Logger, Log } from '@deephaven/log';
+import Log from './Log';
+import type Logger from './Logger';
+import LogHistory from './LogHistory';
+import LogProxy from './LogProxy';
 
 declare global {
   interface Window {

--- a/packages/log/src/index.ts
+++ b/packages/log/src/index.ts
@@ -6,3 +6,5 @@ export { default as Logger } from './Logger';
 export { default as LogHistory } from './LogHistory';
 export { default as LogProxy } from './LogProxy';
 export { default as LoggerLevel } from './LoggerLevel';
+export * from './LogExport';
+export * from './LogInit';


### PR DESCRIPTION
Cherry-pick changes made to `LogExport.ts` in `main` into `v0.78` to address [DH-18984](https://deephaven.atlassian.net/browse/DH-18984)

- https://github.com/deephaven/web-client-ui/pull/2396
- https://github.com/deephaven/web-client-ui/pull/2382
- https://github.com/deephaven/web-client-ui/pull/2279

[DH-18984]: https://deephaven.atlassian.net/browse/DH-18984?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ