### PR TITLE
feat: DH-18840: Add dx linker support

### DIFF
--- a/packages/dashboard-core-plugins/src/linker/LinkerUtils.ts
+++ b/packages/dashboard-core-plugins/src/linker/LinkerUtils.ts
@@ -92,6 +92,7 @@ class LinkerUtils {
         LayoutUtils.getComponentName(IrisGridPanel),
         LayoutUtils.getComponentName(ChartPanel),
         LayoutUtils.getComponentName(DropdownFilterPanel),
+        '@deephaven/plotly-express',
       ],
     ],
   ]);
@@ -154,6 +155,7 @@ class LinkerUtils {
     // If all checks pass, link type is determined by the target panel component
     switch (end.panelComponent) {
       case LayoutUtils.getComponentName(ChartPanel):
+      case '@deephaven/plotly-express':
         return 'chartLink';
       case LayoutUtils.getComponentName(IrisGridPanel):
         return 'tableLink';


### PR DESCRIPTION
This requires https://github.com/deephaven/deephaven-plugins/pull/1185 for full support, but this is all that's needed to support linker directly with those changes.