### PR TITLE
fix: DH-19911: Fix initial isLoading state in usePromiseFactory when autoload is true

### DIFF
--- a/packages/react-hooks/src/usePromiseFactory.test.ts
+++ b/packages/react-hooks/src/usePromiseFactory.test.ts
@@ -92,6 +92,9 @@ it.each([true, false])(
       usePromiseFactory(promiseFactory, args, { autoLoad })
     );
 
+    // isLoading should be true on the initial render if autoLoad is true
+    expect(result.current.isLoading).toEqual(autoLoad);
+
     if (autoLoad) {
       await waitForNextUpdate();
     }

--- a/packages/react-hooks/src/usePromiseFactory.ts
+++ b/packages/react-hooks/src/usePromiseFactory.ts
@@ -48,7 +48,7 @@ export default function usePromiseFactory<T, TArgs extends unknown[]>(
 ): UsePromiseFactoryResult<T> {
   const [data, setData] = useState<T | null>(null);
   const [error, setError] = useState<Error | string | null>(null);
-  const [isLoading, setIsLoading] = useState(false);
+  const [isLoading, setIsLoading] = useState(autoLoad);
 
   const loadPromise = useCallback(async () => {
     setIsLoading(true);


### PR DESCRIPTION
usePromiseFactory returns `loading = false` on first pass, even though it starts loading immediately