### PR TITLE
feat: DH-19632: Add shortcuts to cycle stacks and panels

### DIFF
--- a/packages/code-studio/src/main/AppMainContainer.tsx
+++ b/packages/code-studio/src/main/AppMainContainer.tsx
@@ -40,6 +40,10 @@ import {
   setDashboardData as setDashboardDataAction,
   setDashboardPluginData as setDashboardPluginDataAction,
   updateDashboardData as updateDashboardDataAction,
+  emitCycleToNextStack,
+  emitCycleToPreviousStack,
+  emitCycleToNextTab,
+  emitCycleToPreviousTab,
 } from '@deephaven/dashboard';
 import {
   ConsolePlugin,
@@ -441,19 +445,19 @@ export class AppMainContainer extends Component<
   }
 
   sendCycleStackForward(): void {
-    this.emitLayoutEvent(PanelEvent.CYCLE_TO_NEXT_STACK);
+    emitCycleToNextStack(this.getActiveEventHub());
   }
 
   sendCycleStackBackward(): void {
-    this.emitLayoutEvent(PanelEvent.CYCLE_TO_PREVIOUS_STACK);
+    emitCycleToPreviousStack(this.getActiveEventHub());
   }
 
   sendCycleTabForward(): void {
-    this.emitLayoutEvent(PanelEvent.CYCLE_TO_NEXT_TAB);
+    emitCycleToNextTab(this.getActiveEventHub());
   }
 
   sendCycleTabBackward(): void {
-    this.emitLayoutEvent(PanelEvent.CYCLE_TO_PREVIOUS_TAB);
+    emitCycleToPreviousTab(this.getActiveEventHub());
   }
 
   sendReopenLast(): void {

--- a/packages/code-studio/src/main/AppMainContainer.tsx
+++ b/packages/code-studio/src/main/AppMainContainer.tsx
@@ -14,6 +14,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import {
   ContextActions,
   GLOBAL_SHORTCUTS,
+  NAVIGATION_SHORTCUTS,
   Popper,
   type ContextAction,
   Button,
@@ -237,6 +238,34 @@ export class AppMainContainer extends Component<
         },
         {
           action: () => {
+            this.sendCycleStackForward();
+          },
+          shortcut: NAVIGATION_SHORTCUTS.CYCLE_TO_NEXT_STACK,
+          isGlobal: true,
+        },
+        {
+          action: () => {
+            this.sendCycleStackBackward();
+          },
+          shortcut: NAVIGATION_SHORTCUTS.CYCLE_TO_PREVIOUS_STACK,
+          isGlobal: true,
+        },
+        {
+          action: () => {
+            this.sendCycleTabForward();
+          },
+          shortcut: NAVIGATION_SHORTCUTS.CYCLE_TO_NEXT_TAB,
+          isGlobal: true,
+        },
+        {
+          action: () => {
+            this.sendCycleTabBackward();
+          },
+          shortcut: NAVIGATION_SHORTCUTS.CYCLE_TO_PREVIOUS_TAB,
+          isGlobal: true,
+        },
+        {
+          action: () => {
             this.sendReopenLast();
           },
           shortcut: GLOBAL_SHORTCUTS.REOPEN_CLOSED_PANEL,
@@ -409,6 +438,22 @@ export class AppMainContainer extends Component<
 
   sendClearFilter(): void {
     this.emitLayoutEvent(InputFilterEvent.CLEAR_ALL_FILTERS);
+  }
+
+  sendCycleStackForward(): void {
+    this.emitLayoutEvent(PanelEvent.CYCLE_TO_NEXT_STACK);
+  }
+
+  sendCycleStackBackward(): void {
+    this.emitLayoutEvent(PanelEvent.CYCLE_TO_PREVIOUS_STACK);
+  }
+
+  sendCycleTabForward(): void {
+    this.emitLayoutEvent(PanelEvent.CYCLE_TO_NEXT_TAB);
+  }
+
+  sendCycleTabBackward(): void {
+    this.emitLayoutEvent(PanelEvent.CYCLE_TO_PREVIOUS_TAB);
   }
 
   sendReopenLast(): void {

--- a/packages/components/src/shortcuts/NavigationShortcuts.ts
+++ b/packages/components/src/shortcuts/NavigationShortcuts.ts
@@ -1,0 +1,35 @@
+import ShortcutRegistry from './ShortcutRegistry';
+import { MODIFIER, KEY } from './Shortcut';
+
+const NAVIGATION_SHORTCUTS = {
+  CYCLE_TO_NEXT_STACK: ShortcutRegistry.createAndAdd({
+    id: 'NAVIGATION.CYCLE_TO_NEXT_STACK',
+    name: 'Cycle To Next Stack',
+    shortcut: [MODIFIER.CTRL, KEY.SINGLE_QUOTE],
+    macShortcut: [MODIFIER.CMD, KEY.SINGLE_QUOTE],
+    isEditable: true,
+  }),
+  CYCLE_TO_PREVIOUS_STACK: ShortcutRegistry.createAndAdd({
+    id: 'NAVIGATION.CYCLE_TO_PREVIOUS_STACK',
+    name: 'Cycle To Previous Stack',
+    shortcut: [MODIFIER.CTRL, KEY.SEMICOLON],
+    macShortcut: [MODIFIER.CMD, KEY.SEMICOLON],
+    isEditable: true,
+  }),
+  CYCLE_TO_NEXT_TAB: ShortcutRegistry.createAndAdd({
+    id: 'NAVIGATION.CYCLE_TO_NEXT_TAB',
+    name: 'Cycle To Next Tab',
+    shortcut: [MODIFIER.CTRL, MODIFIER.SHIFT, KEY.SINGLE_QUOTE],
+    macShortcut: [MODIFIER.CMD, MODIFIER.SHIFT, KEY.SINGLE_QUOTE],
+    isEditable: true,
+  }),
+  CYCLE_TO_PREVIOUS_TAB: ShortcutRegistry.createAndAdd({
+    id: 'NAVIGATION.CYCLE_TO_PREVIOUS_TAB',
+    name: 'Cycle To Previous TAB',
+    shortcut: [MODIFIER.CTRL, MODIFIER.SHIFT, KEY.SEMICOLON],
+    macShortcut: [MODIFIER.CMD, MODIFIER.SHIFT, KEY.SEMICOLON],
+    isEditable: true,
+  }),
+};
+
+export default NAVIGATION_SHORTCUTS;

--- a/packages/components/src/shortcuts/NavigationShortcuts.ts
+++ b/packages/components/src/shortcuts/NavigationShortcuts.ts
@@ -19,14 +19,14 @@ const NAVIGATION_SHORTCUTS = {
   CYCLE_TO_NEXT_TAB: ShortcutRegistry.createAndAdd({
     id: 'NAVIGATION.CYCLE_TO_NEXT_TAB',
     name: 'Cycle To Next Tab',
-    shortcut: [MODIFIER.CTRL, MODIFIER.SHIFT, KEY.SINGLE_QUOTE],
+    shortcut: [MODIFIER.CTRL, MODIFIER.SHIFT, KEY.DOUBLE_QUOTE],
     macShortcut: [MODIFIER.CMD, MODIFIER.SHIFT, KEY.SINGLE_QUOTE],
     isEditable: true,
   }),
   CYCLE_TO_PREVIOUS_TAB: ShortcutRegistry.createAndAdd({
     id: 'NAVIGATION.CYCLE_TO_PREVIOUS_TAB',
     name: 'Cycle To Previous TAB',
-    shortcut: [MODIFIER.CTRL, MODIFIER.SHIFT, KEY.SEMICOLON],
+    shortcut: [MODIFIER.CTRL, MODIFIER.SHIFT, KEY.COLON],
     macShortcut: [MODIFIER.CMD, MODIFIER.SHIFT, KEY.SEMICOLON],
     isEditable: true,
   }),

--- a/packages/components/src/shortcuts/index.ts
+++ b/packages/components/src/shortcuts/index.ts
@@ -1,4 +1,5 @@
 export { default as GLOBAL_SHORTCUTS } from './GlobalShortcuts';
+export { default as NAVIGATION_SHORTCUTS } from './NavigationShortcuts';
 export { default as Shortcut } from './Shortcut';
 export * from './Shortcut';
 export { default as ShortcutRegistry } from './ShortcutRegistry';

--- a/packages/dashboard/src/NavigationEvent.ts
+++ b/packages/dashboard/src/NavigationEvent.ts
@@ -1,0 +1,34 @@
+import { makeEventFunctions } from '@deephaven/golden-layout';
+
+const NavigationEvent = Object.freeze({
+  CYCLE_TO_NEXT_STACK: 'NavigationEvent.CYCLE_TO_NEXT_STACK',
+  CYCLE_TO_PREVIOUS_STACK: 'NavigationEvent.CYCLE_TO_PREVIOUS_STACK',
+  CYCLE_TO_NEXT_TAB: 'NavigationEvent.CYCLE_TO_NEXT_TAB',
+  CYCLE_TO_PREVIOUS_TAB: 'NavigationEvent.CYCLE_TO_PREVIOUS_TAB',
+});
+
+export const {
+  listen: listenForCycleToNextStack,
+  emit: emitCycleToNextStack,
+  useListener: useCycleToNextStackListener,
+} = makeEventFunctions(NavigationEvent.CYCLE_TO_NEXT_STACK);
+
+export const {
+  listen: listenForCycleToPreviousStack,
+  emit: emitCycleToPreviousStack,
+  useListener: useCycleToPreviousStackListener,
+} = makeEventFunctions(NavigationEvent.CYCLE_TO_PREVIOUS_STACK);
+
+export const {
+  listen: listenForCycleToNextTab,
+  emit: emitCycleToNextTab,
+  useListener: useCycleToNextTabListener,
+} = makeEventFunctions(NavigationEvent.CYCLE_TO_NEXT_TAB);
+
+export const {
+  listen: listenForCycleToPreviousTab,
+  emit: emitCycleToPreviousTab,
+  useListener: useCycleToPreviousTabListener,
+} = makeEventFunctions(NavigationEvent.CYCLE_TO_PREVIOUS_TAB);
+
+export default NavigationEvent;

--- a/packages/dashboard/src/PanelEvent.ts
+++ b/packages/dashboard/src/PanelEvent.ts
@@ -70,18 +70,6 @@ export const PanelEvent = Object.freeze({
 
   // Panel is dropped
   DROPPED: 'PanelEvent.DROPPED',
-
-  // Event to change focus to next stack
-  CYCLE_TO_NEXT_STACK: 'PanelEvent.CYCLE_TO_NEXT_STACK',
-
-  // Event to change focus to previous stack
-  CYCLE_TO_PREVIOUS_STACK: 'PanelEvent.CYCLE_TO_PREVIOUS_STACK',
-
-  // Event to change focus to next tab
-  CYCLE_TO_NEXT_TAB: 'PanelEvent.CYCLE_TO_NEXT_TAB',
-
-  // Event to change focus to previous tab
-  CYCLE_TO_PREVIOUS_TAB: 'PanelEvent.CYCLE_TO_PREVIOUS_TAB',
 });
 
 export const {

--- a/packages/dashboard/src/PanelEvent.ts
+++ b/packages/dashboard/src/PanelEvent.ts
@@ -70,6 +70,18 @@ export const PanelEvent = Object.freeze({
 
   // Panel is dropped
   DROPPED: 'PanelEvent.DROPPED',
+
+  // Event to change focus to next stack
+  CYCLE_TO_NEXT_STACK: 'PanelEvent.CYCLE_TO_NEXT_STACK',
+
+  // Event to change focus to previous stack
+  CYCLE_TO_PREVIOUS_STACK: 'PanelEvent.CYCLE_TO_PREVIOUS_STACK',
+
+  // Event to change focus to next tab
+  CYCLE_TO_NEXT_TAB: 'PanelEvent.CYCLE_TO_NEXT_TAB',
+
+  // Event to change focus to previous tab
+  CYCLE_TO_PREVIOUS_TAB: 'PanelEvent.CYCLE_TO_PREVIOUS_TAB',
 });
 
 export const {

--- a/packages/dashboard/src/index.ts
+++ b/packages/dashboard/src/index.ts
@@ -14,5 +14,6 @@ export * from './layout';
 export * from './redux';
 export * from './PanelManager';
 export * from './PanelEvent';
+export * from './NavigationEvent';
 export { default as PanelErrorBoundary } from './PanelErrorBoundary';
 export { default as PanelManager } from './PanelManager';

--- a/packages/dashboard/src/layout/LayoutUtils.ts
+++ b/packages/dashboard/src/layout/LayoutUtils.ts
@@ -176,22 +176,18 @@ class LayoutUtils {
 
   /**
    * Get the index of the stack that is currently focused
-   * @param layout GoldenLayout instance
+   * @param allStacks All the stacks
    * @returns The focused stack's index or -1 if not found
    */
-  static getFocusedStackIndex(layout: GoldenLayout): number {
-    const allStacks = LayoutUtils.getAllStackContainers(layout);
-
+  static getFocusedStackIndex(allStacks: Stack[]): number {
     // NOTE: We target the 'lm_focusin' class because GoldenLayout automatically applies this class
     // to tab elements when they receive focus. Until we enhance focus tracking in GoldenLayout, we
     // will have to rely on this internal CSS class.
-    const foundIndex = allStacks.findIndex(stack =>
+    return allStacks.findIndex(stack =>
       stack.header.tabs.some(tab =>
         tab.element[0].classList.contains('lm_focusin')
       )
     );
-
-    return foundIndex;
   }
 
   /**
@@ -201,17 +197,8 @@ class LayoutUtils {
    */
   static getFocusedStack(layout: GoldenLayout): Stack | undefined {
     const allStacks = LayoutUtils.getAllStackContainers(layout);
-
-    // NOTE: We target the 'lm_focusin' class because GoldenLayout automatically applies this class
-    // to tab elements when they receive focus. Until we enhance focus tracking in GoldenLayout, we
-    // will have to rely on this internal CSS class.
-    const focusedStack = allStacks.find(stack =>
-      stack.header.tabs.some(tab =>
-        tab.element[0].classList.contains('lm_focusin')
-      )
-    );
-
-    return focusedStack;
+    const focusedStackIndex = LayoutUtils.getFocusedStackIndex(allStacks);
+    return allStacks[focusedStackIndex];
   }
 
   /**

--- a/packages/dashboard/src/layout/LayoutUtils.ts
+++ b/packages/dashboard/src/layout/LayoutUtils.ts
@@ -165,6 +165,56 @@ class LayoutUtils {
   }
 
   /**
+   * Gets all stack containers in the layout
+   * @param layout GoldenLayout instance
+   * @returns The found stack containers
+   */
+  static getAllStackContainers(layout: GoldenLayout): Stack[] {
+    // eslint-disable-next-line no-underscore-dangle
+    return layout._findAllStackContainers();
+  }
+
+  /**
+   * Get the index of the stack that is currently focused
+   * @param layout GoldenLayout instance
+   * @returns The focused stack's index or -1 if not found
+   */
+  static getFocusedStackIndex(layout: GoldenLayout): number {
+    const allStacks = LayoutUtils.getAllStackContainers(layout);
+
+    // NOTE: We target the 'lm_focusin' class because GoldenLayout automatically applies this class
+    // to tab elements when they receive focus. Until we enhance focus tracking in GoldenLayout, we
+    // will have to rely on this internal CSS class.
+    const foundIndex = allStacks.findIndex(stack =>
+      stack.header.tabs.some(tab =>
+        tab.element[0].classList.contains('lm_focusin')
+      )
+    );
+
+    return foundIndex;
+  }
+
+  /**
+   * Get the stack that is currently focused
+   * @param layout GoldenLayout instance
+   * @returns The focused stack or undefined if none found
+   */
+  static getFocusedStack(layout: GoldenLayout): Stack | undefined {
+    const allStacks = LayoutUtils.getAllStackContainers(layout);
+
+    // NOTE: We target the 'lm_focusin' class because GoldenLayout automatically applies this class
+    // to tab elements when they receive focus. Until we enhance focus tracking in GoldenLayout, we
+    // will have to rely on this internal CSS class.
+    const focusedStack = allStacks.find(stack =>
+      stack.header.tabs.some(tab =>
+        tab.element[0].classList.contains('lm_focusin')
+      )
+    );
+
+    return focusedStack;
+  }
+
+  /**
    * Gets a stack by its ID
    * @param item Golden layout content item to search for the stack
    * @param searchId the ID

--- a/packages/golden-layout/src/items/Component.ts
+++ b/packages/golden-layout/src/items/Component.ts
@@ -86,9 +86,9 @@ export default class Component extends AbstractContentItem {
     AbstractContentItem.prototype._$hide.call(this);
   }
 
-  _$show() {
+  _$show(forceFocus?: boolean) {
     this.container.show();
-    if (this.container._config.isFocusOnShow) {
+    if (this.container._config.isFocusOnShow || forceFocus) {
       // focus the shown container element on show
       // preventScroll isn't supported in safari, but also doesn't matter for illumon when 100% window
       this.container._contentElement[0].focus({ preventScroll: true });

--- a/packages/golden-layout/src/items/Stack.ts
+++ b/packages/golden-layout/src/items/Stack.ts
@@ -145,7 +145,7 @@ export default class Stack extends AbstractContentItem {
     }
   }
 
-  setActiveContentItem(contentItem: AbstractContentItem) {
+  setActiveContentItem(contentItem: AbstractContentItem, forceFocus?: boolean) {
     if (this.contentItems.indexOf(contentItem) === -1) {
       throw new Error('contentItem is not a child of this stack');
     }
@@ -156,7 +156,11 @@ export default class Stack extends AbstractContentItem {
 
     this._activeContentItem = contentItem;
     this.header.setActiveContentItem(contentItem);
-    contentItem._$show();
+    if (isComponent(contentItem)) {
+      contentItem._$show(forceFocus);
+    } else {
+      contentItem._$show();
+    }
     this.emit('activeContentItemChanged', contentItem);
     this.layoutManager.emit('activeContentItemChanged', contentItem);
     this.emitBubblingEvent('stateChanged');


### PR DESCRIPTION
Part of DH-19632. Introduces keyboard navigation to cycle between and within stacks. Navigating through shortcuts activates content items and respects any existing active selections.

`Ctrl + '` / `Ctrl + ;`: to cycle forward/backward between different stacks in the layout
`Ctrl + Shift + '` / `Ctrl + Shift + ;`: to cycle forward/backward between tabs within the currently focused stack

Changes:
- Create`NavigationEvent` system
- Implement stack and tab cycling handlers in `PanelManager`
- Add `getFocusedStack()` and `getFocusedStackIndex()` helper methods to `LayoutUtils` for focus detection
- Add `forceFocus` parameter that bypasses the normal `isFocusonShow` check