### PR TITLE
fix: DH-19917: reduce contrast of light theme disabled color

### DIFF
--- a/packages/components/scss/bootstrap_overrides.scss
+++ b/packages/components/scss/bootstrap_overrides.scss
@@ -253,7 +253,7 @@ $dropdown-divider-bg: $gray-700;
 //context menus
 $contextmenu-bg: var(--dh-color-popover-bg);
 $contextmenu-color: var(--dh-color-text);
-$contextmenu-disabled-color: var(--dh-color-input-disabled-fg);
+$contextmenu-disabled-color: var(--dh-color-text-disabled);
 $contextmenu-keyboard-selected-bg: var(--dh-color-keyboard-selected-bg);
 $contextmenu-selected-bg: var(--dh-color-item-list-hover-bg);
 $contextmenu-selected-color: var(--dh-color-item-list-selected-fg);

--- a/packages/components/src/theme/theme-light/theme-light-semantic.css
+++ b/packages/components/src/theme/theme-light/theme-light-semantic.css
@@ -16,7 +16,7 @@
   /* Text */
   --dh-color-heading-text: var(--dh-color-gray-900);
   --dh-color-text: var(--dh-color-gray-800);
-  --dh-color-text-disabled: var(--dh-color-gray-700);
+  --dh-color-text-disabled: var(--dh-color-gray-500);
   --dh-color-text-highlight: color-mix(
     in srgb,
     var(--dh-color-blue-700) 15%,


### PR DESCRIPTION
Changes light themes disabled text color to be an even lighter color. Changed to show more difference between enabled and disabled states.

Color change didn't seem to trigger enough difference to change e2e tests.