### PR TITLE
fix: DH-19864 Close tables used by Picker and ComboBox (#2482)

### DIFF
--- a/packages/jsapi-components/src/spectrum/utils/usePickerProps.ts
+++ b/packages/jsapi-components/src/spectrum/utils/usePickerProps.ts
@@ -15,6 +15,7 @@ import { getItemKeyColumn, getItemLabelColumn } from './itemUtils';
 import { useItemRowDeserializer } from './useItemRowDeserializer';
 import { useGetItemIndexByValue } from '../../useGetItemIndexByValue';
 import useSearchableViewportData from '../../useSearchableViewportData';
+import useTableClose from '../../useTableClose';
 
 const log = Log.module('jsapi-components.usePickerProps');
 
@@ -76,6 +77,8 @@ export function usePickerProps<TProps>({
     TableUtils.copyTableAndApplyFilters,
     [tableSource]
   );
+
+  useTableClose(tableCopy);
 
   const keyColumn = useMemo(
     () =>


### PR DESCRIPTION
Cherry pick for Grizzly

DH-19864 seems to be caused by not closing these tables making the JS API client unhappy and it refuses to send data after so many re-renders with pickers in dh.ui