### PR TITLE
fix: Exports needed for ui.table aggregations (#2385)

### DIFF
--- a/packages/iris-grid/src/sidebar/aggregations/AggregationUtils.ts
+++ b/packages/iris-grid/src/sidebar/aggregations/AggregationUtils.ts
@@ -102,6 +102,7 @@ export const getOperationColumnNames = (
     .filter(name => (selected.includes(name) ? !invert : invert));
 
 export default {
+  isValidOperation,
   isRollupOperation,
   isRollupProhibited,
   filterValidColumns,

--- a/packages/iris-grid/src/sidebar/aggregations/index.ts
+++ b/packages/iris-grid/src/sidebar/aggregations/index.ts
@@ -1,1 +1,3 @@
 export * from './Aggregations';
+export { default as AggregationOperation } from './AggregationOperation';
+export { default as AggregationUtils } from './AggregationUtils';


### PR DESCRIPTION
Need to export the aggregation operations so dh.ui can convert to the proper case for available aggregations. The JS API is case sensitive and expects `Sum` or `CountDistinct` not `count` or `COUNT`