### PR TITLE
fix: Download worker and monaco initializing multiple times in dev

### DIFF
--- a/packages/code-studio/src/AppRoot.tsx
+++ b/packages/code-studio/src/AppRoot.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { MonacoUtils } from '@deephaven/console';
 import { DownloadServiceWorkerUtils } from '@deephaven/iris-grid';
 import MonacoWorker from 'monaco-editor/esm/vs/editor/editor.worker?worker';
@@ -11,25 +11,28 @@ if (import.meta.env.VITE_PLAYWRIGHT_CSS === '1') {
 }
 
 export function AppRoot(): JSX.Element {
-  DownloadServiceWorkerUtils.register(
-    new URL(
-      `${import.meta.env.BASE_URL ?? ''}download/serviceWorker.js`,
-      window.location.href
-    )
-  );
-  MonacoUtils.init({
-    getWorker: (id: string, label: string) => {
-      if (label === 'json') {
-        return new MonacoJsonWorker();
-      }
-      return new MonacoWorker();
-    },
-  });
+  useEffect(function init() {
+    DownloadServiceWorkerUtils.register(
+      new URL(
+        `${import.meta.env.BASE_URL ?? ''}download/serviceWorker.js`,
+        window.location.href
+      )
+    );
 
-  // disable annoying dnd-react warnings
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
-  window['__react-beautiful-dnd-disable-dev-warnings'] = true;
+    MonacoUtils.init({
+      getWorker: (id: string, label: string) => {
+        if (label === 'json') {
+          return new MonacoJsonWorker();
+        }
+        return new MonacoWorker();
+      },
+    });
+
+    // disable annoying dnd-react warnings
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    window['__react-beautiful-dnd-disable-dev-warnings'] = true;
+  }, []);
 
   return <AppRouter />;
 }

--- a/packages/code-studio/src/styleguide/StyleGuideRoot.tsx
+++ b/packages/code-studio/src/styleguide/StyleGuideRoot.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Provider } from 'react-redux';
 import { FontBootstrap } from '@deephaven/app-utils';
 import '@deephaven/components/scss/BaseStyleSheet.scss';
@@ -9,18 +9,20 @@ import MonacoWorker from 'monaco-editor/esm/vs/editor/editor.worker?worker';
 import StyleGuideInit from './StyleGuideInit';
 
 export function StyleGuideRoot(): JSX.Element {
-  DownloadServiceWorkerUtils.register(
-    new URL(
-      `${import.meta.env.BASE_URL ?? ''}download/serviceWorker.js`,
-      window.location.href
-    )
-  );
-  MonacoUtils.init({ getWorker: () => new MonacoWorker() });
+  useEffect(function init() {
+    DownloadServiceWorkerUtils.register(
+      new URL(
+        `${import.meta.env.BASE_URL ?? ''}download/serviceWorker.js`,
+        window.location.href
+      )
+    );
+    MonacoUtils.init({ getWorker: () => new MonacoWorker() });
 
-  // disable annoying dnd-react warnings
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
-  window['__react-beautiful-dnd-disable-dev-warnings'] = true;
+    // disable annoying dnd-react warnings
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    window['__react-beautiful-dnd-disable-dev-warnings'] = true;
+  }, []);
 
   return (
     <FontBootstrap>


### PR DESCRIPTION
I noticed my console logs spammed with `Registering service worker` in dev mode (with dh.ui tables/panels with tables) and multiple service workers in the sources tab.

This doesn't seem to be an issue in prod, so I'm guessing it has something to do with React dev mode. I also think previously these initializers were actually at the root, but now they are under a bunch of contexts that can be changed and cause the dev re-render.

Didn't see the same behavior in enterprise where these inits are either under a `useEffect` or above the contexts at the root.