### PR TITLE
fix: DH-19693: Add null/empty formatting to constituent strings

### DIFF
--- a/packages/iris-grid/src/IrisGridTreeTableModel.test.ts
+++ b/packages/iris-grid/src/IrisGridTreeTableModel.test.ts
@@ -4,6 +4,7 @@ import { type dh as DhType } from '@deephaven/jsapi-types';
 import { TestUtils } from '@deephaven/test-utils';
 import { act } from 'react-dom/test-utils';
 import IrisGridTestUtils from './IrisGridTestUtils';
+import IrisGridTableModelTemplate from './IrisGridTableModelTemplate';
 import IrisGridTreeTableModel, {
   type UITreeRow,
 } from './IrisGridTreeTableModel';
@@ -314,6 +315,143 @@ describe('IrisGridTreeTableModel colorForCell and textAlignForCell', () => {
       mockCell('ignored', undefined, constituentColumn, rows.parent);
       const result = model.textAlignForCell(0, 0);
       expect(result).toBe('left');
+    });
+  });
+});
+
+describe('IrisGridTreeTableModel textForCell', () => {
+  let model: IrisGridTreeTableModel;
+
+  const columns = {
+    string: irisGridTestUtils.makeColumn('StrCol', 'java.lang.String', 0),
+    stringColWithStringConstituent: {
+      ...irisGridTestUtils.makeColumn('StrCol', 'java.lang.String', 0),
+      constituentType: 'java.lang.String',
+    },
+    stringColWithIntConstituent: {
+      ...irisGridTestUtils.makeColumn('IntCol', 'int', 0),
+      constituentType: 'int',
+    } as DhType.Column,
+  };
+
+  const rows = {
+    leaf: {
+      data: new Map(),
+      hasChildren: false,
+      isExpanded: false,
+      depth: 2,
+    } as UITreeRow,
+    parent: {
+      data: new Map(),
+      hasChildren: true,
+      isExpanded: false,
+      depth: 1,
+    } as UITreeRow,
+  };
+
+  beforeEach(() => {
+    const testColumns = irisGridTestUtils.makeColumns();
+    const table = irisGridTestUtils.makeTreeTable(
+      testColumns,
+      testColumns.slice(0, 1),
+      100,
+      []
+    );
+    model = new IrisGridTreeTableModel(dh, table);
+  });
+
+  const mockTextCell = (
+    value: unknown,
+    column: DhType.Column,
+    row: UITreeRow,
+    displayText?: string
+  ) => {
+    jest.spyOn(model, 'sourceColumn').mockReturnValue(column);
+    jest.spyOn(model, 'row').mockReturnValue(row);
+    jest.spyOn(model, 'valueForCell').mockReturnValue(value);
+    if (displayText !== undefined) {
+      jest.spyOn(model, 'displayString').mockReturnValue(displayText);
+    }
+  };
+
+  describe('leaf nodes with non-string constituent type', () => {
+    it('handles null values', () => {
+      jest
+        .spyOn(model, 'columns', 'get')
+        .mockReturnValue([columns.stringColWithIntConstituent]);
+      mockTextCell(null, columns.stringColWithIntConstituent, rows.leaf, '');
+      const result = model.textForCell(0, 0);
+      expect(result).toBe('');
+    });
+
+    it('handles normal values', () => {
+      jest
+        .spyOn(model, 'columns', 'get')
+        .mockReturnValue([columns.stringColWithIntConstituent]);
+      mockTextCell(21, columns.stringColWithIntConstituent, rows.leaf, '21');
+      const result = model.textForCell(0, 0);
+      expect(result).toBe('21');
+    });
+  });
+
+  describe('leaf nodes with formatter settings', () => {
+    beforeEach(() => {
+      jest.spyOn(model, 'columns', 'get').mockReturnValue([columns.string]);
+    });
+
+    it('shows "null" when showNullStrings is true', () => {
+      model.formatter.showNullStrings = true;
+      mockTextCell(null, columns.stringColWithIntConstituent, rows.leaf, '');
+      const result = model.textForCell(0, 0);
+      expect(result).toBe('null');
+    });
+
+    it('shows empty string when showNullStrings is false', () => {
+      model.formatter.showNullStrings = false;
+      mockTextCell(null, columns.stringColWithIntConstituent, rows.leaf, '');
+      const result = model.textForCell(0, 0);
+      expect(result).toBe('');
+    });
+
+    it('shows "empty" when showEmptyStrings is true', () => {
+      model.formatter.showEmptyStrings = true;
+      mockTextCell('', columns.stringColWithIntConstituent, rows.leaf, '');
+      const result = model.textForCell(0, 0);
+      expect(result).toBe('empty');
+    });
+
+    it('shows empty string when showEmptyStrings is false', () => {
+      model.formatter.showEmptyStrings = false;
+      mockTextCell('', columns.stringColWithIntConstituent, rows.leaf, '');
+      const result = model.textForCell(0, 0);
+      expect(result).toBe('');
+    });
+  });
+
+  describe('grouping column edge cases', () => {
+    it('shows empty string for null values in rollup grouping columns', () => {
+      jest
+        .spyOn(model, 'getCachedGroupedColumnSet')
+        .mockReturnValue(new Set([0]));
+      mockTextCell(null, columns.string, { ...rows.parent, depth: 1 });
+      const result = model.textForCell(0, 0);
+      expect(result).toBe('');
+    });
+  });
+
+  describe('non-leaf nodes', () => {
+    it('delegates to superClass for parent nodes', () => {
+      jest
+        .spyOn(IrisGridTableModelTemplate.prototype, 'textForCell')
+        .mockReturnValue('parentString');
+      mockTextCell(
+        'parentString',
+        columns.stringColWithIntConstituent,
+        rows.parent,
+        'parentString'
+      );
+      const result = model.textForCell(0, 0);
+      expect(result).toBe('parentString');
     });
   });
 });

--- a/packages/iris-grid/src/IrisGridTreeTableModel.test.ts
+++ b/packages/iris-grid/src/IrisGridTreeTableModel.test.ts
@@ -428,8 +428,11 @@ describe('IrisGridTreeTableModel textForCell', () => {
     });
   });
 
-  describe('grouping column edge cases', () => {
+  describe('grouping column', () => {
     it('shows empty string for null values in rollup grouping columns', () => {
+      Object.defineProperty(model.table, 'groupedColumns', {
+        value: [],
+      });
       jest
         .spyOn(model, 'getCachedGroupedColumnSet')
         .mockReturnValue(new Set([0]));

--- a/packages/iris-grid/src/IrisGridTreeTableModel.ts
+++ b/packages/iris-grid/src/IrisGridTreeTableModel.ts
@@ -166,7 +166,7 @@ class IrisGridTreeTableModel extends IrisGridTableModelTemplate<
         );
 
         if (TableUtils.isTextType(this.columns[x]?.type)) {
-          if (text === null) {
+          if (value === null) {
             return this.formatter.showNullStrings ? 'null' : '';
           }
 

--- a/packages/iris-grid/src/IrisGridTreeTableModel.ts
+++ b/packages/iris-grid/src/IrisGridTreeTableModel.ts
@@ -159,8 +159,25 @@ class IrisGridTreeTableModel extends IrisGridTableModelTemplate<
     if (row != null && column != null) {
       if (!row.hasChildren && column.constituentType != null) {
         const value = this.valueForCell(x, y);
-        return this.displayString(value, column.constituentType, column.name);
+        const text = this.displayString(
+          value,
+          column.constituentType,
+          column.name
+        );
+
+        if (TableUtils.isTextType(this.columns[x]?.type)) {
+          if (text === null) {
+            return this.formatter.showNullStrings ? 'null' : '';
+          }
+
+          if (text === '') {
+            return this.formatter.showEmptyStrings ? 'empty' : '';
+          }
+        }
+
+        return text;
       }
+
       // Show empty string instead of null in rollup grouping columns (issue #1483)
       if (
         row.hasChildren &&


### PR DESCRIPTION
Part of DH-19693. Anything that renders as "empty" for empty strings, and "null" for null strings, should still render the same when rolledup. This adds the missing null and empty string formatting logic for tree table constituent values.

Changes:
- Checks if the result should show "null" or "empty" based on formatter