### PR TITLE
fix: Grid making unnecessary onSelectionChanged calls

### DIFF
--- a/packages/grid/src/Grid.test.tsx
+++ b/packages/grid/src/Grid.test.tsx
@@ -1,6 +1,6 @@
 import React, { type ReactElement } from 'react';
 import TestRenderer from 'react-test-renderer';
-import Grid from './Grid';
+import Grid, { type GridProps } from './Grid';
 import GridRange from './GridRange';
 import GridRenderer from './GridRenderer';
 import GridTheme, { type GridTheme as GridThemeType } from './GridTheme';
@@ -90,10 +90,17 @@ function createNodeMock(element: ReactElement) {
 
 function makeGridComponent(
   model: GridModel = new MockGridModel(),
-  theme: GridThemeType = defaultTheme
+  theme: GridThemeType = defaultTheme,
+  { onSelectionChanged }: Pick<GridProps, 'onSelectionChanged'> = {
+    onSelectionChanged: jest.fn(),
+  }
 ): Grid {
   const testRenderer = TestRenderer.create(
-    <Grid model={model} theme={theme} />,
+    <Grid
+      model={model}
+      theme={theme}
+      onSelectionChanged={onSelectionChanged}
+    />,
     {
       createNodeMock,
     }
@@ -310,6 +317,17 @@ it('handles mouse down in middle of grid to update selection', () => {
   expect(component.state.cursorRow).toBe(5);
   expect(component.state.cursorColumn).toBe(3);
   expect(component.state.selectedRanges[0]).toEqual(new GridRange(3, 5, 3, 5));
+});
+
+it('only calls onSelectionChanged once when clicking a cell', () => {
+  const onSelectionChanged = jest.fn();
+  const component = makeGridComponent(undefined, defaultTheme, {
+    onSelectionChanged,
+  });
+
+  mouseClick(3, 5, component);
+
+  expect(onSelectionChanged).toHaveBeenCalledTimes(1);
 });
 
 it('handles mouse down in the very bottom right of last cell to update selection', () => {

--- a/packages/grid/src/Grid.tsx
+++ b/packages/grid/src/Grid.tsx
@@ -1218,8 +1218,9 @@ class Grid extends PureComponent<GridProps, GridState> {
       return {
         cursorRow: newCursorRow,
         cursorColumn: newCursorColumn,
-        // If the selection ranges are non-overlapping, then selectedRanges already includes everything
-        // and the onSelectionChanged callback has already been called. No need to change to the same ranges in a new array.
+        // The onSelectionChanged callback has already been called with the selectedRanges at this point.
+        // If the selection is not changed (e.g., the user is adding via ctrl+click and not removing),
+        // there is no need to change and trigger the callback again.
         selectedRanges: selectionChanged ? newSelectedRanges : selectedRanges,
         lastSelectedRanges: selectedRanges,
       };

--- a/packages/grid/src/Grid.tsx
+++ b/packages/grid/src/Grid.tsx
@@ -1001,7 +1001,10 @@ class Grid extends PureComponent<GridProps, GridState> {
    */
   clearSelectedRanges(): void {
     const { selectedRanges } = this.state;
-    this.setState({ selectedRanges: [], lastSelectedRanges: selectedRanges });
+    this.setState({
+      selectedRanges: EMPTY_ARRAY,
+      lastSelectedRanges: selectedRanges,
+    });
   }
 
   /** Clears all but the last selected range */
@@ -1206,10 +1209,18 @@ class Grid extends PureComponent<GridProps, GridState> {
         newCursorRow = null;
       }
 
+      const selectionChanged =
+        newSelectedRanges.length !== selectedRanges.length ||
+        newSelectedRanges.some(
+          (range, index) => !range.equals(selectedRanges[index])
+        );
+
       return {
         cursorRow: newCursorRow,
         cursorColumn: newCursorColumn,
-        selectedRanges: newSelectedRanges,
+        // If the selection ranges are non-overlapping, then selectedRanges already includes everything
+        // and the onSelectionChanged callback has already been called. No need to change to the same ranges in a new array.
+        selectedRanges: selectionChanged ? newSelectedRanges : selectedRanges,
         lastSelectedRanges: selectedRanges,
       };
     });

--- a/packages/grid/src/GridRange.ts
+++ b/packages/grid/src/GridRange.ts
@@ -504,7 +504,7 @@ export class GridRange {
     range: GridRange,
     columnCount: number,
     rowCount: number
-  ): GridRange {
+  ): BoundedGridRange {
     if (GridRange.isBounded(range)) {
       return range;
     }
@@ -514,7 +514,7 @@ export class GridRange {
       range.startRow ?? 0,
       range.endColumn ?? columnCount - 1,
       range.endRow ?? rowCount - 1
-    );
+    ) as BoundedGridRange;
   }
 
   /**
@@ -529,7 +529,7 @@ export class GridRange {
     ranges: readonly GridRange[],
     columnCount: number,
     rowCount: number
-  ): GridRange[] {
+  ): BoundedGridRange[] {
     return ranges.map(r => GridRange.boundedRange(r, columnCount, rowCount));
   }
 
@@ -671,8 +671,8 @@ export class GridRange {
   /**
    * Iterate through each cell in the provided ranges
    * @param ranges The ranges to iterate through
-   * @param {(column: number, row: number, index: number) => void} callback The callback to execute. `index` is the index within that range
-   * @param {GridRange.SELECTION_DIRECTION} direction The direction to iterate in
+   * @param callback The callback to execute. `index` is the index within that range
+   * @param direction The direction to iterate in
    */
   static forEachCell(
     ranges: readonly GridRange[],


### PR DESCRIPTION
Needed as part of DH-19292 to ensure we don't emit duplicate selection events. Even with debouncing, we might emit the event, and then emit the same selection (in a different array reference) on mouse up. This fixes that so we don't emit the unnecessary events if the mouse up did not remove selections

There are still some quirks around the selection events like when using ctrl+click+drag to deselect part of a range, `onSelectionChanged` is emitted with the subtracted portion as an extra range (e.g., `[[0, 5], [1, 2]]`) until mouse up which commits the selection and removes the overlapping ranges (`[[0, 0], [3, 5]]`). On the dh.ui side I'm just consolidating the ranges, but would probably be good to fix that at some point.