### PR TITLE
fix: Context menu using stale selection

### DIFF
--- a/packages/grid/src/mouse-handlers/GridSelectionMouseHandler.ts
+++ b/packages/grid/src/mouse-handlers/GridSelectionMouseHandler.ts
@@ -246,7 +246,7 @@ class GridSelectionMouseHandler extends GridMouseHandler {
     );
 
     // only change the selected range if the selected cell is not in the selected range
-    if (!isInRange && gridPoint.row !== null) {
+    if (!isInRange && gridPoint.row !== null && gridPoint.column !== null) {
       this.startPoint = undefined;
       this.stopTimer();
       grid.clearSelectedRanges();

--- a/packages/iris-grid/src/mousehandlers/IrisGridContextMenuHandler.test.tsx
+++ b/packages/iris-grid/src/mousehandlers/IrisGridContextMenuHandler.test.tsx
@@ -1,0 +1,53 @@
+import { GridRange } from '@deephaven/grid';
+import IrisGridContextMenuHandler from './IrisGridContextMenuHandler';
+
+describe('getLatestSelection', () => {
+  it('should return the original selection if the clicked cell is within the original selection', () => {
+    const originalSelection = [new GridRange(1, 1, 2, 2)];
+    const result = IrisGridContextMenuHandler.getLatestSelection(
+      originalSelection,
+      1,
+      1
+    );
+
+    expect(result).toBe(originalSelection);
+  });
+
+  it('should return a new selection with the clicked cell if it is outside the original selection', () => {
+    const originalSelection = [new GridRange(1, 1, 2, 2)];
+    const columnIndex = 3;
+    const rowIndex = 3;
+
+    const result = IrisGridContextMenuHandler.getLatestSelection(
+      originalSelection,
+      columnIndex,
+      rowIndex
+    );
+
+    expect(result).toEqual([GridRange.makeCell(columnIndex, rowIndex)]);
+  });
+
+  it('should return the original selection if columnIndex is null', () => {
+    const originalSelection = [new GridRange(1, 1, 2, 2)];
+
+    const result = IrisGridContextMenuHandler.getLatestSelection(
+      originalSelection,
+      null,
+      1
+    );
+
+    expect(result).toBe(originalSelection);
+  });
+
+  it('should return the original selection if rowIndex is null', () => {
+    const originalSelection = [new GridRange(1, 1, 2, 2)];
+
+    const result = IrisGridContextMenuHandler.getLatestSelection(
+      originalSelection,
+      null,
+      1
+    );
+
+    expect(result).toBe(originalSelection);
+  });
+});

--- a/packages/iris-grid/src/mousehandlers/IrisGridContextMenuHandler.tsx
+++ b/packages/iris-grid/src/mousehandlers/IrisGridContextMenuHandler.tsx
@@ -152,6 +152,7 @@ class IrisGridContextMenuHandler extends GridMouseHandler {
 
   /**
    * Returns the latest grid selection based on the current grid selection and where the user clicked
+   * This code is dependent on the behavior of GridSelectionMouseHandler.onContextMenu
    * @param originalSelection The selection from the current grid state which may be stale
    * @param columnIndex The column index where the user clicked
    * @param rowIndex The row index where the user clicked

--- a/packages/iris-grid/src/mousehandlers/IrisGridContextMenuHandler.tsx
+++ b/packages/iris-grid/src/mousehandlers/IrisGridContextMenuHandler.tsx
@@ -22,6 +22,7 @@ import {
   GridMouseHandler,
   type GridPoint,
   GridRange,
+  type GridRangeIndex,
   GridRenderer,
   isDeletableGridModel,
   isEditableGridModel,
@@ -147,6 +148,30 @@ class IrisGridContextMenuHandler extends GridMouseHandler {
       cellValue,
       len - command.length - 3
     )}"`;
+  }
+
+  /**
+   * Returns the latest grid selection based on the current grid selection and where the user clicked
+   * @param originalSelection The selection from the current grid state which may be stale
+   * @param columnIndex The column index where the user clicked
+   * @param rowIndex The row index where the user clicked
+   */
+  static getLatestSelection(
+    originalSelection: readonly GridRange[],
+    columnIndex: GridRangeIndex,
+    rowIndex: GridRangeIndex
+  ): readonly GridRange[] {
+    const clickedInOriginalSelection = GridRange.containsCell(
+      originalSelection,
+      columnIndex,
+      rowIndex
+    );
+
+    // If the user clicked in a valid cell outside of the original selection,
+    // the selection will be changed to just that cell.
+    return clickedInOriginalSelection || columnIndex == null || rowIndex == null
+      ? originalSelection
+      : [GridRange.makeCell(columnIndex, rowIndex)];
   }
 
   irisGrid: IrisGrid;
@@ -886,8 +911,14 @@ class IrisGridContextMenuHandler extends GridMouseHandler {
       isFilterBarShown,
       quickFilters,
       advancedFilters,
-      selectedRanges,
+      selectedRanges: stateSelectedRanges,
     } = irisGrid.state;
+
+    const selectedRanges = IrisGridContextMenuHandler.getLatestSelection(
+      stateSelectedRanges,
+      columnIndex,
+      rowIndex
+    );
 
     assertNotNull(metrics);
 


### PR DESCRIPTION
- Although we handle the case where the grid is right-clicked outside of the current selection in `GridSelectionHandler.ts`, where the new selection will be updated to the row the cursor is on, state changes are batched in event handlers so `IrisGridContextMenuHandler.tsx` will be using a stale value for `selectedRanges` when it runs. 
- To fix this we can implement the exact same logic in both components, such that the selected ranges used in `onContextMenu` in `IrisGridContextMenuHandler.tsx` will be the same as what `onContextMenu` in `GridSelectionHandler.ts` will set it to after all handlers have ran.

Test Snippet (any table will work though)
```
from deephaven import empty_table, input_table
source = empty_table(10).update(["X = i", "Y = i"])
result = input_table(init_table=source)
```

Before this change, it was seen that right clicking any cell when the table first opens will not produce the full context menu as expected, and only subsequent clicks will open the full context menu (probably for the wrong cell).