### PR TITLE
fix: DH-19864 Close tables used by Picker and ComboBox

### DIFF
--- a/packages/jsapi-components/src/spectrum/utils/usePickerProps.ts
+++ b/packages/jsapi-components/src/spectrum/utils/usePickerProps.ts
@@ -77,6 +77,9 @@ export function usePickerProps<TProps>({
     [tableSource]
   );
 
+  useEffect(() => () => tableSource?.close(), [tableSource]);
+  useEffect(() => () => tableCopy?.close(), [tableCopy]);
+
   const keyColumn = useMemo(
     () =>
       tableCopy == null ? null : getItemKeyColumn(tableCopy, keyColumnName),


### PR DESCRIPTION
DH-19864 seems to be caused by not closing these tables making the JS API client unhappy and it refuses to send data after so many re-renders with pickers in dh.ui

Not reproducible in DHC, so I will branch this off v0.85, publish an alpha, and deploy a grizzly BHS to confirm. This fixed for me with `npm run start-community` in DHE

Colin and I are still going to track down why exactly the JS API is unhappy about these tables not being closed