### PR TITLE
fix: DH-19614: Add tree table formatting logic to tree model (#2461)

### DIFF
--- a/packages/iris-grid/src/IrisGridTableModelTemplate.ts
+++ b/packages/iris-grid/src/IrisGridTableModelTemplate.ts
@@ -619,22 +619,12 @@ class IrisGridTableModelTemplate<
       // Fallback to formatting based on the value/type of the cell
       if (value != null) {
         const column = this.sourceColumn(x, y);
-        if (TableUtils.isDateType(column.type) || column.name === 'Date') {
-          assertNotNull(theme.dateColor);
-          return theme.dateColor;
-        }
-        if (TableUtils.isNumberType(column.type)) {
-          if ((value as number) > 0) {
-            assertNotNull(theme.positiveNumberColor);
-            return theme.positiveNumberColor;
-          }
-          if ((value as number) < 0) {
-            assertNotNull(theme.negativeNumberColor);
-            return theme.negativeNumberColor;
-          }
-          assertNotNull(theme.zeroNumberColor);
-          return theme.zeroNumberColor;
-        }
+        return IrisGridUtils.colorForValue(
+          theme,
+          column.type,
+          column.name,
+          value
+        );
       }
     } else if (this.isPendingRow(y) && this.isKeyColumn(x)) {
       assertNotNull(theme.errorTextColor);
@@ -652,17 +642,10 @@ class IrisGridTableModelTemplate<
     return this.formatForCell(x, y)?.backgroundColor ?? null;
   }
 
-  textAlignForCell(x: ModelIndex): CanvasTextAlign {
-    const column = this.columns[x];
-    const { type } = column;
+  textAlignForCell(x: ModelIndex, y: ModelIndex): CanvasTextAlign {
+    const column = this.sourceColumn(x, y);
 
-    if (TableUtils.isNumberType(type)) {
-      return 'right';
-    }
-    if (TableUtils.isDateType(type) || column.name === 'Date') {
-      return 'center';
-    }
-    return 'left';
+    return IrisGridUtils.textAlignForValue(column.type, column.name);
   }
 
   textForColumnHeader(x: ModelIndex, depth = 0): string | undefined {

--- a/packages/iris-grid/src/IrisGridTreeTableModel.test.ts
+++ b/packages/iris-grid/src/IrisGridTreeTableModel.test.ts
@@ -284,8 +284,12 @@ describe('IrisGridTreeTableModel colorForCell', () => {
     column?: DhType.Column,
     row?: UITreeRow
   ) => {
-    if (column) jest.spyOn(model, 'sourceColumn').mockReturnValue(column);
-    if (row) jest.spyOn(model, 'row').mockReturnValue(row);
+    if (column != null) {
+      jest.spyOn(model, 'sourceColumn').mockReturnValue(column);
+    }
+    if (row != null) {
+      jest.spyOn(model, 'row').mockReturnValue(row);
+    }
     jest.spyOn(model, 'dataForCell').mockReturnValue({ value, format });
   };
 

--- a/packages/iris-grid/src/IrisGridTreeTableModel.test.ts
+++ b/packages/iris-grid/src/IrisGridTreeTableModel.test.ts
@@ -1,6 +1,9 @@
 import dh from '@deephaven/jsapi-shim';
 import IrisGridTestUtils from './IrisGridTestUtils';
-import IrisGridTreeTableModel from './IrisGridTreeTableModel';
+import IrisGridTreeTableModel, {
+  type UITreeRow,
+} from './IrisGridTreeTableModel';
+import type { IrisGridThemeType } from './IrisGridTheme';
 
 const irisGridTestUtils = new IrisGridTestUtils(dh);
 
@@ -213,5 +216,159 @@ describe('IrisGridTreeTableModel isFilterable', () => {
     expect(model.isFilterable(3)).toBe(false);
     expect(model.isFilterable(4)).toBe(false);
     expect(model.isFilterable(5)).toBe(false);
+  });
+});
+
+describe('IrisGridTreeTableModel colorForCell and textAlignForCell', () => {
+  let model: IrisGridTreeTableModel;
+
+  const mockTheme: IrisGridThemeType = {
+    textColor: '#text-color',
+    dateColor: '#date-color',
+    positiveNumberColor: '#positive-color',
+    negativeNumberColor: '#negative-color',
+    zeroNumberColor: '#zero-color',
+    nullStringColor: '#null-string-color',
+  } as IrisGridThemeType;
+
+  const columns = {
+    string: irisGridTestUtils.makeColumn('StrCol', 'java.lang.String', 0),
+    number: irisGridTestUtils.makeColumn('NumCol', 'int', 0),
+    date: irisGridTestUtils.makeColumn(
+      'DateCol',
+      'io.deephaven.time.DateTime',
+      0
+    ),
+    dateNamed: irisGridTestUtils.makeColumn('Date', 'java.lang.String', 0),
+  };
+
+  const rows = {
+    default: {
+      data: new Map(),
+      hasChildren: false,
+      isExpanded: false,
+      depth: 1,
+    } as UITreeRow,
+    parent: {
+      data: new Map(),
+      hasChildren: true,
+      isExpanded: false,
+      depth: 1,
+    } as UITreeRow,
+    leaf: {
+      data: new Map(),
+      hasChildren: false,
+      isExpanded: false,
+      depth: 2,
+    } as UITreeRow,
+  };
+
+  beforeEach(() => {
+    const testColumns = irisGridTestUtils.makeColumns();
+    const table = irisGridTestUtils.makeTreeTable(
+      testColumns,
+      testColumns.slice(0, 1),
+      100,
+      []
+    );
+    model = new IrisGridTreeTableModel(dh, table);
+
+    // Setup the basic mocks needed for assertNotNull checks
+    jest.spyOn(model, 'sourceColumn').mockReturnValue(columns.string);
+    jest.spyOn(model, 'row').mockReturnValue(rows.default);
+  });
+
+  const mockCell = (
+    value: unknown,
+    format?: { color?: string },
+    column?: DhType.Column,
+    row?: UITreeRow
+  ) => {
+    if (column) jest.spyOn(model, 'sourceColumn').mockReturnValue(column);
+    if (row) jest.spyOn(model, 'row').mockReturnValue(row);
+    jest.spyOn(model, 'dataForCell').mockReturnValue({ value, format });
+  };
+
+  describe('colorForCell', () => {
+    it('returns nullStringColor for null values', () => {
+      mockCell(null);
+      const result = model.colorForCell(0, 0, mockTheme);
+      expect(result).toBe(mockTheme.nullStringColor);
+    });
+
+    it('returns nullStringColor for empty strings', () => {
+      mockCell('');
+      const result = model.colorForCell(0, 0, mockTheme);
+      expect(result).toBe(mockTheme.nullStringColor);
+    });
+
+    it('returns custom color when available', () => {
+      const customColor = '#e0e0e0';
+      mockCell('test', { color: customColor });
+      const result = model.colorForCell(0, 0, mockTheme);
+      expect(result).toBe(customColor);
+    });
+
+    it('delegates to IrisGridUtils.colorForValue for standard color logic', () => {
+      mockCell(42, undefined, columns.number);
+      const result = model.colorForCell(0, 0, mockTheme);
+      expect(result).toBe(mockTheme.positiveNumberColor);
+    });
+  });
+
+  describe('colorForCell constituent type handling', () => {
+    it('uses constituent type for tree table leaf nodes', () => {
+      const constituentColumn = {
+        ...irisGridTestUtils.makeColumn('TestCol', 'java.lang.String', 0),
+        constituentType: 'int',
+      } as DhType.Column;
+
+      mockCell(1, undefined, constituentColumn, rows.leaf);
+      const result = model.colorForCell(0, 0, mockTheme);
+      expect(result).toBe(mockTheme.positiveNumberColor);
+    });
+
+    it('ignores constituent type for non-leaf nodes', () => {
+      const constituentColumn = {
+        ...irisGridTestUtils.makeColumn('TestCol', 'java.lang.String', 0),
+        constituentType: 'int',
+      } as DhType.Column;
+
+      mockCell('test', undefined, constituentColumn, rows.parent);
+      const result = model.colorForCell(0, 0, mockTheme);
+      expect(result).toBe(mockTheme.textColor);
+    });
+  });
+
+  describe('textAlignForCell', () => {
+    it('delegates to IrisGridUtils.textAlignForValue for standard alignment logic', () => {
+      mockCell('ignored', undefined, columns.number);
+      const result = model.textAlignForCell(0, 0);
+      expect(result).toBe('right');
+    });
+  });
+
+  describe('textAlignForCell constituent type handling', () => {
+    it('uses constituent type for tree table leaf nodes', () => {
+      const constituentColumn = {
+        ...irisGridTestUtils.makeColumn('TestCol', 'java.lang.String', 0),
+        constituentType: 'double',
+      } as DhType.Column;
+
+      mockCell('ignored', undefined, constituentColumn, rows.leaf);
+      const result = model.textAlignForCell(0, 0);
+      expect(result).toBe('right');
+    });
+
+    it('ignores constituent type for non-leaf nodes', () => {
+      const constituentColumn = {
+        ...irisGridTestUtils.makeColumn('TestCol', 'java.lang.String', 0),
+        constituentType: 'int',
+      } as DhType.Column;
+
+      mockCell('ignored', undefined, constituentColumn, rows.parent);
+      const result = model.textAlignForCell(0, 0);
+      expect(result).toBe('left');
+    });
   });
 });

--- a/packages/iris-grid/src/IrisGridTreeTableModel.test.ts
+++ b/packages/iris-grid/src/IrisGridTreeTableModel.test.ts
@@ -219,7 +219,7 @@ describe('IrisGridTreeTableModel isFilterable', () => {
   });
 });
 
-describe('IrisGridTreeTableModel colorForCell and textAlignForCell', () => {
+describe('IrisGridTreeTableModel colorForCell', () => {
   let model: IrisGridTreeTableModel;
 
   const mockTheme: IrisGridThemeType = {
@@ -339,36 +339,76 @@ describe('IrisGridTreeTableModel colorForCell and textAlignForCell', () => {
       expect(result).toBe(mockTheme.textColor);
     });
   });
+});
 
-  describe('textAlignForCell', () => {
-    it('delegates to IrisGridUtils.textAlignForValue for standard alignment logic', () => {
-      mockCell('ignored', undefined, columns.number);
-      const result = model.textAlignForCell(0, 0);
-      expect(result).toBe('right');
-    });
+describe('IrisGridTreeTableModel textAlignForCell', () => {
+  let model: IrisGridTreeTableModel;
+
+  const rows = {
+    default: {
+      data: new Map(),
+      hasChildren: false,
+      isExpanded: false,
+      depth: 1,
+    } as UITreeRow,
+    parent: {
+      data: new Map(),
+      hasChildren: true,
+      isExpanded: false,
+      depth: 1,
+    } as UITreeRow,
+    leaf: {
+      data: new Map(),
+      hasChildren: false,
+      isExpanded: false,
+      depth: 2,
+    } as UITreeRow,
+  };
+
+  beforeEach(() => {
+    const testColumns = irisGridTestUtils.makeColumns();
+    const table = irisGridTestUtils.makeTreeTable(
+      testColumns,
+      testColumns.slice(0, 1),
+      100,
+      []
+    );
+    model = new IrisGridTreeTableModel(dh, table);
   });
 
-  describe('textAlignForCell constituent type handling', () => {
-    it('uses constituent type for tree table leaf nodes', () => {
-      const constituentColumn = {
-        ...irisGridTestUtils.makeColumn('TestCol', 'java.lang.String', 0),
-        constituentType: 'double',
-      } as DhType.Column;
+  it('delegates to IrisGridUtils.textAlignForValue for standard alignment logic', () => {
+    const numberColumn = irisGridTestUtils.makeColumn('NumCol', 'int', 0);
 
-      mockCell('ignored', undefined, constituentColumn, rows.leaf);
-      const result = model.textAlignForCell(0, 0);
-      expect(result).toBe('right');
-    });
+    jest.spyOn(model, 'sourceColumn').mockReturnValue(numberColumn);
+    jest.spyOn(model, 'row').mockReturnValue(rows.default);
 
-    it('ignores constituent type for non-leaf nodes', () => {
-      const constituentColumn = {
-        ...irisGridTestUtils.makeColumn('TestCol', 'java.lang.String', 0),
-        constituentType: 'int',
-      } as DhType.Column;
+    const result = model.textAlignForCell(0, 0);
+    expect(result).toBe('right');
+  });
 
-      mockCell('ignored', undefined, constituentColumn, rows.parent);
-      const result = model.textAlignForCell(0, 0);
-      expect(result).toBe('left');
-    });
+  it('uses constituent type for tree table leaf row', () => {
+    const constituentColumn = {
+      ...irisGridTestUtils.makeColumn('TestCol', 'java.lang.String', 0),
+      constituentType: 'double',
+    } as DhType.Column;
+
+    jest.spyOn(model, 'sourceColumn').mockReturnValue(constituentColumn);
+    jest.spyOn(model, 'row').mockReturnValue(rows.leaf);
+
+    const result = model.textAlignForCell(0, 0);
+    expect(result).toBe('right');
+  });
+
+  it('ignores constituent type for non-leaf row', () => {
+    const constituentColumn = {
+      ...irisGridTestUtils.makeColumn('TestCol', 'java.lang.String', 0),
+      constituentType: 'int',
+    } as DhType.Column;
+
+    jest.spyOn(model, 'sourceColumn').mockReturnValue(constituentColumn);
+    jest.spyOn(model, 'row').mockReturnValue(rows.parent);
+
+    const result = model.textAlignForCell(0, 0);
+    expect(result).toBe('left');
   });
 });

--- a/packages/iris-grid/src/IrisGridTreeTableModel.ts
+++ b/packages/iris-grid/src/IrisGridTreeTableModel.ts
@@ -12,7 +12,9 @@ import { Formatter, TableUtils } from '@deephaven/jsapi-utils';
 import { assertNotNull, EMPTY_ARRAY } from '@deephaven/utils';
 import { type UIRow, type ColumnName } from './CommonTypes';
 import IrisGridTableModelTemplate from './IrisGridTableModelTemplate';
-import { DisplayColumn } from './IrisGridModel';
+import { type DisplayColumn } from './IrisGridModel';
+import { type IrisGridThemeType } from './IrisGridTheme';
+import IrisGridUtils from './IrisGridUtils';
 
 const log = Log.module('IrisGridTreeTableModel');
 
@@ -20,6 +22,24 @@ export interface UITreeRow extends UIRow {
   isExpanded: boolean;
   hasChildren: boolean;
   depth: number;
+}
+
+/**
+ * Check if a row is a UITreeRow
+ * @param row The row to check
+ * @returns True if the row is a UITreeRow and false otherwise
+ */
+export function isUITreeRow(row: unknown): row is UITreeRow {
+  return (
+    row != null &&
+    typeof row === 'object' &&
+    'hasChildren' in row &&
+    'isExpanded' in row &&
+    'depth' in row &&
+    typeof row.hasChildren === 'boolean' &&
+    typeof row.isExpanded === 'boolean' &&
+    typeof row.depth === 'number'
+  );
 }
 
 type LayoutTreeTable = DhType.TreeTable & {
@@ -124,6 +144,66 @@ class IrisGridTreeTableModel extends IrisGridTableModelTemplate<
     }
 
     return super.textForCell(x, y);
+  }
+
+  colorForCell(x: ModelIndex, y: ModelIndex, theme: IrisGridThemeType): string {
+    const data = this.dataForCell(x, y);
+    if (data) {
+      const { format, value } = data;
+      if (value == null || value === '') {
+        assertNotNull(theme.nullStringColor);
+        return theme.nullStringColor;
+      }
+      if (format?.color != null && format.color !== '') {
+        return format.color;
+      }
+
+      // Fallback to formatting based on the value/type of the cell
+      if (value != null) {
+        const column = this.sourceColumn(x, y);
+        const row = this.row(y);
+        assertNotNull(row);
+
+        let columnTypeForFormatting = column.type;
+
+        // For tree table leaf nodes, use the constituent type for formatting
+        if (
+          isUITreeRow(row) &&
+          row.hasChildren === false &&
+          column.constituentType != null
+        ) {
+          columnTypeForFormatting = column.constituentType;
+        }
+
+        return IrisGridUtils.colorForValue(
+          theme,
+          columnTypeForFormatting,
+          column.name,
+          value
+        );
+      }
+    }
+
+    return theme.textColor;
+  }
+
+  textAlignForCell(x: ModelIndex, y: ModelIndex): CanvasTextAlign {
+    const column = this.sourceColumn(x, y);
+    const row = this.row(y);
+    assertNotNull(row);
+
+    let typeForFormatting = column.type;
+
+    // For tree table leaf nodes, use the constituent type for formatting
+    if (
+      isUITreeRow(row) &&
+      row.hasChildren === false &&
+      column.constituentType != null
+    ) {
+      typeForFormatting = column.constituentType;
+    }
+
+    return IrisGridUtils.textAlignForValue(typeForFormatting, column.name);
   }
 
   extractViewportRow(row: DhType.TreeRow, columns: DhType.Column[]): UITreeRow {

--- a/packages/iris-grid/src/IrisGridUtils.test.ts
+++ b/packages/iris-grid/src/IrisGridUtils.test.ts
@@ -16,6 +16,7 @@ import IrisGridUtils, {
   DehydratedSort,
   LegacyDehydratedSort,
 } from './IrisGridUtils';
+import type { IrisGridThemeType } from './IrisGridTheme';
 
 const irisGridUtils = new IrisGridUtils(dh);
 const irisGridTestUtils = new IrisGridTestUtils(dh);
@@ -791,4 +792,114 @@ describe('hydration methods', () => {
       expect(result.partitions).toEqual(expectedPartitions);
     }
   );
+});
+
+describe('colorForValue', () => {
+  const mockTheme: IrisGridThemeType = {
+    textColor: '#text-color',
+    dateColor: '#date-color',
+    positiveNumberColor: '#positive-color',
+    negativeNumberColor: '#negative-color',
+    zeroNumberColor: '#zero-color',
+    nullStringColor: '#null-string-color',
+  } as IrisGridThemeType;
+
+  it('returns dateColor for date type columns', () => {
+    const result = IrisGridUtils.colorForValue(
+      mockTheme,
+      'io.deephaven.time.DateTime',
+      'TestColumn',
+      new Date()
+    );
+    expect(result).toBe('#date-color');
+  });
+
+  it('returns dateColor for columns named Date', () => {
+    const result = IrisGridUtils.colorForValue(
+      mockTheme,
+      'java.lang.String',
+      'Date',
+      'Fri Jun 13'
+    );
+    expect(result).toBe('#date-color');
+  });
+
+  it('returns positiveNumberColor for positive numbers', () => {
+    const result = IrisGridUtils.colorForValue(
+      mockTheme,
+      'int',
+      'TestColumn',
+      42
+    );
+    expect(result).toBe('#positive-color');
+  });
+
+  it('returns negativeNumberColor for negative numbers', () => {
+    const result = IrisGridUtils.colorForValue(
+      mockTheme,
+      'short',
+      'TestColumn',
+      -5
+    );
+    expect(result).toBe('#negative-color');
+  });
+
+  it('returns zeroNumberColor for zero values', () => {
+    const result = IrisGridUtils.colorForValue(
+      mockTheme,
+      'long',
+      'TestColumn',
+      0
+    );
+    expect(result).toBe('#zero-color');
+  });
+
+  it('returns textColor as fallback', () => {
+    const result = IrisGridUtils.colorForValue(
+      mockTheme,
+      'java.lang.String',
+      'TestColumn',
+      'Hello world'
+    );
+    expect(result).toBe('#text-color');
+  });
+});
+
+describe('textAlignForValue', () => {
+  it('returns center for date type columns', () => {
+    expect(
+      IrisGridUtils.textAlignForValue(
+        'io.deephaven.time.DateTime',
+        'TestColumn'
+      )
+    ).toBe('center');
+    expect(
+      IrisGridUtils.textAlignForValue('java.time.Instant', 'TestColumn')
+    ).toBe('center');
+  });
+
+  it('returns center for columns named Date', () => {
+    expect(IrisGridUtils.textAlignForValue('java.lang.String', 'Date')).toBe(
+      'center'
+    );
+    expect(IrisGridUtils.textAlignForValue('int', 'Date')).toBe('center');
+  });
+
+  it('returns right for number type columns', () => {
+    expect(IrisGridUtils.textAlignForValue('int', 'TestColumn')).toBe('right');
+    expect(IrisGridUtils.textAlignForValue('double', 'TestColumn')).toBe(
+      'right'
+    );
+    expect(IrisGridUtils.textAlignForValue('long', 'TestColumn')).toBe('right');
+    expect(IrisGridUtils.textAlignForValue('float', 'TestColumn')).toBe(
+      'right'
+    );
+  });
+
+  it('returns left as fallback', () => {
+    expect(
+      IrisGridUtils.textAlignForValue('java.lang.String', 'TestColumn')
+    ).toBe('left');
+    expect(IrisGridUtils.textAlignForValue('char', 'TestColumn')).toBe('left');
+  });
 });

--- a/packages/iris-grid/src/IrisGridUtils.ts
+++ b/packages/iris-grid/src/IrisGridUtils.ts
@@ -46,6 +46,7 @@ import {
   isPartitionedGridModelProvider,
   PartitionConfig,
 } from './PartitionedGridModel';
+import { type IrisGridThemeType } from './IrisGridTheme';
 
 const log = Log.module('IrisGridUtils');
 
@@ -1791,6 +1792,60 @@ class IrisGridUtils {
         return dh.RangeSet.ofRange(startRow, endRow);
       });
     return dh.RangeSet.ofRanges(rangeSets);
+  }
+
+  /**
+   * Get the color for a cell value
+   * @param theme The IrisGrid theme
+   * @param columnType The type of the column
+   * @param columnName The name of the column
+   * @param value The value of the cell
+   * @returns The color for the cell value
+   */
+  static colorForValue(
+    theme: IrisGridThemeType,
+    columnType: string,
+    columnName: string,
+    value: unknown
+  ): string {
+    if (TableUtils.isDateType(columnType) || columnName === 'Date') {
+      assertNotNull(theme.dateColor);
+      return theme.dateColor;
+    }
+    if (TableUtils.isNumberType(columnType)) {
+      if ((value as number) > 0) {
+        assertNotNull(theme.positiveNumberColor);
+        return theme.positiveNumberColor;
+      }
+      if ((value as number) < 0) {
+        assertNotNull(theme.negativeNumberColor);
+        return theme.negativeNumberColor;
+      }
+      assertNotNull(theme.zeroNumberColor);
+      return theme.zeroNumberColor;
+    }
+    return theme.textColor;
+  }
+
+  /**
+   * Determines the text alignment for a cell value
+   * @param columnType The type of the column
+   * @param columnName The name of the column
+   * @returns The text alignment for the cell value
+   */
+  static textAlignForValue(
+    columnType: string,
+    columnName: string
+  ): CanvasTextAlign {
+    if (TableUtils.isDateType(columnType) || columnName === 'Date') {
+      return 'center';
+    }
+
+    if (TableUtils.isNumberType(columnType)) {
+      return 'right';
+    }
+
+    return 'left';
   }
 }
 


### PR DESCRIPTION
Part of DH-19614. Fixes an issue with rollups where tree table aggregated constituents were not being rendered based on the original column type. This change ensures that leaf nodes in tree tables use the appropriate column type for formatting and alignment.

Changes:
- Added tree table specific overrides to `IrisGridTreeTableModel`:
- Updated `colorForCell` to use `column.constituentType` instead of `column,type` for leaf node values
- Updated `textAlignForCell` to use `column.constituentType` for leaf node values
- Added type guard `isUITreeRow` function in `IrisGridTreeTableModel.ts`