### PR TITLE
fix: DH-18562: Deephaven picker hover blends with non-hovered styling in dark mode

### DIFF
--- a/packages/components/src/theme/theme-dark/theme-dark-semantic.css
+++ b/packages/components/src/theme/theme-dark/theme-dark-semantic.css
@@ -148,7 +148,7 @@
   );
   --dh-color-overlay-hover-bg: color-mix(
     in srgb,
-    var(--dh-color-black) 8%,
+    var(--dh-color-white) 8%,
     transparent
   );
 


### PR DESCRIPTION
DH-18562: Fixes issue with picker styling when using dark mode. Previously the background did not serve as a good indicator when hovering over items.

I checked in with @dsmmcken to confirm the styling changes. I also tested the picker component in both the style guide and theme selector under settings.

**Hovered Styling (Before)**
![Before Screenshot](https://github.com/user-attachments/assets/efc64dfd-c93a-4c6d-88c3-73710e94dfe5)

**Hovered Styling (After)**
![After Screenshot](https://github.com/user-attachments/assets/f7ad4ebe-ffb8-4978-bc06-4c030d7a9ec8)
