### PR TITLE
fix: DH-19393: clear aggregations in handleSelectDistinctChanged to prevent stale re…

### DIFF
--- a/packages/iris-grid/src/IrisGrid.tsx
+++ b/packages/iris-grid/src/IrisGrid.tsx
@@ -1820,6 +1820,12 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
     });
   }
 
+  clearAllAggregations(): void {
+    log.debug('Clearing all aggregations');
+
+    this.setState({ aggregationSettings: DEFAULT_AGGREGATION_SETTINGS });
+  }
+
   clearCrossColumSearch(): void {
     log.debug('Clearing cross-column search');
 
@@ -3637,6 +3643,7 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
 
     this.showAllColumns();
     this.clearAllFilters();
+    this.clearAllAggregations();
 
     this.startLoading(
       `Selecting distinct values in ${


### PR DESCRIPTION
DH-19393: ensures that aggregations are cleared when applying selectDistinct from the table sidebar.

- Introduced a call to `clearAllAggreations` inside `handleSelectDistinctchanged` to reset any existing aggregation state before applying selectDistinct