### PR TITLE
fix: DH-19601: Pin aggregations to the top in input tables

### DIFF
--- a/packages/iris-grid/src/IrisGrid.tsx
+++ b/packages/iris-grid/src/IrisGrid.tsx
@@ -864,6 +864,7 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
       rollupConfig,
       rollupSelectedColumns: [],
       aggregationSettings:
+        // Fix aggregations to the top if the grid is editable, so that the bottom is reserved for pending rows
         isEditableGridModel(model) && model.isEditable
           ? { ...aggregationSettings, showOnTop: true }
           : aggregationSettings,

--- a/packages/iris-grid/src/IrisGrid.tsx
+++ b/packages/iris-grid/src/IrisGrid.tsx
@@ -864,7 +864,7 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
       rollupConfig,
       rollupSelectedColumns: [],
       aggregationSettings:
-        // Fix aggregations to the top if the grid is editable, so that the bottom is reserved for pending rows
+        // Pin aggregations to the top if the grid is editable, so that the bottom is reserved for pending rows
         isEditableGridModel(model) && model.isEditable
           ? { ...aggregationSettings, showOnTop: true }
           : aggregationSettings,

--- a/packages/iris-grid/src/IrisGrid.tsx
+++ b/packages/iris-grid/src/IrisGrid.tsx
@@ -213,6 +213,19 @@ const DEFAULT_AGGREGATION_SETTINGS = Object.freeze({
   showOnTop: false,
 });
 
+function getAggregationSettingsForModel(
+  aggregationSettings: AggregationSettings,
+  model: IrisGridModel
+): AggregationSettings {
+  if (isEditableGridModel(model) && model.isEditable) {
+    return {
+      ...aggregationSettings,
+      showOnTop: true,
+    };
+  }
+  return aggregationSettings;
+}
+
 const UNFORMATTED_DATE_PATTERN = `yyyy-MM-dd'T'HH:mm:ss.SSSSSSSSS z`;
 
 function isEmptyConfig({
@@ -863,7 +876,10 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
 
       rollupConfig,
       rollupSelectedColumns: [],
-      aggregationSettings,
+      aggregationSettings: getAggregationSettingsForModel(
+        aggregationSettings,
+        model
+      ),
       selectedAggregation: null,
 
       openOptions: [],
@@ -4833,6 +4849,7 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
             <Aggregations
               settings={aggregationSettings}
               isRollup={isRollup}
+              isEditable={isEditableGridModel(model) && model.isEditable}
               onChange={this.handleAggregationsChange}
               onEdit={this.handleAggregationEdit}
               dh={model.dh}

--- a/packages/iris-grid/src/IrisGrid.tsx
+++ b/packages/iris-grid/src/IrisGrid.tsx
@@ -213,19 +213,6 @@ const DEFAULT_AGGREGATION_SETTINGS = Object.freeze({
   showOnTop: false,
 });
 
-function getAggregationSettingsForModel(
-  aggregationSettings: AggregationSettings,
-  model: IrisGridModel
-): AggregationSettings {
-  if (isEditableGridModel(model) && model.isEditable) {
-    return {
-      ...aggregationSettings,
-      showOnTop: true,
-    };
-  }
-  return aggregationSettings;
-}
-
 const UNFORMATTED_DATE_PATTERN = `yyyy-MM-dd'T'HH:mm:ss.SSSSSSSSS z`;
 
 function isEmptyConfig({
@@ -876,10 +863,10 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
 
       rollupConfig,
       rollupSelectedColumns: [],
-      aggregationSettings: getAggregationSettingsForModel(
-        aggregationSettings,
-        model
-      ),
+      aggregationSettings:
+        isEditableGridModel(model) && model.isEditable
+          ? { ...aggregationSettings, showOnTop: true }
+          : aggregationSettings,
       selectedAggregation: null,
 
       openOptions: [],

--- a/packages/iris-grid/src/IrisGrid.tsx
+++ b/packages/iris-grid/src/IrisGrid.tsx
@@ -4837,7 +4837,11 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
             <Aggregations
               settings={aggregationSettings}
               isRollup={isRollup}
-              isEditable={isEditableGridModel(model) && model.isEditable}
+              availablePlacements={
+                isEditableGridModel(model) && model.isEditable
+                  ? ['top']
+                  : ['top', 'bottom']
+              }
               onChange={this.handleAggregationsChange}
               onEdit={this.handleAggregationEdit}
               dh={model.dh}

--- a/packages/iris-grid/src/sidebar/aggregations/Aggregations.tsx
+++ b/packages/iris-grid/src/sidebar/aggregations/Aggregations.tsx
@@ -40,6 +40,7 @@ export type AggregationSettings = {
 
 export type AggregationsProps = {
   isRollup: boolean;
+  isEditable: boolean;
   settings: AggregationSettings;
   onChange: (
     settings: AggregationSettings,
@@ -52,6 +53,7 @@ export type AggregationsProps = {
 
 function Aggregations({
   isRollup,
+  isEditable,
   settings,
   onChange,
   onEdit,
@@ -219,7 +221,7 @@ function Aggregations({
       const isRollupProhibited = AggregationUtils.isRollupProhibited(
         item.operation
       );
-      const isEditable = !isClone && !isRollupOperation;
+      const isItemEditable = !isClone && !isRollupOperation;
       return (
         <>
           <div
@@ -254,7 +256,7 @@ function Aggregations({
                 icon={vsEdit}
                 tooltip="Edit Columns"
                 onClick={() => onEdit(item)}
-                disabled={!isEditable}
+                disabled={!isItemEditable}
               />
               <Button
                 kind="ghost"
@@ -309,7 +311,9 @@ function Aggregations({
                 value={`${showOnTop}`}
               >
                 <Radio value="true">Top</Radio>
-                <Radio value="false">Bottom</Radio>
+                <Radio value="false" isDisabled={isEditable}>
+                  Bottom
+                </Radio>
               </RadioGroup>
             </div>
           )}

--- a/packages/iris-grid/src/sidebar/aggregations/Aggregations.tsx
+++ b/packages/iris-grid/src/sidebar/aggregations/Aggregations.tsx
@@ -40,7 +40,7 @@ export type AggregationSettings = {
 
 export type AggregationsProps = {
   isRollup: boolean;
-  isEditable: boolean;
+  availablePlacements: ('top' | 'bottom')[];
   settings: AggregationSettings;
   onChange: (
     settings: AggregationSettings,
@@ -53,7 +53,7 @@ export type AggregationsProps = {
 
 function Aggregations({
   isRollup,
-  isEditable,
+  availablePlacements,
   settings,
   onChange,
   onEdit,
@@ -310,8 +310,16 @@ function Aggregations({
                 onChange={handleShowOnTopChange}
                 value={`${showOnTop}`}
               >
-                <Radio value="true">Top</Radio>
-                <Radio value="false" isDisabled={isEditable}>
+                <Radio
+                  value="true"
+                  isDisabled={!availablePlacements.includes('top')}
+                >
+                  Top
+                </Radio>
+                <Radio
+                  value="false"
+                  isDisabled={!availablePlacements.includes('bottom')}
+                >
                   Bottom
                 </Radio>
               </RadioGroup>

--- a/packages/iris-grid/src/sidebar/aggregations/Aggregations.tsx
+++ b/packages/iris-grid/src/sidebar/aggregations/Aggregations.tsx
@@ -221,7 +221,7 @@ function Aggregations({
       const isRollupProhibited = AggregationUtils.isRollupProhibited(
         item.operation
       );
-      const isItemEditable = !isClone && !isRollupOperation;
+      const isEditable = !isClone && !isRollupOperation;
       return (
         <>
           <div
@@ -256,7 +256,7 @@ function Aggregations({
                 icon={vsEdit}
                 tooltip="Edit Columns"
                 onClick={() => onEdit(item)}
-                disabled={!isItemEditable}
+                disabled={!isEditable}
               />
               <Button
                 kind="ghost"

--- a/packages/iris-grid/src/sidebar/aggregations/Aggregations.tsx
+++ b/packages/iris-grid/src/sidebar/aggregations/Aggregations.tsx
@@ -40,7 +40,7 @@ export type AggregationSettings = {
 
 export type AggregationsProps = {
   isRollup: boolean;
-  availablePlacements: ('top' | 'bottom')[];
+  availablePlacements?: ('top' | 'bottom')[];
   settings: AggregationSettings;
   onChange: (
     settings: AggregationSettings,

--- a/packages/iris-grid/src/sidebar/aggregations/Aggregations.tsx
+++ b/packages/iris-grid/src/sidebar/aggregations/Aggregations.tsx
@@ -53,8 +53,8 @@ export type AggregationsProps = {
 
 function Aggregations({
   isRollup,
-  availablePlacements,
   settings,
+  availablePlacements = ['top', 'bottom'],
   onChange,
   onEdit,
   dh,


### PR DESCRIPTION
For DH-19601. Input tables with aggregations in the footer were experiencing conflicts between aggregated data and insertions to the pending area. This pr pins aggregations to the top of input tables, that way we have the bottom of the table reserved for pending rows, and we don't need to worry about conflicts.