### PR TITLE
fix: DH-19963: Remove grid-block-events when Grid unmounts (#2507)

### DIFF
--- a/packages/grid/src/Grid.tsx
+++ b/packages/grid/src/Grid.tsx
@@ -605,6 +605,8 @@ class Grid extends PureComponent<GridProps, GridState> {
     this.resizeObserver.disconnect();
 
     this.stopDragTimer();
+
+    this.removeDocumentCursor();
   }
 
   getTheme(): GridThemeType {


### PR DESCRIPTION
Fix for https://deephaven.atlassian.net/browse/DH-19963