### PR TITLE
test: Fix issues with e2e when running locally

### DIFF
--- a/tests/table-multiselect.spec.ts
+++ b/tests/table-multiselect.spec.ts
@@ -62,9 +62,9 @@ async function filterAndScreenshot(
   });
 
   await test.step('Reset filter', async () => {
-    await page.keyboard.down('Control');
+    await page.keyboard.down('ControlOrMeta');
     await page.keyboard.press('E');
-    await page.keyboard.up('Control');
+    await page.keyboard.up('ControlOrMeta');
     await waitForLoadingDone(page, '.iris-grid-loading-status-bar');
   });
 }
@@ -78,7 +78,9 @@ function runSpecialSelectFilter(
     await gotoPage(page, '');
     await openTable(page, `multiselect_${columnType}`);
     const gridLocation = await getGridLocation(page);
-    if (gridLocation === null) return;
+    if (gridLocation === null) {
+      throw new Error('Grid location is null');
+    }
 
     await page.mouse.click(
       gridLocation.x + 1,
@@ -105,14 +107,20 @@ function runMultiSelectFilter(
     await gotoPage(page, '');
     await openTable(page, `multiselect_${columnType}`);
     const gridLocation = await getGridLocation(page);
-    if (gridLocation === null) return;
+    if (gridLocation === null) {
+      throw new Error('Grid location is null');
+    }
 
     // activate the quick filter to get that text as well
     await test.step('Show quick filter step', async () => {
-      await page.mouse.click(gridLocation.x + 805, gridLocation.y + 1);
-      await page.keyboard.down('Control');
+      // Click the tab above the grid to focus the panel
+      await page.mouse.click(gridLocation.x + 1, gridLocation.y - 1);
+      await page.keyboard.down('ControlOrMeta');
       await page.keyboard.press('F');
-      await page.keyboard.up('Control');
+      await page.keyboard.up('ControlOrMeta');
+      await expect(
+        page.locator('.iris-grid-input-autosized-wrapper')
+      ).toHaveCount(1);
     });
 
     /* eslint-disable no-await-in-loop */
@@ -171,7 +179,7 @@ test('char formatting, non selected right click, preview formatting', async ({
   if (gridLocation === null) return;
 
   // select row 2, 4
-  await page.keyboard.down('Control');
+  await page.keyboard.down('ControlOrMeta');
   await page.mouse.click(
     gridLocation.x + 1,
     gridLocation.y + 1 + columnHeight + rowHeight
@@ -180,7 +188,7 @@ test('char formatting, non selected right click, preview formatting', async ({
     gridLocation.x + 1,
     gridLocation.y + 1 + columnHeight + rowHeight * 3
   );
-  await page.keyboard.up('Control');
+  await page.keyboard.up('ControlOrMeta');
 
   await page.mouse.click(
     gridLocation.x + 1,

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -84,17 +84,26 @@ export async function openTable(
   waitForLoadFinished = true
 ): Promise<void> {
   const panelCount = await page.locator('.iris-grid-panel').count();
+  const panelsBefore = await page.locator('.iris-grid-panel').all();
   await openPanel(page, name);
 
   if (waitForLoadFinished) {
     await expect(page.locator('.iris-grid-panel')).toHaveCount(panelCount + 1);
-    await expect(page.locator('.iris-grid-panel .loading-spinner')).toHaveCount(
+    const panelsAfter = await page.locator('.iris-grid-panel').all();
+    const newPanel = panelsAfter.find(panel => !panelsBefore.includes(panel));
+    if (newPanel == null) {
+      throw new Error('New panel not found');
+    }
+    await expect(newPanel.locator('canvas')).toHaveCount(1);
+    await expect(newPanel.locator('.loading-spinner')).toHaveCount(0);
+    await expect(
+      newPanel.locator('.iris-grid .iris-grid-loading-status')
+    ).toHaveCount(0);
+    await expect(newPanel.locator('.grid-wrapper')).toHaveCount(panelCount + 1);
+    // Wait for the loading overlay to fade out and be removed from the DOM
+    await expect(newPanel.locator('.iris-panel-message-overlay')).toHaveCount(
       0
     );
-    await expect(
-      page.locator('.iris-grid .iris-grid-loading-status')
-    ).toHaveCount(0);
-    await expect(page.locator('.grid-wrapper')).toHaveCount(panelCount + 1);
   }
 }
 


### PR DESCRIPTION
- Update `openTable` in `tests/utils.ts` to better target the added panel, check for the canvas element to be present and the overlay to be removed from the DOM.
- Throw error to fail tests instead of just skipping.
- Change `Control` to `ControlOrMeta` for shortcuts.
- Wait for the filter input to appear after activating Quick Filters.
