### PR TITLE
fix: DH-19882: Render loop occurring in React v18

### DIFF
--- a/packages/grid/src/Grid.tsx
+++ b/packages/grid/src/Grid.tsx
@@ -216,6 +216,9 @@ export type GridState = {
    * so we need to throw them in componentDidUpdate
    */
   renderError?: unknown;
+
+  /** What revision the grid is drawing. Automatically increments when a forceUpdate is called. */
+  updateRevision: number;
 };
 
 /**
@@ -486,6 +489,9 @@ class Grid extends PureComponent<GridProps, GridState> {
 
       isStuckToBottom,
       isStuckToRight,
+
+      /** What revision the grid is drawing. Automatically increments when a forceUpdate is called. */
+      updateRevision: 0,
     };
   }
 
@@ -531,8 +537,6 @@ class Grid extends PureComponent<GridProps, GridState> {
         (changedProps.length === 1 && changedProps[0] === 'children')) &&
       changedState.length === 0
     ) {
-      // We should still draw the canvas though, as we may have been called with a `forceUpdate`
-      this.requestUpdateCanvas();
       return;
     }
 
@@ -1923,6 +1927,13 @@ class Grid extends PureComponent<GridProps, GridState> {
     if (!this.metrics) throw new Error('metrics not set');
 
     this.forceUpdate();
+  }
+
+  forceUpdate(callback?: (() => void) | undefined): void {
+    this.setState(({ updateRevision = 0 }) => ({
+      updateRevision: (updateRevision + 1) % Number.MAX_SAFE_INTEGER,
+    }));
+    super.forceUpdate(callback);
   }
 
   handleWheel(event: WheelEvent): void {


### PR DESCRIPTION
- Have an `updateRevision` state property that will update when forceUpdate is called, so we actually have a state variable that changes
  - Similar to how Plotly handles data updates
- Removed the old logic that would trigger a draw any time componentDidUpdate was called
