### PR TITLE
feat: Add IrisGridCacheUtils for memoizing iris grid state (#2416)

### DIFF
--- a/@types/memoize-one/index.d.ts
+++ b/@types/memoize-one/index.d.ts
@@ -1,12 +1,9 @@
-export declare type EqualityFn = (
-  newArgs: unknown[],
-  lastArgs: unknown[]
-) => boolean;
+export declare type EqualityFn<P> = (newArgs: P, lastArgs: P) => boolean;
 
 // eslint-disable-next-line @typescript-eslint/ban-types
 declare function memoizeOne<ResultFn extends Function>(
   resultFn: ResultFn,
-  isEqual?: EqualityFn
+  isEqual?: EqualityFn<Parameters<ResultFn>>
 ): ResultFn;
 
 export default memoizeOne;

--- a/packages/iris-grid/src/IrisGridCacheUtils.test.ts
+++ b/packages/iris-grid/src/IrisGridCacheUtils.test.ts
@@ -1,0 +1,192 @@
+import { type GridMetrics } from '@deephaven/grid';
+import dh from '@deephaven/jsapi-shim';
+import IrisGridTestUtils from './IrisGridTestUtils';
+import {
+  type HydratedGridState,
+  type HydratedIrisGridState,
+} from './IrisGridUtils';
+import { IrisGridCacheUtils } from './IrisGridCacheUtils';
+
+const irisGridTestUtils = new IrisGridTestUtils(dh);
+
+const gridState = {
+  isStuckToBottom: false,
+  isStuckToRight: false,
+  movedRows: [],
+  movedColumns: [],
+} satisfies HydratedGridState;
+
+const irisGridState = {
+  advancedFilters: new Map(),
+  partitionConfig: {
+    partitions: [],
+    mode: 'merged',
+  },
+  aggregationSettings: {
+    aggregations: [],
+    showOnTop: false,
+  },
+  customColumnFormatMap: new Map(),
+  isFilterBarShown: false,
+  quickFilters: new Map(),
+  customColumns: [],
+  reverse: false,
+  rollupConfig: {
+    columns: [],
+    showConstituents: false,
+    showNonAggregatedColumns: false,
+    includeDescriptions: true,
+  },
+  showSearchBar: false,
+  searchValue: '',
+  selectDistinctColumns: [],
+  selectedSearchColumns: [],
+  sorts: [],
+  invertSearchColumns: false,
+  pendingDataMap: new Map(),
+  frozenColumns: [],
+  conditionalFormats: [],
+  columnHeaderGroups: [],
+  metrics: {
+    userColumnWidths: new Map(),
+    userRowHeights: new Map(),
+  } as GridMetrics,
+} satisfies HydratedIrisGridState;
+
+describe('makeMemoizedGridStateDehydrator', () => {
+  test('creates a new memoization function with each call', () => {
+    const cacheA = IrisGridCacheUtils.makeMemoizedGridStateDehydrator();
+    const cacheB = IrisGridCacheUtils.makeMemoizedGridStateDehydrator();
+    expect(cacheA).not.toBe(cacheB);
+  });
+
+  test('memoizes dehydration', () => {
+    const model = irisGridTestUtils.makeModel();
+
+    const dehydrate = IrisGridCacheUtils.makeMemoizedGridStateDehydrator();
+
+    // Same state in different objects
+    expect(dehydrate(model, gridState)).toBe(
+      dehydrate(model, { ...gridState })
+    );
+
+    const differentModel = irisGridTestUtils.makeModel();
+    expect(dehydrate(model, gridState)).not.toBe(
+      dehydrate(differentModel, gridState)
+    );
+
+    const differentState = {
+      ...gridState,
+      isStuckToBottom: true,
+    };
+    expect(dehydrate(model, gridState)).not.toBe(
+      dehydrate(model, differentState)
+    );
+
+    const extraneousState = {
+      ...gridState,
+      lastLeft: 10,
+    };
+    expect(dehydrate(model, gridState)).toBe(dehydrate(model, extraneousState));
+  });
+});
+
+describe('makeMemoizedIrisGridStateDehydrator', () => {
+  test('creates a new memoization function with each call', () => {
+    const cacheA = IrisGridCacheUtils.makeMemoizedIrisGridStateDehydrator();
+    const cacheB = IrisGridCacheUtils.makeMemoizedIrisGridStateDehydrator();
+    expect(cacheA).not.toBe(cacheB);
+  });
+
+  test('memoizes dehydration', () => {
+    const model = irisGridTestUtils.makeModel();
+
+    const dehydrate = IrisGridCacheUtils.makeMemoizedIrisGridStateDehydrator();
+
+    // Same state in different objects
+    expect(dehydrate(model, irisGridState)).toBe(
+      dehydrate(model, { ...irisGridState })
+    );
+
+    const differentModel = irisGridTestUtils.makeModel();
+    expect(dehydrate(model, irisGridState)).not.toBe(
+      dehydrate(differentModel, irisGridState)
+    );
+
+    const differentState = {
+      ...irisGridState,
+      isFilterBarShown: true,
+    };
+    expect(dehydrate(model, irisGridState)).not.toBe(
+      dehydrate(model, differentState)
+    );
+
+    const extraneousState = {
+      ...irisGridState,
+      lastLeft: 10,
+    };
+    expect(dehydrate(model, irisGridState)).toBe(
+      dehydrate(model, extraneousState)
+    );
+  });
+});
+
+describe('makeMemoizedCombinedGridStateDehydrator', () => {
+  test('creates a new memoization function with each call', () => {
+    const cacheA = IrisGridCacheUtils.makeMemoizedCombinedGridStateDehydrator();
+    const cacheB = IrisGridCacheUtils.makeMemoizedCombinedGridStateDehydrator();
+    expect(cacheA).not.toBe(cacheB);
+  });
+  test('memoizes dehydration', () => {
+    const model = irisGridTestUtils.makeModel();
+
+    const dehydrate =
+      IrisGridCacheUtils.makeMemoizedCombinedGridStateDehydrator();
+
+    // Same state in different objects
+    expect(dehydrate(model, irisGridState, gridState)).toBe(
+      dehydrate(model, { ...irisGridState }, { ...gridState })
+    );
+
+    const differentModel = irisGridTestUtils.makeModel();
+    expect(dehydrate(model, irisGridState, gridState)).not.toBe(
+      dehydrate(differentModel, irisGridState, gridState)
+    );
+
+    const differentGridState = {
+      ...gridState,
+      isStuckToBottom: true,
+    };
+    expect(dehydrate(model, irisGridState, gridState)).not.toBe(
+      dehydrate(model, irisGridState, differentGridState)
+    );
+
+    const extraneousGridState = {
+      ...gridState,
+      lastLeft: 10,
+    };
+    expect(dehydrate(model, irisGridState, gridState)).toBe(
+      dehydrate(model, irisGridState, extraneousGridState)
+    );
+
+    const differentIrisGridState = {
+      ...irisGridState,
+      isFilterBarShown: true,
+    };
+    expect(dehydrate(model, irisGridState, gridState)).not.toBe(
+      dehydrate(model, differentIrisGridState, gridState)
+    );
+
+    const extraneousIrisGridState = {
+      ...irisGridState,
+      lastLeft: 10,
+    };
+    expect(dehydrate(model, irisGridState, gridState)).toBe(
+      dehydrate(model, extraneousIrisGridState, gridState)
+    );
+
+    expect(dehydrate(model, irisGridState, gridState)).toBe(
+      dehydrate(model, extraneousIrisGridState, extraneousGridState)
+    );
+  });
+});

--- a/packages/iris-grid/src/IrisGridCacheUtils.ts
+++ b/packages/iris-grid/src/IrisGridCacheUtils.ts
@@ -1,0 +1,157 @@
+/* eslint-disable import/prefer-default-export */
+import { type GridState } from '@deephaven/grid';
+import memoizeOne from 'memoize-one';
+import type IrisGridModel from './IrisGridModel';
+import IrisGridUtils, {
+  type DehydratedGridState,
+  type DehydratedIrisGridState,
+  type HydratedGridState,
+  type HydratedIrisGridState,
+} from './IrisGridUtils';
+
+/**
+ * Checks if 2 grid states are equivalent.
+ * Checks values and does not require referential equality of the entire state, just the values we care about.
+ * @param gridStateA First grid state
+ * @param gridStateB Second grid state
+ * @returns True if the states are equivalent
+ */
+function areGridStatesEqual(
+  gridStateA: HydratedGridState,
+  gridStateB: HydratedGridState
+): boolean {
+  const compareKeys = [
+    'isStuckToBottom',
+    'isStuckToRight',
+    'movedColumns',
+    'movedRows',
+  ] satisfies Array<keyof GridState>;
+  return (
+    gridStateA === gridStateB ||
+    compareKeys.every(key => gridStateA[key] === gridStateB[key])
+  );
+}
+
+/**
+ * Checks if 2 iris grid states are equivalent.
+ * Checks values and does not require referential equality of the entire state, just the values we care about.
+ * @param irisGridStateA First iris grid state
+ * @param irisGridStateB Second iris grid state
+ * @returns True if the states are equivalent
+ */
+function areIrisGridStatesEqual(
+  irisGridStateA: HydratedIrisGridState,
+  irisGridStateB: HydratedIrisGridState
+): boolean {
+  // Top level keys we want to check for referential equality
+  const compareStateKeys = [
+    'advancedFilters',
+    'aggregationSettings',
+    'customColumnFormatMap',
+    'isFilterBarShown',
+    'quickFilters',
+    'customColumns',
+    'reverse',
+    'rollupConfig',
+    'showSearchBar',
+    'searchValue',
+    'selectDistinctColumns',
+    'selectedSearchColumns',
+    'sorts',
+    'invertSearchColumns',
+    'pendingDataMap',
+    'frozenColumns',
+    'conditionalFormats',
+    'columnHeaderGroups',
+    'partitionConfig',
+  ] satisfies Array<keyof HydratedIrisGridState>;
+
+  return (
+    irisGridStateA === irisGridStateB ||
+    (irisGridStateA.metrics != null &&
+      irisGridStateB.metrics != null &&
+      irisGridStateA.metrics.userColumnWidths ===
+        irisGridStateB.metrics.userColumnWidths &&
+      irisGridStateA.metrics.userRowHeights ===
+        irisGridStateB.metrics.userRowHeights &&
+      compareStateKeys.every(
+        key => irisGridStateA[key] === irisGridStateB[key]
+      ))
+  );
+}
+
+/**
+ * Creates a dehydrator function for grid state that is memoized on the last call.
+ * Only tracks 1 state at a time. If the model and input states are equal, returns the same dehydrated state object reference.
+ * @returns A dehydrator function memoized on the last call
+ */
+function makeMemoizedGridStateDehydrator(): (
+  model: IrisGridModel,
+  gridState: HydratedGridState
+) => DehydratedGridState {
+  return memoizeOne(
+    (model: IrisGridModel, gridState: HydratedGridState) =>
+      IrisGridUtils.dehydrateGridState(model, gridState),
+    ([modelA, gridStateA], [modelB, gridStateB]) =>
+      modelA === modelB && areGridStatesEqual(gridStateA, gridStateB)
+  );
+}
+
+/**
+ * Creates a dehydrator function for iris grid state that is memoized on the last call.
+ * Only tracks 1 state at a time. If the model and input states are equal, returns the same dehydrated state object reference.
+ * @returns A dehydrator function memoized on the last call
+ */
+function makeMemoizedIrisGridStateDehydrator(): (
+  model: IrisGridModel,
+  irisGridState: HydratedIrisGridState
+) => DehydratedIrisGridState {
+  return memoizeOne(
+    (model: IrisGridModel, irisGridState: HydratedIrisGridState) => {
+      const irisGridUtils = new IrisGridUtils(model.dh);
+      return irisGridUtils.dehydrateIrisGridState(model, irisGridState);
+    },
+    ([modelA, irisGridStateA], [modelB, irisGridStateB]) =>
+      modelA === modelB &&
+      areIrisGridStatesEqual(irisGridStateA, irisGridStateB)
+  );
+}
+
+/**
+ * Creates a dehydrator function for grid and iris grid state that is memoized on the last call.
+ * Only tracks 1 state at a time. If the model and input states are equal, returns the same dehydrated state object reference.
+ * Combines the dehydrated grid and iris grid states into a single object.
+ * @returns A dehydrator function memoized on the last call
+ */
+function makeMemoizedCombinedGridStateDehydrator(): (
+  model: IrisGridModel,
+  irisGridState: HydratedIrisGridState,
+  gridState: HydratedGridState
+) => DehydratedIrisGridState & DehydratedGridState {
+  return memoizeOne(
+    (
+      model: IrisGridModel,
+      irisGridState: HydratedIrisGridState,
+      gridState: HydratedGridState
+    ): DehydratedIrisGridState & DehydratedGridState => {
+      const irisGridUtils = new IrisGridUtils(model.dh);
+      return {
+        ...irisGridUtils.dehydrateIrisGridState(model, irisGridState),
+        ...IrisGridUtils.dehydrateGridState(model, gridState),
+      };
+    },
+    (
+      [modelA, irisGridStateA, gridStateA],
+      [modelB, irisGridStateB, gridStateB]
+    ) =>
+      modelA === modelB &&
+      areIrisGridStatesEqual(irisGridStateA, irisGridStateB) &&
+      areGridStatesEqual(gridStateA, gridStateB)
+  );
+}
+
+export const IrisGridCacheUtils = {
+  makeMemoizedGridStateDehydrator,
+  makeMemoizedIrisGridStateDehydrator,
+  makeMemoizedCombinedGridStateDehydrator,
+};

--- a/packages/iris-grid/src/IrisGridUtils.test.ts
+++ b/packages/iris-grid/src/IrisGridUtils.test.ts
@@ -1,8 +1,13 @@
 import deepEqual from 'deep-equal';
-import { GridUtils, GridRange, MoveOperation } from '@deephaven/grid';
+import {
+  GridUtils,
+  GridRange,
+  type MoveOperation,
+  type GridMetrics,
+} from '@deephaven/grid';
 import dh from '@deephaven/jsapi-shim';
-import type { Column, Table, Sort } from '@deephaven/jsapi-types';
-import { TypeValue as FilterTypeValue } from '@deephaven/filters';
+import type { dh as DhType } from '@deephaven/jsapi-types';
+import { type TypeValue as FilterTypeValue } from '@deephaven/filters';
 import { DateUtils } from '@deephaven/jsapi-utils';
 import type { AdvancedFilter } from './CommonTypes';
 import { FilterData } from './IrisGrid';
@@ -15,7 +20,7 @@ import IrisGridUtils, {
 const irisGridUtils = new IrisGridUtils(dh);
 const irisGridTestUtils = new IrisGridTestUtils(dh);
 
-function makeColumn(index: number): Column {
+function makeColumn(index: number): DhType.Column {
   return irisGridTestUtils.makeColumn(
     `${index}`,
     IrisGridTestUtils.DEFAULT_TYPE,
@@ -25,8 +30,8 @@ function makeColumn(index: number): Column {
 
 function makeTable({
   columns = irisGridTestUtils.makeColumns(10, 'name_'),
-  sort = [] as Sort[],
-} = {}): Table {
+  sort = [] as DhType.Sort[],
+} = {}): DhType.Table {
   return irisGridTestUtils.makeTable({
     columns,
     sort,
@@ -649,12 +654,51 @@ describe('dehydration methods', () => {
       }),
     ],
     [
-      'dehydrateIrisGridState',
+      'dehydrateGridState',
       IrisGridUtils.dehydrateGridState(irisGridTestUtils.makeModel(), {
         isStuckToBottom: false,
         isStuckToRight: false,
         movedRows: [],
         movedColumns: [],
+      }),
+    ],
+    [
+      'dehydrateIrisGridState',
+      irisGridUtils.dehydrateIrisGridState(irisGridTestUtils.makeModel(), {
+        advancedFilters: new Map(),
+        partitionConfig: {
+          partitions: [],
+          mode: 'merged',
+        },
+        aggregationSettings: {
+          aggregations: [],
+          showOnTop: false,
+        },
+        customColumnFormatMap: new Map(),
+        isFilterBarShown: false,
+        quickFilters: new Map(),
+        customColumns: [],
+        reverse: false,
+        rollupConfig: {
+          columns: [],
+          showConstituents: false,
+          showNonAggregatedColumns: false,
+          includeDescriptions: true,
+        },
+        showSearchBar: false,
+        searchValue: '',
+        selectDistinctColumns: [],
+        selectedSearchColumns: [],
+        sorts: [],
+        invertSearchColumns: false,
+        pendingDataMap: new Map(),
+        frozenColumns: [],
+        conditionalFormats: [],
+        columnHeaderGroups: [],
+        metrics: {
+          userColumnWidths: new Map(),
+          userRowHeights: new Map(),
+        } as GridMetrics,
       }),
     ],
   ])('%s should be serializable', (_label, result) => {

--- a/packages/iris-grid/src/index.ts
+++ b/packages/iris-grid/src/index.ts
@@ -29,3 +29,4 @@ export { default as IrisGridUtils } from './IrisGridUtils';
 export * from './IrisGridUtils';
 export * from './IrisGridMetricCalculator';
 export * from './IrisGridRenderer';
+export * from './IrisGridCacheUtils';


### PR DESCRIPTION
Cherry pick 4 of 5 for usePersistentState

Adds `IrisGridCacheUtils` which provides 3 methods to create memoized dehydrators: `makeMemoizedGridStateDehydrator`,
`makeMemoizedIrisGridStateDehydrator`, and
`makeMemoizedCombinedGridStateDehydrator`. The first 2 are used for `IrisGridPanel` which saves the state under separate keys for `gridState` and `irisGridState`. The 3rd is for newer uses like `UITable` which can just save the combined state and spread it to `IrisGrid` since `IrisGrid` accepts both `GridState` and `IrisGridState` props.

Added tests for `dehydrateIrisGridState`.

Improved the `memoize-one` type override to infer the types of the equality function based on the actual function args.