### PR TITLE
fix: Re-export isMessage and deprecate it

### DIFF
--- a/packages/jsapi-utils/src/MessageUtils.ts
+++ b/packages/jsapi-utils/src/MessageUtils.ts
@@ -3,6 +3,8 @@ import { isMessage, type PostMessage } from '@deephaven/utils';
 export {
   /** @deprecated Use `@deephaven/utils` `getWindowParent` instead. */
   getWindowParent,
+  /** @deprecated Use `@deephaven/utils` `isMessage` instead. */
+  isMessage,
   /** @deprecated Use `@deephaven/utils` `isResponse` instead. */
   isResponse,
   /** @deprecated Use `@deephaven/utils` `makeMessage` instead. */


### PR DESCRIPTION
- We broke this in https://github.com/deephaven/web-client-ui/pull/2425/files#diff-538c1b9fba1be844a9515eb2f507e4d14d56318d6be38bb96d166acafd45c810
  - It wasn't re-exporting isMessage, even though it imported it
- Just re-export isMessage, now #2425 is not a breaking change
