### PR TITLE
fix: Cherry-pick DH-17599: Fix table name validation (#2403)

### DIFF
--- a/packages/utils/src/DbNameValidator.test.ts
+++ b/packages/utils/src/DbNameValidator.test.ts
@@ -4,8 +4,8 @@ const TABLE_PREFIX = 'table_';
 const COLUMN_PREFIX = 'column_';
 
 const VALID_TABLE_NAME = '$+@abc-123_ABC';
-const INVALID_TABLE_NAME = '%^&ab-c';
-const CLEANED_INVALID_TABLE_NAME = 'ab-c';
+const INVALID_TABLE_NAMES = ['%^&ab-c', '-abc', '-'];
+const CLEANED_INVALID_TABLE_NAMES = ['ab-c', '-abc', '-'];
 
 const VALID_COL_NAME = 'abc123_ABC';
 const INVALID_COL_NAME = '@abc123_ABC-123';
@@ -20,9 +20,12 @@ describe('Table name validation', () => {
     expect(DbNameValidator.isValidTableName(VALID_TABLE_NAME)).toBe(true);
   });
 
-  it('Returns false on invalid table names', () => {
-    expect(DbNameValidator.isValidTableName(INVALID_TABLE_NAME)).toBe(false);
-  });
+  it.each(INVALID_TABLE_NAMES)(
+    'Returns false on invalid table name %s',
+    name => {
+      expect(DbNameValidator.isValidTableName(name)).toBe(false);
+    }
+  );
 });
 
 describe('Column name validation', () => {
@@ -52,10 +55,10 @@ describe('legalizeTableName', () => {
     );
   });
 
-  it('Legalize an invalid table name', () => {
-    expect(DbNameValidator.legalizeTableName(INVALID_TABLE_NAME)).toBe(
-      CLEANED_INVALID_TABLE_NAME
-    );
+  it.each(
+    INVALID_TABLE_NAMES.map((name, i) => [name, CLEANED_INVALID_TABLE_NAMES[i]])
+  )('Legalize an invalid table name %s > %s', (invalid, cleaned) => {
+    expect(DbNameValidator.legalizeTableName(invalid)).toBe(cleaned);
   });
 
   it('Renames a table name with no valid chars to table_0', () => {

--- a/packages/utils/src/DbNameValidator.ts
+++ b/packages/utils/src/DbNameValidator.ts
@@ -68,6 +68,9 @@ const STERILE_TABLE_AND_NAMESPACE_REGEX = /[^a-zA-Z0-9_$\-+@]/g;
 // From io.deephaven.db.tables.utils.DBNameValidator#STERILE_COLUMN_AND_QUERY_REGEX
 const STERILE_COLUMN_AND_QUERY_REGEX = /[^A-Za-z0-9_$]/g;
 
+// From io.deephaven.db.tables.utils.DBNameValidator#TABLE_NAME_PATTERN
+const TABLE_NAME_PATTERN = /^[a-zA-Z_$][a-zA-Z0-9_$\-+@]*$/g;
+
 function columnNameReplacer(input: string): string {
   // Replace all dashes and spaces with underscores
   return input.replace(/[ -]/g, '_');
@@ -155,7 +158,7 @@ class DbNameValidator {
     );
 
   static isValidTableName = (name: string): boolean =>
-    DbNameValidator.legalizeTableName(name) === name;
+    TABLE_NAME_PATTERN.test(name);
 
   static isValidColumnName = (name: string): boolean =>
     DbNameValidator.legalizeColumnName(name) === name;


### PR DESCRIPTION
PR #2398 allowed hyphens in namespace and table names. However, I
noticed that server-side validation rejects names starting with a
hyphen, while these names appear valid on the client-side.

`io.deephaven.db.tables.utils.DBNameValidator` uses separate regular
expressions to sanitize and validate names. This change adds the correct
`TABLE_NAME_PATTERN` for table name validation instead of checking if
the name matches its sanitized version.

---------

Co-authored-by: Copilot <175728472+Copilot@users.noreply.github.com>