### PR TITLE
refactor: move getLatestSelection to GridSelectionMouseHandler

### DIFF
--- a/packages/grid/src/mouse-handlers/GridSelectionMouseHandler.test.ts
+++ b/packages/grid/src/mouse-handlers/GridSelectionMouseHandler.test.ts
@@ -1,10 +1,10 @@
-import { GridRange } from '@deephaven/grid';
-import IrisGridContextMenuHandler from './IrisGridContextMenuHandler';
+import { GridRange } from '../GridRange';
+import GridSelectionMouseHandler from './GridSelectionMouseHandler';
 
 describe('getLatestSelection', () => {
   it('should return the original selection if the clicked cell is within the original selection', () => {
     const originalSelection = [new GridRange(1, 1, 2, 2)];
-    const result = IrisGridContextMenuHandler.getLatestSelection(
+    const result = GridSelectionMouseHandler.getLatestSelection(
       originalSelection,
       1,
       1
@@ -18,7 +18,7 @@ describe('getLatestSelection', () => {
     const columnIndex = 3;
     const rowIndex = 3;
 
-    const result = IrisGridContextMenuHandler.getLatestSelection(
+    const result = GridSelectionMouseHandler.getLatestSelection(
       originalSelection,
       columnIndex,
       rowIndex
@@ -30,7 +30,7 @@ describe('getLatestSelection', () => {
   it('should return the original selection if columnIndex is null', () => {
     const originalSelection = [new GridRange(1, 1, 2, 2)];
 
-    const result = IrisGridContextMenuHandler.getLatestSelection(
+    const result = GridSelectionMouseHandler.getLatestSelection(
       originalSelection,
       null,
       1
@@ -42,7 +42,7 @@ describe('getLatestSelection', () => {
   it('should return the original selection if rowIndex is null', () => {
     const originalSelection = [new GridRange(1, 1, 2, 2)];
 
-    const result = IrisGridContextMenuHandler.getLatestSelection(
+    const result = GridSelectionMouseHandler.getLatestSelection(
       originalSelection,
       null,
       1

--- a/packages/grid/src/mouse-handlers/GridSelectionMouseHandler.ts
+++ b/packages/grid/src/mouse-handlers/GridSelectionMouseHandler.ts
@@ -1,12 +1,37 @@
 import { type EventHandlerResult } from '../EventHandlerResult';
 import type Grid from '../Grid';
 import GridMouseHandler, { type GridMouseEvent } from '../GridMouseHandler';
-import GridRange from '../GridRange';
+import GridRange, { type GridRangeIndex } from '../GridRange';
 import GridUtils, { type GridPoint } from '../GridUtils';
 
 const DEFAULT_INTERVAL_MS = 100;
 
 class GridSelectionMouseHandler extends GridMouseHandler {
+  /**
+   * Returns the latest grid selection based on the current grid selection and where the user clicked
+   * This code is dependent on the behavior of onContextMenu
+   * @param originalSelection The selection from the current grid state which may be stale
+   * @param columnIndex The column index where the user clicked
+   * @param rowIndex The row index where the user clicked
+   */
+  static getLatestSelection(
+    originalSelection: readonly GridRange[],
+    columnIndex: GridRangeIndex,
+    rowIndex: GridRangeIndex
+  ): readonly GridRange[] {
+    const clickedInOriginalSelection = GridRange.containsCell(
+      originalSelection,
+      columnIndex,
+      rowIndex
+    );
+
+    // If the user clicked in a valid cell outside of the original selection,
+    // the selection will be changed to just that cell.
+    return clickedInOriginalSelection || columnIndex == null || rowIndex == null
+      ? originalSelection
+      : [GridRange.makeCell(columnIndex, rowIndex)];
+  }
+
   private startPoint?: GridPoint;
 
   private hasExtendedFloating = false;

--- a/packages/iris-grid/src/mousehandlers/IrisGridContextMenuHandler.tsx
+++ b/packages/iris-grid/src/mousehandlers/IrisGridContextMenuHandler.tsx
@@ -22,8 +22,8 @@ import {
   GridMouseHandler,
   type GridPoint,
   GridRange,
-  type GridRangeIndex,
   GridRenderer,
+  GridSelectionMouseHandler,
   isDeletableGridModel,
   isEditableGridModel,
   isExpandableGridModel,
@@ -148,31 +148,6 @@ class IrisGridContextMenuHandler extends GridMouseHandler {
       cellValue,
       len - command.length - 3
     )}"`;
-  }
-
-  /**
-   * Returns the latest grid selection based on the current grid selection and where the user clicked
-   * This code is dependent on the behavior of GridSelectionMouseHandler.onContextMenu
-   * @param originalSelection The selection from the current grid state which may be stale
-   * @param columnIndex The column index where the user clicked
-   * @param rowIndex The row index where the user clicked
-   */
-  static getLatestSelection(
-    originalSelection: readonly GridRange[],
-    columnIndex: GridRangeIndex,
-    rowIndex: GridRangeIndex
-  ): readonly GridRange[] {
-    const clickedInOriginalSelection = GridRange.containsCell(
-      originalSelection,
-      columnIndex,
-      rowIndex
-    );
-
-    // If the user clicked in a valid cell outside of the original selection,
-    // the selection will be changed to just that cell.
-    return clickedInOriginalSelection || columnIndex == null || rowIndex == null
-      ? originalSelection
-      : [GridRange.makeCell(columnIndex, rowIndex)];
   }
 
   irisGrid: IrisGrid;
@@ -915,7 +890,7 @@ class IrisGridContextMenuHandler extends GridMouseHandler {
       selectedRanges: stateSelectedRanges,
     } = irisGrid.state;
 
-    const selectedRanges = IrisGridContextMenuHandler.getLatestSelection(
+    const selectedRanges = GridSelectionMouseHandler.getLatestSelection(
       stateSelectedRanges,
       columnIndex,
       rowIndex


### PR DESCRIPTION
After merging in https://github.com/deephaven/web-client-ui/pull/2407, I thought a bit more about my implementation and decided to refactor it (before picking this back to `v0.85`)

It makes more sense for `getLatestSelection` to live in `GridSelectionMouseHandler` since its logic also depends on the implementation of `onContextMenu` in this class, and this will make it more straightforward for other mouse handlers that might want to use this method to get the Grid's most recent selected ranges.