### PR TITLE
fix: Cherry-pick Simple Pivot prerequisites

### DIFF
--- a/packages/grid/src/Grid.tsx
+++ b/packages/grid/src/Grid.tsx
@@ -536,12 +536,14 @@ class Grid extends PureComponent<GridProps, GridState> {
       movedRows: currentStateMovedRows,
     } = this.state;
 
+    const stateUpdates: Partial<GridState> = {};
+
     if (prevPropMovedColumns !== movedColumns) {
-      this.setState({ movedColumns });
+      stateUpdates.movedColumns = movedColumns;
     }
 
     if (prevPropMovedRows !== movedRows) {
-      this.setState({ movedRows });
+      stateUpdates.movedRows = movedRows;
     }
 
     if (prevStateMovedColumns !== currentStateMovedColumns) {
@@ -561,14 +563,16 @@ class Grid extends PureComponent<GridProps, GridState> {
     }
 
     if (isStickyBottom !== prevIsStickyBottom) {
-      this.setState({ isStuckToBottom: false });
+      stateUpdates.isStuckToBottom = false;
     }
 
     if (isStickyRight !== prevIsStickyRight) {
-      this.setState({ isStuckToRight: false });
+      stateUpdates.isStuckToRight = false;
     }
 
-    this.updateMetrics();
+    const updatedState = { ...this.state, ...stateUpdates };
+
+    this.updateMetrics(updatedState);
 
     this.requestUpdateCanvas();
 
@@ -577,6 +581,8 @@ class Grid extends PureComponent<GridProps, GridState> {
     if (this.validateSelection()) {
       this.checkSelectionChange(prevState);
     }
+
+    this.setState(updatedState);
   }
 
   componentWillUnmount(): void {

--- a/packages/iris-grid/src/IrisGrid.tsx
+++ b/packages/iris-grid/src/IrisGrid.tsx
@@ -576,6 +576,7 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
     this.handleMovedColumnsChanged = this.handleMovedColumnsChanged.bind(this);
     this.handleHeaderGroupsChanged = this.handleHeaderGroupsChanged.bind(this);
     this.handleUpdate = this.handleUpdate.bind(this);
+    this.handleTableChanged = this.handleTableChanged.bind(this);
     this.handleTooltipRef = this.handleTooltipRef.bind(this);
     this.handleViewChanged = this.handleViewChanged.bind(this);
     this.handleFormatSelection = this.handleFormatSelection.bind(this);
@@ -2339,6 +2340,10 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
       IrisGridModel.EVENT.VIEWPORT_UPDATED,
       this.handleViewportUpdated
     );
+    model.addEventListener(
+      IrisGridModel.EVENT.TABLE_CHANGED,
+      this.handleTableChanged
+    );
   }
 
   stopListening(model: IrisGridModel): void {
@@ -2358,6 +2363,10 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
     model.removeEventListener(
       IrisGridModel.EVENT.VIEWPORT_UPDATED,
       this.handleViewportUpdated
+    );
+    model.removeEventListener(
+      IrisGridModel.EVENT.TABLE_CHANGED,
+      this.handleTableChanged
     );
   }
 
@@ -3150,6 +3159,12 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
 
     this.grid?.forceUpdate();
     this.stopLoading();
+  }
+
+  handleTableChanged(): void {
+    const { model } = this.props;
+    // movedColumns reset triggers metricCalculator update in the Grid component
+    this.setState({ movedColumns: model.initialMovedColumns });
   }
 
   handleViewChanged(metrics?: GridMetrics): void {

--- a/packages/iris-grid/src/IrisGridTableModel.ts
+++ b/packages/iris-grid/src/IrisGridTableModel.ts
@@ -188,8 +188,8 @@ class IrisGridTableModel
   updateFrozenColumns(columns: ColumnName[]): void {
     this.userFrozenColumns = columns;
     this.dispatchEvent(
-      new EventShimCustomEvent(IrisGridModel.EVENT.TABLE_CHANGED, {
-        detail: this.table,
+      new EventShimCustomEvent(IrisGridModel.EVENT.COLUMNS_CHANGED, {
+        detail: this.columns,
       })
     );
   }

--- a/packages/iris-grid/src/index.ts
+++ b/packages/iris-grid/src/index.ts
@@ -12,6 +12,7 @@ export * from './IrisGrid';
 export type { default as IrisGridType } from './IrisGrid';
 export { default as SHORTCUTS } from './IrisGridShortcuts';
 export { default as IrisGridModel } from './IrisGridModel';
+export * from './IrisGridModel';
 export { default as IrisGridTableModel } from './IrisGridTableModel';
 export * from './IrisGridTableModel';
 export { default as IrisGridPartitionedTableModel } from './IrisGridPartitionedTableModel';

--- a/packages/iris-grid/src/mousehandlers/IrisGridContextMenuHandler.tsx
+++ b/packages/iris-grid/src/mousehandlers/IrisGridContextMenuHandler.tsx
@@ -265,6 +265,7 @@ class IrisGridContextMenuHandler extends GridMouseHandler {
       action: () => {
         this.irisGrid.handleAdvancedMenuOpened(visibleIndex);
       },
+      disabled: !model.isFilterable(modelIndex),
     });
     actions.push({
       title: 'Clear Table Filters',


### PR DESCRIPTION
Cherry-pick #2437:

- Reset movedColumns in IrisGrid and re-calculate metrics on TABLE_CHANGED event
- Fix the issue with grid metrics calculations based on stale state in Grid.componentDidUpdate
- Disable advanced filters for non-filterable columns
- Expose DisplayColumn type export
- Trigger COLUMNS_CHANGED instead of TABLE_CHANGED in updateFrozenColumns

Tested alpha build on `vlad-18275-3`