### PR TITLE
fix: DH-19350: Ruff tries to lint before initializing when disabled

### DIFF
--- a/packages/console/src/monaco/MonacoProviders.tsx
+++ b/packages/console/src/monaco/MonacoProviders.tsx
@@ -71,9 +71,6 @@ class MonacoProviders extends PureComponent<
       MonacoProviders.ruffWorkspace = new Workspace(
         MonacoProviders.ruffSettings
       );
-    } catch (e) {
-      console.log = prevLog; // Restore console.log in case the re-throw isn't caught and finally doesn't run
-      throw e;
     } finally {
       console.log = prevLog; // Restore console.log
     }

--- a/packages/console/src/monaco/MonacoProviders.tsx
+++ b/packages/console/src/monaco/MonacoProviders.tsx
@@ -66,9 +66,14 @@ class MonacoProviders extends PureComponent<
 
     /* eslint-disable no-console */
     const prevLog = console.log;
-    console.log = () => undefined; // Suppress not useful ruff-wasm-web logs when it creates the workspace
-    MonacoProviders.ruffWorkspace = new Workspace(MonacoProviders.ruffSettings);
-    console.log = prevLog; // Restore console.log
+    try {
+      console.log = () => undefined; // Suppress not useful ruff-wasm-web logs when it creates the workspace
+      MonacoProviders.ruffWorkspace = new Workspace(
+        MonacoProviders.ruffSettings
+      );
+    } finally {
+      console.log = prevLog; // Restore console.log
+    }
     /* eslint-enable no-console */
 
     MonacoProviders.lintAllPython();
@@ -78,9 +83,9 @@ class MonacoProviders extends PureComponent<
    * Sets ruff settings
    * @param settings The ruff settings
    */
-  static async setRuffSettings(
+  static setRuffSettings(
     settings: Record<string, unknown> = MonacoProviders.ruffSettings
-  ): Promise<void> {
+  ): void {
     MonacoProviders.ruffSettings = settings;
 
     if (!MonacoProviders.isRuffInitialized) {

--- a/packages/console/src/monaco/MonacoProviders.tsx
+++ b/packages/console/src/monaco/MonacoProviders.tsx
@@ -71,6 +71,9 @@ class MonacoProviders extends PureComponent<
       MonacoProviders.ruffWorkspace = new Workspace(
         MonacoProviders.ruffSettings
       );
+    } catch (e) {
+      console.log = prevLog; // Restore console.log in case the re-throw isn't caught and finally doesn't run
+      throw e;
     } finally {
       console.log = prevLog; // Restore console.log
     }

--- a/packages/console/src/monaco/MonacoProviders.tsx
+++ b/packages/console/src/monaco/MonacoProviders.tsx
@@ -28,29 +28,50 @@ class MonacoProviders extends PureComponent<
 
   static initRuffPromise?: Promise<void>;
 
+  static isRuffInitialized = false;
+
   static isRuffEnabled = true;
 
   static ruffSettings: Record<string, unknown> = RUFF_DEFAULT_SETTINGS;
 
   /**
-   * Loads and initializes Ruff.
+   * Loads and initializes Ruff if it is enabled.
    * Subsequent calls will return the same promise.
    */
   static async initRuff(): Promise<void> {
+    if (!MonacoProviders.isRuffEnabled) {
+      return;
+    }
     if (MonacoProviders.initRuffPromise) {
       return MonacoProviders.initRuffPromise;
     }
 
     MonacoProviders.initRuffPromise = init({}).then(() => {
       log.debug('Initialized Ruff', Workspace.version());
-
-      MonacoProviders.ruffWorkspace = new Workspace(
-        MonacoProviders.ruffSettings
-      );
-      MonacoProviders.lintAllPython();
+      MonacoProviders.isRuffInitialized = true;
+      MonacoProviders.updateRuffWorkspace();
     });
 
     return MonacoProviders.initRuffPromise;
+  }
+
+  /**
+   * Updates the current ruff workspace with MonacoProviders.ruffSettings.
+   * Re-lints all Python models after updating.
+   */
+  static updateRuffWorkspace(): void {
+    if (!MonacoProviders.isRuffInitialized) {
+      return;
+    }
+
+    /* eslint-disable no-console */
+    const prevLog = console.log;
+    console.log = () => undefined; // Suppress not useful ruff-wasm-web logs when it creates the workspace
+    MonacoProviders.ruffWorkspace = new Workspace(MonacoProviders.ruffSettings);
+    console.log = prevLog; // Restore console.log
+    /* eslint-enable no-console */
+
+    MonacoProviders.lintAllPython();
   }
 
   /**
@@ -62,17 +83,12 @@ class MonacoProviders extends PureComponent<
   ): Promise<void> {
     MonacoProviders.ruffSettings = settings;
 
-    // Ruff has not been initialized yet
-    if (
-      MonacoProviders.ruffWorkspace == null &&
-      MonacoProviders.isRuffEnabled
-    ) {
+    if (!MonacoProviders.isRuffInitialized) {
       MonacoProviders.initRuff();
       return;
     }
 
-    MonacoProviders.ruffWorkspace = new Workspace(settings);
-    MonacoProviders.lintAllPython();
+    MonacoProviders.updateRuffWorkspace();
   }
 
   static getDiagnostics(model: monaco.editor.ITextModel): Diagnostic[] {


### PR DESCRIPTION
Looks like it was an issue caused if Ruff was disabled when we changed settings (we set settings on initial load). This was causing a check to pass and then trying to use Ruff without initializing it

Also added some log suppression because Ruff internals call `console.log` when the workspace is created and it's not useful to us. It's something along the lines of `glob 25 created ...` and I just found it unnecessary noise