### PR TITLE
refactor: DH-19267: columns changed filter event takes an id rather than a panel

### DIFF
--- a/packages/dashboard-core-plugins/src/FilterPlugin.tsx
+++ b/packages/dashboard-core-plugins/src/FilterPlugin.tsx
@@ -138,7 +138,9 @@ export function FilterPlugin(props: FilterPluginProps): JSX.Element | null {
     panel => {
       log.debug2('handlePanelUnmount', panel);
       const panelId = LayoutUtils.getIdFromPanel(panel);
-      panelColumns.delete(panelId);
+      if (panelId != null) {
+        panelColumns.delete(panelId);
+      }
       panelFilters.delete(panel);
       panelTables.delete(panelId);
       sendUpdate();

--- a/packages/dashboard-core-plugins/src/linker/Linker.tsx
+++ b/packages/dashboard-core-plugins/src/linker/Linker.tsx
@@ -46,6 +46,7 @@ import LinkerUtils, {
   type LinkType,
   isLinkableColumn,
 } from './LinkerUtils';
+import { type FilterColumnSourceId } from '../FilterPlugin';
 
 const log = Log.module('Linker');
 
@@ -252,21 +253,24 @@ export class Linker extends Component<LinkerProps, LinkerState> {
     this.columnSelected(panel, column, true);
   }
 
-  handleColumnsChanged(panel: PanelComponent, columns: LinkColumn[]): void {
-    log.debug('handleColumnsChanged', panel, columns);
+  handleColumnsChanged(
+    sourceId: FilterColumnSourceId,
+    columns: LinkColumn[]
+  ): void {
+    log.debug('handleColumnsChanged', sourceId, columns);
     const { links } = this.props;
-    const panelId = LayoutUtils.getIdFromPanel(panel);
-    if (panelId == null) {
-      log.error('Invalid panelId', panel);
+    if (sourceId == null) {
+      log.error('Invalid filter columns source id', sourceId);
       return;
     }
+    // NOTE: links need to be updated to use sourceId instead of panelId. This will be done when we implement linker for dh.ui widgets DH-18840
     // Delete links that start or end on non-existent column in the updated panel
     const linksToDelete = links.filter(
       ({ start, end }) =>
-        (start.panelId === panelId &&
+        (start.panelId === sourceId &&
           LinkerUtils.findColumn(columns, start) == null) ||
         (end != null &&
-          end.panelId === panelId &&
+          end.panelId === sourceId &&
           LinkerUtils.findColumn(columns, end) == null)
     );
     this.deleteLinks(linksToDelete);

--- a/packages/dashboard-core-plugins/src/panels/ChartPanel.tsx
+++ b/packages/dashboard-core-plugins/src/panels/ChartPanel.tsx
@@ -787,7 +787,7 @@ export class ChartPanel extends Component<ChartPanelProps, ChartPanelState> {
     const { glEventHub } = this.props;
     glEventHub.emit(
       InputFilterEvent.COLUMNS_CHANGED,
-      this,
+      LayoutUtils.getIdFromPanel(this),
       Array.from(model.getFilterColumnMap().values())
     );
   }

--- a/packages/dashboard-core-plugins/src/panels/IrisGridPanel.tsx
+++ b/packages/dashboard-core-plugins/src/panels/IrisGridPanel.tsx
@@ -850,7 +850,11 @@ export class IrisGridPanel extends PureComponent<
   sendColumnsChange(columns: readonly dh.Column[]): void {
     log.debug2('sendColumnsChange', columns);
     const { glEventHub } = this.props;
-    glEventHub.emit(InputFilterEvent.COLUMNS_CHANGED, this, columns);
+    glEventHub.emit(
+      InputFilterEvent.COLUMNS_CHANGED,
+      LayoutUtils.getIdFromPanel(this),
+      columns
+    );
   }
 
   startModelListening(model: IrisGridModel): void {

--- a/packages/dashboard-core-plugins/src/panels/WidgetPanelTypes.ts
+++ b/packages/dashboard-core-plugins/src/panels/WidgetPanelTypes.ts
@@ -1,4 +1,5 @@
 import { type ReactNode } from 'react';
+import { type Brand } from '@deephaven/utils';
 
 export type WidgetPanelDescriptor = {
   /** Type of the widget. */
@@ -25,4 +26,4 @@ export type WidgetPanelTooltipProps = {
   children?: ReactNode;
 };
 
-export type WidgetId = string;
+export type WidgetId = Brand<'WidgetId'>;

--- a/packages/dashboard-core-plugins/src/panels/WidgetPanelTypes.ts
+++ b/packages/dashboard-core-plugins/src/panels/WidgetPanelTypes.ts
@@ -24,3 +24,5 @@ export type WidgetPanelTooltipProps = {
   /** Children to render within this tooltip */
   children?: ReactNode;
 };
+
+export type WidgetId = string;

--- a/packages/dashboard/src/layout/LayoutUtils.ts
+++ b/packages/dashboard/src/layout/LayoutUtils.ts
@@ -21,7 +21,7 @@ import type {
   CloseOptions,
   GLPanelProps,
 } from '@deephaven/golden-layout';
-import { assertNotNull } from '@deephaven/utils';
+import { assertNotNull, type Brand } from '@deephaven/utils';
 import { type DashboardLayoutConfig } from '../DashboardLayout';
 import { type PanelConfig } from '../DashboardPlugin';
 
@@ -29,7 +29,7 @@ const log = Log.module('LayoutUtils');
 
 type LayoutConfig = { id?: string; component?: string };
 
-export type PanelId = string | string[] | null | undefined;
+export type PanelId = Brand<'PanelId', string | string[] | undefined>;
 
 export type LayoutPanel = {
   props: GLPanelProps;
@@ -820,10 +820,10 @@ class LayoutUtils {
    * @param glContainer The container to get the panel ID for
    * @returns Panel ID
    */
-  static getIdFromContainer(glContainer: Container): PanelId {
+  static getIdFromContainer(glContainer: Container): PanelId | null {
     const config = LayoutUtils.getComponentConfigFromContainer(glContainer);
     if (config) {
-      return config.id;
+      return config.id as PanelId;
     }
     return null;
   }
@@ -833,7 +833,7 @@ class LayoutUtils {
    * @param panel The panel to get the ID for
    * @returns Panel ID
    */
-  static getIdFromPanel(panel: LayoutPanel): PanelId {
+  static getIdFromPanel(panel: LayoutPanel): PanelId | null {
     const { glContainer } = panel.props;
     return LayoutUtils.getIdFromContainer(glContainer);
   }

--- a/packages/dashboard/src/layout/LayoutUtils.ts
+++ b/packages/dashboard/src/layout/LayoutUtils.ts
@@ -29,6 +29,8 @@ const log = Log.module('LayoutUtils');
 
 type LayoutConfig = { id?: string; component?: string };
 
+export type PanelId = string | string[] | null | undefined;
+
 export type LayoutPanel = {
   props: GLPanelProps;
 };
@@ -818,9 +820,7 @@ class LayoutUtils {
    * @param glContainer The container to get the panel ID for
    * @returns Panel ID
    */
-  static getIdFromContainer(
-    glContainer: Container
-  ): string | string[] | null | undefined {
+  static getIdFromContainer(glContainer: Container): PanelId {
     const config = LayoutUtils.getComponentConfigFromContainer(glContainer);
     if (config) {
       return config.id;
@@ -833,9 +833,7 @@ class LayoutUtils {
    * @param panel The panel to get the ID for
    * @returns Panel ID
    */
-  static getIdFromPanel(
-    panel: LayoutPanel
-  ): string | string[] | null | undefined {
+  static getIdFromPanel(panel: LayoutPanel): PanelId {
     const { glContainer } = panel.props;
     return LayoutUtils.getIdFromContainer(glContainer);
   }

--- a/packages/dashboard/src/layout/index.ts
+++ b/packages/dashboard/src/layout/index.ts
@@ -1,5 +1,5 @@
 export { default as LayoutManagerContext } from './LayoutManagerContext';
-export { default as LayoutUtils } from './LayoutUtils';
+export { default as LayoutUtils, type PanelId } from './LayoutUtils';
 export { default as GLPropTypes } from './GLPropTypes';
 export { default as useDashboardPanel } from './useDashboardPanel';
 export { default as useLayoutManager } from './useLayoutManager';


### PR DESCRIPTION
https://deephaven.atlassian.net/browse/DH-19267

Refactors `InputFilterEvent.COLUMNS_CHANGED` to take an id instead of a panel. This can be a panel id or a widget id.  This will allow `deephaven.ui` components to send this event. Note that more work will need to be done on Linker. This will be done later when we address https://deephaven.atlassian.net/browse/DH-18840