### PR TITLE
fix: missing specturm accordian icon due to styling

### DIFF
--- a/packages/components/src/theme/theme-spectrum/theme-spectrum-overrides.css
+++ b/packages/components/src/theme/theme-spectrum/theme-spectrum-overrides.css
@@ -24,6 +24,11 @@ svg[class*='spectrum-Textfield-validationIcon'] {
   box-sizing: content-box;
 }
 
+svg[class*='spectrum-Accordion-itemIndicator'] {
+  /* set as border-box by reboot, but spectrum expects this to be content-box */
+  box-sizing: content-box;
+}
+
 .svg-inline--fa[class*='spectrum-Icon--sizeS'] {
   /* 
   Resize fontawesome icons used inside a spectrum icon wrapper to match


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/9957d4fe-997f-426c-afb7-9ad6c94f03f4)
