### PR TITLE
feat: DH-19897: Handle missing jsapi/dh-internal.js files on core workers

### DIFF
--- a/packages/jsapi-nodejs/src/errorUtils.ts
+++ b/packages/jsapi-nodejs/src/errorUtils.ts
@@ -1,3 +1,16 @@
+import { STATUS_CODES } from 'node:http';
+
+/** General Http Error class. */
+export class HttpError extends Error {
+  constructor(
+    public statusCode: number,
+    message?: string
+  ) {
+    super(message ?? STATUS_CODES[statusCode]);
+    this.name = 'HttpError';
+  }
+}
+
 /**
  * Return true if given error has a code:string prop. Optionally check if the
  * code matches a given value.

--- a/packages/jsapi-nodejs/src/loaderUtils.ts
+++ b/packages/jsapi-nodejs/src/loaderUtils.ts
@@ -69,9 +69,7 @@ export async function loadModules<TMainModule>({
 
     let contents: string[];
 
-    if (typeof download !== 'function' || handleErrorsInPostDownload !== true) {
-      contents = await Promise.all(downloadPromises);
-    } else {
+    if (typeof download === 'function' && handleErrorsInPostDownload === true) {
       const results = await Promise.allSettled(downloadPromises);
       contents = results.map((result, i) => {
         if (result.status === 'fulfilled') {
@@ -86,6 +84,8 @@ export async function loadModules<TMainModule>({
 
         throw result.reason;
       });
+    } else {
+      contents = await Promise.all(downloadPromises);
     }
 
     // Write to disk

--- a/packages/jsapi-nodejs/src/serverUtils.ts
+++ b/packages/jsapi-nodejs/src/serverUtils.ts
@@ -12,23 +12,14 @@ export const SERVER_STATUS_CHECK_TIMEOUT = 3000;
  * @param retries The number of retries on failure
  * @param retryDelay The delay between retries in milliseconds
  * @param logger An optional logger object. Defaults to `console`
- * @param treat404asEmptyContent Optional flag to resolve 404s as empty content.
- * Otherwise throws an error.
  * @returns Promise which resolves to the module's exports
  */
-export async function downloadFromURL({
-  url,
+export async function downloadFromURL(
+  url: URL,
   retries = 10,
   retryDelay = 1000,
-  logger = console,
-  treat404asEmptyContent = false,
-}: {
-  url: URL;
-  retries?: number;
-  retryDelay?: number;
-  logger?: { error: (...args: unknown[]) => void };
-  treat404asEmptyContent?: boolean;
-}): Promise<string> {
+  logger: { error: (...args: unknown[]) => void } = console
+): Promise<string> {
   return new Promise((resolve, reject) => {
     const urlObj = new URL(url);
 
@@ -55,11 +46,7 @@ export async function downloadFromURL({
 
         res.on('end', async () => {
           if (res.statusCode === 404) {
-            if (treat404asEmptyContent) {
-              resolve('');
-            } else {
-              reject(new HttpError(404, `File not found: "${url}"`));
-            }
+            reject(new HttpError(404, `File not found: "${url}"`));
             return;
           }
 
@@ -75,12 +62,10 @@ export async function downloadFromURL({
           logger.error('Retrying url:', url);
           setTimeout(
             () =>
-              downloadFromURL({
-                url,
-                retries: retries - 1,
-                retryDelay,
-                logger,
-              }).then(resolve, reject),
+              downloadFromURL(url, retries - 1, retryDelay, logger).then(
+                resolve,
+                reject
+              ),
             retryDelay
           );
         } else {


### PR DESCRIPTION
DH-19897: Handle missing jsapi/dh-internal.js files on core workers

I added a flag to resolve 404s as empty content instead of throwing an error. 404s were already differentiated from other errors that get retry attempts, so it was a simple change.

Testing
I tested locally by renaming `jsapi/dh-internal.js` in the `loadModules` call to `jsapi/dh-internal2.js` to mimick a 404. Confirmed empty content file gets created in VS Code extension.

I also tested stopping the server which produces a different error that invokes the retry mechanism instead of a 404. Worst case scenario, if we ever get out of sorts, restarting VS Code will delete the tmp download folder and retry everything again.
