### PR TITLE
fix: prevent keyboard shortcuts from triggering unwanted behaviour when disconnected

### DIFF
--- a/packages/console/src/notebook/ScriptEditor.tsx
+++ b/packages/console/src/notebook/ScriptEditor.tsx
@@ -86,8 +86,7 @@ class ScriptEditor extends Component<ScriptEditorProps, ScriptEditorState> {
       (sessionLanguage !== undefined && prevLanguageMatch && !languageMatch)
     ) {
       // Session disconnected or language changed from matching the session language to non-matching
-      log.debug('De-init completion and context actions');
-      this.deInitContextActions();
+      log.debug('De-init completion');
       this.deInitCodeCompletion();
     }
 
@@ -98,8 +97,7 @@ class ScriptEditor extends Component<ScriptEditorProps, ScriptEditorState> {
       (sessionLanguage !== undefined && !prevLanguageMatch && languageMatch)
     ) {
       // Session connected with a matching language or notebook language changed to matching
-      log.debug('Init completion and context actions');
-      this.initContextActions();
+      log.debug('Init completion');
       this.initCodeCompletion();
     }
   }
@@ -161,8 +159,11 @@ class ScriptEditor extends Component<ScriptEditorProps, ScriptEditorState> {
     MonacoUtils.setEOL(innerEditor);
     MonacoUtils.registerPasteHandler(innerEditor);
 
+    // Always initialize context actions when the editor is created to ensure that unwanted default
+    // OS shortcuts are overridden by custom shortcuts.
+    this.initContextActions();
+
     if (session != null && settings && sessionLanguage === settings.language) {
-      this.initContextActions();
       this.initCodeCompletion();
     }
 
@@ -185,16 +186,42 @@ class ScriptEditor extends Component<ScriptEditorProps, ScriptEditorState> {
   }
 
   handleRun(): void {
-    const { onRunCommand } = this.props;
+    const { onRunCommand, session, sessionLanguage, settings } = this.props;
     const command = this.getValue();
+
+    const language = settings?.language;
+    const languageMatch = language === sessionLanguage;
+
+    if (session == null || !languageMatch) {
+      log.info(
+        `Run disabled - ${
+          session == null ? 'session disconnected' : 'language mismatch'
+        }`
+      );
+      return;
+    }
+
     if (command != null) {
       onRunCommand(command);
     }
   }
 
   handleRunSelected(): void {
-    const { onRunCommand } = this.props;
+    const { onRunCommand, session, sessionLanguage, settings } = this.props;
     const command = this.getSelectedCommand();
+
+    const language = settings?.language;
+    const languageMatch = language === sessionLanguage;
+
+    if (session == null || !languageMatch) {
+      log.info(
+        `Run selected disabled - ${
+          session == null ? 'session disconnected' : 'language mismatch'
+        }`
+      );
+      return;
+    }
+
     onRunCommand(command);
   }
 


### PR DESCRIPTION
DH-14302: Prevents 'run' and 'run selected' shortcuts from triggering unintended behavior when session disconnects or if there is a language mismatch.

Changes:
- Always initialize contextActions when editor is created
- Only cleanup contextActions when editor is destroyed
- Add session/language checks to the shortcut handlers

When the session is disconnected, or the notebook language does not match the session (e.g. running a Groovy notebook with a Python session), the 'run' and 'run selected' shortcuts will log a message to console instead of falling back to default browser/OS behavior.