### PR TITLE
feat: Table plugin support for GridWidgetPlugin

### DIFF
--- a/packages/dashboard-core-plugins/src/GridWidgetPlugin.tsx
+++ b/packages/dashboard-core-plugins/src/GridWidgetPlugin.tsx
@@ -18,7 +18,7 @@ import { useSelector } from 'react-redux';
 import { getSettings, type RootState } from '@deephaven/redux';
 import { LoadingOverlay } from '@deephaven/components';
 import { useLayoutManager, useListener } from '@deephaven/dashboard';
-import { getErrorMessage } from '@deephaven/utils';
+import { assertNotNull, getErrorMessage } from '@deephaven/utils';
 import { useApi } from '@deephaven/jsapi-bootstrap';
 import { type GridRange, type GridState } from '@deephaven/grid';
 import { useIrisGridModel } from './useIrisGridModel';
@@ -34,7 +34,8 @@ export function GridWidgetPlugin({
   const { eventHub } = useLayoutManager();
 
   const fetchResult = useIrisGridModel(fetch);
-  const { model } = fetchResult;
+  const model =
+    fetchResult.status === 'success' ? fetchResult.model : undefined;
 
   const dh = useApi();
   const irisGridUtils = useMemo(() => new IrisGridUtils(dh), [dh]);
@@ -145,7 +146,7 @@ export function GridWidgetPlugin({
     return <LoadingOverlay isLoading />;
   }
 
-  if (fetchResult.status === 'error' || model == null) {
+  if (fetchResult.status === 'error') {
     return (
       <LoadingOverlay
         errorMessage={getErrorMessage(fetchResult.error)}
@@ -153,6 +154,8 @@ export function GridWidgetPlugin({
       />
     );
   }
+
+  assertNotNull(model, 'Model should be defined when fetch is successful');
 
   return (
     <IrisGrid

--- a/packages/dashboard-core-plugins/src/TablePluginWrapper.tsx
+++ b/packages/dashboard-core-plugins/src/TablePluginWrapper.tsx
@@ -54,6 +54,14 @@ export const TablePluginWrapper = forwardRef(
       return panelItem?.config.title ?? 'unknown';
     }, [layoutManager.root, panelId]);
 
+    const panel = useMemo(
+      () => ({
+        irisGrid: irisGridRef,
+        getTableName: () => panelName,
+      }),
+      [irisGridRef, panelName]
+    );
+
     return (
       <div className="iris-grid-plugin">
         <Plugin
@@ -70,10 +78,7 @@ export const TablePluginWrapper = forwardRef(
           // since we don't have an IrisGridPanel to use here.
           // eslint-disable-next-line @typescript-eslint/ban-ts-comment
           // @ts-ignore
-          panel={{
-            irisGrid: irisGridRef,
-            getTableName: () => panelName,
-          }}
+          panel={panel}
         />
       </div>
     );

--- a/packages/dashboard-core-plugins/src/useIrisGridModel.ts
+++ b/packages/dashboard-core-plugins/src/useIrisGridModel.ts
@@ -8,12 +8,10 @@ export type IrisGridModelFetch = () => Promise<dh.Table>;
 export type IrisGridModelFetchErrorResult = {
   error: NonNullable<unknown>;
   status: 'error';
-  model: undefined;
 };
 
 export type IrisGridModelFetchLoadingResult = {
   status: 'loading';
-  model: undefined;
 };
 
 export type IrisGridModelFetchSuccessResult = {

--- a/packages/dashboard-core-plugins/src/useTablePlugin.tsx
+++ b/packages/dashboard-core-plugins/src/useTablePlugin.tsx
@@ -13,12 +13,35 @@ import { type GridRange } from '@deephaven/grid';
 import { TablePluginWrapper } from './TablePluginWrapper';
 
 interface UseTablePluginProps {
+  /**
+   * The IrisGrid model for this plugin.
+   * Currently only IrisGridTableModelTemplate types are supported.
+   * Other IrisGrid model types will be ignored for now.
+   */
   model: IrisGridModel | undefined;
+  /**
+   * A reference to the IrisGrid component instance.
+   */
   irisGridRef: React.MutableRefObject<IrisGridType | null>;
+  /**
+   * A IrisGridUtils instance.
+   */
   irisGridUtils: IrisGridUtils;
+  /**
+   * The currently selected ranges in the grid.
+   */
   selectedRanges: readonly GridRange[] | undefined;
 }
 
+/**
+ * Hook to get a TablePlugin component and the IrisGrid props derived from the plugin.
+ * The returned props should be passed to the IrisGrid component or merged with other sources
+ * of the same props.
+ * @param props The properties for the table plugin. The props object itself does not need to be memoized,
+ *              but the values inside it should be stable to avoid unnecessary re-renders.
+ * @returns Object containing `Plugin` key which is the Plugin component.
+ *          The remaining object keys are IrisGrid props associated with the plugin.
+ */
 export function useTablePlugin({
   model,
   irisGridRef,

--- a/packages/dashboard/src/layout/LayoutUtils.test.ts
+++ b/packages/dashboard/src/layout/LayoutUtils.test.ts
@@ -167,3 +167,41 @@ describe('isEqual', () => {
     ).toBe(false);
   });
 });
+
+describe('getContentItemById', () => {
+  it('finds item with the specified ID', () => {
+    const root = makeContentItem('column');
+    const needle1 = Object.assign(makeContentItem('component'), {
+      config: { id: 'needle1' },
+    });
+    const needle2 = Object.assign(makeContentItem('component'), {
+      config: { id: 'needle2' },
+    });
+    root.addChild(needle1 as ContentItem);
+    root.addChild(needle2 as ContentItem);
+
+    const found = LayoutUtils.getContentItemById(
+      root as ContentItem,
+      'needle2'
+    );
+    expect(found).toEqual(needle2);
+  });
+
+  it('returns null if item with the specified ID not found', () => {
+    const root = makeContentItem('column');
+    const needle1 = Object.assign(makeContentItem('component'), {
+      config: { id: 'needle1' },
+    });
+    const needle2 = Object.assign(makeContentItem('component'), {
+      config: { id: 'needle2' },
+    });
+    root.addChild(needle1 as ContentItem);
+    root.addChild(needle2 as ContentItem);
+
+    const found = LayoutUtils.getContentItemById(
+      root as ContentItem,
+      'noItemFound'
+    );
+    expect(found).toBeNull();
+  });
+});

--- a/packages/dashboard/src/layout/LayoutUtils.ts
+++ b/packages/dashboard/src/layout/LayoutUtils.ts
@@ -242,7 +242,7 @@ class LayoutUtils {
 
   /**
    * Gets a content item by its ID
-   * @param item Golden layout content item to search for the content item
+   * @param item Golden layout content item to search for the content item. Typically the root.
    * @param searchId the ID
    */
   static getContentItemById(


### PR DESCRIPTION
Also fixes selection and panelState reactivity (for GridWidget, not IrisGridPanel). Could fix for IrisGridPanel here as well if desired.

Passes the panel name as `tableName` since tables do not actually have names. Mimics the `panel` prop passed to plugins to give `irisGrid` and `getTableName` which might have been previously used. Should keep most things backwards compatible unless there were other items from the panel being used.

One concern I have is the filters from plugins are completely invisible to users once they are applied. They don't go to quick filters or anywhere else, just applied with no visual. This probably makes sense as a separate ticket though.

## Testing

You can checkout my plugins branch https://github.com/mattrunyon/deephaven-plugins/tree/table-plugin-example and use the local JS plugin server.

Then use the following code to test (`stocks` will not update the counter state since it uses the `IrisGridPanel` version which doesn't update state prop to the component)

```py
import deephaven.ui as ui
import deephaven.plot.express as dx

stocks = dx.data.stocks().with_attributes({'PluginName' : 'table-example'})
t = ui.panel(stocks)
```