### PR TITLE
fix: DH-19963: Remove grid-block-events when Grid unmounts

### DIFF
--- a/packages/grid/src/Grid.tsx
+++ b/packages/grid/src/Grid.tsx
@@ -638,7 +638,7 @@ class Grid extends PureComponent<GridProps, GridState> {
 
     this.stopDragTimer();
 
-    document.documentElement.classList.remove('grid-block-events');
+    this.removeDocumentCursor();
   }
 
   getTheme(): GridThemeType {


### PR DESCRIPTION
Fix for https://deephaven.atlassian.net/browse/DH-19963