### PR TITLE
fix: DH-13095 Ignore right click while dragging table column

### DIFF
--- a/packages/grid/src/Grid.tsx
+++ b/packages/grid/src/Grid.tsx
@@ -1868,6 +1868,12 @@ class Grid extends PureComponent<GridProps, GridState> {
   }
 
   handleMouseUp(event: MouseEvent): void {
+    // Ignore right click while dragging
+    const { isDragging } = this.state;
+    if (isDragging && event.button === 2) {
+      return;
+    }
+
     window.removeEventListener('mousemove', this.handleMouseDrag, true);
     window.removeEventListener('mouseup', this.handleMouseUp, true);
 


### PR DESCRIPTION
https://deephaven.atlassian.net/browse/DH-13095

While dragging a column, `handleMouseUp` would fire on second right click which would remove event listeners. Ignoring the right click while dragging fixes the issue.