### PR TITLE
refactor: Rename DhIdContext to PanelIdContext

### DIFF
--- a/packages/dashboard/src/DashboardLayout.tsx
+++ b/packages/dashboard/src/DashboardLayout.tsx
@@ -36,7 +36,7 @@ import {
   type PanelProps,
 } from './DashboardPlugin';
 import DashboardPanelWrapper from './DashboardPanelWrapper';
-import { DhIdContext } from './useDhId';
+import { PanelIdContext } from './usePanelId';
 
 export type DashboardLayoutConfig = ItemConfig[];
 
@@ -142,7 +142,7 @@ export function DashboardLayout({
         const panelId = LayoutUtils.getIdFromContainer(glContainer);
         return (
           <PanelErrorBoundary glContainer={glContainer} glEventHub={glEventHub}>
-            <DhIdContext.Provider value={panelId as string | null}>
+            <PanelIdContext.Provider value={panelId as string | null}>
               {/* eslint-disable-next-line react/jsx-props-no-spreading */}
               <PanelWrapperType {...props}>
                 {hasRef ? (
@@ -153,7 +153,7 @@ export function DashboardLayout({
                   <CType {...props} />
                 )}
               </PanelWrapperType>
-            </DhIdContext.Provider>
+            </PanelIdContext.Provider>
           </PanelErrorBoundary>
         );
       }

--- a/packages/dashboard/src/index.ts
+++ b/packages/dashboard/src/index.ts
@@ -18,3 +18,4 @@ export { default as PanelErrorBoundary } from './PanelErrorBoundary';
 export { default as PanelManager } from './PanelManager';
 export * from './useDashboardId';
 export * from './useDhId';
+export * from './usePanelId';

--- a/packages/dashboard/src/useDhId.test.tsx
+++ b/packages/dashboard/src/useDhId.test.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { renderHook } from '@testing-library/react-hooks';
-import { DhIdContext, useDhId, DH_ID_PROP } from './useDhId';
+import { useDhId, DH_ID_PROP } from './useDhId';
 import { FiberProvider } from './useFiber';
+import { PanelIdContext } from './usePanelId';
 
 describe('useDhId', () => {
   it('should use __dhId prop if no context', () => {
@@ -30,14 +31,14 @@ describe('useDhId', () => {
     const { result } = renderHook(() => useDhId(), {
       wrapper: ({ children }) => (
         <FiberProvider>
-          <DhIdContext.Provider value={mockContextDhId}>
+          <PanelIdContext.Provider value={mockContextDhId}>
             {React.Children.map(children, c => {
               if (React.isValidElement(c)) {
                 return React.cloneElement(c, { [DH_ID_PROP]: mockDhId });
               }
               return c;
             })}
-          </DhIdContext.Provider>
+          </PanelIdContext.Provider>
         </FiberProvider>
       ),
     });
@@ -51,9 +52,9 @@ describe('useDhId', () => {
     const { result } = renderHook(() => useDhId(), {
       wrapper: ({ children }) => (
         <FiberProvider>
-          <DhIdContext.Provider value={mockDhId}>
+          <PanelIdContext.Provider value={mockDhId}>
             {children}
-          </DhIdContext.Provider>
+          </PanelIdContext.Provider>
         </FiberProvider>
       ),
     });

--- a/packages/dashboard/src/useDhId.ts
+++ b/packages/dashboard/src/useDhId.ts
@@ -1,12 +1,10 @@
-import { createContext, useContext } from 'react';
 import Log from '@deephaven/log';
 import { useFiber } from './useFiber';
+import { usePanelId } from './usePanelId';
 
 const log = Log.module('useDhId');
 
 export const DH_ID_PROP = '__dhId';
-
-export const DhIdContext = createContext<string | null>(null);
 
 /**
  * Gets the Deephaven ID of a component.
@@ -14,7 +12,7 @@ export const DhIdContext = createContext<string | null>(null);
  * Usually this is just a panel ID, but in some contexts such as dh.ui,
  * it may be an ID for a component within a panel.
  *
- * Looks for a __dhId prop on the component, and if not found, looks in the DhIdContext.
+ * Looks for a __dhId prop on the component, and if not found, looks in the PanelIdContext.
  * @param props The props of the component using this hook
  * @returns The Deephaven ID of the component or null if not found.
  */
@@ -23,7 +21,7 @@ export function useDhId(): string | null {
   const props =
     (useFiber()?.pendingProps as Record<string, unknown> | undefined) ?? {};
   const dhIdProp = props[DH_ID_PROP];
-  const dhId = useContext(DhIdContext);
+  const panelId = usePanelId();
 
   if (dhIdProp != null) {
     if (typeof dhIdProp !== 'string') {
@@ -34,12 +32,12 @@ export function useDhId(): string | null {
     return dhIdProp;
   }
 
-  if (dhId == null) {
+  if (panelId == null) {
     log.warn(
-      `useDhId must be used within a DhIdContext provider if there is no ${DH_ID_PROP} prop. Defaulting to null.`
+      `useDhId must be used within a PanelIdContext provider if there is no ${DH_ID_PROP} prop. Defaulting to null.`
     );
     return null;
   }
 
-  return dhId;
+  return panelId;
 }

--- a/packages/dashboard/src/usePanelId.ts
+++ b/packages/dashboard/src/usePanelId.ts
@@ -1,0 +1,14 @@
+import { createContext, useContext } from 'react';
+
+/**
+ * Context to provide the golden layout panel ID.
+ */
+export const PanelIdContext = createContext<string | null>(null);
+
+/**
+ * Gets the current panel ID from the nearest context.
+ * @returns The current panel ID from the context, or null if not set or there is no context.
+ */
+export function usePanelId(): string | null {
+  return useContext(PanelIdContext);
+}


### PR DESCRIPTION
Not breaking because `DhIdContext` was added recently and is not in any releases