### PR TITLE
fix: DH-19138: Determine Totals Column Name by Num Aggs Per Column (#2411)

### DIFF
--- a/packages/iris-grid/src/IrisGridTableModelTemplate.ts
+++ b/packages/iris-grid/src/IrisGridTableModelTemplate.ts
@@ -987,13 +987,13 @@ class IrisGridTableModelTemplate<
       const tableColumn = this.columns[column];
 
       // Find the matching totals table column for the operation
-      // When there are multiple aggregations, the column name will be the original name of the column with the operation appended afterward
-      // When the the operation is the default operation OR there is only one operation, then the totals column name is just the original column name
+      // When there are multiple aggregations for the column, the column name will be the original name of the column with the operation appended afterward
+      // When the the operation is the default operation OR there is only one operation for the column, then the totals column name is just the original column name
       const totalsColumn = this.totalsTable?.columns.find(
         col =>
           col.name === `${tableColumn.name}__${operation}` ||
           ((operation === defaultOperation ||
-            this.totals?.operationOrder.length === 1) &&
+            this.totals?.operationMap[col.name]?.length === 1) &&
             col.name === tableColumn.name)
       );
       if (totalsColumn != null) {


### PR DESCRIPTION
https://deephaven.atlassian.net/browse/DH-19138
For totals table columns, we were applying renaming logic based on number of operations in the config, but it should be on number of operations for each given column.

E.g., for a config `{X : [SUM, COUNT], Y: [COUNT]}` then your columns will be `[X_SUM, X_COUNT, Y]` but we were expecting `[X_SUM, X_COUNT, Y_COUNT]`