### PR TITLE
fix: DH-17599: Change illegal characters to underscores in variable names

### DIFF
--- a/packages/console/src/csv/CsvInputBar.tsx
+++ b/packages/console/src/csv/CsvInputBar.tsx
@@ -89,7 +89,7 @@ class CsvInputBar extends Component<CsvInputBarProps, CsvInputBarState> {
     // Set the table name from a file
     if (!tableNameSet && file != null && !tableName) {
       const dotIndex = file.name.lastIndexOf('.');
-      const fileTableName = DbNameValidator.legalizeTableName(
+      const fileTableName = DbNameValidator.makeVariableName(
         file.name.substring(0, dotIndex)
       );
       this.setState({

--- a/packages/utils/src/DbNameValidator.test.ts
+++ b/packages/utils/src/DbNameValidator.test.ts
@@ -3,7 +3,6 @@ import DbNameValidator from './DbNameValidator';
 const TABLE_PREFIX = 'table_';
 const COLUMN_PREFIX = 'column_';
 
-// $ is not a valid table name in Deephaven, but this behavior is consistent with the Java class
 const VALID_TABLE_NAMES = ['$+@abc-123_ABC', '$'];
 const VARIABLE_NAMES_FROM_VALID = ['$__abc_123_ABC', '$'];
 

--- a/packages/utils/src/DbNameValidator.test.ts
+++ b/packages/utils/src/DbNameValidator.test.ts
@@ -4,7 +4,7 @@ const TABLE_PREFIX = 'table_';
 const COLUMN_PREFIX = 'column_';
 
 const VALID_TABLE_NAMES = ['$+@abc-123_ABC', '$'];
-const VARIABLE_NAMES_FROM_VALID = ['$__abc_123_ABC', '$'];
+const VARIABLE_NAMES_FROM_VALID = ['___abc_123_ABC', '_'];
 
 const INVALID_TABLE_NAMES = ['%^&ab-c', '-a_b c', '-', '0', '%', ''];
 const LEGALIZED_INVALID_TABLE_NAMES = [

--- a/packages/utils/src/DbNameValidator.test.ts
+++ b/packages/utils/src/DbNameValidator.test.ts
@@ -4,8 +4,9 @@ const TABLE_PREFIX = 'table_';
 const COLUMN_PREFIX = 'column_';
 
 const VALID_TABLE_NAME = '$+@abc-123_ABC';
-const INVALID_TABLE_NAMES = ['%^&ab-c', '-abc', '-'];
-const CLEANED_INVALID_TABLE_NAMES = ['ab-c', '-abc', '-'];
+const CLEANED_VALID_TABLE_NAME = 'abc_123_ABC';
+const INVALID_TABLE_NAMES = ['%^&ab-c', '-a_b c', '-'];
+const CLEANED_INVALID_TABLE_NAMES = ['ab_c', '_a_b_c', '_'];
 
 const VALID_COL_NAME = 'abc123_ABC';
 const INVALID_COL_NAME = '@abc123_ABC-123';
@@ -49,9 +50,9 @@ describe('Column name validation', () => {
 });
 
 describe('legalizeTableName', () => {
-  it('Does not change a valid table name', () => {
+  it('Sanitizes a table name even if it is valid', () => {
     expect(DbNameValidator.legalizeTableName(VALID_TABLE_NAME)).toBe(
-      VALID_TABLE_NAME
+      CLEANED_VALID_TABLE_NAME
     );
   });
 

--- a/packages/utils/src/DbNameValidator.test.ts
+++ b/packages/utils/src/DbNameValidator.test.ts
@@ -66,7 +66,7 @@ describe('Column name validation', () => {
 });
 
 describe('legalizeTableName', () => {
-  it.each(VALID_TABLE_NAMES)('Does not change a valid table name $s', name => {
+  it.each(VALID_TABLE_NAMES)('Does not change a valid table name %s', name => {
     expect(DbNameValidator.legalizeTableName(name)).toBe(name);
   });
 

--- a/packages/utils/src/DbNameValidator.ts
+++ b/packages/utils/src/DbNameValidator.ts
@@ -64,7 +64,7 @@ const JAVA_KEYWORDS = new Set([
 
 // The '$' character is not valid in Deephaven table and column names,
 // yet it is treated as valid in the DbNameValidator Java class.
-// TODO: Update the regexes once DH-19169 is merged.
+// TODO: Update the regexes once (or if) DH-19169 is merged.
 
 // From io.deephaven.db.tables.utils.DBNameValidator#STERILE_TABLE_AND_NAMESPACE_REGEX
 const STERILE_TABLE_AND_NAMESPACE_REGEX = /[^a-zA-Z0-9_$\-+@]/g;
@@ -75,7 +75,7 @@ const STERILE_COLUMN_AND_QUERY_REGEX = /[^A-Za-z0-9_$]/g;
 // From io.deephaven.db.tables.utils.DBNameValidator#TABLE_NAME_PATTERN
 const TABLE_NAME_PATTERN = /^[a-zA-Z_$][a-zA-Z0-9_$\-+@]*$/;
 
-const STERILE_VARIABLE_NAME_REGEX = /[^a-zA-Z0-9_$]/g;
+const STERILE_VARIABLE_NAME_REGEX = /[^a-zA-Z0-9_]/g;
 
 function columnNameReplacer(input: string): string {
   // Replace all dashes and spaces with underscores
@@ -147,7 +147,7 @@ class DbNameValidator {
     );
 
   /**
-   * Get a variable name based on the passed in string.
+   * Make a valid variable name based on the passed in string.
    * @param name The name to get the variable name for
    * @returns Variable name
    */

--- a/packages/utils/src/DbNameValidator.ts
+++ b/packages/utils/src/DbNameValidator.ts
@@ -71,16 +71,6 @@ const STERILE_COLUMN_AND_QUERY_REGEX = /[^A-Za-z0-9_$]/g;
 // From io.deephaven.db.tables.utils.DBNameValidator#TABLE_NAME_PATTERN
 const TABLE_NAME_PATTERN = /^[a-zA-Z_$][a-zA-Z0-9_$\-+@]*$/g;
 
-function columnNameReplacer(input: string): string {
-  // Replace all dashes and spaces with underscores
-  return input.replace(/[ -]/g, '_');
-}
-
-function tableNameReplacer(input: string): string {
-  // Replace spaces with underscores
-  return input.replace(/\s/g, '_');
-}
-
 /**
  * Similar to DBNameValidator.java, this class has utilities for validating and legalizing
  * Table and Column names.
@@ -88,13 +78,12 @@ function tableNameReplacer(input: string): string {
 class DbNameValidator {
   static legalize = (
     name: string,
-    replace: (input: string) => string,
     prefix: string,
     regex: RegExp,
     checkReserved: boolean,
     i: number
   ): string => {
-    let legalName = replace(name.trim());
+    let legalName = name.trim().replace(/[ -]/g, '_');
 
     // Add prefix to reserved names
     if (
@@ -124,7 +113,6 @@ class DbNameValidator {
   static legalizeTableName = (name: string): string =>
     DbNameValidator.legalize(
       name,
-      tableNameReplacer,
       TABLE_PREFIX,
       STERILE_TABLE_AND_NAMESPACE_REGEX,
       false,
@@ -150,7 +138,6 @@ class DbNameValidator {
     // Replace all dashes and spaces with underscores
     DbNameValidator.legalize(
       header,
-      columnNameReplacer,
       COLUMN_PREFIX,
       STERILE_COLUMN_AND_QUERY_REGEX,
       true,

--- a/packages/utils/src/DbNameValidator.ts
+++ b/packages/utils/src/DbNameValidator.ts
@@ -62,6 +62,10 @@ const JAVA_KEYWORDS = new Set([
   'false',
 ]);
 
+// The '$' character is not valid in Deephaven table and column names,
+// yet it is treated as valid in the DbNameValidator Java class.
+// TODO: Update the regexes once DH-19169 is merged.
+
 // From io.deephaven.db.tables.utils.DBNameValidator#STERILE_TABLE_AND_NAMESPACE_REGEX
 const STERILE_TABLE_AND_NAMESPACE_REGEX = /[^a-zA-Z0-9_$\-+@]/g;
 

--- a/packages/utils/src/DbNameValidator.ts
+++ b/packages/utils/src/DbNameValidator.ts
@@ -69,7 +69,19 @@ const STERILE_TABLE_AND_NAMESPACE_REGEX = /[^a-zA-Z0-9_$\-+@]/g;
 const STERILE_COLUMN_AND_QUERY_REGEX = /[^A-Za-z0-9_$]/g;
 
 // From io.deephaven.db.tables.utils.DBNameValidator#TABLE_NAME_PATTERN
-const TABLE_NAME_PATTERN = /^[a-zA-Z_$][a-zA-Z0-9_$\-+@]*$/g;
+const TABLE_NAME_PATTERN = /^[a-zA-Z_$][a-zA-Z0-9_$\-+@]*$/;
+
+const STERILE_VARIABLE_NAME_REGEX = /[^a-zA-Z0-9_$]/g;
+
+function columnNameReplacer(input: string): string {
+  // Replace all dashes and spaces with underscores
+  return input.replace(/[ -]/g, '_');
+}
+
+function tableNameReplacer(input: string): string {
+  // Replace spaces with underscores
+  return input.replace(/\s/g, '_');
+}
 
 /**
  * Similar to DBNameValidator.java, this class has utilities for validating and legalizing
@@ -78,12 +90,13 @@ const TABLE_NAME_PATTERN = /^[a-zA-Z_$][a-zA-Z0-9_$\-+@]*$/g;
 class DbNameValidator {
   static legalize = (
     name: string,
+    replace: (input: string) => string,
     prefix: string,
     regex: RegExp,
     checkReserved: boolean,
     i: number
   ): string => {
-    let legalName = name.trim().replace(/[ -]/g, '_');
+    let legalName = replace(name.trim());
 
     // Add prefix to reserved names
     if (
@@ -97,26 +110,47 @@ class DbNameValidator {
     // Remove illegal characters
     legalName = legalName.replace(regex, '');
 
-    // Check if the name ended up blank
+    // Check if the name ended up blank and append the prefix.
+    // Note, io.deephaven.db.tables.utils.DBNameValidator throws an exception in this case.
     if (!legalName) {
-      legalName = prefix + i;
+      return prefix + i;
     }
 
-    // If name starts with a number, append prefix to the front
-    if (!Number.isNaN(Number(legalName.charAt(0)))) {
+    // If name starts with a number or a dash, append the prefix.
+    // Note, io.deephaven.db.tables.utils.DBNameValidator throws an exception for names starting with a dash.
+    if (/^[0-9-]/.test(legalName)) {
       legalName = prefix + legalName;
     }
 
     return legalName;
   };
 
+  /**
+   * Get a legal table name based on the passed in string.
+   * Follows the same rules as DBNameValidator.java except that here
+   * we prepend a prefix in cases where the Java class throws an exception.
+   * @param name The name to legalize
+   * @returns Legalized table name
+   */
   static legalizeTableName = (name: string): string =>
     DbNameValidator.legalize(
       name,
+      tableNameReplacer,
       TABLE_PREFIX,
       STERILE_TABLE_AND_NAMESPACE_REGEX,
       false,
       0
+    );
+
+  /**
+   * Get a variable name based on the passed in string.
+   * @param name The name to get the variable name for
+   * @returns Variable name
+   */
+  static makeVariableName = (name: string): string =>
+    DbNameValidator.legalizeTableName(name).replace(
+      STERILE_VARIABLE_NAME_REGEX,
+      '_'
     );
 
   static legalizeColumnNames = (headers: string[]): string[] => {
@@ -138,6 +172,7 @@ class DbNameValidator {
     // Replace all dashes and spaces with underscores
     DbNameValidator.legalize(
       header,
+      columnNameReplacer,
       COLUMN_PREFIX,
       STERILE_COLUMN_AND_QUERY_REGEX,
       true,


### PR DESCRIPTION
- Add `makeVariableName` method to create valid variable names
- Add/update unit tests.