### PR TITLE
fix: Export useTablePlugin for use in dh.ui

### DIFF
--- a/packages/dashboard-core-plugins/src/index.ts
+++ b/packages/dashboard-core-plugins/src/index.ts
@@ -26,6 +26,7 @@ export * from './useConfigureRuff';
 export * from './useDashboardColumnFilters';
 export * from './useGridLinker';
 export * from './useLoadTablePlugin';
+export * from './useTablePlugin';
 
 export * from './events';
 export * from './panels';


### PR DESCRIPTION
Looks like I forgot to export this when adding the hook so it could also be used by `ui.table`.