### PR TITLE
refactor: DH-19267: columns changed filter event takes an id rather than a panel (#2417)

### DIFF
--- a/packages/dashboard-core-plugins/src/FilterPlugin.tsx
+++ b/packages/dashboard-core-plugins/src/FilterPlugin.tsx
@@ -6,6 +6,7 @@ import {
   DashboardPluginComponentProps,
   LayoutUtils,
   PanelEvent,
+  type PanelId,
   updateDashboardData,
   useListener,
 } from '@deephaven/dashboard';
@@ -16,6 +17,7 @@ import {
   DropdownFilterPanel,
   FilterSetManagerPanel,
   InputFilterPanel,
+  type WidgetId,
 } from './panels';
 
 const log = Log.module('FilterPlugin');
@@ -24,6 +26,9 @@ type Column = {
   name: string;
   type: string;
 };
+
+// A panel or widget can have columns for filters
+export type FilterColumnSourceId = PanelId | WidgetId;
 
 export type FilterChangeEvent = Column & {
   value: string;
@@ -41,7 +46,9 @@ export function FilterPlugin(props: FilterPluginProps): JSX.Element | null {
   assertIsDashboardPluginProps(props);
   const { id: localDashboardId, layout, registerComponent } = props;
   const dispatch = useDispatch();
-  const [panelColumns] = useState(() => new Map<Component, Column[]>());
+  const [panelColumns] = useState(
+    () => new Map<FilterColumnSourceId, Column[]>()
+  );
   const [panelFilters] = useState(
     () => new Map<Component, FilterChangeEvent[]>()
   );
@@ -92,13 +99,13 @@ export function FilterPlugin(props: FilterPluginProps): JSX.Element | null {
 
   /**
    * Handler for the COLUMNS_CHANGED event.
-   * @param panel The component that's emitting the filter change
+   * @param sourceId The id of the component that's emitting the filter change
    * @param columns The columns in this panel
    */
   const handleColumnsChanged = useCallback(
-    (panel: Component, columns: Column | Column[]) => {
-      log.debug2('handleColumnsChanged', panel, columns);
-      panelColumns.set(panel, ([] as Column[]).concat(columns));
+    (sourceId: FilterColumnSourceId, columns: Column | Column[]) => {
+      log.debug2('handleColumnsChanged', sourceId, columns);
+      panelColumns.set(sourceId, ([] as Column[]).concat(columns));
       sendUpdate();
     },
     [panelColumns, sendUpdate]
@@ -130,9 +137,12 @@ export function FilterPlugin(props: FilterPluginProps): JSX.Element | null {
   const handlePanelUnmount = useCallback(
     panel => {
       log.debug2('handlePanelUnmount', panel);
-      panelColumns.delete(panel);
+      const panelId = LayoutUtils.getIdFromPanel(panel);
+      if (panelId != null) {
+        panelColumns.delete(panelId);
+      }
       panelFilters.delete(panel);
-      panelTables.delete(LayoutUtils.getIdFromPanel(panel));
+      panelTables.delete(panelId);
       sendUpdate();
     },
     [panelColumns, panelFilters, panelTables, sendUpdate]

--- a/packages/dashboard-core-plugins/src/linker/Linker.tsx
+++ b/packages/dashboard-core-plugins/src/linker/Linker.tsx
@@ -46,6 +46,7 @@ import LinkerUtils, {
   LinkType,
   isLinkableColumn,
 } from './LinkerUtils';
+import { type FilterColumnSourceId } from '../FilterPlugin';
 
 const log = Log.module('Linker');
 
@@ -252,21 +253,24 @@ export class Linker extends Component<LinkerProps, LinkerState> {
     this.columnSelected(panel, column, true);
   }
 
-  handleColumnsChanged(panel: PanelComponent, columns: LinkColumn[]): void {
-    log.debug('handleColumnsChanged', panel, columns);
+  handleColumnsChanged(
+    sourceId: FilterColumnSourceId,
+    columns: LinkColumn[]
+  ): void {
+    log.debug('handleColumnsChanged', sourceId, columns);
     const { links } = this.props;
-    const panelId = LayoutUtils.getIdFromPanel(panel);
-    if (panelId == null) {
-      log.error('Invalid panelId', panel);
+    if (sourceId == null) {
+      log.error('Invalid filter columns source id', sourceId);
       return;
     }
+    // NOTE: links need to be updated to use sourceId instead of panelId. This will be done when we implement linker for dh.ui widgets DH-18840
     // Delete links that start or end on non-existent column in the updated panel
     const linksToDelete = links.filter(
       ({ start, end }) =>
-        (start.panelId === panelId &&
+        (start.panelId === sourceId &&
           LinkerUtils.findColumn(columns, start) == null) ||
         (end != null &&
-          end.panelId === panelId &&
+          end.panelId === sourceId &&
           LinkerUtils.findColumn(columns, end) == null)
     );
     this.deleteLinks(linksToDelete);

--- a/packages/dashboard-core-plugins/src/panels/ChartPanel.tsx
+++ b/packages/dashboard-core-plugins/src/panels/ChartPanel.tsx
@@ -765,7 +765,7 @@ export class ChartPanel extends Component<ChartPanelProps, ChartPanelState> {
     const { glEventHub } = this.props;
     glEventHub.emit(
       InputFilterEvent.COLUMNS_CHANGED,
-      this,
+      LayoutUtils.getIdFromPanel(this),
       Array.from(model.getFilterColumnMap().values())
     );
   }

--- a/packages/dashboard-core-plugins/src/panels/IrisGridPanel.tsx
+++ b/packages/dashboard-core-plugins/src/panels/IrisGridPanel.tsx
@@ -761,7 +761,11 @@ export class IrisGridPanel extends PureComponent<
   sendColumnsChange(columns: readonly dh.Column[]): void {
     log.debug2('sendColumnsChange', columns);
     const { glEventHub } = this.props;
-    glEventHub.emit(InputFilterEvent.COLUMNS_CHANGED, this, columns);
+    glEventHub.emit(
+      InputFilterEvent.COLUMNS_CHANGED,
+      LayoutUtils.getIdFromPanel(this),
+      columns
+    );
   }
 
   startModelListening(model: IrisGridModel): void {

--- a/packages/dashboard-core-plugins/src/panels/WidgetPanelTypes.ts
+++ b/packages/dashboard-core-plugins/src/panels/WidgetPanelTypes.ts
@@ -1,0 +1,29 @@
+import { type ReactNode } from 'react';
+import { type Brand } from '@deephaven/utils';
+
+export type WidgetPanelDescriptor = {
+  /** Type of the widget. */
+  type: string;
+
+  /** Name of the widget. */
+  name: string;
+
+  /** Display name of the widget. May be different than the assigned name. */
+  displayName?: string;
+
+  /** Display type of the widget. May be different than the assigned type. */
+  displayType?: string;
+
+  /** Description of the widget. */
+  description?: string;
+};
+
+export type WidgetPanelTooltipProps = {
+  /** A descriptor of the widget. */
+  descriptor: WidgetPanelDescriptor;
+
+  /** Children to render within this tooltip */
+  children?: ReactNode;
+};
+
+export type WidgetId = Brand<'WidgetId'>;

--- a/packages/dashboard-core-plugins/src/panels/index.ts
+++ b/packages/dashboard-core-plugins/src/panels/index.ts
@@ -18,6 +18,7 @@ export { default as NotebookPanel } from './NotebookPanel';
 export { default as PandasPanel } from './PandasPanel';
 export * from './PandasPanel';
 export { default as Panel } from './Panel';
+export * from './WidgetPanelTypes';
 export { default as WidgetPanel } from './WidgetPanel';
 export { default as WidgetPanelTooltip } from './WidgetPanelTooltip';
 export { default as MockFileStorage } from './MockFileStorage';

--- a/packages/dashboard/src/layout/LayoutUtils.ts
+++ b/packages/dashboard/src/layout/LayoutUtils.ts
@@ -22,13 +22,15 @@ import type {
   Tab,
   CloseOptions,
 } from '@deephaven/golden-layout';
-import { assertNotNull } from '@deephaven/utils';
-import { DashboardLayoutConfig } from '../DashboardLayout';
-import { PanelConfig } from '../DashboardPlugin';
+import { assertNotNull, type Brand } from '@deephaven/utils';
+import { type DashboardLayoutConfig } from '../DashboardLayout';
+import { type PanelConfig } from '../DashboardPlugin';
 
 const log = Log.module('LayoutUtils');
 
 type LayoutConfig = { id?: string; component?: string };
+
+export type PanelId = Brand<'PanelId', string | string[] | undefined>;
 
 export type LayoutPanel = {
   props: GLPanelProps;
@@ -807,12 +809,10 @@ class LayoutUtils {
    * @param glContainer The container to get the panel ID for
    * @returns Panel ID
    */
-  static getIdFromContainer(
-    glContainer: Container
-  ): string | string[] | null | undefined {
+  static getIdFromContainer(glContainer: Container): PanelId | null {
     const config = LayoutUtils.getComponentConfigFromContainer(glContainer);
     if (config) {
-      return config.id;
+      return config.id as PanelId;
     }
     return null;
   }
@@ -822,9 +822,7 @@ class LayoutUtils {
    * @param panel The panel to get the ID for
    * @returns Panel ID
    */
-  static getIdFromPanel(
-    panel: LayoutPanel
-  ): string | string[] | null | undefined {
+  static getIdFromPanel(panel: LayoutPanel): PanelId | null {
     const { glContainer } = panel.props;
     return LayoutUtils.getIdFromContainer(glContainer);
   }

--- a/packages/dashboard/src/layout/index.ts
+++ b/packages/dashboard/src/layout/index.ts
@@ -1,5 +1,5 @@
 export { default as LayoutManagerContext } from './LayoutManagerContext';
-export { default as LayoutUtils } from './LayoutUtils';
+export { default as LayoutUtils, type PanelId } from './LayoutUtils';
 export { default as GLPropTypes } from './GLPropTypes';
 export { default as useDashboardPanel } from './useDashboardPanel';
 export { default as useLayoutManager } from './useLayoutManager';

--- a/packages/utils/src/TypeUtils.ts
+++ b/packages/utils/src/TypeUtils.ts
@@ -1,5 +1,23 @@
 import type { Component, FunctionComponent } from 'react';
 
+/*
+ * Branded type helpers. Allows creating "branded" types that satisfy a base type
+ * but are distinct from other types that satisfy the same base type.
+ *
+ * e.g. These 2 types are still strings, but they are unique from each other:
+ * declare const UserID: Brand<string, 'userId'>;
+ * declare const RoleID: Brand<string, 'roleID'>;
+ *
+ * This protects against accidentally assigning one type to another.
+ * const roleId: RoleID = '123';
+ * const userId: UserID = roleId; // Compiler error
+ */
+// eslint-disable-next-line no-underscore-dangle
+declare const __brand: unique symbol;
+export type Brand<T extends string, TBase = string> = TBase & {
+  readonly [__brand]: T;
+};
+
 /**
  * Util type to create a "subtype" of T. Useful for creating subsets of union
  * types.


### PR DESCRIPTION
Cherry-pick of #2417, #2264, and `WidgetPanelTypes` from the XComponent PR (was included already in the cherry-pick as a "deleted by us" file)