### PR TITLE
fix: DH-19882: Table not updating correctly when using react v18

### DIFF
--- a/packages/grid/src/Grid.tsx
+++ b/packages/grid/src/Grid.tsx
@@ -525,12 +525,14 @@ class Grid extends PureComponent<GridProps, GridState> {
 
     const changedProps = getChangedKeys(prevProps, this.props);
     const changedState = getChangedKeys(prevState, this.state);
-    // We don't need to bother re-checking any of the metrics if only the children have changed
+    // We don't need to bother re-checking any of the metrics if no props have changed or only the children have changed
     if (
-      changedProps.length === 1 &&
-      changedProps[0] === 'children' &&
+      (changedProps.length === 0 ||
+        (changedProps.length === 1 && changedProps[0] === 'children')) &&
       changedState.length === 0
     ) {
+      // We should still draw the canvas though, as we may have been called with a `forceUpdate`
+      this.requestUpdateCanvas();
       return;
     }
 
@@ -852,6 +854,9 @@ class Grid extends PureComponent<GridProps, GridState> {
     });
   }
 
+  /**
+   * Updates the canvas, metrics, and render state, then draws the canvas.
+   */
   updateCanvas(): void {
     this.updateCanvasScale();
 
@@ -869,7 +874,7 @@ class Grid extends PureComponent<GridProps, GridState> {
     const { onViewChanged } = this.props;
     onViewChanged(metrics);
 
-    this.drawCanvas(metrics);
+    this.drawCanvas();
   }
 
   private updateCanvasScale(): void {
@@ -1701,9 +1706,8 @@ class Grid extends PureComponent<GridProps, GridState> {
    * Draw the grid with the metrics provided
    * When scrolling you've have to re-draw the whole canvas. As a consequence, all these drawing methods
    * must be very quick.
-   * @param metrics Metrics to use for rendering the grid
    */
-  private drawCanvas(metrics = this.updateMetrics()): void {
+  private drawCanvas(): void {
     if (!this.canvas) throw new Error('canvas is not set');
     if (!this.canvasContext) throw new Error('context not set');
 


### PR DESCRIPTION
- We added a check in #1631 in Grid.componentDidUpdate to avoid doing more work than necessary, however that actually broke things on React v18
  - In v17 it would still go through the rest of the function, because changedProps.length was === 0 and would skip the early return, and then it would draw the grid
- Just update the canvas in this case
