### PR TITLE
docs: Initial grid docs commit

### DIFF
--- a/packages/grid/docs/README.md
+++ b/packages/grid/docs/README.md
@@ -1,4 +1,4 @@
-# JavaScript Data grid
+# JavaScript Data Grid
 
 Deephaven's data grid is an [open-source](https://github.com/deephaven/web-client-ui/blob/main/LICENSE), [React.js](https://reactjs.org/) package that is purpose-built for displaying [massive](/blog/2022/01/24/displaying-a-quadrillion-rows) streaming data sets and is written with TypeScript. Our grid renders viewported data from your own server-side model or a Deephaven worker, using [HTML Canvas](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/canvas). It excels at displaying large data sets for data science, monitoring, analytics, and from streaming data sources. We built it to meet the sophisticated and complex needs of quant traders, but it has some really neat features for data scientists. It was inspired by the now-defunct [hypergrid](https://github.com/fin-hypergrid/core).
 

--- a/packages/grid/docs/README.md
+++ b/packages/grid/docs/README.md
@@ -6,14 +6,12 @@ Rather than DOM virtualization, our approach uses a canvas-based grid to draw on
 
 <GridMarketing />
 
-<div className="padding-vert--sm" />
-
 ## Data grid comes in two flavors:
 
 1. [@deephaven/grid](https://www.npmjs.com/package/@deephaven/grid) for standalone use cases, where you bring your own data model and backend.
 2. [@deephaven/iris-grid](https://www.npmjs.com/package/@deephaven/iris-grid) extends the former with additional features for use with the Deephaven [JS API](/core/docs/reference/js-api/concepts), and is expected to run against a Deephaven backend. If you are [building your own frontend](https://github.com/deephaven-examples/deephaven-react-app) and running against a Deephaven table, we suggest you use this version.
 
-<div className="row padding-vert--lg">
+<div className="row">
 <div className="col">
 
 ## Grid features

--- a/packages/grid/docs/README.md
+++ b/packages/grid/docs/README.md
@@ -1,0 +1,86 @@
+# JavaScript Data grid
+
+Deephaven's data grid is an [open-source](https://github.com/deephaven/web-client-ui/blob/main/LICENSE), [React.js](https://reactjs.org/) package that is purpose-built for displaying [massive](/blog/2022/01/24/displaying-a-quadrillion-rows) streaming data sets and is written with TypeScript. Our grid renders viewported data from your own server-side model or a Deephaven worker, using [HTML Canvas](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/canvas). It excels at displaying large data sets for data science, monitoring, analytics, and from streaming data sources. We built it to meet the sophisticated and complex needs of quant traders, but it has some really neat features for data scientists. It was inspired by the now-defunct [hypergrid](https://github.com/fin-hypergrid/core).
+
+Rather than DOM virtualization, our approach uses a canvas-based grid to draw only what is on screen. You fetch just what is displayed (plus a buffer for snappier scrolling), and the grid will re-draw exactly what is displayed. This allows you to display quadrillions of rows and columns, all at 60fps.
+
+<GridMarketing />
+
+<div className="padding-vert--sm" />
+
+## Data grid comes in two flavors:
+
+1. [@deephaven/grid](https://www.npmjs.com/package/@deephaven/grid) for standalone use cases, where you bring your own data model and backend.
+2. [@deephaven/iris-grid](https://www.npmjs.com/package/@deephaven/iris-grid) extends the former with additional features for use with the Deephaven [JS API](/core/docs/reference/js-api/concepts), and is expected to run against a Deephaven backend. If you are [building your own frontend](https://github.com/deephaven-examples/deephaven-react-app) and running against a Deephaven table, we suggest you use this version.
+
+<div className="row padding-vert--lg">
+<div className="col">
+
+## Grid features
+
+Bring your own server-side data model:
+
+- Fast rendering, using an optimized HTML canvas element
+- Support for quadrillions of rows and columns
+- Ticking/streaming data support
+- A flexible data model that can add, remove, or change a tables rows or even columns
+- Excel-like keyboard shortcuts
+- Resizable rows/columns
+- Rearrangeable rows/columns
+- Freezable rows/columns
+- Column visibility options; hideable columns
+- Customizable themes
+- Row, column and range selections
+- Input for editable models
+
+</div>
+<div className="col">
+
+## Iris grid features
+
+Additional features when backed by Deephaven server instance:
+
+- Automatic row and column viewporting
+- Sorting, multi-column sorting, reversing
+- Advanced filtering
+- Column descriptions
+- Automatic column summary statistics
+- Row grouping
+- Aggregations
+- Conditional row/cell formatting
+- CSV export
+- Formula-based columns added to tables
+
+</div>
+</div>
+
+> [!NOTE]
+> Grid was built for desktop use cases, and doesn't currently respond to touch-events. It will render on mobile, but is not interactive.
+
+## Quickstart
+
+```js
+// Standalone grid for use with your own model
+// npm install --save @deephaven/grid
+
+import React, { useState } from 'react';
+import { Grid, StaticDataGridModel } from '@deephaven/grid';
+
+const GridExample = () => {
+  const [model] = useState(
+    new StaticDataGridModel(
+      [
+        ['Matthew Austins', 'Toronto', 35, 22],
+        ['Doug Millgore', 'Toronto', 14, 33],
+        ['Bart Marchant', 'Boston', 20, 14],
+        ['Luigi Dabest', 'Pittsburgh', 66, 33],
+      ],
+      ['Name', 'Team', 'Goals', 'Assists']
+    )
+  );
+
+  return <Grid model={model} />;
+};
+
+export default GridExample;
+```

--- a/packages/grid/docs/README.md
+++ b/packages/grid/docs/README.md
@@ -21,7 +21,7 @@ Bring your own server-side data model:
 - Fast rendering, using an optimized HTML canvas element
 - Support for quadrillions of rows and columns
 - Ticking/streaming data support
-- A flexible data model that can add, remove, or change a tables rows or even columns
+- A flexible data model that can add, remove, or change a table's rows or even columns
 - Excel-like keyboard shortcuts
 - Resizable rows/columns
 - Rearrangeable rows/columns

--- a/packages/grid/docs/customize/frozen.md
+++ b/packages/grid/docs/customize/frozen.md
@@ -1,0 +1,17 @@
+# How to freeze columns
+
+Extending [GridModel](https://github.com/deephaven/web-client-ui/blob/main/packages/grid/src/GridModel.ts) allows you to customize behavior, such as freezing rows and/or columns to the side of a viewport.
+
+```jsx live
+function Example() {
+  const [model] = useState(
+    () =>
+      new MockGridModel({
+        floatingLeftColumnCount: 3,
+        floatingTopRowCount: 1,
+      })
+  );
+
+  return <Grid model={model} />;
+}
+```

--- a/packages/grid/docs/customize/interaction.md
+++ b/packages/grid/docs/customize/interaction.md
@@ -1,0 +1,55 @@
+# How to customize interaction
+
+You can customize mouse and keyboard events in Grid by passing in your own mouse and keyboard handlers. By passing in custom handlers, you can determine the behavior of mouse and keyboard events.
+
+In this example below, we display an alert whenever a cell is double-clicked or whenever a key is pressed.
+
+```jsx live noInline
+const model = new MockGridModel();
+class CustomMouseHandler extends GridMouseHandler {
+  onDoubleClick(gridPoint) {
+    alert(`Double clicked: (${gridPoint.column}, ${gridPoint.row})`);
+    return true;
+  }
+}
+class CustomKeyHandler extends KeyHandler {
+  onDown(event) {
+    alert(`Key pressed: ${event.key}`);
+    return true;
+  }
+}
+const myMouseHandler = new CustomMouseHandler();
+const myKeyHandler = new CustomKeyHandler();
+render(
+  <Grid
+    model={model}
+    mouseHandlers={[myMouseHandler]}
+    keyHandlers={[myKeyHandler]}
+  />
+);
+```
+
+In addition to adding your own custom behaviour, it's possible to override existing behaviour. When a mouse or keyboard event occurs, Grid will iterate through all registered handlers, sorted by their specified `order`. If a handler returns `true`, Grid will stop iterating and not call any other handlers. If no handler returns `true`, Grid will continue to the next handler in the list.
+
+For example, if you want to prevent the default behaviour of selecting a cell when it is clicked, you can return `true` in the `onClick` method of your custom mouse handler.
+
+```jsx live noInline
+const model = new MockGridModel();
+class CustomMouseHandler extends GridMouseHandler {
+  onDown(gridPoint) {
+    if (gridPoint.column % 2 === 0 || gridPoint.row % 2 === 0) {
+      alert(
+        `Clicked even column or row: (${gridPoint.column}, ${gridPoint.row})`
+      );
+      return true;
+    }
+    return false;
+  }
+}
+
+// Set order to 10 to ensure this handler is called before the default handler
+const myMouseHandler = new CustomMouseHandler(50);
+render(<Grid model={model} mouseHandlers={[myMouseHandler]} />);
+```
+
+You can see the default registered mouse handlers and their registered priority orders in [Grid initialization code](https://github.com/deephaven/web-client-ui/blob/main/packages/grid/src/Grid.tsx#L399).

--- a/packages/grid/docs/customize/selection.md
+++ b/packages/grid/docs/customize/selection.md
@@ -1,0 +1,14 @@
+# How to automatically select columns and rows
+
+In addition to customizing the color, you can use a custom theme to change some of the Grid's behavior. All parameters are optional and will fall back to default values if omitted. See [GridTheme](https://github.com/deephaven/web-client-ui/blob/main/packages/grid/src/GridTheme.ts) for full list of properties and default values.
+
+In this example below, we set the `autoSelectColumn` property to `true`, which will automatically select the entire column when you click inside the grid.
+
+```jsx live
+function Example() {
+  const [model] = useState(() => new MockTreeGridModel());
+  const theme = useMemo(() => ({ autoSelectColumn: true }), []);
+
+  return <Grid model={model} theme={theme} />;
+}
+```

--- a/packages/grid/docs/customize/theme.md
+++ b/packages/grid/docs/customize/theme.md
@@ -1,0 +1,95 @@
+# How to customize your grid theme and behavior
+
+You customize the look of your Grid by passing in a custom theme. All parameters are optional and will fall back to default values if omitted. See [GridTheme](https://github.com/deephaven/web-client-ui/blob/main/packages/grid/src/GridTheme.ts) for a full list of properties and default values.
+
+Modify the values in the Live Editor below to try out some possibilities. For example, adjust the colors to see the Grid update in real time.
+
+```jsx live
+function Example() {
+  const [model] = useState(() => new MockTreeGridModel());
+  const theme = useMemo(
+    () => ({
+      allowColumnResize: true,
+      allowRowResize: true,
+      autoSelectRow: false, // Select the full row upon selection
+      autoSelectColumn: false, // Select the full column upon selection
+      autoSizeColumns: true, // Automatically size the columns to fit content
+      autoSizeRows: true,
+      backgroundColor: '#000000',
+      cellHorizontalPadding: 5,
+      headerHorizontalPadding: 5,
+      font: '12px Arial, sans serif',
+      gridColumnColor: '#8f8f8f66',
+      gridRowColor: '#8f8f8f66',
+      headerBackgroundColor: '#222222',
+      headerSeparatorColor: '#000000',
+      headerSeparatorHoverColor: '#888888',
+      headerSeparatorHandleSize: 5,
+      headerHiddenSeparatorSize: 5,
+      headerHiddenSeparatorHoverColor: '#8888FF',
+      headerColor: '#d5d5d5',
+      headerFont: '10px Arial, sans serif',
+      columnHoverBackgroundColor: '#444444',
+      selectedColumnHoverBackgroundColor: '#494949',
+      rowBackgroundColors: '#333333 #222222',
+      rowHoverBackgroundColor: '#444444',
+      selectedRowHoverBackgroundColor: '#494949',
+      minScrollHandleSize: 50,
+      scrollBarBackgroundColor: '#111111',
+      scrollBarHoverBackgroundColor: '#333333',
+      scrollBarCasingColor: '#000000',
+      scrollBarCornerColor: '#000000',
+      scrollBarColor: '#555555',
+      scrollBarHoverColor: '#888888',
+      scrollBarActiveColor: '#AAAAAA',
+      scrollBarSize: 12,
+      scrollBarHoverSize: 16,
+      scrollBarCasingWidth: 1,
+      scrollSnapToColumn: false,
+      scrollSnapToRow: false,
+      selectionColor: '#4286f433',
+      selectionOutlineColor: '#4286f4',
+      selectionOutlineCasingColor: '#222222',
+      shadowBlur: 8,
+      shadowColor: '#000000',
+      textColor: '#ffffff',
+      maxDepth: 6,
+      treeDepthIndent: 10,
+      treeHorizontalPadding: 5,
+      treeLineColor: '#888888',
+      treeMarkerColor: '#cccccc',
+      treeMarkerHoverColor: '#ffffff',
+
+      rowHeight: 20,
+      columnWidth: 100,
+      minRowHeight: 20,
+      minColumnWidth: 55,
+      columnHeaderHeight: 20,
+      rowHeaderWidth: 30,
+      rowFooterWidth: 0,
+
+      // When resizing the header, will snap to the auto size of the header within this threshold
+      headerResizeSnapThreshold: 10,
+      headerResizeHiddenSnapThreshold: 8,
+
+      allowColumnReorder: true,
+      allowRowReorder: true,
+      reorderOffset: 2,
+
+      // Colors for the grid in floating sections
+      floatingGridColumnColor: '#8f8f8f66',
+      floatingGridRowColor: '#8f8f8f66',
+
+      // Background row colors for grid in the floating sections
+      floatingRowBackgroundColors: '#393939 #292929',
+
+      // Divider colors between the floating parts and the grid
+      floatingDividerOuterColor: '#000000',
+      floatingDividerInnerColor: '#cccccc',
+    }),
+    []
+  );
+
+  return <Grid model={model} theme={theme} />;
+}
+```

--- a/packages/grid/docs/display-data/asynchronous.md
+++ b/packages/grid/docs/display-data/asynchronous.md
@@ -1,0 +1,63 @@
+# Asynchronous data
+
+When working with big data, it's more than likely you will not have the data accessible immediately, and will be fetching it from a server. Here is an example that simulates setting data by using a timeout:
+
+```jsx live
+/**
+ * An example showing data loading asnychronously for a grid.
+ */
+function AsyncExample() {
+  // Use a Viewport data model that we update asynchronously to display the data
+  const [model] = useState(
+    () => new ViewportDataGridModel(1000000000, 1000000)
+  );
+  const grid = useRef();
+
+  // The current viewport
+  const [viewport, setViewport] = useState({
+    top: 0,
+    bottom: 0,
+    left: 0,
+    right: 0,
+  });
+
+  const handleViewChanged = useCallback(metrics => {
+    // Pull out the viewport from the metrics
+    const { top, bottom, left, right } = metrics;
+    setViewport({ top, bottom, left, right });
+  }, []);
+
+  const { top, bottom, left, right } = viewport;
+  useEffect(() => {
+    let isCancelled = false;
+
+    // Simulate fetching data asynchronously by using at timeout
+    setTimeout(() => {
+      if (isCancelled) return;
+
+      // Generate the data for the viewport
+      const data = [];
+      for (let i = top; i <= bottom; i += 1) {
+        const rowData = [];
+        for (let j = left; j <= right; j += 1) {
+          rowData.push(`${i},${j}`);
+        }
+        data.push(rowData);
+      }
+      model.viewportData = {
+        rowOffset: top,
+        columnOffset: left,
+        data,
+      };
+
+      // Refresh the grid
+      grid.current.forceUpdate();
+    }, 250);
+    return () => {
+      isCancelled = true;
+    };
+  }, [top, bottom, left, right, model]);
+
+  return <Grid model={model} onViewChanged={handleViewChanged} ref={grid} />;
+}
+```

--- a/packages/grid/docs/display-data/asynchronous.md
+++ b/packages/grid/docs/display-data/asynchronous.md
@@ -4,7 +4,7 @@ When working with big data, it's more than likely you will not have the data acc
 
 ```jsx live
 /**
- * An example showing data loading asnychronously for a grid.
+ * An example showing data loading asynchronously for a grid.
  */
 function AsyncExample() {
   // Use a Viewport data model that we update asynchronously to display the data
@@ -31,7 +31,7 @@ function AsyncExample() {
   useEffect(() => {
     let isCancelled = false;
 
-    // Simulate fetching data asynchronously by using at timeout
+    // Simulate fetching data asynchronously by using a timeout
     setTimeout(() => {
       if (isCancelled) return;
 

--- a/packages/grid/docs/display-data/grouped.md
+++ b/packages/grid/docs/display-data/grouped.md
@@ -1,0 +1,11 @@
+# Grouped data
+
+Some data can be displayed as a tree. This example uses [MockTreeGridModel](https://github.com/deephaven/web-client-ui/blob/main/packages/grid/src/MockTreeGridModel.ts) to display exandable rows of data:
+
+```jsx live
+function Example() {
+  const [model] = useState(() => new MockTreeGridModel());
+
+  return <Grid model={model} />;
+}
+```

--- a/packages/grid/docs/display-data/grouped.md
+++ b/packages/grid/docs/display-data/grouped.md
@@ -1,6 +1,6 @@
 # Grouped data
 
-Some data can be displayed as a tree. This example uses [MockTreeGridModel](https://github.com/deephaven/web-client-ui/blob/main/packages/grid/src/MockTreeGridModel.ts) to display exandable rows of data:
+Some data can be displayed as a tree. This example uses [MockTreeGridModel](https://github.com/deephaven/web-client-ui/blob/main/packages/grid/src/MockTreeGridModel.ts) to display expandable rows of data:
 
 ```jsx live
 function Example() {

--- a/packages/grid/docs/display-data/quadrillion.md
+++ b/packages/grid/docs/display-data/quadrillion.md
@@ -1,0 +1,22 @@
+# Quadrillions of rows and columns
+
+Both rows and columns are virtualized in this grid solution, so you can theoretically have up to `Number.MAX_SAFE_INTEGER` (about 9 quadrillion) rows and columns. Not only are the row and columns virtualized, but you can drag columns/rows to reposition them without affecting the underlying model, effectively allowing quadrillions of rows and columns that can be moved around. Here is an example using [MockGridModel](https://github.com/deephaven/web-client-ui/blob/main/packages/grid/src/MockGridModel.ts) that displays quadrillions of rows/columns. You can:
+
+- scroll around using the mouse or keyboard
+- edit by double clicking on a value or by typing
+- move columns or rows by dragging the headers.
+
+```jsx live
+function Example() {
+  const [model] = useState(
+    () =>
+      new MockGridModel({
+        rowCount: Number.MAX_SAFE_INTEGER,
+        columnCount: Number.MAX_SAFE_INTEGER,
+        isEditable: true,
+      })
+  );
+
+  return <Grid model={model} />;
+}
+```

--- a/packages/grid/docs/display-data/static.md
+++ b/packages/grid/docs/display-data/static.md
@@ -1,0 +1,21 @@
+# Static data
+
+It's easy to display a static array of data using [StaticDataGridModel](https://github.com/deephaven/web-client-ui/blob/main/packages/grid/src/StaticDataGridModel.ts). Pass in the data you'd like to display, and the grid displays it. Simple!
+
+```jsx live
+function Example() {
+  const [model] = useState(
+    new StaticDataGridModel(
+      [
+        ['Matthew Austins', 'Toronto', 35, 22],
+        ['Doug Millgore', 'Toronto', 14, 33],
+        ['Bart Marchant', 'Boston', 20, 14],
+        ['Luigi Dabest', 'Pittsburgh', 66, 33],
+      ],
+      ['Name', 'Team', 'Goals', 'Assists']
+    )
+  );
+
+  return <Grid model={model} />;
+}
+```

--- a/packages/grid/docs/sidebar.json
+++ b/packages/grid/docs/sidebar.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://raw.githubusercontent.com/deephaven/salmon-sync/refs/heads/main/sidebar.schema.json",
+  "config": {
+    "name": "Deephaven Grid Docs"
+  },
+  "sidebars": {
+    "main": [
+      {
+        "label": "Introduction",
+        "path": "README.md"
+      },
+      {
+        "label": "Display data",
+        "collapsible": false,
+        "items": [
+          { "label": "Static data", "path": "display-data/static.md" },
+          {
+            "label": "Quadrillions of Rows",
+            "path": "display-data/quadrillion.md"
+          },
+          { "label": "Grouped data", "path": "display-data/grouped.md" },
+          {
+            "label": "Asynchronous data",
+            "path": "display-data/asynchronous.md"
+          }
+        ]
+      },
+      {
+        "label": "Customize",
+        "collapsible": false,
+        "items": [
+          { "label": "Customize theme", "path": "customize/theme.md" },
+          {
+            "label": "Customize interaction",
+            "path": "customize/interaction.md"
+          },
+          {
+            "label": "Select rows or columns",
+            "path": "customize/selection.md"
+          },
+          { "label": "Frozen columns", "path": "customize/frozen.md" }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Adds initial set of grid docs, porting from deephaven.io repo.

Changes:
- Removed frontmatter, making title just #h1 
- Added sidebar in salmon format

Note: Will publish initial version manually. Publishing action TBD later.