### PR TITLE
fix: Enable golden-layout jest test and fix broken EventUtils test

### DIFF
--- a/packages/golden-layout/jest.config.cjs
+++ b/packages/golden-layout/jest.config.cjs
@@ -1,0 +1,7 @@
+const baseConfig = require('../../jest.config.base.cjs');
+const packageJson = require('./package');
+
+module.exports = {
+  ...baseConfig,
+  displayName: packageJson.name,
+};

--- a/packages/golden-layout/src/utils/EventUtils.ts
+++ b/packages/golden-layout/src/utils/EventUtils.ts
@@ -1,4 +1,4 @@
-import { useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import EventEmitter from './EventEmitter';
 
 type AsArray<P> = P extends unknown[] ? P : [P];
@@ -70,6 +70,14 @@ export function makeUseListenerFunction<TParameters = []>(
 
     eventEmitterRef.current = eventEmitter;
     handlerRef.current = handler;
+
+    // Cleanup on unmount
+    // Mounting the listener in useEffect causes a race condition with embed-widget
+    // where the event is emitted during render before the useEffect runs after render.
+    useEffect(
+      () => () => eventEmitterRef.current?.off(event, handlerRef.current),
+      []
+    );
   };
 }
 


### PR DESCRIPTION
Noticed we had migrated a test into golden-layout, but it never ran. At a future point I then broke the test (not cleaning up event handlers on unmount), but it wasn't running so it wasn't caught.

This enables the test and fixes the broken logic so the test passes.