### PR TITLE
feat: Add linker support to GridWidgetPlugin (#2459)

### DIFF
--- a/packages/dashboard-core-plugins/src/GridWidgetPlugin.tsx
+++ b/packages/dashboard-core-plugins/src/GridWidgetPlugin.tsx
@@ -18,12 +18,13 @@ import { useSelector } from 'react-redux';
 import { getSettings, RootState } from '@deephaven/redux';
 import { LoadingOverlay } from '@deephaven/components';
 import { useLayoutManager, useListener } from '@deephaven/dashboard';
-import { EMPTY_ARRAY, getErrorMessage } from '@deephaven/utils';
+import { getErrorMessage } from '@deephaven/utils';
 import { useApi } from '@deephaven/jsapi-bootstrap';
 import { type GridState } from '@deephaven/grid';
 import { useIrisGridModel } from './useIrisGridModel';
 import useDashboardColumnFilters from './useDashboardColumnFilters';
 import { InputFilterEvent } from './events';
+import useGridLinker from './useGridLinker';
 
 export function GridWidgetPlugin({
   fetch,
@@ -89,7 +90,7 @@ export function GridWidgetPlugin({
   );
 
   const inputFilters = useDashboardColumnFilters(
-    fetchResult.status === 'success' ? fetchResult.model.columns : EMPTY_ARRAY,
+    fetchResult.status === 'success' ? fetchResult.model.columns : null,
     fetchResult.status === 'success' &&
       isIrisGridTableModelTemplate(fetchResult.model)
       ? fetchResult.model.table
@@ -97,6 +98,11 @@ export function GridWidgetPlugin({
   );
 
   const irisGridRef = useRef<IrisGridType | null>(null);
+
+  const linkerProps = useGridLinker(
+    fetchResult.status === 'success' ? fetchResult.model : null,
+    irisGridRef.current
+  );
 
   const handleClearAllFilters = useCallback(() => {
     if (irisGridRef.current == null) {
@@ -125,15 +131,18 @@ export function GridWidgetPlugin({
   }
 
   const { model } = fetchResult;
+
   return (
     <IrisGrid
       ref={irisGridRef}
       model={model}
       settings={settings}
       onStateChange={handleIrisGridChange}
+      inputFilters={inputFilters}
+      // eslint-disable-next-line react/jsx-props-no-spreading
+      {...linkerProps}
       // eslint-disable-next-line react/jsx-props-no-spreading
       {...hydratedState}
-      inputFilters={inputFilters}
     />
   );
 }

--- a/packages/dashboard-core-plugins/src/index.ts
+++ b/packages/dashboard-core-plugins/src/index.ts
@@ -23,6 +23,7 @@ export { default as LinkerUtils } from './linker/LinkerUtils';
 export type { Link } from './linker/LinkerUtils';
 export { default as ToolType } from './linker/ToolType';
 export * from './useDashboardColumnFilters';
+export * from './useGridLinker';
 export * from './useLoadTablePlugin';
 
 export * from './events';

--- a/packages/dashboard-core-plugins/src/linker/ColumnSelectionValidator.ts
+++ b/packages/dashboard-core-plugins/src/linker/ColumnSelectionValidator.ts
@@ -1,7 +1,8 @@
-import { PanelComponent } from '@deephaven/dashboard';
-import { LinkColumn } from './LinkerUtils';
+import { type PanelComponent } from '@deephaven/dashboard';
+import { type LinkPointOptions, type LinkColumn } from './LinkerUtils';
 
 export type ColumnSelectionValidator = (
-  panel: PanelComponent,
-  tableColumn?: LinkColumn
+  panelOrId: PanelComponent | string,
+  tableColumn: LinkColumn | undefined,
+  options: LinkPointOptions
 ) => boolean;

--- a/packages/dashboard-core-plugins/src/linker/LinkerEvent.ts
+++ b/packages/dashboard-core-plugins/src/linker/LinkerEvent.ts
@@ -1,0 +1,76 @@
+import { makeEventFunctions } from '@deephaven/golden-layout';
+import { type RowDataMap } from '@deephaven/jsapi-utils';
+import {
+  type LinkPointOptions,
+  type LinkColumn,
+  type LinkFilterMap,
+} from './LinkerUtils';
+
+export const LinkerEvent = Object.freeze({
+  LINK_POINT_SELECTED: 'LinkerEvent.LINK_POINT_SELECTED',
+  SOURCE_DATA_SELECTED: 'LinkerEvent.SOURCE_DATA_SELECTED',
+  REGISTER_TARGET: 'LinkerEvent.REGISTER_TARGET',
+});
+
+const linkPointSelectedFns = makeEventFunctions<
+  [sourceId: string, column: LinkColumn, options: LinkPointOptions]
+>(LinkerEvent.LINK_POINT_SELECTED);
+export const listenForLinkPointSelected = linkPointSelectedFns.listen;
+
+/**
+ * Emit a linker point selected event
+ * @param sourceId The source ID for the link point. Typically panel ID or widget ID
+ * @param column The column selected as the link point
+ * @param options Optional parameters for the link point selection
+ * @param options.isAlwaysEnd Whether this link point is always the end of a link
+ * @param options.isIsolatedLinker Whether this link point is selected in an isolated linker context
+ */
+export const emitLinkPointSelected = linkPointSelectedFns.emit;
+export const useLinkPointSelectedListener = linkPointSelectedFns.useListener;
+
+const linkSourceDataSelectedFns = makeEventFunctions<
+  [sourceId: string, data: RowDataMap]
+>(LinkerEvent.SOURCE_DATA_SELECTED);
+export const listenForLinkSourceDataSelected = linkSourceDataSelectedFns.listen;
+export const emitLinkSourceDataSelected = linkSourceDataSelectedFns.emit;
+export const useLinkSourceDataSelectedListener =
+  linkSourceDataSelectedFns.useListener;
+
+export type LinkTargetProps = {
+  /**
+   * Gets the coordinates for displaying a link point in the target.
+   * Coordinates are relative to the window, not the panel.
+   * @param columnName The column name to get coordinates for
+   * @returns The coordinates for the column, or null if column not visible
+   * @throws Error if the column is not valid for this target
+   */
+  getCoordinates: (columnName: string) => [number, number] | null;
+
+  /**
+   * Called when a link source value is selected.
+   * Only includes the values from the current event, not previously set links.
+   * @param filterMap The filter map to set for the target. May include multiple columns.
+   */
+  setFilterValues: (filterMap: LinkFilterMap) => void;
+
+  /**
+   * Called when a link is deleted or a filter value is unset.
+   * @param columnName The column name to unset the filter value for.
+   * @param type The column type of the filter to unset.
+   */
+  unsetFilterValue: (columnName: string, type: string | null) => void;
+
+  /**
+   * The ID of the golden layout panel the target is in.
+   * May be the same as the sourceId if the target is a panel component.
+   */
+  panelId: string;
+};
+
+const registerLinkTargetFns = makeEventFunctions<
+  [sourceId: string, props: LinkTargetProps | null]
+>(LinkerEvent.REGISTER_TARGET);
+
+export const listenForRegisterLinkTarget = registerLinkTargetFns.listen;
+export const emitRegisterLinkTarget = registerLinkTargetFns.emit;
+export const useRegisterLinkTargetListener = registerLinkTargetFns.useListener;

--- a/packages/dashboard-core-plugins/src/panels/ChartPanel.tsx
+++ b/packages/dashboard-core-plugins/src/panels/ChartPanel.tsx
@@ -44,7 +44,7 @@ import {
 } from '@deephaven/utils';
 import WidgetPanel from './WidgetPanel';
 import ToolType from '../linker/ToolType';
-import { InputFilterEvent, ChartEvent } from '../events';
+import { InputFilterEvent } from '../events';
 import {
   getColumnSelectionValidatorForDashboard,
   getInputFiltersForDashboard,
@@ -66,6 +66,7 @@ import {
 } from './ChartPanelUtils';
 import { type ColumnSelectionValidator } from '../linker/ColumnSelectionValidator';
 import { emitFilterColumnsChanged } from '../FilterEvents';
+import { emitLinkPointSelected } from '../linker/LinkerEvent';
 
 const log = Log.module('ChartPanel');
 const UPDATE_MODEL_DEBOUNCE = 150;
@@ -160,11 +161,15 @@ interface ChartPanelState {
   isLoaded: boolean;
   isLinked: boolean;
 
-  // Map of all non-empty filters applied to the chart.
-  // Initialize the filter map to the previously stored values; input filters will be applied after load.
+  /**
+   * Map of all non-empty filters applied to the chart.
+   * Initialize the filter map to the previously stored values; input filters will be applied after load.
+   */
   filterMap: FilterMap;
-  // Map of filter values set from links, stored in panelState.
-  // Combined with inputFilters to get applied filters (filterMap).
+  /**
+   * Map of filter values set from links, stored in panelState.
+   * Combined with inputFilters to get applied filters (filterMap).
+   */
   filterValueMap: FilterMap;
   model?: ChartModel;
   columnMap: ColumnMap;
@@ -456,7 +461,7 @@ export class ChartPanel extends Component<ChartPanelProps, ChartPanelState> {
         name: column.name,
         type: column.type,
         isValid: columnSelectionValidator
-          ? columnSelectionValidator(this, column)
+          ? columnSelectionValidator(this, column, { type: 'chartLink' })
           : false,
         isActive: linkedColumnMap.has(column.name),
       }))
@@ -516,11 +521,15 @@ export class ChartPanel extends Component<ChartPanelProps, ChartPanelState> {
   handleColumnSelected(columnName: string): void {
     const { glEventHub } = this.props;
     const { columnMap } = this.state;
-    glEventHub.emit(
-      ChartEvent.COLUMN_SELECTED,
-      this,
-      columnMap.get(columnName)
-    );
+    const panelId = LayoutUtils.getIdFromPanel(this);
+    assertNotNull(panelId);
+    const column = columnMap.get(columnName);
+    if (column == null) {
+      return;
+    }
+    emitLinkPointSelected(glEventHub, panelId, column, {
+      type: 'chartLink',
+    });
   }
 
   handleColumnMouseEnter({ type, name }: SelectorColumn): void {
@@ -529,7 +538,7 @@ export class ChartPanel extends Component<ChartPanelProps, ChartPanelState> {
     if (!columnSelectionValidator) {
       return;
     }
-    columnSelectionValidator(this, { type, name });
+    columnSelectionValidator(this, { type, name }, { type: 'chartLink' });
   }
 
   handleColumnMouseLeave(): void {
@@ -538,7 +547,7 @@ export class ChartPanel extends Component<ChartPanelProps, ChartPanelState> {
     if (!columnSelectionValidator) {
       return;
     }
-    columnSelectionValidator(this, undefined);
+    columnSelectionValidator(this, undefined, { type: 'chartLink' });
   }
 
   handleDisconnect(): void {
@@ -806,7 +815,7 @@ export class ChartPanel extends Component<ChartPanelProps, ChartPanelState> {
         if (column == null || column.type !== columnType) {
           return;
         }
-        if (filterList.length < 1) {
+        if (filterList.length === 0) {
           log.debug('Ignoring empty filterList for column', columnName);
           return;
         }

--- a/packages/dashboard-core-plugins/src/panels/DropdownFilterPanel.tsx
+++ b/packages/dashboard-core-plugins/src/panels/DropdownFilterPanel.tsx
@@ -23,7 +23,6 @@ import { assertNotNull, Pending, PromiseUtils } from '@deephaven/utils';
 import DropdownFilter, {
   DropdownFilterColumn,
 } from '../controls/dropdown-filter/DropdownFilter';
-import { InputFilterEvent } from '../events';
 import {
   getColumnsForDashboard,
   getColumnSelectionValidatorForDashboard,
@@ -38,6 +37,7 @@ import type { Link, LinkPoint } from '../linker/LinkerUtils';
 import { type ColumnSelectionValidator } from '../linker/ColumnSelectionValidator';
 import { type PanelState as InputFilterPanelState } from './InputFilterPanel';
 import { emitFilterChanged } from '../FilterEvents';
+import { emitLinkPointSelected } from '../linker/LinkerEvent';
 
 const log = Log.module('DropdownFilterPanel');
 
@@ -536,10 +536,13 @@ export class DropdownFilterPanel extends Component<
   handleColumnSelected(): void {
     log.debug('handleColumnSelected');
     const { glEventHub } = this.props;
-    glEventHub.emit(
-      InputFilterEvent.COLUMN_SELECTED,
-      this,
-      DropdownFilterPanel.SOURCE_COLUMN
+    const panelId = LayoutUtils.getIdFromPanel(this);
+    assertNotNull(panelId);
+    emitLinkPointSelected(
+      glEventHub,
+      panelId,
+      DropdownFilterPanel.SOURCE_COLUMN,
+      { type: 'filterSource' }
     );
   }
 
@@ -746,7 +749,9 @@ export class DropdownFilterPanel extends Component<
     if (!columnSelectionValidator) {
       return;
     }
-    columnSelectionValidator(this, DropdownFilterPanel.SOURCE_COLUMN);
+    columnSelectionValidator(this, DropdownFilterPanel.SOURCE_COLUMN, {
+      type: 'filterSource',
+    });
   }
 
   handleSourceMouseLeave(): void {
@@ -754,7 +759,7 @@ export class DropdownFilterPanel extends Component<
     if (!columnSelectionValidator) {
       return;
     }
-    columnSelectionValidator(this, undefined);
+    columnSelectionValidator(this, undefined, { type: 'filterSource' });
   }
 
   render(): React.ReactElement {

--- a/packages/dashboard-core-plugins/src/useDashboardColumnFilters.ts
+++ b/packages/dashboard-core-plugins/src/useDashboardColumnFilters.ts
@@ -19,13 +19,15 @@ import {
  * Subscribes to the dashboard column filters (a.k.a. InputFilter) for the current panel or widget, and
  * adds the columns provided to the filter options in the dashboard.
  * @param columns The columns this source has available for filtering.
- *                These are used to populate filter options in the UI (InputFilter, DropdownFilter)
+ *                These are used to populate filter options in the UI (InputFilter, DropdownFilter).
+ *                null can be used to indicate the source is not yet ready which is useful
+ *                to preserve
  * @param table The table for this source if applicable.
  *              This is used to enable ChartBuilder from IrisGrid.
  * @returns The dashboard column filters (InputFilter[]) that apply to the columns provided.
  */
 export function useDashboardColumnFilters(
-  columns: readonly { name: string; type: string }[],
+  columns: readonly { name: string; type: string }[] | null,
   table?: dh.Table
 ): InputFilter[] {
   const { eventHub } = useLayoutManager();
@@ -34,7 +36,7 @@ export function useDashboardColumnFilters(
 
   useEffect(
     function columnsChanged() {
-      if (panelId == null) {
+      if (panelId == null || columns == null) {
         return;
       }
       emitFilterColumnsChanged(eventHub, panelId, columns);
@@ -77,7 +79,7 @@ export function useDashboardColumnFilters(
   const inputFilters = useMemo(
     () =>
       IrisGridUtils.getInputFiltersForColumns(
-        columns,
+        columns ?? [],
         // They may have picked a column, but not actually entered a value yet. In that case, don't need to update.
         reduxInputFilters.filter(
           ({ value, excludePanelIds }) =>

--- a/packages/dashboard-core-plugins/src/useGridLinker.ts
+++ b/packages/dashboard-core-plugins/src/useGridLinker.ts
@@ -1,0 +1,170 @@
+import { useCallback, useEffect, useMemo } from 'react';
+import clamp from 'lodash.clamp';
+import {
+  useAppSelector,
+  useDashboardId,
+  useDhId,
+  useLayoutManager,
+  usePanelId,
+} from '@deephaven/dashboard';
+import { type RootState } from '@deephaven/redux';
+import {
+  type IrisGridProps,
+  type IrisGridModel,
+  type IrisGridType,
+} from '@deephaven/iris-grid';
+import { type ModelIndex } from '@deephaven/grid';
+import { type RowDataMap } from '@deephaven/jsapi-utils';
+import { type dh } from '@deephaven/jsapi-types';
+import { assertNotNull } from '@deephaven/utils';
+import {
+  emitLinkPointSelected,
+  emitLinkSourceDataSelected,
+  emitRegisterLinkTarget,
+} from './linker/LinkerEvent';
+import {
+  getColumnSelectionValidatorForDashboard,
+  getLinksForDashboard,
+} from './redux';
+
+export function useGridLinker(
+  model: IrisGridModel | null,
+  irisGrid: IrisGridType | null
+): Pick<
+  IrisGridProps,
+  | 'alwaysFetchColumns'
+  | 'columnSelectionValidator'
+  | 'isSelectingColumn'
+  | 'onColumnSelected'
+  | 'onDataSelected'
+> {
+  const { eventHub } = useLayoutManager();
+  const dashboardId = useDashboardId();
+  const dhId = useDhId();
+  const panelId = usePanelId();
+
+  const getLinks = useCallback(
+    (s: RootState) => getLinksForDashboard(s, dashboardId),
+    [dashboardId]
+  );
+
+  const links = useAppSelector(getLinks);
+  const linkColumns = useMemo(() => {
+    const columnSet = new Set<string>();
+    links.forEach(link => {
+      if (link.start.panelId === dhId) {
+        columnSet.add(link.start.columnName);
+      }
+    });
+    return [...columnSet];
+  }, [links, dhId]);
+
+  const getColumnSelectionValidator = useCallback(
+    (s: RootState) => getColumnSelectionValidatorForDashboard(s, dashboardId),
+    [dashboardId]
+  );
+  const columnSelectionValidator = useAppSelector(getColumnSelectionValidator);
+
+  const isColumnSelectionValid = useCallback(
+    (column: dh.Column | null) => {
+      if (columnSelectionValidator && column && dhId != null) {
+        return columnSelectionValidator(dhId, column, { type: 'tableLink' });
+      }
+      return false;
+    },
+    [columnSelectionValidator, dhId]
+  );
+  const isSelectingColumn = columnSelectionValidator != null;
+
+  const onDataSelected = useCallback(
+    (row: ModelIndex, dataMap: RowDataMap) => {
+      if (dhId == null) {
+        return;
+      }
+      emitLinkSourceDataSelected(eventHub, dhId, dataMap);
+    },
+    [eventHub, dhId]
+  );
+
+  const getCoordinates = useCallback(
+    (columnName: string): [number, number] | null => {
+      if (!model || !irisGrid) {
+        return null;
+      }
+
+      const { gridWrapper } = irisGrid;
+      const rect = gridWrapper?.getBoundingClientRect() ?? null;
+      if (rect == null || rect.width <= 0 || rect.height <= 0) {
+        return null;
+      }
+      const { metrics } = irisGrid.state;
+      assertNotNull(metrics);
+      const {
+        columnHeaderHeight,
+        allColumnXs,
+        allColumnWidths,
+        right,
+        columnHeaderMaxDepth,
+      } = metrics;
+      const columnIndex = model.getColumnIndexByName(columnName);
+      assertNotNull(columnIndex);
+      const visibleIndex = irisGrid.getVisibleColumn(columnIndex);
+      const columnX = allColumnXs.get(visibleIndex) ?? 0;
+      const columnWidth = allColumnWidths.get(visibleIndex) ?? 0;
+
+      const x = clamp(
+        visibleIndex > right
+          ? rect.right
+          : rect.left + columnX + columnWidth * 0.5,
+        rect.left,
+        rect.right
+      );
+      const y = rect.top + columnHeaderHeight * columnHeaderMaxDepth;
+
+      return [x, y];
+    },
+    [model, irisGrid]
+  );
+
+  const onColumnSelected = useCallback(
+    (column: dh.Column) => {
+      if (dhId == null) {
+        return;
+      }
+      emitLinkPointSelected(eventHub, dhId, column, {
+        type: 'tableLink',
+      });
+    },
+    [eventHub, dhId]
+  );
+
+  useEffect(
+    function registerTarget() {
+      if (!irisGrid || panelId == null || dhId == null) {
+        return;
+      }
+      emitRegisterLinkTarget(eventHub, dhId, {
+        getCoordinates,
+        setFilterValues: irisGrid.setFilterMap,
+        unsetFilterValue: () => {
+          // No-op
+        },
+        panelId,
+      });
+      return () => {
+        emitRegisterLinkTarget(eventHub, dhId, null);
+      };
+    },
+    [eventHub, dhId, getCoordinates, irisGrid, panelId]
+  );
+
+  return {
+    alwaysFetchColumns: linkColumns,
+    columnSelectionValidator: isColumnSelectionValid,
+    isSelectingColumn,
+    onColumnSelected,
+    onDataSelected,
+  };
+}
+
+export default useGridLinker;

--- a/packages/grid/src/GridMetrics.ts
+++ b/packages/grid/src/GridMetrics.ts
@@ -64,9 +64,21 @@ export type GridMetrics = {
   treePaddingY: number;
 
   // What viewport is currently visible, limited by data size
+  /**
+   * The visible index of the left-most column that is at least partially visible.
+   */
   left: VisibleIndex;
+  /**
+   * The visible index of the top row that is at least partially visible.
+   */
   top: VisibleIndex;
+  /**
+   * The visible index of the bottom row that is at least partially visible.
+   */
   bottom: VisibleIndex;
+  /**
+   * The visible index of the right-most column that is at least partially visible.
+   */
   right: VisibleIndex;
   topOffset: Coordinate;
   leftOffset: Coordinate;

--- a/packages/iris-grid/src/IrisGrid.tsx
+++ b/packages/iris-grid/src/IrisGrid.tsx
@@ -254,7 +254,7 @@ export type FilterData = {
 export type FilterMap = Map<
   ColumnName,
   {
-    columnType: string;
+    columnType: string | null;
     filterList: FilterData[];
   }
 >;
@@ -506,8 +506,8 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
     isStuckToBottom: false,
     isStuckToRight: false,
     columnSelectionValidator: null,
-    columnAllowedCursor: null,
-    columnNotAllowedCursor: null,
+    columnAllowedCursor: 'linker',
+    columnNotAllowedCursor: 'linker-not-allowed',
     copyCursor: 'copy',
     name: 'table',
     onlyFetchVisibleColumns: true,
@@ -631,6 +631,7 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
     this.handleGotoValueSubmitted = this.handleGotoValueSubmitted.bind(this);
     this.handleViewportUpdated = this.handleViewportUpdated.bind(this);
     this.makeQuickFilter = this.makeQuickFilter.bind(this);
+    this.setFilterMap = this.setFilterMap.bind(this);
 
     this.grid = null;
     this.lastLoadedConfig = null;

--- a/packages/iris-grid/src/IrisGridUtils.ts
+++ b/packages/iris-grid/src/IrisGridUtils.ts
@@ -953,7 +953,7 @@ class IrisGridUtils {
    * @returns The combination of the filters in filterList as text.
    */
   static combineFiltersFromList(
-    columnType: string,
+    columnType: string | null,
     filterList: FilterData[]
   ): string {
     filterList.sort((a, b) => {


### PR DESCRIPTION
Cherry-pick for Grizzly

This adds support for linker to `GridWidgetPlugin` so if you have tables within a dh.ui component (like 2 tables in a flex), you can link with them.