### PR TITLE
fix: DH-13244: remove trailing whitespace from console log messages

### DIFF
--- a/packages/console/src/console-history/ConsoleHistoryResultErrorMessage.tsx
+++ b/packages/console/src/console-history/ConsoleHistoryResultErrorMessage.tsx
@@ -121,13 +121,15 @@ class ConsoleHistoryResultErrorMessage extends PureComponent<
     const { isExpanded, isTriggerHovered } = this.state;
     const { message: messageProp } = this.props;
     assertNotNull(messageProp);
-    const lineBreakIndex = messageProp.indexOf('\n');
+    // Trim trailing whitespace to avoid unnecessary empty lines
+    const message = messageProp.trimEnd();
+    const lineBreakIndex = message.indexOf('\n');
     const isMultiline = lineBreakIndex > -1;
-    let topLineOfMessage = messageProp;
+    let topLineOfMessage = message;
     if (isMultiline) {
-      topLineOfMessage = messageProp.slice(0, lineBreakIndex);
+      topLineOfMessage = message.slice(0, lineBreakIndex);
     }
-    const remainderOfMessage = messageProp.slice(lineBreakIndex);
+    const remainderOfMessage = message.slice(lineBreakIndex);
     const arrowBtnClasses = isTriggerHovered
       ? 'error-btn-link error-btn-link--active'
       : 'error-btn-link';


### PR DESCRIPTION
https://deephaven.atlassian.net/browse/DH-13244

There was a fix for single line console messages here: https://github.com/deephaven/web-client-ui/pull/350
However, this fix did not account for trailing newline characters in the message. This fix trims whitespace from the end of the message.