### PR TITLE
feat: Add IrisGridCacheUtils for memoizing iris grid state

### DIFF
--- a/@types/memoize-one/index.d.ts
+++ b/@types/memoize-one/index.d.ts
@@ -1,12 +1,9 @@
-export declare type EqualityFn = (
-  newArgs: unknown[],
-  lastArgs: unknown[]
-) => boolean;
+export declare type EqualityFn<P> = (newArgs: P, lastArgs: P) => boolean;
 
 // eslint-disable-next-line @typescript-eslint/ban-types
 declare function memoizeOne<ResultFn extends Function>(
   resultFn: ResultFn,
-  isEqual?: EqualityFn
+  isEqual?: EqualityFn<Parameters<ResultFn>>
 ): ResultFn;
 
 export default memoizeOne;

--- a/packages/dashboard-core-plugins/src/panels/IrisGridPanel.tsx
+++ b/packages/dashboard-core-plugins/src/panels/IrisGridPanel.tsx
@@ -103,11 +103,11 @@ export interface PanelState {
   gridState: {
     isStuckToBottom: boolean;
     isStuckToRight: boolean;
-    movedColumns: {
+    movedColumns: readonly {
       from: string | ModelIndex | [string, string] | [ModelIndex, ModelIndex];
       to: string | ModelIndex;
     }[];
-    movedRows: MoveOperation[];
+    movedRows: readonly MoveOperation[];
   };
   irisGridState: DehydratedIrisGridState;
   irisGridPanelState: DehydratedIrisGridPanelState;
@@ -458,76 +458,6 @@ export class IrisGridPanel extends PureComponent<
         isSelectingPartition,
         partitions,
         advancedSettings,
-      })
-  );
-
-  getDehydratedIrisGridState = memoize(
-    (
-      model: IrisGridModel,
-      sorts: readonly dh.Sort[],
-      advancedFilters: ReadonlyAdvancedFilterMap,
-      customColumnFormatMap: Map<ColumnName, FormattingRule>,
-      isFilterBarShown: boolean,
-      quickFilters: ReadonlyQuickFilterMap,
-      customColumns: readonly ColumnName[],
-      reverse: boolean,
-      rollupConfig: UIRollupConfig | undefined,
-      showSearchBar: boolean,
-      searchValue: string,
-      selectDistinctColumns: readonly ColumnName[],
-      selectedSearchColumns: readonly ColumnName[],
-      invertSearchColumns: boolean,
-      userColumnWidths: ModelSizeMap,
-      userRowHeights: ModelSizeMap,
-      aggregationSettings: AggregationSettings,
-      pendingDataMap: PendingDataMap<UIRow>,
-      frozenColumns: readonly ColumnName[],
-      conditionalFormats: readonly SidebarFormattingRule[],
-      columnHeaderGroups: readonly ColumnHeaderGroup[],
-      partitionConfig: PartitionConfig | undefined
-    ) => {
-      assertNotNull(this.irisGridUtils);
-      return this.irisGridUtils.dehydrateIrisGridState(model, {
-        advancedFilters,
-        aggregationSettings,
-        customColumnFormatMap,
-        isFilterBarShown,
-        metrics: {
-          userColumnWidths,
-          userRowHeights,
-        },
-        quickFilters,
-        customColumns,
-        reverse,
-        rollupConfig,
-        showSearchBar,
-        searchValue,
-        selectDistinctColumns,
-        selectedSearchColumns,
-        sorts,
-        invertSearchColumns,
-        pendingDataMap,
-        frozenColumns,
-        conditionalFormats,
-        columnHeaderGroups,
-        partitionConfig,
-      });
-    }
-  );
-
-  getDehydratedGridState = memoize(
-    (
-      model: IrisGridModel,
-      movedColumns: readonly MoveOperation[],
-      movedRows: readonly MoveOperation[],
-      isStuckToBottom: boolean,
-      isStuckToRight: boolean
-    ) =>
-      IrisGridUtils.dehydrateGridState(model, {
-        isStuckToBottom,
-        isStuckToRight,
-        movedColumns,
-        movedRows,
       })
   );
 
@@ -1124,34 +1054,9 @@ export class IrisGridPanel extends PureComponent<
       partitions,
       advancedSettings,
     } = this.state;
-    const {
-      advancedFilters,
-      aggregationSettings,
-      customColumnFormatMap,
-      isFilterBarShown,
-      quickFilters,
-      customColumns,
-      reverse,
-      rollupConfig,
-      showSearchBar,
-      searchValue,
-      selectDistinctColumns,
-      selectedSearchColumns,
-      sorts,
-      invertSearchColumns,
-      metrics,
-      pendingDataMap,
-      frozenColumns,
-      conditionalFormats,
-      columnHeaderGroups,
-      partitionConfig,
-    } = irisGridState;
+    assertNotNull(this.irisGridUtils);
     assertNotNull(model);
-    assertNotNull(metrics);
-    const { userColumnWidths, userRowHeights } = metrics;
     assertNotNull(gridState);
-    const { isStuckToBottom, isStuckToRight, movedColumns, movedRows } =
-      gridState;
 
     const panelState = this.getCachedPanelState(
       this.getDehydratedIrisGridPanelState(
@@ -1160,37 +1065,8 @@ export class IrisGridPanel extends PureComponent<
         partitions,
         advancedSettings
       ),
-      this.getDehydratedIrisGridState(
-        model,
-        sorts,
-        advancedFilters,
-        customColumnFormatMap,
-        isFilterBarShown,
-        quickFilters,
-        customColumns,
-        reverse,
-        rollupConfig,
-        showSearchBar,
-        searchValue,
-        selectDistinctColumns,
-        selectedSearchColumns,
-        invertSearchColumns,
-        userColumnWidths,
-        userRowHeights,
-        aggregationSettings,
-        pendingDataMap,
-        frozenColumns,
-        conditionalFormats,
-        columnHeaderGroups,
-        partitionConfig
-      ),
-      this.getDehydratedGridState(
-        model,
-        movedColumns,
-        movedRows,
-        isStuckToBottom,
-        isStuckToRight
-      ),
+      this.irisGridUtils.dehydrateIrisGridState(model, irisGridState),
+      IrisGridUtils.dehydrateGridState(model, gridState),
       pluginState
     );
 

--- a/packages/dashboard-core-plugins/src/panels/IrisGridPanel.tsx
+++ b/packages/dashboard-core-plugins/src/panels/IrisGridPanel.tsx
@@ -21,6 +21,7 @@ import {
   IrisGrid,
   type IrisGridType,
   IrisGridModel,
+  IrisGridCacheUtils,
   IrisGridUtils,
   isIrisGridTableModelTemplate,
   type ColumnName,
@@ -367,6 +368,12 @@ export class IrisGridPanel extends PureComponent<
   pluginState: unknown;
 
   private irisGridUtils: IrisGridUtils | null;
+
+  private gridStateDehydrator =
+    IrisGridCacheUtils.makeMemoizedGridStateDehydrator();
+
+  private irisGridStateDehydrator =
+    IrisGridCacheUtils.makeMemoizedIrisGridStateDehydrator();
 
   getTableName(): string {
     const { metadata } = this.props;
@@ -1065,8 +1072,8 @@ export class IrisGridPanel extends PureComponent<
         partitions,
         advancedSettings
       ),
-      this.irisGridUtils.dehydrateIrisGridState(model, irisGridState),
-      IrisGridUtils.dehydrateGridState(model, gridState),
+      this.irisGridStateDehydrator(model, irisGridState),
+      this.gridStateDehydrator(model, gridState),
       pluginState
     );
 

--- a/packages/iris-grid/src/IrisGridCacheUtils.test.ts
+++ b/packages/iris-grid/src/IrisGridCacheUtils.test.ts
@@ -1,0 +1,192 @@
+import { type GridMetrics } from '@deephaven/grid';
+import dh from '@deephaven/jsapi-shim';
+import IrisGridTestUtils from './IrisGridTestUtils';
+import {
+  type HydratedGridState,
+  type HydratedIrisGridState,
+} from './IrisGridUtils';
+import { IrisGridCacheUtils } from './IrisGridCacheUtils';
+
+const irisGridTestUtils = new IrisGridTestUtils(dh);
+
+const gridState = {
+  isStuckToBottom: false,
+  isStuckToRight: false,
+  movedRows: [],
+  movedColumns: [],
+} satisfies HydratedGridState;
+
+const irisGridState = {
+  advancedFilters: new Map(),
+  partitionConfig: {
+    partitions: [],
+    mode: 'merged',
+  },
+  aggregationSettings: {
+    aggregations: [],
+    showOnTop: false,
+  },
+  customColumnFormatMap: new Map(),
+  isFilterBarShown: false,
+  quickFilters: new Map(),
+  customColumns: [],
+  reverse: false,
+  rollupConfig: {
+    columns: [],
+    showConstituents: false,
+    showNonAggregatedColumns: false,
+    includeDescriptions: true,
+  },
+  showSearchBar: false,
+  searchValue: '',
+  selectDistinctColumns: [],
+  selectedSearchColumns: [],
+  sorts: [],
+  invertSearchColumns: false,
+  pendingDataMap: new Map(),
+  frozenColumns: [],
+  conditionalFormats: [],
+  columnHeaderGroups: [],
+  metrics: {
+    userColumnWidths: new Map(),
+    userRowHeights: new Map(),
+  } as GridMetrics,
+} satisfies HydratedIrisGridState;
+
+describe('makeMemoizedGridStateDehydrator', () => {
+  test('creates a new memoization function with each call', () => {
+    const cacheA = IrisGridCacheUtils.makeMemoizedGridStateDehydrator();
+    const cacheB = IrisGridCacheUtils.makeMemoizedGridStateDehydrator();
+    expect(cacheA).not.toBe(cacheB);
+  });
+
+  test('memoizes dehydration', () => {
+    const model = irisGridTestUtils.makeModel();
+
+    const dehydrate = IrisGridCacheUtils.makeMemoizedGridStateDehydrator();
+
+    // Same state in different objects
+    expect(dehydrate(model, gridState)).toBe(
+      dehydrate(model, { ...gridState })
+    );
+
+    const differentModel = irisGridTestUtils.makeModel();
+    expect(dehydrate(model, gridState)).not.toBe(
+      dehydrate(differentModel, gridState)
+    );
+
+    const differentState = {
+      ...gridState,
+      isStuckToBottom: true,
+    };
+    expect(dehydrate(model, gridState)).not.toBe(
+      dehydrate(model, differentState)
+    );
+
+    const extraneousState = {
+      ...gridState,
+      lastLeft: 10,
+    };
+    expect(dehydrate(model, gridState)).toBe(dehydrate(model, extraneousState));
+  });
+});
+
+describe('makeMemoizedIrisGridStateDehydrator', () => {
+  test('creates a new memoization function with each call', () => {
+    const cacheA = IrisGridCacheUtils.makeMemoizedIrisGridStateDehydrator();
+    const cacheB = IrisGridCacheUtils.makeMemoizedIrisGridStateDehydrator();
+    expect(cacheA).not.toBe(cacheB);
+  });
+
+  test('memoizes dehydration', () => {
+    const model = irisGridTestUtils.makeModel();
+
+    const dehydrate = IrisGridCacheUtils.makeMemoizedIrisGridStateDehydrator();
+
+    // Same state in different objects
+    expect(dehydrate(model, irisGridState)).toBe(
+      dehydrate(model, { ...irisGridState })
+    );
+
+    const differentModel = irisGridTestUtils.makeModel();
+    expect(dehydrate(model, irisGridState)).not.toBe(
+      dehydrate(differentModel, irisGridState)
+    );
+
+    const differentState = {
+      ...irisGridState,
+      isFilterBarShown: true,
+    };
+    expect(dehydrate(model, irisGridState)).not.toBe(
+      dehydrate(model, differentState)
+    );
+
+    const extraneousState = {
+      ...irisGridState,
+      lastLeft: 10,
+    };
+    expect(dehydrate(model, irisGridState)).toBe(
+      dehydrate(model, extraneousState)
+    );
+  });
+});
+
+describe('makeMemoizedCombinedGridStateDehydrator', () => {
+  test('creates a new memoization function with each call', () => {
+    const cacheA = IrisGridCacheUtils.makeMemoizedCombinedGridStateDehydrator();
+    const cacheB = IrisGridCacheUtils.makeMemoizedCombinedGridStateDehydrator();
+    expect(cacheA).not.toBe(cacheB);
+  });
+  test('memoizes dehydration', () => {
+    const model = irisGridTestUtils.makeModel();
+
+    const dehydrate =
+      IrisGridCacheUtils.makeMemoizedCombinedGridStateDehydrator();
+
+    // Same state in different objects
+    expect(dehydrate(model, irisGridState, gridState)).toBe(
+      dehydrate(model, { ...irisGridState }, { ...gridState })
+    );
+
+    const differentModel = irisGridTestUtils.makeModel();
+    expect(dehydrate(model, irisGridState, gridState)).not.toBe(
+      dehydrate(differentModel, irisGridState, gridState)
+    );
+
+    const differentGridState = {
+      ...gridState,
+      isStuckToBottom: true,
+    };
+    expect(dehydrate(model, irisGridState, gridState)).not.toBe(
+      dehydrate(model, irisGridState, differentGridState)
+    );
+
+    const extraneousGridState = {
+      ...gridState,
+      lastLeft: 10,
+    };
+    expect(dehydrate(model, irisGridState, gridState)).toBe(
+      dehydrate(model, irisGridState, extraneousGridState)
+    );
+
+    const differentIrisGridState = {
+      ...irisGridState,
+      isFilterBarShown: true,
+    };
+    expect(dehydrate(model, irisGridState, gridState)).not.toBe(
+      dehydrate(model, differentIrisGridState, gridState)
+    );
+
+    const extraneousIrisGridState = {
+      ...irisGridState,
+      lastLeft: 10,
+    };
+    expect(dehydrate(model, irisGridState, gridState)).toBe(
+      dehydrate(model, extraneousIrisGridState, gridState)
+    );
+
+    expect(dehydrate(model, irisGridState, gridState)).toBe(
+      dehydrate(model, extraneousIrisGridState, extraneousGridState)
+    );
+  });
+});

--- a/packages/iris-grid/src/IrisGridCacheUtils.ts
+++ b/packages/iris-grid/src/IrisGridCacheUtils.ts
@@ -9,6 +9,13 @@ import IrisGridUtils, {
   type HydratedIrisGridState,
 } from './IrisGridUtils';
 
+/**
+ * Checks if 2 grid states are equivalent.
+ * Checks values and does not require referential equality of the entire state, just the values we care about.
+ * @param gridStateA First grid state
+ * @param gridStateB Second grid state
+ * @returns True if the states are equivalent
+ */
 function areGridStatesEqual(
   gridStateA: HydratedGridState,
   gridStateB: HydratedGridState
@@ -25,6 +32,13 @@ function areGridStatesEqual(
   );
 }
 
+/**
+ * Checks if 2 iris grid states are equivalent.
+ * Checks values and does not require referential equality of the entire state, just the values we care about.
+ * @param irisGridStateA First iris grid state
+ * @param irisGridStateB Second iris grid state
+ * @returns True if the states are equivalent
+ */
 function areIrisGridStatesEqual(
   irisGridStateA: HydratedIrisGridState,
   irisGridStateB: HydratedIrisGridState
@@ -66,6 +80,11 @@ function areIrisGridStatesEqual(
   );
 }
 
+/**
+ * Creates a dehydrator function for grid state that is memoized on the last call.
+ * Only tracks 1 state at a time. If the model and input states are equal, returns the same dehydrated state object reference.
+ * @returns A dehydrator function memoized on the last call
+ */
 function makeMemoizedGridStateDehydrator(): (
   model: IrisGridModel,
   gridState: HydratedGridState
@@ -78,6 +97,11 @@ function makeMemoizedGridStateDehydrator(): (
   );
 }
 
+/**
+ * Creates a dehydrator function for iris grid state that is memoized on the last call.
+ * Only tracks 1 state at a time. If the model and input states are equal, returns the same dehydrated state object reference.
+ * @returns A dehydrator function memoized on the last call
+ */
 function makeMemoizedIrisGridStateDehydrator(): (
   model: IrisGridModel,
   irisGridState: HydratedIrisGridState
@@ -93,6 +117,12 @@ function makeMemoizedIrisGridStateDehydrator(): (
   );
 }
 
+/**
+ * Creates a dehydrator function for grid and iris grid state that is memoized on the last call.
+ * Only tracks 1 state at a time. If the model and input states are equal, returns the same dehydrated state object reference.
+ * Combines the dehydrated grid and iris grid states into a single object.
+ * @returns A dehydrator function memoized on the last call
+ */
 function makeMemoizedCombinedGridStateDehydrator(): (
   model: IrisGridModel,
   irisGridState: HydratedIrisGridState,

--- a/packages/iris-grid/src/IrisGridCacheUtils.ts
+++ b/packages/iris-grid/src/IrisGridCacheUtils.ts
@@ -1,0 +1,127 @@
+/* eslint-disable import/prefer-default-export */
+import { type GridState } from '@deephaven/grid';
+import memoizeOne from 'memoize-one';
+import type IrisGridModel from './IrisGridModel';
+import IrisGridUtils, {
+  type DehydratedGridState,
+  type DehydratedIrisGridState,
+  type HydratedGridState,
+  type HydratedIrisGridState,
+} from './IrisGridUtils';
+
+function areGridStatesEqual(
+  gridStateA: HydratedGridState,
+  gridStateB: HydratedGridState
+): boolean {
+  const compareKeys = [
+    'isStuckToBottom',
+    'isStuckToRight',
+    'movedColumns',
+    'movedRows',
+  ] satisfies Array<keyof GridState>;
+  return (
+    gridStateA === gridStateB ||
+    compareKeys.every(key => gridStateA[key] === gridStateB[key])
+  );
+}
+
+function areIrisGridStatesEqual(
+  irisGridStateA: HydratedIrisGridState,
+  irisGridStateB: HydratedIrisGridState
+): boolean {
+  // Top level keys we want to check for referential equality
+  const compareStateKeys = [
+    'advancedFilters',
+    'aggregationSettings',
+    'customColumnFormatMap',
+    'isFilterBarShown',
+    'quickFilters',
+    'customColumns',
+    'reverse',
+    'rollupConfig',
+    'showSearchBar',
+    'searchValue',
+    'selectDistinctColumns',
+    'selectedSearchColumns',
+    'sorts',
+    'invertSearchColumns',
+    'pendingDataMap',
+    'frozenColumns',
+    'conditionalFormats',
+    'columnHeaderGroups',
+    'partitionConfig',
+  ] satisfies Array<keyof HydratedIrisGridState>;
+
+  return (
+    irisGridStateA === irisGridStateB ||
+    (irisGridStateA.metrics != null &&
+      irisGridStateB.metrics != null &&
+      irisGridStateA.metrics.userColumnWidths ===
+        irisGridStateB.metrics.userColumnWidths &&
+      irisGridStateA.metrics.userRowHeights ===
+        irisGridStateB.metrics.userRowHeights &&
+      compareStateKeys.every(
+        key => irisGridStateA[key] === irisGridStateB[key]
+      ))
+  );
+}
+
+function makeMemoizedGridStateDehydrator(): (
+  model: IrisGridModel,
+  gridState: HydratedGridState
+) => DehydratedGridState {
+  return memoizeOne(
+    (model: IrisGridModel, gridState: HydratedGridState) =>
+      IrisGridUtils.dehydrateGridState(model, gridState),
+    ([modelA, gridStateA], [modelB, gridStateB]) =>
+      modelA === modelB && areGridStatesEqual(gridStateA, gridStateB)
+  );
+}
+
+function makeMemoizedIrisGridStateDehydrator(): (
+  model: IrisGridModel,
+  irisGridState: HydratedIrisGridState
+) => DehydratedIrisGridState {
+  return memoizeOne(
+    (model: IrisGridModel, irisGridState: HydratedIrisGridState) => {
+      const irisGridUtils = new IrisGridUtils(model.dh);
+      return irisGridUtils.dehydrateIrisGridState(model, irisGridState);
+    },
+    ([modelA, irisGridStateA], [modelB, irisGridStateB]) =>
+      modelA === modelB &&
+      areIrisGridStatesEqual(irisGridStateA, irisGridStateB)
+  );
+}
+
+function makeMemoizedCombinedGridStateDehydrator(): (
+  model: IrisGridModel,
+  irisGridState: HydratedIrisGridState,
+  gridState: HydratedGridState
+) => DehydratedIrisGridState & DehydratedGridState {
+  return memoizeOne(
+    (
+      model: IrisGridModel,
+      irisGridState: HydratedIrisGridState,
+      gridState: HydratedGridState
+    ): DehydratedIrisGridState & DehydratedGridState => {
+      const irisGridUtils = new IrisGridUtils(model.dh);
+      return {
+        ...irisGridUtils.dehydrateIrisGridState(model, irisGridState),
+        ...IrisGridUtils.dehydrateGridState(model, gridState),
+      };
+    },
+    (
+      [modelA, irisGridStateA, gridStateA],
+      [modelB, irisGridStateB, gridStateB]
+    ) =>
+      modelA === modelB &&
+      areIrisGridStatesEqual(irisGridStateA, irisGridStateB) &&
+      areGridStatesEqual(gridStateA, gridStateB)
+  );
+}
+
+export const IrisGridCacheUtils = {
+  makeMemoizedGridStateDehydrator,
+  makeMemoizedIrisGridStateDehydrator,
+  makeMemoizedCombinedGridStateDehydrator,
+};

--- a/packages/iris-grid/src/IrisGridUtils.test.ts
+++ b/packages/iris-grid/src/IrisGridUtils.test.ts
@@ -13,8 +13,6 @@ import type { AdvancedFilter } from './CommonTypes';
 import { type FilterData } from './IrisGrid';
 import IrisGridTestUtils from './IrisGridTestUtils';
 import IrisGridUtils, {
-  type HydratedGridState,
-  type HydratedIrisGridState,
   type DehydratedSort,
   type LegacyDehydratedSort,
 } from './IrisGridUtils';

--- a/packages/iris-grid/src/IrisGridUtils.test.ts
+++ b/packages/iris-grid/src/IrisGridUtils.test.ts
@@ -13,8 +13,8 @@ import type { AdvancedFilter } from './CommonTypes';
 import { type FilterData } from './IrisGrid';
 import IrisGridTestUtils from './IrisGridTestUtils';
 import IrisGridUtils, {
-  HydratedGridState,
-  HydratedIrisGridState,
+  type HydratedGridState,
+  type HydratedIrisGridState,
   type DehydratedSort,
   type LegacyDehydratedSort,
 } from './IrisGridUtils';

--- a/packages/iris-grid/src/IrisGridUtils.test.ts
+++ b/packages/iris-grid/src/IrisGridUtils.test.ts
@@ -646,16 +646,64 @@ describe('convert other column types to text', () => {
 });
 
 describe('dehydration methods', () => {
-  test('dehydrateIrisGridPanelState should be serializable', () => {
-    const result = IrisGridUtils.dehydrateIrisGridPanelState(
-      irisGridTestUtils.makeModel(),
-      {
+  it.each([
+    [
+      'dehydrateIrisGridPanelState',
+      IrisGridUtils.dehydrateIrisGridPanelState(irisGridTestUtils.makeModel(), {
         isSelectingPartition: false,
         partitions: [],
         advancedSettings: new Map(),
-      }
-    );
-
+      }),
+    ],
+    [
+      'dehydrateGridState',
+      IrisGridUtils.dehydrateGridState(irisGridTestUtils.makeModel(), {
+        isStuckToBottom: false,
+        isStuckToRight: false,
+        movedRows: [],
+        movedColumns: [],
+      }),
+    ],
+    [
+      'dehydrateIrisGridState',
+      irisGridUtils.dehydrateIrisGridState(irisGridTestUtils.makeModel(), {
+        advancedFilters: new Map(),
+        partitionConfig: {
+          partitions: [],
+          mode: 'merged',
+        },
+        aggregationSettings: {
+          aggregations: [],
+          showOnTop: false,
+        },
+        customColumnFormatMap: new Map(),
+        isFilterBarShown: false,
+        quickFilters: new Map(),
+        customColumns: [],
+        reverse: false,
+        rollupConfig: {
+          columns: [],
+          showConstituents: false,
+          showNonAggregatedColumns: false,
+          includeDescriptions: true,
+        },
+        showSearchBar: false,
+        searchValue: '',
+        selectDistinctColumns: [],
+        selectedSearchColumns: [],
+        sorts: [],
+        invertSearchColumns: false,
+        pendingDataMap: new Map(),
+        frozenColumns: [],
+        conditionalFormats: [],
+        columnHeaderGroups: [],
+        metrics: {
+          userColumnWidths: new Map(),
+          userRowHeights: new Map(),
+        } as GridMetrics,
+      }),
+    ],
+  ])('%s should be serializable', (_label, result) => {
     expect(
       // This makes sure the result doesn't contain undefined
       // so it can be serialized and de-serialized without changes
@@ -663,116 +711,6 @@ describe('dehydration methods', () => {
       // e.g. { foo: undefined } when stringified will be '{}', we want to catch that case
       deepEqual(result, JSON.parse(JSON.stringify(result)), { strict: true })
     ).toBe(true);
-  });
-
-  test('dehydrateGridState should be serializable and memoized', () => {
-    const model = irisGridTestUtils.makeModel();
-    const gridState = {
-      isStuckToBottom: false,
-      isStuckToRight: false,
-      movedRows: [],
-      movedColumns: [],
-    } satisfies HydratedGridState;
-
-    const result = IrisGridUtils.dehydrateGridState(model, gridState);
-
-    const sameStateDifferentStateObject = IrisGridUtils.dehydrateGridState(
-      model,
-      {
-        ...gridState,
-      }
-    );
-
-    const sameStateDifferentModel = IrisGridUtils.dehydrateGridState(
-      irisGridTestUtils.makeModel(),
-      gridState
-    );
-
-    const sameModelDifferentState = IrisGridUtils.dehydrateGridState(model, {
-      ...gridState,
-      isStuckToBottom: true,
-    });
-
-    expect(
-      deepEqual(result, JSON.parse(JSON.stringify(result)), { strict: true })
-    ).toBe(true);
-
-    expect(result).toBe(sameStateDifferentStateObject);
-    expect(result).not.toBe(sameStateDifferentModel);
-    expect(result).not.toBe(sameModelDifferentState);
-  });
-
-  test('dehydrateIrisGridState should be serializable and memoized', () => {
-    const model = irisGridTestUtils.makeModel();
-    const irisGridState = {
-      advancedFilters: new Map(),
-      partitionConfig: {
-        partitions: [],
-        mode: 'merged',
-      },
-      aggregationSettings: {
-        aggregations: [],
-        showOnTop: false,
-      },
-      customColumnFormatMap: new Map(),
-      isFilterBarShown: false,
-      quickFilters: new Map(),
-      customColumns: [],
-      reverse: false,
-      rollupConfig: {
-        columns: [],
-        showConstituents: false,
-        showNonAggregatedColumns: false,
-        includeDescriptions: true,
-      },
-      showSearchBar: false,
-      searchValue: '',
-      selectDistinctColumns: [],
-      selectedSearchColumns: [],
-      sorts: [],
-      invertSearchColumns: false,
-      pendingDataMap: new Map(),
-      frozenColumns: [],
-      conditionalFormats: [],
-      columnHeaderGroups: [],
-      metrics: {
-        userColumnWidths: new Map(),
-        userRowHeights: new Map(),
-      } as GridMetrics,
-    } satisfies HydratedIrisGridState;
-
-    const testIrisGridUtils = new IrisGridUtils(dh);
-
-    const result = testIrisGridUtils.dehydrateIrisGridState(
-      model,
-      irisGridState
-    );
-
-    const sameStateDifferentStateObject =
-      testIrisGridUtils.dehydrateIrisGridState(model, {
-        ...irisGridState,
-      });
-
-    const sameStateDifferentModel = testIrisGridUtils.dehydrateIrisGridState(
-      irisGridTestUtils.makeModel(),
-      irisGridState
-    );
-
-    const sameModelDifferentState = testIrisGridUtils.dehydrateIrisGridState(
-      model,
-      {
-        ...irisGridState,
-        isFilterBarShown: true,
-      }
-    );
-
-    expect(
-      deepEqual(result, JSON.parse(JSON.stringify(result)), { strict: true })
-    ).toBe(true);
-
-    expect(result).toBe(sameStateDifferentStateObject);
-    expect(result).not.toBe(sameStateDifferentModel);
-    expect(result).not.toBe(sameModelDifferentState);
   });
 });
 

--- a/packages/iris-grid/src/IrisGridUtils.ts
+++ b/packages/iris-grid/src/IrisGridUtils.ts
@@ -17,7 +17,6 @@ import {
 } from '@deephaven/jsapi-utils';
 import Log from '@deephaven/log';
 import { assertNotNull, bindAllMethods, EMPTY_MAP } from '@deephaven/utils';
-import memoizeOne from 'memoize-one';
 import AggregationUtils from './sidebar/aggregations/AggregationUtils';
 import AggregationOperation from './sidebar/aggregations/AggregationOperation';
 import { type FilterData, type IrisGridState } from './IrisGrid';
@@ -199,18 +198,8 @@ export type DehydratedGridState = {
 };
 
 class IrisGridUtils {
-  // Memoized function to dehydrate the grid state
-  // Uses a WeakMap so there is a weakref to the model (key)
-  // If the model gets garbage collected, the memoized function will be garbage collected too
-  // This should result in an eventually auto-cleaning cache
-  private static dehydratedGridStateMemoizedFns = new WeakMap<
-    IrisGridModel,
-    (gridState: HydratedGridState) => DehydratedGridState
-  >();
-
   /**
    * Exports the state from Grid component to a JSON stringifiable object.
-   * Memoized so if the model and gridState keys that are dehydrated are the same, this function returns the same object.
    * @param model The table model to export the Grid state for
    * @param gridState The state of the Grid to export
    * @returns An object that can be stringified and imported with {{@link hydrateGridState}}
@@ -219,54 +208,31 @@ class IrisGridUtils {
     model: IrisGridModel,
     gridState: HydratedGridState
   ): DehydratedGridState {
-    let memoizedFn = IrisGridUtils.dehydratedGridStateMemoizedFns.get(model);
-    if (memoizedFn) {
-      return memoizedFn(gridState);
-    }
+    const { isStuckToBottom, isStuckToRight, movedColumns, movedRows } =
+      gridState;
 
-    memoizedFn = memoizeOne(
-      (newGridState: typeof gridState): DehydratedGridState => {
-        const { isStuckToBottom, isStuckToRight, movedColumns, movedRows } =
-          newGridState;
+    const { columns } = model;
 
-        const { columns } = model;
-
-        return {
-          isStuckToBottom,
-          isStuckToRight,
-          movedColumns: [...movedColumns]
-            .filter(
-              ({ to, from }) =>
-                isValidIndex(to, columns) &&
-                ((typeof from === 'number' && isValidIndex(from, columns)) ||
-                  (Array.isArray(from) &&
-                    isValidIndex(from[0], columns) &&
-                    isValidIndex(from[1], columns)))
-            )
-            .map(({ to, from }) => ({
-              to: columns[to].name,
-              from: Array.isArray(from)
-                ? [columns[from[0]].name, columns[from[1]].name]
-                : columns[from].name,
-            })),
-          movedRows: [...movedRows],
-        };
-      },
-      // Check if the values are equivalent to compare if we need to create a new value
-      ([a], [b]) => {
-        const compareKeys = [
-          'isStuckToBottom',
-          'isStuckToRight',
-          'movedColumns',
-          'movedRows',
-        ] satisfies Array<keyof GridState>;
-        return compareKeys.every(key => a[key] === b[key]);
-      }
-    );
-
-    IrisGridUtils.dehydratedGridStateMemoizedFns.set(model, memoizedFn);
-
-    return memoizedFn(gridState);
+    return {
+      isStuckToBottom,
+      isStuckToRight,
+      movedColumns: [...movedColumns]
+        .filter(
+          ({ to, from }) =>
+            isValidIndex(to, columns) &&
+            ((typeof from === 'number' && isValidIndex(from, columns)) ||
+              (Array.isArray(from) &&
+                isValidIndex(from[0], columns) &&
+                isValidIndex(from[1], columns)))
+        )
+        .map(({ to, from }) => ({
+          to: columns[to].name,
+          from: Array.isArray(from)
+            ? [columns[from[0]].name, columns[from[1]].name]
+            : columns[from].name,
+        })),
+      movedRows: [...movedRows],
+    };
   }
 
   /**
@@ -1190,120 +1156,79 @@ class IrisGridUtils {
    * @param model The table model to export the state for
    * @param irisGridState The current state of the IrisGrid
    */
-  dehydrateIrisGridState = memoizeOne(
-    (
-      model: IrisGridModel,
-      irisGridState: HydratedIrisGridState
-    ): DehydratedIrisGridState => {
-      const {
-        aggregationSettings,
-        advancedFilters,
-        customColumnFormatMap,
-        isFilterBarShown,
-        metrics: { userColumnWidths, userRowHeights } = {
-          userColumnWidths: EMPTY_MAP,
-          userRowHeights: EMPTY_MAP,
-        },
-        quickFilters,
-        customColumns,
-        conditionalFormats,
-        reverse,
-        rollupConfig,
-        showSearchBar,
-        searchValue,
-        selectDistinctColumns,
-        selectedSearchColumns,
-        sorts,
-        invertSearchColumns,
-        pendingDataMap,
-        frozenColumns,
-        columnHeaderGroups,
-        partitionConfig,
-      } = irisGridState;
-      const { columns } = model;
-      const partitionColumns = isPartitionedGridModelProvider(model)
-        ? model.partitionColumns
-        : [];
+  dehydrateIrisGridState(
+    model: IrisGridModel,
+    irisGridState: HydratedIrisGridState
+  ): DehydratedIrisGridState {
+    const {
+      aggregationSettings,
+      advancedFilters,
+      customColumnFormatMap,
+      isFilterBarShown,
+      metrics: { userColumnWidths, userRowHeights } = {
+        userColumnWidths: EMPTY_MAP,
+        userRowHeights: EMPTY_MAP,
+      },
+      quickFilters,
+      customColumns,
+      conditionalFormats,
+      reverse,
+      rollupConfig,
+      showSearchBar,
+      searchValue,
+      selectDistinctColumns,
+      selectedSearchColumns,
+      sorts,
+      invertSearchColumns,
+      pendingDataMap,
+      frozenColumns,
+      columnHeaderGroups,
+      partitionConfig,
+    } = irisGridState;
+    const { columns } = model;
+    const partitionColumns = isPartitionedGridModelProvider(model)
+      ? model.partitionColumns
+      : [];
 
-      // Return value will be serialized, should not contain undefined
-      // NOTE: Any return values added here should be added to the equality function as well
-      return {
-        advancedFilters: this.dehydrateAdvancedFilters(
-          columns,
-          advancedFilters
-        ),
-        aggregationSettings,
-        customColumnFormatMap: [...customColumnFormatMap],
-        isFilterBarShown,
-        quickFilters: IrisGridUtils.dehydrateQuickFilters(quickFilters),
-        sorts: IrisGridUtils.dehydrateSort(sorts),
-        userColumnWidths: [...userColumnWidths]
-          .filter(
-            ([columnIndex]) =>
-              columnIndex != null &&
-              columnIndex >= 0 &&
-              columnIndex < columns.length
-          )
-          .map(([columnIndex, width]) => [columns[columnIndex].name, width]),
-        userRowHeights: [...userRowHeights],
-        customColumns: [...customColumns],
-        conditionalFormats: [...conditionalFormats],
-        reverse,
-        rollupConfig,
-        showSearchBar,
-        searchValue,
-        selectDistinctColumns: [...selectDistinctColumns],
-        selectedSearchColumns,
-        invertSearchColumns,
-        pendingDataMap: this.dehydratePendingDataMap(columns, pendingDataMap),
-        frozenColumns,
-        columnHeaderGroups: columnHeaderGroups?.map(item => ({
-          name: item.name,
-          children: item.children,
-          color: item.color ?? null,
-        })),
-        partitionConfig: this.dehydratePartitionConfig(
-          partitionColumns,
-          partitionConfig
-        ),
-      };
-    },
-    // Equality function to check if the state has changed
-    // This way we can just pass in the entire state instead of memoizing on 20 different parameters in order
-    (a, b) => {
-      // Top level keys we want to check for referential equality
-      const compareStateKeys = [
-        'advancedFilters',
-        'aggregationSettings',
-        'customColumnFormatMap',
-        'isFilterBarShown',
-        'quickFilters',
-        'customColumns',
-        'reverse',
-        'rollupConfig',
-        'showSearchBar',
-        'searchValue',
-        'selectDistinctColumns',
-        'selectedSearchColumns',
-        'sorts',
-        'invertSearchColumns',
-        'pendingDataMap',
-        'frozenColumns',
-        'conditionalFormats',
-        'columnHeaderGroups',
-        'partitionConfig',
-      ] satisfies Array<keyof HydratedIrisGridState>;
-
-      return (
-        a[0] === b[0] &&
-        a[1].metrics != null &&
-        b[1].metrics != null &&
-        a[1].metrics.userColumnWidths === b[1].metrics.userColumnWidths &&
-        a[1].metrics.userRowHeights === b[1].metrics.userRowHeights &&
-        compareStateKeys.every(key => a[1][key] === b[1][key])
-      );
-    }
-  );
+    // Return value will be serialized, should not contain undefined
+    return {
+      advancedFilters: this.dehydrateAdvancedFilters(columns, advancedFilters),
+      aggregationSettings,
+      customColumnFormatMap: [...customColumnFormatMap],
+      isFilterBarShown,
+      quickFilters: IrisGridUtils.dehydrateQuickFilters(quickFilters),
+      sorts: IrisGridUtils.dehydrateSort(sorts),
+      userColumnWidths: [...userColumnWidths]
+        .filter(
+          ([columnIndex]) =>
+            columnIndex != null &&
+            columnIndex >= 0 &&
+            columnIndex < columns.length
+        )
+        .map(([columnIndex, width]) => [columns[columnIndex].name, width]),
+      userRowHeights: [...userRowHeights],
+      customColumns: [...customColumns],
+      conditionalFormats: [...conditionalFormats],
+      reverse,
+      rollupConfig,
+      showSearchBar,
+      searchValue,
+      selectDistinctColumns: [...selectDistinctColumns],
+      selectedSearchColumns,
+      invertSearchColumns,
+      pendingDataMap: this.dehydratePendingDataMap(columns, pendingDataMap),
+      frozenColumns,
+      columnHeaderGroups: columnHeaderGroups?.map(item => ({
+        name: item.name,
+        children: item.children,
+        color: item.color ?? null,
+      })),
+      partitionConfig: this.dehydratePartitionConfig(
+        partitionColumns,
+        partitionConfig
+      ),
+    };
+  }
 
   /**
    * Import a state for IrisGrid that was exported with {{@link dehydrateIrisGridState}}

--- a/packages/iris-grid/src/IrisGridUtils.ts
+++ b/packages/iris-grid/src/IrisGridUtils.ts
@@ -200,6 +200,7 @@ export type DehydratedGridState = {
 class IrisGridUtils {
   /**
    * Exports the state from Grid component to a JSON stringifiable object.
+   * See IrisGridCacheUtil for memoization and comparing dehydrated states.
    * @param model The table model to export the Grid state for
    * @param gridState The state of the Grid to export
    * @returns An object that can be stringified and imported with {{@link hydrateGridState}}
@@ -1152,7 +1153,7 @@ class IrisGridUtils {
 
   /**
    * Exports the state from IrisGrid to a JSON stringifiable object.
-   * Memoized to only change if the values in irisGridState that get dehydrated change.
+   * See IrisGridCacheUtil for memoization and comparing dehydrated states.
    * @param model The table model to export the state for
    * @param irisGridState The current state of the IrisGrid
    */

--- a/packages/iris-grid/src/index.ts
+++ b/packages/iris-grid/src/index.ts
@@ -28,3 +28,4 @@ export { default as IrisGridUtils } from './IrisGridUtils';
 export * from './IrisGridUtils';
 export * from './IrisGridMetricCalculator';
 export * from './IrisGridRenderer';
+export * from './IrisGridCacheUtils';


### PR DESCRIPTION
Adds `IrisGridCacheUtils` which provides 3 methods to create memoized dehydrators: `makeMemoizedGridStateDehydrator`, `makeMemoizedIrisGridStateDehydrator`, and `makeMemoizedCombinedGridStateDehydrator`. The first 2 are used for `IrisGridPanel` which saves the state under separate keys for `gridState` and `irisGridState`. The 3rd is for newer uses like `UITable` which can just save the combined state and spread it to `IrisGrid` since `IrisGrid` accepts both `GridState` and `IrisGridState` props.

Added tests for `dehydrateIrisGridState`.

Improved the `memoize-one` type override to infer the types of the equality function based on the actual function args.