### PR TITLE
fix: DH-17292 Handle disconnect from GridWidgetPlugin (#2086)

### DIFF
--- a/packages/dashboard-core-plugins/src/useIrisGridModel.test.ts
+++ b/packages/dashboard-core-plugins/src/useIrisGridModel.test.ts
@@ -1,0 +1,136 @@
+import { IrisGridModel } from '@deephaven/iris-grid';
+import { type dh } from '@deephaven/jsapi-types';
+import { TestUtils } from '@deephaven/utils';
+import { renderHook } from '@testing-library/react-hooks';
+import { act } from 'react-test-renderer';
+import {
+  IrisGridModelFetchErrorResult,
+  IrisGridModelFetchSuccessResult,
+  useIrisGridModel,
+} from './useIrisGridModel';
+
+const mockApi = TestUtils.createMockProxy<typeof dh>();
+// Mock out the useApi hook to just return the API
+jest.mock('@deephaven/jsapi-bootstrap', () => ({
+  useApi: () => mockApi,
+}));
+
+const mockModel = TestUtils.createMockProxy<IrisGridModel>();
+// Mock out the IrisGridModelFactory as well
+jest.mock('@deephaven/iris-grid', () => ({
+  ...jest.requireActual('@deephaven/iris-grid'),
+  IrisGridModelFactory: {
+    makeModel: jest.fn(() => mockModel),
+  },
+}));
+
+it('should return loading status while fetching', () => {
+  const fetch = jest.fn(
+    () =>
+      new Promise<dh.Table>(() => {
+        // Do nothing
+      })
+  );
+  const { result } = renderHook(() => useIrisGridModel(fetch));
+  expect(result.current.status).toBe('loading');
+});
+
+it('should return error status on fetch error', async () => {
+  const error = new Error('Test error');
+  const fetch = jest.fn(() => Promise.reject(error));
+  const { result, waitForNextUpdate } = renderHook(() =>
+    useIrisGridModel(fetch)
+  );
+  await waitForNextUpdate();
+  const fetchResult = result.current;
+  expect(fetchResult.status).toBe('error');
+  expect((fetchResult as IrisGridModelFetchErrorResult).error).toBe(error);
+});
+
+it('should return success status on fetch success', async () => {
+  const table = TestUtils.createMockProxy<dh.Table>();
+  const fetch = jest.fn(() => Promise.resolve(table));
+  const { result, waitForNextUpdate } = renderHook(() =>
+    useIrisGridModel(fetch)
+  );
+  await waitForNextUpdate();
+  const fetchResult = result.current;
+  expect(fetchResult.status).toBe('success');
+  expect((fetchResult as IrisGridModelFetchSuccessResult).model).toBeDefined();
+});
+
+it('should reload the model on reload', async () => {
+  const table = TestUtils.createMockProxy<dh.Table>();
+  let fetchResolve;
+  const fetch = jest.fn(
+    () =>
+      new Promise<dh.Table>(resolve => {
+        fetchResolve = resolve;
+      })
+  );
+  const { result, waitForNextUpdate } = renderHook(() =>
+    useIrisGridModel(fetch)
+  );
+  expect(result.current.status).toBe('loading');
+  fetchResolve(table);
+  await waitForNextUpdate();
+  expect(result.current.status).toBe('success');
+  // Check that it will reload, transitioning to loading then to success again
+
+  fetch.mockClear();
+  fetch.mockReturnValue(
+    new Promise(resolve => {
+      fetchResolve = resolve;
+    })
+  );
+  await act(async () => {
+    result.current.reload();
+  });
+  expect(fetch).toHaveBeenCalledTimes(1);
+  expect(result.current.status).toBe('loading');
+  fetchResolve(table);
+  await waitForNextUpdate();
+  expect(result.current.status).toBe('success');
+  expect(
+    (result.current as IrisGridModelFetchSuccessResult).model
+  ).toBeDefined();
+
+  // Now check that it will handle a failure on reload, transitioning from loading to failure
+  fetch.mockClear();
+
+  let fetchReject;
+  fetch.mockReturnValue(
+    new Promise((resolve, reject) => {
+      fetchReject = reject;
+    })
+  );
+  await act(async () => {
+    result.current.reload();
+  });
+  expect(fetch).toHaveBeenCalledTimes(1);
+  expect(result.current.status).toBe('loading');
+  const error = new Error('Test error');
+  fetchReject(error);
+  await waitForNextUpdate();
+  expect(result.current.status).toBe('error');
+  expect((result.current as IrisGridModelFetchErrorResult).error).toBe(error);
+
+  // Check that it will reload again after an error
+  fetch.mockClear();
+  fetch.mockReturnValue(
+    new Promise(resolve => {
+      fetchResolve = resolve;
+    })
+  );
+  await act(async () => {
+    result.current.reload();
+  });
+  expect(fetch).toHaveBeenCalledTimes(1);
+  expect(result.current.status).toBe('loading');
+  fetchResolve(table);
+  await waitForNextUpdate();
+  expect(result.current.status).toBe('success');
+  expect(
+    (result.current as IrisGridModelFetchSuccessResult).model
+  ).toBeDefined();
+});

--- a/packages/dashboard-core-plugins/src/useIrisGridModel.ts
+++ b/packages/dashboard-core-plugins/src/useIrisGridModel.ts
@@ -1,0 +1,119 @@
+import { type dh } from '@deephaven/jsapi-types';
+import { useApi } from '@deephaven/jsapi-bootstrap';
+import { IrisGridModel, IrisGridModelFactory } from '@deephaven/iris-grid';
+import { useCallback, useEffect, useState } from 'react';
+
+export type IrisGridModelFetch = () => Promise<dh.Table>;
+
+export type IrisGridModelFetchErrorResult = {
+  error: NonNullable<unknown>;
+  status: 'error';
+};
+
+export type IrisGridModelFetchLoadingResult = {
+  status: 'loading';
+};
+
+export type IrisGridModelFetchSuccessResult = {
+  status: 'success';
+  model: IrisGridModel;
+};
+
+export type IrisGridModelFetchResult = (
+  | IrisGridModelFetchErrorResult
+  | IrisGridModelFetchLoadingResult
+  | IrisGridModelFetchSuccessResult
+) & {
+  reload: () => void;
+};
+
+/** Pass in a table `fetch` function, will load the model and handle any errors */
+export function useIrisGridModel(
+  fetch: IrisGridModelFetch
+): IrisGridModelFetchResult {
+  const dh = useApi();
+  const [model, setModel] = useState<IrisGridModel>();
+  const [error, setError] = useState<unknown>();
+  const [isLoading, setIsLoading] = useState(true);
+
+  const makeModel = useCallback(async () => {
+    const table = await fetch();
+    return IrisGridModelFactory.makeModel(dh, table);
+  }, [dh, fetch]);
+
+  const reload = useCallback(async () => {
+    setIsLoading(true);
+    setError(undefined);
+    try {
+      const newModel = await makeModel();
+      setModel(newModel);
+      setIsLoading(false);
+    } catch (e) {
+      setError(e);
+      setIsLoading(false);
+    }
+  }, [makeModel]);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function init() {
+      setIsLoading(true);
+      setError(undefined);
+      try {
+        const newModel = await makeModel();
+        if (!cancelled) {
+          setModel(newModel);
+          setIsLoading(false);
+        }
+      } catch (e) {
+        if (!cancelled) {
+          setError(e);
+          setIsLoading(false);
+        }
+      }
+    }
+
+    init();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [makeModel]);
+
+  useEffect(
+    function startListeningModel() {
+      if (!model) {
+        return;
+      }
+
+      // If the table inside a widget is disconnected, then don't bother trying to listen to reconnect, just close it and show a message
+      // Widget closes the table already when it is disconnected, so no need to close it again
+      function handleDisconnect() {
+        setError(new Error('Table disconnected'));
+        setModel(undefined);
+        setIsLoading(false);
+      }
+
+      model.addEventListener(IrisGridModel.EVENT.DISCONNECT, handleDisconnect);
+
+      return () => {
+        model.removeEventListener(
+          IrisGridModel.EVENT.DISCONNECT,
+          handleDisconnect
+        );
+      };
+    },
+    [model]
+  );
+
+  if (isLoading) {
+    return { reload, status: 'loading' };
+  }
+  if (error != null) {
+    return { error, reload, status: 'error' };
+  }
+  if (model != null) {
+    return { model, reload, status: 'success' };
+  }
+  throw new Error('Invalid state');
+}


### PR DESCRIPTION
1st of 3 cherry-picks for dh.ui persistent state in grizzly

- When the model is disconnected, we should just display an error. There's no option to reconnect, as the widget schema could change entirely
- By unloading the IrisGrid component, it's no longer throwing an error by trying to access table methods after a table.close()
- Fixes DH-17292 from Enterprise
  - Tested using the steps in the description