### PR TITLE
feat: DH-10205: Add column text alignment to web

### DIFF
--- a/packages/code-studio/src/styleguide/MockIrisGridTreeModel.ts
+++ b/packages/code-studio/src/styleguide/MockIrisGridTreeModel.ts
@@ -17,6 +17,7 @@ import {
   type PendingDataMap,
   type UITreeRow,
   type ColumnHeaderGroup,
+  type TextAlignment,
 } from '@deephaven/iris-grid';
 import type { dh as DhType } from '@deephaven/jsapi-types';
 import { type Formatter } from '@deephaven/jsapi-utils';
@@ -234,6 +235,16 @@ class MockIrisGridTreeModel
   }
 
   set formatter(formatter: Formatter) {
+    // Ignore for mock
+  }
+
+  get customColumnAlignmentMap(): Map<string, TextAlignment> | undefined {
+    return undefined;
+  }
+
+  set customColumnAlignmentMap(
+    customColumnAlignmentMap: Map<string, TextAlignment> | undefined
+  ) {
     // Ignore for mock
   }
 

--- a/packages/code-studio/src/styleguide/MockIrisGridTreeModel.ts
+++ b/packages/code-studio/src/styleguide/MockIrisGridTreeModel.ts
@@ -238,12 +238,12 @@ class MockIrisGridTreeModel
     // Ignore for mock
   }
 
-  get customColumnAlignmentMap(): Map<string, TextAlignment> | undefined {
-    return undefined;
+  get customColumnAlignmentMap(): Map<string, TextAlignment> {
+    return new Map<string, TextAlignment>();
   }
 
   set customColumnAlignmentMap(
-    customColumnAlignmentMap: Map<string, TextAlignment> | undefined
+    customColumnAlignmentMap: Map<string, TextAlignment>
   ) {
     // Ignore for mock
   }

--- a/packages/code-studio/src/styleguide/MockIrisGridTreeModel.ts
+++ b/packages/code-studio/src/styleguide/MockIrisGridTreeModel.ts
@@ -17,7 +17,6 @@ import {
   type PendingDataMap,
   type UITreeRow,
   type ColumnHeaderGroup,
-  type TextAlignment,
 } from '@deephaven/iris-grid';
 import type { dh as DhType } from '@deephaven/jsapi-types';
 import { type Formatter } from '@deephaven/jsapi-utils';
@@ -238,12 +237,12 @@ class MockIrisGridTreeModel
     // Ignore for mock
   }
 
-  get customColumnAlignmentMap(): Map<string, TextAlignment> {
-    return new Map<string, TextAlignment>();
+  get customColumnAlignmentMap(): Map<string, CanvasTextAlign> {
+    return new Map<string, CanvasTextAlign>();
   }
 
   set customColumnAlignmentMap(
-    customColumnAlignmentMap: Map<string, TextAlignment>
+    customColumnAlignmentMap: Map<string, CanvasTextAlign>
   ) {
     // Ignore for mock
   }

--- a/packages/code-studio/src/styleguide/MockIrisGridTreeModel.ts
+++ b/packages/code-studio/src/styleguide/MockIrisGridTreeModel.ts
@@ -237,13 +237,11 @@ class MockIrisGridTreeModel
     // Ignore for mock
   }
 
-  get customColumnAlignmentMap(): Map<string, CanvasTextAlign> {
+  get columnAlignmentMap(): ReadonlyMap<string, CanvasTextAlign> {
     return new Map<string, CanvasTextAlign>();
   }
 
-  set customColumnAlignmentMap(
-    customColumnAlignmentMap: Map<string, CanvasTextAlign>
-  ) {
+  set columnAlignmentMap(columnAlignmentMap: Map<string, CanvasTextAlign>) {
     // Ignore for mock
   }
 

--- a/packages/dashboard-core-plugins/src/panels/IrisGridPanel.tsx
+++ b/packages/dashboard-core-plugins/src/panels/IrisGridPanel.tsx
@@ -187,7 +187,7 @@ interface IrisGridPanelState {
   advancedSettings: Map<AdvancedSettingsType, boolean>;
   customColumns: readonly ColumnName[];
   customColumnFormatMap: Map<string, FormattingRule>;
-  customColumnAlignmentMap: Map<string, CanvasTextAlign>;
+  columnAlignmentMap: Map<string, CanvasTextAlign>;
   isFilterBarShown: boolean;
   quickFilters: ReadonlyQuickFilterMap;
   sorts: readonly dh.Sort[];
@@ -298,7 +298,7 @@ export class IrisGridPanel extends PureComponent<
       advancedSettings: new Map(AdvancedSettings.DEFAULTS),
       customColumns: [],
       customColumnFormatMap: new Map(),
-      customColumnAlignmentMap: new Map(),
+      columnAlignmentMap: new Map(),
       isFilterBarShown: false,
       quickFilters: new Map(),
       sorts: [],
@@ -1015,7 +1015,7 @@ export class IrisGridPanel extends PureComponent<
         advancedFilters,
         customColumns,
         customColumnFormatMap,
-        customColumnAlignmentMap,
+        columnAlignmentMap,
         isFilterBarShown,
         quickFilters,
         reverse,
@@ -1050,7 +1050,7 @@ export class IrisGridPanel extends PureComponent<
         conditionalFormats,
         customColumns,
         customColumnFormatMap,
-        customColumnAlignmentMap,
+        columnAlignmentMap,
         isFilterBarShown,
         isSelectingPartition,
         movedColumns,
@@ -1145,7 +1145,7 @@ export class IrisGridPanel extends PureComponent<
       conditionalFormats,
       customColumns,
       customColumnFormatMap,
-      customColumnAlignmentMap,
+      columnAlignmentMap,
       error,
       isDisconnected,
       isFilterBarShown,
@@ -1227,7 +1227,7 @@ export class IrisGridPanel extends PureComponent<
             copyCursor="copy"
             customColumns={customColumns}
             customColumnFormatMap={customColumnFormatMap}
-            customColumnAlignmentMap={customColumnAlignmentMap}
+            columnAlignmentMap={columnAlignmentMap}
             columnSelectionValidator={this.isColumnSelectionValid}
             conditionalFormats={conditionalFormats}
             inputFilters={this.getGridInputFilters(model.columns, inputFilters)}

--- a/packages/dashboard-core-plugins/src/panels/IrisGridPanel.tsx
+++ b/packages/dashboard-core-plugins/src/panels/IrisGridPanel.tsx
@@ -45,7 +45,6 @@ import {
   type ColumnHeaderGroup,
   type IrisGridContextMenuData,
   type PartitionConfig,
-  type TextAlignment,
 } from '@deephaven/iris-grid';
 import {
   type RowDataMap,
@@ -188,7 +187,7 @@ interface IrisGridPanelState {
   advancedSettings: Map<AdvancedSettingsType, boolean>;
   customColumns: readonly ColumnName[];
   customColumnFormatMap: Map<string, FormattingRule>;
-  customColumnAlignmentMap: Map<string, TextAlignment>;
+  customColumnAlignmentMap: Map<string, CanvasTextAlign>;
   isFilterBarShown: boolean;
   quickFilters: ReadonlyQuickFilterMap;
   sorts: readonly dh.Sort[];

--- a/packages/dashboard-core-plugins/src/panels/IrisGridPanel.tsx
+++ b/packages/dashboard-core-plugins/src/panels/IrisGridPanel.tsx
@@ -45,6 +45,7 @@ import {
   type ColumnHeaderGroup,
   type IrisGridContextMenuData,
   type PartitionConfig,
+  type TextAlignment,
 } from '@deephaven/iris-grid';
 import {
   type RowDataMap,
@@ -187,6 +188,7 @@ interface IrisGridPanelState {
   advancedSettings: Map<AdvancedSettingsType, boolean>;
   customColumns: readonly ColumnName[];
   customColumnFormatMap: Map<string, FormattingRule>;
+  customColumnAlignmentMap: Map<string, TextAlignment>;
   isFilterBarShown: boolean;
   quickFilters: ReadonlyQuickFilterMap;
   sorts: readonly dh.Sort[];
@@ -297,6 +299,7 @@ export class IrisGridPanel extends PureComponent<
       advancedSettings: new Map(AdvancedSettings.DEFAULTS),
       customColumns: [],
       customColumnFormatMap: new Map(),
+      customColumnAlignmentMap: new Map(),
       isFilterBarShown: false,
       quickFilters: new Map(),
       sorts: [],
@@ -1013,6 +1016,7 @@ export class IrisGridPanel extends PureComponent<
         advancedFilters,
         customColumns,
         customColumnFormatMap,
+        customColumnAlignmentMap,
         isFilterBarShown,
         quickFilters,
         reverse,
@@ -1047,6 +1051,7 @@ export class IrisGridPanel extends PureComponent<
         conditionalFormats,
         customColumns,
         customColumnFormatMap,
+        customColumnAlignmentMap,
         isFilterBarShown,
         isSelectingPartition,
         movedColumns,
@@ -1141,6 +1146,7 @@ export class IrisGridPanel extends PureComponent<
       conditionalFormats,
       customColumns,
       customColumnFormatMap,
+      customColumnAlignmentMap,
       error,
       isDisconnected,
       isFilterBarShown,
@@ -1222,6 +1228,7 @@ export class IrisGridPanel extends PureComponent<
             copyCursor="copy"
             customColumns={customColumns}
             customColumnFormatMap={customColumnFormatMap}
+            customColumnAlignmentMap={customColumnAlignmentMap}
             columnSelectionValidator={this.isColumnSelectionValid}
             conditionalFormats={conditionalFormats}
             inputFilters={this.getGridInputFilters(model.columns, inputFilters)}

--- a/packages/iris-grid/src/CommonTypes.tsx
+++ b/packages/iris-grid/src/CommonTypes.tsx
@@ -10,7 +10,6 @@ export type RowIndex = ModelIndex;
 
 export type { AdvancedFilterOptions };
 export type ColumnName = string;
-export type TextAlignment = 'left' | 'center' | 'right';
 export type AdvancedFilterMap = Map<ModelIndex, AdvancedFilter>;
 export type QuickFilterMap = Map<ModelIndex, QuickFilter>;
 export type ReadonlyAdvancedFilterMap = ReadonlyMap<ModelIndex, AdvancedFilter>;

--- a/packages/iris-grid/src/CommonTypes.tsx
+++ b/packages/iris-grid/src/CommonTypes.tsx
@@ -10,6 +10,7 @@ export type RowIndex = ModelIndex;
 
 export type { AdvancedFilterOptions };
 export type ColumnName = string;
+export type TextAlignment = 'left' | 'center' | 'right';
 export type AdvancedFilterMap = Map<ModelIndex, AdvancedFilter>;
 export type QuickFilterMap = Map<ModelIndex, QuickFilter>;
 export type ReadonlyAdvancedFilterMap = ReadonlyMap<ModelIndex, AdvancedFilter>;

--- a/packages/iris-grid/src/EmptyIrisGridModel.ts
+++ b/packages/iris-grid/src/EmptyIrisGridModel.ts
@@ -11,6 +11,7 @@ import { EMPTY_ARRAY, EMPTY_MAP } from '@deephaven/utils';
 import IrisGridModel from './IrisGridModel';
 import type ColumnHeaderGroup from './ColumnHeaderGroup';
 import {
+  type TextAlignment,
   type PendingDataErrorMap,
   type PendingDataMap,
   type UITotalsTableConfig,
@@ -24,6 +25,8 @@ class EmptyIrisGridModel extends IrisGridModel {
   }
 
   modelFormatter: Formatter;
+
+  modelCustomColumnAlignmentMap: Map<string, TextAlignment> | undefined;
 
   get rowCount(): number {
     return 0;
@@ -102,6 +105,16 @@ class EmptyIrisGridModel extends IrisGridModel {
 
   set formatter(formatter: Formatter) {
     this.modelFormatter = formatter;
+  }
+
+  get customColumnAlignmentMap(): Map<string, TextAlignment> | undefined {
+    return this.modelCustomColumnAlignmentMap;
+  }
+
+  set customColumnAlignmentMap(
+    customColumnAlignmentMap: Map<string, TextAlignment> | undefined
+  ) {
+    this.modelCustomColumnAlignmentMap = customColumnAlignmentMap;
   }
 
   displayString(

--- a/packages/iris-grid/src/EmptyIrisGridModel.ts
+++ b/packages/iris-grid/src/EmptyIrisGridModel.ts
@@ -21,12 +21,12 @@ class EmptyIrisGridModel extends IrisGridModel {
     super(dh);
 
     this.modelFormatter = formatter;
-    this.modelCustomColumnAlignmentMap = new Map<string, CanvasTextAlign>();
+    this.modelColumnAlignmentMap = new Map<string, CanvasTextAlign>();
   }
 
   modelFormatter: Formatter;
 
-  modelCustomColumnAlignmentMap: Map<string, CanvasTextAlign>;
+  modelColumnAlignmentMap: Map<string, CanvasTextAlign>;
 
   get rowCount(): number {
     return 0;
@@ -107,14 +107,12 @@ class EmptyIrisGridModel extends IrisGridModel {
     this.modelFormatter = formatter;
   }
 
-  get customColumnAlignmentMap(): Map<string, CanvasTextAlign> {
-    return this.modelCustomColumnAlignmentMap;
+  get columnAlignmentMap(): ReadonlyMap<string, CanvasTextAlign> {
+    return this.modelColumnAlignmentMap;
   }
 
-  set customColumnAlignmentMap(
-    customColumnAlignmentMap: Map<string, CanvasTextAlign>
-  ) {
-    this.modelCustomColumnAlignmentMap = customColumnAlignmentMap;
+  set columnAlignmentMap(columnAlignmentMap: Map<string, CanvasTextAlign>) {
+    this.modelColumnAlignmentMap = columnAlignmentMap;
   }
 
   displayString(

--- a/packages/iris-grid/src/EmptyIrisGridModel.ts
+++ b/packages/iris-grid/src/EmptyIrisGridModel.ts
@@ -22,11 +22,12 @@ class EmptyIrisGridModel extends IrisGridModel {
     super(dh);
 
     this.modelFormatter = formatter;
+    this.modelCustomColumnAlignmentMap = new Map<string, TextAlignment>();
   }
 
   modelFormatter: Formatter;
 
-  modelCustomColumnAlignmentMap: Map<string, TextAlignment> | undefined;
+  modelCustomColumnAlignmentMap: Map<string, TextAlignment>;
 
   get rowCount(): number {
     return 0;
@@ -107,12 +108,12 @@ class EmptyIrisGridModel extends IrisGridModel {
     this.modelFormatter = formatter;
   }
 
-  get customColumnAlignmentMap(): Map<string, TextAlignment> | undefined {
+  get customColumnAlignmentMap(): Map<string, TextAlignment> {
     return this.modelCustomColumnAlignmentMap;
   }
 
   set customColumnAlignmentMap(
-    customColumnAlignmentMap: Map<string, TextAlignment> | undefined
+    customColumnAlignmentMap: Map<string, TextAlignment>
   ) {
     this.modelCustomColumnAlignmentMap = customColumnAlignmentMap;
   }

--- a/packages/iris-grid/src/EmptyIrisGridModel.ts
+++ b/packages/iris-grid/src/EmptyIrisGridModel.ts
@@ -11,7 +11,6 @@ import { EMPTY_ARRAY, EMPTY_MAP } from '@deephaven/utils';
 import IrisGridModel from './IrisGridModel';
 import type ColumnHeaderGroup from './ColumnHeaderGroup';
 import {
-  type TextAlignment,
   type PendingDataErrorMap,
   type PendingDataMap,
   type UITotalsTableConfig,
@@ -22,12 +21,12 @@ class EmptyIrisGridModel extends IrisGridModel {
     super(dh);
 
     this.modelFormatter = formatter;
-    this.modelCustomColumnAlignmentMap = new Map<string, TextAlignment>();
+    this.modelCustomColumnAlignmentMap = new Map<string, CanvasTextAlign>();
   }
 
   modelFormatter: Formatter;
 
-  modelCustomColumnAlignmentMap: Map<string, TextAlignment>;
+  modelCustomColumnAlignmentMap: Map<string, CanvasTextAlign>;
 
   get rowCount(): number {
     return 0;
@@ -108,12 +107,12 @@ class EmptyIrisGridModel extends IrisGridModel {
     this.modelFormatter = formatter;
   }
 
-  get customColumnAlignmentMap(): Map<string, TextAlignment> {
+  get customColumnAlignmentMap(): Map<string, CanvasTextAlign> {
     return this.modelCustomColumnAlignmentMap;
   }
 
   set customColumnAlignmentMap(
-    customColumnAlignmentMap: Map<string, TextAlignment>
+    customColumnAlignmentMap: Map<string, CanvasTextAlign>
   ) {
     this.modelCustomColumnAlignmentMap = customColumnAlignmentMap;
   }

--- a/packages/iris-grid/src/IrisGrid.tsx
+++ b/packages/iris-grid/src/IrisGrid.tsx
@@ -3141,7 +3141,7 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
     const { model } = this.props;
     const column = model.columns[modelIndex];
     const {
-      customColumnAlignmentMap: prevCustomColumnAlignmentMap = new Map(),
+      customColumnAlignmentMap: prevCustomColumnAlignmentMap = EMPTY_MAP,
     } = this.state;
     const customColumnAlignmentMap = new Map(prevCustomColumnAlignmentMap);
 

--- a/packages/iris-grid/src/IrisGrid.tsx
+++ b/packages/iris-grid/src/IrisGrid.tsx
@@ -284,7 +284,7 @@ export interface IrisGridProps {
   applyInputFiltersOnInit: boolean;
   conditionalFormats: readonly SidebarFormattingRule[];
   customColumnFormatMap: Map<ColumnName, FormattingRule>;
-  customColumnAlignmentMap: Map<string, CanvasTextAlign>;
+  columnAlignmentMap: Map<string, CanvasTextAlign>;
   movedColumns: readonly MoveOperation[];
   movedRows: readonly MoveOperation[];
   inputFilters: readonly InputFilter[];
@@ -409,7 +409,7 @@ export interface IrisGridState {
   isMenuShown: boolean;
   customColumnFormatMap: Map<ColumnName, FormattingRule>;
 
-  customColumnAlignmentMap: Map<string, CanvasTextAlign>;
+  columnAlignmentMap: Map<string, CanvasTextAlign>;
 
   conditionalFormats: readonly SidebarFormattingRule[];
   conditionalFormatEditIndex: number | null;
@@ -487,7 +487,7 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
     alwaysFetchColumns: EMPTY_ARRAY,
     conditionalFormats: EMPTY_ARRAY,
     customColumnFormatMap: EMPTY_MAP,
-    customColumnAlignmentMap: EMPTY_MAP,
+    columnAlignmentMap: EMPTY_MAP,
     isFilterBarShown: false,
     applyInputFiltersOnInit: false,
     movedColumns: EMPTY_ARRAY,
@@ -724,7 +724,7 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
       aggregationSettings,
       conditionalFormats,
       customColumnFormatMap,
-      customColumnAlignmentMap,
+      columnAlignmentMap,
       isFilterBarShown,
       isSelectingPartition,
       partitions,
@@ -848,7 +848,7 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
       formatter: new Formatter(dh),
       isMenuShown: false,
       customColumnFormatMap: new Map(customColumnFormatMap),
-      customColumnAlignmentMap: new Map(customColumnAlignmentMap),
+      columnAlignmentMap: new Map(columnAlignmentMap),
 
       conditionalFormats,
       conditionalFormatEditIndex: null,
@@ -3140,14 +3140,14 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
     const { model } = this.props;
     const column = model.columns[modelIndex];
 
-    this.setState(({ customColumnAlignmentMap = EMPTY_MAP }) => {
-      const newCustomColumnAlignmentMap = new Map(customColumnAlignmentMap);
+    this.setState(({ columnAlignmentMap = EMPTY_MAP }) => {
+      const newColumnAlignmentMap = new Map(columnAlignmentMap);
       if (alignment != null) {
-        newCustomColumnAlignmentMap.set(column.name, alignment);
+        newColumnAlignmentMap.set(column.name, alignment);
       } else {
-        newCustomColumnAlignmentMap.delete(column.name);
+        newColumnAlignmentMap.delete(column.name);
       }
-      return { customColumnAlignmentMap: newCustomColumnAlignmentMap };
+      return { columnAlignmentMap: newColumnAlignmentMap };
     });
   }
 
@@ -4411,7 +4411,7 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
       conditionalFormatPreview,
       conditionalFormatEditIndex,
 
-      customColumnAlignmentMap,
+      columnAlignmentMap,
 
       sorts,
       reverse,
@@ -4999,7 +4999,7 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
                 right={right}
                 filter={filter}
                 formatter={formatter}
-                customColumnAlignmentMap={customColumnAlignmentMap}
+                columnAlignmentMap={columnAlignmentMap}
                 sorts={sorts}
                 reverse={reverse}
                 movedColumns={movedColumns}

--- a/packages/iris-grid/src/IrisGrid.tsx
+++ b/packages/iris-grid/src/IrisGrid.tsx
@@ -189,7 +189,6 @@ import {
   type ReadonlyAdvancedFilterMap,
   type ReadonlyAggregationMap,
   type ReadonlyQuickFilterMap,
-  type TextAlignment,
   type UITotalsTableConfig,
 } from './CommonTypes';
 import type ColumnHeaderGroup from './ColumnHeaderGroup';
@@ -285,7 +284,7 @@ export interface IrisGridProps {
   applyInputFiltersOnInit: boolean;
   conditionalFormats: readonly SidebarFormattingRule[];
   customColumnFormatMap: Map<ColumnName, FormattingRule>;
-  customColumnAlignmentMap: Map<string, TextAlignment>;
+  customColumnAlignmentMap: Map<string, CanvasTextAlign>;
   movedColumns: readonly MoveOperation[];
   movedRows: readonly MoveOperation[];
   inputFilters: readonly InputFilter[];
@@ -410,7 +409,7 @@ export interface IrisGridState {
   isMenuShown: boolean;
   customColumnFormatMap: Map<ColumnName, FormattingRule>;
 
-  customColumnAlignmentMap: Map<string, TextAlignment>;
+  customColumnAlignmentMap: Map<string, CanvasTextAlign>;
 
   conditionalFormats: readonly SidebarFormattingRule[];
   conditionalFormatEditIndex: number | null;

--- a/packages/iris-grid/src/IrisGrid.tsx
+++ b/packages/iris-grid/src/IrisGrid.tsx
@@ -3140,18 +3140,16 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
   ): void {
     const { model } = this.props;
     const column = model.columns[modelIndex];
-    const {
-      customColumnAlignmentMap: prevCustomColumnAlignmentMap = EMPTY_MAP,
-    } = this.state;
-    const customColumnAlignmentMap = new Map(prevCustomColumnAlignmentMap);
 
-    if (alignment != null) {
-      customColumnAlignmentMap.set(column.name, alignment);
-    } else {
-      customColumnAlignmentMap.delete(column.name);
-    }
-
-    this.setState({ customColumnAlignmentMap });
+    this.setState(({ customColumnAlignmentMap = EMPTY_MAP }) => {
+      const newCustomColumnAlignmentMap = new Map(customColumnAlignmentMap);
+      if (alignment != null) {
+        newCustomColumnAlignmentMap.set(column.name, alignment);
+      } else {
+        newCustomColumnAlignmentMap.delete(column.name);
+      }
+      return { customColumnAlignmentMap: newCustomColumnAlignmentMap };
+    });
   }
 
   handleMenu(e: React.MouseEvent<HTMLButtonElement>): void {

--- a/packages/iris-grid/src/IrisGrid.tsx
+++ b/packages/iris-grid/src/IrisGrid.tsx
@@ -189,6 +189,7 @@ import {
   type ReadonlyAdvancedFilterMap,
   type ReadonlyAggregationMap,
   type ReadonlyQuickFilterMap,
+  type TextAlignment,
   type UITotalsTableConfig,
 } from './CommonTypes';
 import type ColumnHeaderGroup from './ColumnHeaderGroup';
@@ -284,6 +285,7 @@ export interface IrisGridProps {
   applyInputFiltersOnInit: boolean;
   conditionalFormats: readonly SidebarFormattingRule[];
   customColumnFormatMap: Map<ColumnName, FormattingRule>;
+  customColumnAlignmentMap: Map<string, TextAlignment>;
   movedColumns: readonly MoveOperation[];
   movedRows: readonly MoveOperation[];
   inputFilters: readonly InputFilter[];
@@ -408,6 +410,8 @@ export interface IrisGridState {
   isMenuShown: boolean;
   customColumnFormatMap: Map<ColumnName, FormattingRule>;
 
+  customColumnAlignmentMap: Map<string, TextAlignment>;
+
   conditionalFormats: readonly SidebarFormattingRule[];
   conditionalFormatEditIndex: number | null;
   conditionalFormatPreview?: SidebarFormattingRule;
@@ -484,6 +488,7 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
     alwaysFetchColumns: EMPTY_ARRAY,
     conditionalFormats: EMPTY_ARRAY,
     customColumnFormatMap: EMPTY_MAP,
+    customColumnAlignmentMap: EMPTY_MAP,
     isFilterBarShown: false,
     applyInputFiltersOnInit: false,
     movedColumns: EMPTY_ARRAY,
@@ -591,6 +596,8 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
     this.handleTooltipRef = this.handleTooltipRef.bind(this);
     this.handleViewChanged = this.handleViewChanged.bind(this);
     this.handleFormatSelection = this.handleFormatSelection.bind(this);
+    this.handleColumnAlignmentChange =
+      this.handleColumnAlignmentChange.bind(this);
     this.handleConditionalFormatCreate =
       this.handleConditionalFormatCreate.bind(this);
     this.handleConditionalFormatEdit =
@@ -718,6 +725,7 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
       aggregationSettings,
       conditionalFormats,
       customColumnFormatMap,
+      customColumnAlignmentMap,
       isFilterBarShown,
       isSelectingPartition,
       partitions,
@@ -841,6 +849,7 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
       formatter: new Formatter(dh),
       isMenuShown: false,
       customColumnFormatMap: new Map(customColumnFormatMap),
+      customColumnAlignmentMap: new Map(customColumnAlignmentMap),
 
       conditionalFormats,
       conditionalFormatEditIndex: null,
@@ -3125,6 +3134,26 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
     this.updateFormatter({ customColumnFormatMap });
   }
 
+  handleColumnAlignmentChange(
+    modelIndex: ModelIndex,
+    alignment: CanvasTextAlign | null
+  ): void {
+    const { model } = this.props;
+    const column = model.columns[modelIndex];
+    const {
+      customColumnAlignmentMap: prevCustomColumnAlignmentMap = new Map(),
+    } = this.state;
+    const customColumnAlignmentMap = new Map(prevCustomColumnAlignmentMap);
+
+    if (alignment != null) {
+      customColumnAlignmentMap.set(column.name, alignment);
+    } else {
+      customColumnAlignmentMap.delete(column.name);
+    }
+
+    this.setState({ customColumnAlignmentMap });
+  }
+
   handleMenu(e: React.MouseEvent<HTMLButtonElement>): void {
     e.stopPropagation();
     this.setState({ isMenuShown: true });
@@ -4385,6 +4414,8 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
       conditionalFormatPreview,
       conditionalFormatEditIndex,
 
+      customColumnAlignmentMap,
+
       sorts,
       reverse,
       customColumns,
@@ -4971,6 +5002,7 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
                 right={right}
                 filter={filter}
                 formatter={formatter}
+                customColumnAlignmentMap={customColumnAlignmentMap}
                 sorts={sorts}
                 reverse={reverse}
                 movedColumns={movedColumns}

--- a/packages/iris-grid/src/IrisGridCacheUtils.test.ts
+++ b/packages/iris-grid/src/IrisGridCacheUtils.test.ts
@@ -27,6 +27,7 @@ const irisGridState = {
     showOnTop: false,
   },
   customColumnFormatMap: new Map(),
+  customColumnAlignmentMap: new Map(),
   isFilterBarShown: false,
   quickFilters: new Map(),
   customColumns: [],

--- a/packages/iris-grid/src/IrisGridCacheUtils.test.ts
+++ b/packages/iris-grid/src/IrisGridCacheUtils.test.ts
@@ -27,7 +27,7 @@ const irisGridState = {
     showOnTop: false,
   },
   customColumnFormatMap: new Map(),
-  customColumnAlignmentMap: new Map(),
+  columnAlignmentMap: new Map(),
   isFilterBarShown: false,
   quickFilters: new Map(),
   customColumns: [],

--- a/packages/iris-grid/src/IrisGridCacheUtils.ts
+++ b/packages/iris-grid/src/IrisGridCacheUtils.ts
@@ -48,6 +48,7 @@ function areIrisGridStatesEqual(
     'advancedFilters',
     'aggregationSettings',
     'customColumnFormatMap',
+    'customColumnAlignmentMap',
     'isFilterBarShown',
     'quickFilters',
     'customColumns',

--- a/packages/iris-grid/src/IrisGridCacheUtils.ts
+++ b/packages/iris-grid/src/IrisGridCacheUtils.ts
@@ -48,7 +48,7 @@ function areIrisGridStatesEqual(
     'advancedFilters',
     'aggregationSettings',
     'customColumnFormatMap',
-    'customColumnAlignmentMap',
+    'columnAlignmentMap',
     'isFilterBarShown',
     'quickFilters',
     'customColumns',

--- a/packages/iris-grid/src/IrisGridModel.ts
+++ b/packages/iris-grid/src/IrisGridModel.ts
@@ -20,6 +20,7 @@ import {
   type UITotalsTableConfig,
   type PendingDataMap,
   type PendingDataErrorMap,
+  type TextAlignment,
 } from './CommonTypes';
 import type ColumnHeaderGroup from './ColumnHeaderGroup';
 
@@ -248,6 +249,20 @@ abstract class IrisGridModel<
    * @param formatter The formatter to set
    */
   abstract set formatter(formatter: Formatter);
+
+  /**
+   * @returns The custom column alignment map
+   */
+  abstract get customColumnAlignmentMap():
+    | Map<string, TextAlignment>
+    | undefined;
+
+  /**
+   * @param customColumnAlignmentMap The custom column alignment map to set
+   */
+  abstract set customColumnAlignmentMap(
+    customColumnAlignmentMap: Map<string, TextAlignment> | undefined
+  );
 
   /**
    * @param value The value to format

--- a/packages/iris-grid/src/IrisGridModel.ts
+++ b/packages/iris-grid/src/IrisGridModel.ts
@@ -250,7 +250,7 @@ abstract class IrisGridModel<
   abstract set formatter(formatter: Formatter);
 
   /**
-   * @returns The custom column alignment map
+   * @returns The column alignment map
    */
   abstract get columnAlignmentMap(): ReadonlyMap<string, CanvasTextAlign>;
 

--- a/packages/iris-grid/src/IrisGridModel.ts
+++ b/packages/iris-grid/src/IrisGridModel.ts
@@ -253,15 +253,13 @@ abstract class IrisGridModel<
   /**
    * @returns The custom column alignment map
    */
-  abstract get customColumnAlignmentMap():
-    | Map<string, TextAlignment>
-    | undefined;
+  abstract get customColumnAlignmentMap(): Map<string, TextAlignment>;
 
   /**
    * @param customColumnAlignmentMap The custom column alignment map to set
    */
   abstract set customColumnAlignmentMap(
-    customColumnAlignmentMap: Map<string, TextAlignment> | undefined
+    customColumnAlignmentMap: Map<string, TextAlignment>
   );
 
   /**

--- a/packages/iris-grid/src/IrisGridModel.ts
+++ b/packages/iris-grid/src/IrisGridModel.ts
@@ -252,13 +252,13 @@ abstract class IrisGridModel<
   /**
    * @returns The custom column alignment map
    */
-  abstract get customColumnAlignmentMap(): Map<string, CanvasTextAlign>;
+  abstract get columnAlignmentMap(): ReadonlyMap<string, CanvasTextAlign>;
 
   /**
-   * @param customColumnAlignmentMap The custom column alignment map to set
+   * @param columnAlignmentMap The column alignment map to set
    */
-  abstract set customColumnAlignmentMap(
-    customColumnAlignmentMap: Map<string, CanvasTextAlign>
+  abstract set columnAlignmentMap(
+    columnAlignmentMap: Map<string, CanvasTextAlign>
   );
 
   /**

--- a/packages/iris-grid/src/IrisGridModel.ts
+++ b/packages/iris-grid/src/IrisGridModel.ts
@@ -20,7 +20,6 @@ import {
   type UITotalsTableConfig,
   type PendingDataMap,
   type PendingDataErrorMap,
-  type TextAlignment,
 } from './CommonTypes';
 import type ColumnHeaderGroup from './ColumnHeaderGroup';
 
@@ -253,13 +252,13 @@ abstract class IrisGridModel<
   /**
    * @returns The custom column alignment map
    */
-  abstract get customColumnAlignmentMap(): Map<string, TextAlignment>;
+  abstract get customColumnAlignmentMap(): Map<string, CanvasTextAlign>;
 
   /**
    * @param customColumnAlignmentMap The custom column alignment map to set
    */
   abstract set customColumnAlignmentMap(
-    customColumnAlignmentMap: Map<string, TextAlignment>
+    customColumnAlignmentMap: Map<string, CanvasTextAlign>
   );
 
   /**

--- a/packages/iris-grid/src/IrisGridModelUpdater.tsx
+++ b/packages/iris-grid/src/IrisGridModelUpdater.tsx
@@ -40,7 +40,7 @@ interface IrisGridModelUpdaterProps {
   formatColumns: readonly dh.CustomColumn[];
   alwaysFetchColumns: readonly ColumnName[];
   formatter: Formatter;
-  customColumnAlignmentMap?: Map<string, TextAlignment>;
+  customColumnAlignmentMap: Map<string, TextAlignment>;
   rollupConfig?: dh.RollupConfig | null;
   totalsConfig?: UITotalsTableConfig | null;
   selectDistinctColumns?: readonly ColumnName[];

--- a/packages/iris-grid/src/IrisGridModelUpdater.tsx
+++ b/packages/iris-grid/src/IrisGridModelUpdater.tsx
@@ -39,7 +39,7 @@ interface IrisGridModelUpdaterProps {
   formatColumns: readonly dh.CustomColumn[];
   alwaysFetchColumns: readonly ColumnName[];
   formatter: Formatter;
-  customColumnAlignmentMap: Map<string, CanvasTextAlign>;
+  columnAlignmentMap: Map<string, CanvasTextAlign>;
   rollupConfig?: dh.RollupConfig | null;
   totalsConfig?: UITotalsTableConfig | null;
   selectDistinctColumns?: readonly ColumnName[];
@@ -60,7 +60,7 @@ function IrisGridModelUpdater({
   right,
   filter,
   formatter,
-  customColumnAlignmentMap,
+  columnAlignmentMap,
   reverse = false,
   sorts,
   customColumns,
@@ -129,10 +129,10 @@ function IrisGridModelUpdater({
     [model, formatter]
   );
   useOnChange(
-    function updateCustomColumnAlignmentMap() {
-      model.customColumnAlignmentMap = customColumnAlignmentMap;
+    function updateColumnAlignmentMap() {
+      model.columnAlignmentMap = columnAlignmentMap;
     },
-    [model, customColumnAlignmentMap]
+    [model, columnAlignmentMap]
   );
   useOnChange(
     function updateCustomColumns() {

--- a/packages/iris-grid/src/IrisGridModelUpdater.tsx
+++ b/packages/iris-grid/src/IrisGridModelUpdater.tsx
@@ -11,6 +11,7 @@ import {
   type ColumnName,
   type UITotalsTableConfig,
   type PendingDataMap,
+  type TextAlignment,
 } from './CommonTypes';
 import type IrisGridModel from './IrisGridModel';
 import type ColumnHeaderGroup from './ColumnHeaderGroup';
@@ -39,6 +40,7 @@ interface IrisGridModelUpdaterProps {
   formatColumns: readonly dh.CustomColumn[];
   alwaysFetchColumns: readonly ColumnName[];
   formatter: Formatter;
+  customColumnAlignmentMap?: Map<string, TextAlignment>;
   rollupConfig?: dh.RollupConfig | null;
   totalsConfig?: UITotalsTableConfig | null;
   selectDistinctColumns?: readonly ColumnName[];
@@ -59,6 +61,7 @@ function IrisGridModelUpdater({
   right,
   filter,
   formatter,
+  customColumnAlignmentMap,
   reverse = false,
   sorts,
   customColumns,
@@ -125,6 +128,12 @@ function IrisGridModelUpdater({
       model.formatter = formatter;
     },
     [model, formatter]
+  );
+  useOnChange(
+    function updateCustomColumnAlignmentMap() {
+      model.customColumnAlignmentMap = customColumnAlignmentMap;
+    },
+    [model, customColumnAlignmentMap]
   );
   useOnChange(
     function updateCustomColumns() {

--- a/packages/iris-grid/src/IrisGridModelUpdater.tsx
+++ b/packages/iris-grid/src/IrisGridModelUpdater.tsx
@@ -11,7 +11,6 @@ import {
   type ColumnName,
   type UITotalsTableConfig,
   type PendingDataMap,
-  type TextAlignment,
 } from './CommonTypes';
 import type IrisGridModel from './IrisGridModel';
 import type ColumnHeaderGroup from './ColumnHeaderGroup';
@@ -40,7 +39,7 @@ interface IrisGridModelUpdaterProps {
   formatColumns: readonly dh.CustomColumn[];
   alwaysFetchColumns: readonly ColumnName[];
   formatter: Formatter;
-  customColumnAlignmentMap: Map<string, TextAlignment>;
+  customColumnAlignmentMap: Map<string, CanvasTextAlign>;
   rollupConfig?: dh.RollupConfig | null;
   totalsConfig?: UITotalsTableConfig | null;
   selectDistinctColumns?: readonly ColumnName[];

--- a/packages/iris-grid/src/IrisGridProxyModel.ts
+++ b/packages/iris-grid/src/IrisGridProxyModel.ts
@@ -11,7 +11,7 @@ import IrisGridTableModel from './IrisGridTableModel';
 import IrisGridPartitionedTableModel from './IrisGridPartitionedTableModel';
 import IrisGridTreeTableModel from './IrisGridTreeTableModel';
 import IrisGridModel from './IrisGridModel';
-import { type ColumnName } from './CommonTypes';
+import { type TextAlignment, type ColumnName } from './CommonTypes';
 import { isIrisGridTableModelTemplate } from './IrisGridTableModelTemplate';
 import {
   type PartitionConfig,
@@ -455,6 +455,16 @@ class IrisGridProxyModel extends IrisGridModel implements PartitionedGridModel {
 
   set formatter(formatter: Formatter) {
     this.originalModel.formatter = formatter;
+  }
+
+  get customColumnAlignmentMap(): Map<string, TextAlignment> | undefined {
+    return this.originalModel.customColumnAlignmentMap;
+  }
+
+  set customColumnAlignmentMap(
+    customColumnAlignmentMap: Map<string, TextAlignment> | undefined
+  ) {
+    this.originalModel.customColumnAlignmentMap = customColumnAlignmentMap;
   }
 
   setViewport = (

--- a/packages/iris-grid/src/IrisGridProxyModel.ts
+++ b/packages/iris-grid/src/IrisGridProxyModel.ts
@@ -11,7 +11,7 @@ import IrisGridTableModel from './IrisGridTableModel';
 import IrisGridPartitionedTableModel from './IrisGridPartitionedTableModel';
 import IrisGridTreeTableModel from './IrisGridTreeTableModel';
 import IrisGridModel from './IrisGridModel';
-import { type TextAlignment, type ColumnName } from './CommonTypes';
+import { type ColumnName } from './CommonTypes';
 import { isIrisGridTableModelTemplate } from './IrisGridTableModelTemplate';
 import {
   type PartitionConfig,
@@ -457,12 +457,12 @@ class IrisGridProxyModel extends IrisGridModel implements PartitionedGridModel {
     this.originalModel.formatter = formatter;
   }
 
-  get customColumnAlignmentMap(): Map<string, TextAlignment> {
+  get customColumnAlignmentMap(): Map<string, CanvasTextAlign> {
     return this.originalModel.customColumnAlignmentMap;
   }
 
   set customColumnAlignmentMap(
-    customColumnAlignmentMap: Map<string, TextAlignment>
+    customColumnAlignmentMap: Map<string, CanvasTextAlign>
   ) {
     this.originalModel.customColumnAlignmentMap = customColumnAlignmentMap;
   }

--- a/packages/iris-grid/src/IrisGridProxyModel.ts
+++ b/packages/iris-grid/src/IrisGridProxyModel.ts
@@ -457,14 +457,12 @@ class IrisGridProxyModel extends IrisGridModel implements PartitionedGridModel {
     this.originalModel.formatter = formatter;
   }
 
-  get customColumnAlignmentMap(): Map<string, CanvasTextAlign> {
-    return this.originalModel.customColumnAlignmentMap;
+  get columnAlignmentMap(): ReadonlyMap<string, CanvasTextAlign> {
+    return this.originalModel.columnAlignmentMap;
   }
 
-  set customColumnAlignmentMap(
-    customColumnAlignmentMap: Map<string, CanvasTextAlign>
-  ) {
-    this.originalModel.customColumnAlignmentMap = customColumnAlignmentMap;
+  set columnAlignmentMap(columnAlignmentMap: Map<string, CanvasTextAlign>) {
+    this.originalModel.columnAlignmentMap = columnAlignmentMap;
   }
 
   setViewport = (

--- a/packages/iris-grid/src/IrisGridProxyModel.ts
+++ b/packages/iris-grid/src/IrisGridProxyModel.ts
@@ -457,12 +457,12 @@ class IrisGridProxyModel extends IrisGridModel implements PartitionedGridModel {
     this.originalModel.formatter = formatter;
   }
 
-  get customColumnAlignmentMap(): Map<string, TextAlignment> | undefined {
+  get customColumnAlignmentMap(): Map<string, TextAlignment> {
     return this.originalModel.customColumnAlignmentMap;
   }
 
   set customColumnAlignmentMap(
-    customColumnAlignmentMap: Map<string, TextAlignment> | undefined
+    customColumnAlignmentMap: Map<string, TextAlignment>
   ) {
     this.originalModel.customColumnAlignmentMap = customColumnAlignmentMap;
   }

--- a/packages/iris-grid/src/IrisGridTableModelTemplate.ts
+++ b/packages/iris-grid/src/IrisGridTableModelTemplate.ts
@@ -142,7 +142,7 @@ class IrisGridTableModelTemplate<
 
   private irisFormatter: Formatter;
 
-  private irisCustomColumnAlignmentMap: Map<string, TextAlignment> | undefined;
+  private irisCustomColumnAlignmentMap: Map<string, TextAlignment>;
 
   inputTable: DhType.InputTable | null;
 
@@ -662,7 +662,7 @@ class IrisGridTableModelTemplate<
   textAlignForCell(x: ModelIndex, y: ModelIndex): CanvasTextAlign {
     const column = this.sourceColumn(x, y);
 
-    const customAlignment = this.customColumnAlignmentMap?.get(column.name);
+    const customAlignment = this.customColumnAlignmentMap.get(column.name);
     if (customAlignment != null) {
       return customAlignment;
     }
@@ -1231,12 +1231,12 @@ class IrisGridTableModelTemplate<
     );
   }
 
-  get customColumnAlignmentMap(): Map<string, TextAlignment> | undefined {
+  get customColumnAlignmentMap(): Map<string, TextAlignment> {
     return this.irisCustomColumnAlignmentMap;
   }
 
   set customColumnAlignmentMap(
-    customColumnAlignmentMap: Map<string, TextAlignment> | undefined
+    customColumnAlignmentMap: Map<string, TextAlignment>
   ) {
     this.irisCustomColumnAlignmentMap = customColumnAlignmentMap;
   }

--- a/packages/iris-grid/src/IrisGridTableModelTemplate.ts
+++ b/packages/iris-grid/src/IrisGridTableModelTemplate.ts
@@ -141,7 +141,7 @@ class IrisGridTableModelTemplate<
 
   private irisFormatter: Formatter;
 
-  private irisCustomColumnAlignmentMap: Map<string, CanvasTextAlign>;
+  private irisColumnAlignmentMap: Map<string, CanvasTextAlign>;
 
   inputTable: DhType.InputTable | null;
 
@@ -195,14 +195,14 @@ class IrisGridTableModelTemplate<
    * @param table Iris data table to be used in the model
    * @param formatter The formatter to use when getting formats
    * @param inputTable Iris input table associated with this table
-   * @param customColumnAlignmentMap Map of custom column alignments
+   * @param columnAlignmentMap Map of custom column alignments
    */
   constructor(
     dh: typeof DhType,
     table: T,
     formatter = new Formatter(dh),
     inputTable: DhType.InputTable | null = null,
-    customColumnAlignmentMap = new Map<string, CanvasTextAlign>()
+    columnAlignmentMap = new Map<string, CanvasTextAlign>()
   ) {
     super(dh);
 
@@ -216,7 +216,7 @@ class IrisGridTableModelTemplate<
 
     this.dh = dh;
     this.irisFormatter = formatter;
-    this.irisCustomColumnAlignmentMap = customColumnAlignmentMap;
+    this.irisColumnAlignmentMap = columnAlignmentMap;
     this.irisGridUtils = new IrisGridUtils(dh);
     this.inputTable = inputTable;
     this.subscription = null;
@@ -661,7 +661,7 @@ class IrisGridTableModelTemplate<
   textAlignForCell(x: ModelIndex, y: ModelIndex): CanvasTextAlign {
     const column = this.sourceColumn(x, y);
 
-    const customAlignment = this.customColumnAlignmentMap.get(column.name);
+    const customAlignment = this.columnAlignmentMap.get(column.name);
     if (customAlignment != null) {
       return customAlignment;
     }
@@ -1230,14 +1230,12 @@ class IrisGridTableModelTemplate<
     );
   }
 
-  get customColumnAlignmentMap(): Map<string, CanvasTextAlign> {
-    return this.irisCustomColumnAlignmentMap;
+  get columnAlignmentMap(): ReadonlyMap<string, CanvasTextAlign> {
+    return this.irisColumnAlignmentMap;
   }
 
-  set customColumnAlignmentMap(
-    customColumnAlignmentMap: Map<string, CanvasTextAlign>
-  ) {
-    this.irisCustomColumnAlignmentMap = customColumnAlignmentMap;
+  set columnAlignmentMap(columnAlignmentMap: Map<string, CanvasTextAlign>) {
+    this.irisColumnAlignmentMap = columnAlignmentMap;
   }
 
   displayString(

--- a/packages/iris-grid/src/IrisGridTableModelTemplate.ts
+++ b/packages/iris-grid/src/IrisGridTableModelTemplate.ts
@@ -40,6 +40,7 @@ import {
   type CellData,
   type UIViewportData,
   type PendingDataErrorMap,
+  type TextAlignment,
 } from './CommonTypes';
 import { type IrisGridThemeType } from './IrisGridTheme';
 import type ColumnHeaderGroup from './ColumnHeaderGroup';
@@ -141,6 +142,8 @@ class IrisGridTableModelTemplate<
 
   private irisFormatter: Formatter;
 
+  private irisCustomColumnAlignmentMap: Map<string, TextAlignment> | undefined;
+
   inputTable: DhType.InputTable | null;
 
   private subscription: DhType.TableViewportSubscription | null;
@@ -193,12 +196,14 @@ class IrisGridTableModelTemplate<
    * @param table Iris data table to be used in the model
    * @param formatter The formatter to use when getting formats
    * @param inputTable Iris input table associated with this table
+   * @param customColumnAlignmentMap Map of custom column alignments
    */
   constructor(
     dh: typeof DhType,
     table: T,
     formatter = new Formatter(dh),
-    inputTable: DhType.InputTable | null = null
+    inputTable: DhType.InputTable | null = null,
+    customColumnAlignmentMap = new Map<string, TextAlignment>()
   ) {
     super(dh);
 
@@ -212,6 +217,7 @@ class IrisGridTableModelTemplate<
 
     this.dh = dh;
     this.irisFormatter = formatter;
+    this.irisCustomColumnAlignmentMap = customColumnAlignmentMap;
     this.irisGridUtils = new IrisGridUtils(dh);
     this.inputTable = inputTable;
     this.subscription = null;
@@ -655,6 +661,11 @@ class IrisGridTableModelTemplate<
 
   textAlignForCell(x: ModelIndex, y: ModelIndex): CanvasTextAlign {
     const column = this.sourceColumn(x, y);
+
+    const customAlignment = this.customColumnAlignmentMap?.get(column.name);
+    if (customAlignment != null) {
+      return customAlignment;
+    }
 
     return IrisGridUtils.textAlignForValue(column.type, column.name);
   }
@@ -1218,6 +1229,16 @@ class IrisGridTableModelTemplate<
     this.dispatchEvent(
       new EventShimCustomEvent(IrisGridModel.EVENT.FORMATTER_UPDATED)
     );
+  }
+
+  get customColumnAlignmentMap(): Map<string, TextAlignment> | undefined {
+    return this.irisCustomColumnAlignmentMap;
+  }
+
+  set customColumnAlignmentMap(
+    customColumnAlignmentMap: Map<string, TextAlignment> | undefined
+  ) {
+    this.irisCustomColumnAlignmentMap = customColumnAlignmentMap;
   }
 
   displayString(

--- a/packages/iris-grid/src/IrisGridTableModelTemplate.ts
+++ b/packages/iris-grid/src/IrisGridTableModelTemplate.ts
@@ -40,7 +40,6 @@ import {
   type CellData,
   type UIViewportData,
   type PendingDataErrorMap,
-  type TextAlignment,
 } from './CommonTypes';
 import { type IrisGridThemeType } from './IrisGridTheme';
 import type ColumnHeaderGroup from './ColumnHeaderGroup';
@@ -142,7 +141,7 @@ class IrisGridTableModelTemplate<
 
   private irisFormatter: Formatter;
 
-  private irisCustomColumnAlignmentMap: Map<string, TextAlignment>;
+  private irisCustomColumnAlignmentMap: Map<string, CanvasTextAlign>;
 
   inputTable: DhType.InputTable | null;
 
@@ -203,7 +202,7 @@ class IrisGridTableModelTemplate<
     table: T,
     formatter = new Formatter(dh),
     inputTable: DhType.InputTable | null = null,
-    customColumnAlignmentMap = new Map<string, TextAlignment>()
+    customColumnAlignmentMap = new Map<string, CanvasTextAlign>()
   ) {
     super(dh);
 
@@ -1231,12 +1230,12 @@ class IrisGridTableModelTemplate<
     );
   }
 
-  get customColumnAlignmentMap(): Map<string, TextAlignment> {
+  get customColumnAlignmentMap(): Map<string, CanvasTextAlign> {
     return this.irisCustomColumnAlignmentMap;
   }
 
   set customColumnAlignmentMap(
-    customColumnAlignmentMap: Map<string, TextAlignment>
+    customColumnAlignmentMap: Map<string, CanvasTextAlign>
   ) {
     this.irisCustomColumnAlignmentMap = customColumnAlignmentMap;
   }

--- a/packages/iris-grid/src/IrisGridTableModelTemplate.ts
+++ b/packages/iris-grid/src/IrisGridTableModelTemplate.ts
@@ -195,7 +195,7 @@ class IrisGridTableModelTemplate<
    * @param table Iris data table to be used in the model
    * @param formatter The formatter to use when getting formats
    * @param inputTable Iris input table associated with this table
-   * @param columnAlignmentMap Map of custom column alignments
+   * @param columnAlignmentMap Map of column alignments
    */
   constructor(
     dh: typeof DhType,
@@ -661,9 +661,9 @@ class IrisGridTableModelTemplate<
   textAlignForCell(x: ModelIndex, y: ModelIndex): CanvasTextAlign {
     const column = this.sourceColumn(x, y);
 
-    const customAlignment = this.columnAlignmentMap.get(column.name);
-    if (customAlignment != null) {
-      return customAlignment;
+    const userTextAlignment = this.columnAlignmentMap.get(column.name);
+    if (userTextAlignment != null) {
+      return userTextAlignment;
     }
 
     return IrisGridUtils.textAlignForValue(column.type, column.name);

--- a/packages/iris-grid/src/IrisGridTreeTableModel.ts
+++ b/packages/iris-grid/src/IrisGridTreeTableModel.ts
@@ -241,9 +241,9 @@ class IrisGridTreeTableModel extends IrisGridTableModelTemplate<
   textAlignForCell(x: ModelIndex, y: ModelIndex): CanvasTextAlign {
     const column = this.sourceColumn(x, y);
 
-    const customAlignment = this.columnAlignmentMap?.get(column.name);
-    if (customAlignment != null) {
-      return customAlignment;
+    const userTextAlignment = this.columnAlignmentMap?.get(column.name);
+    if (userTextAlignment != null) {
+      return userTextAlignment;
     }
 
     const row = this.row(y);

--- a/packages/iris-grid/src/IrisGridTreeTableModel.ts
+++ b/packages/iris-grid/src/IrisGridTreeTableModel.ts
@@ -107,9 +107,9 @@ class IrisGridTreeTableModel extends IrisGridTableModelTemplate<
     table: DhType.TreeTable,
     formatter = new Formatter(dh),
     inputTable: DhType.InputTable | null = null,
-    customColumnAlignmentMap = new Map<string, CanvasTextAlign>()
+    columnAlignmentMap = new Map<string, CanvasTextAlign>()
   ) {
-    super(dh, table, formatter, inputTable, customColumnAlignmentMap);
+    super(dh, table, formatter, inputTable, columnAlignmentMap);
 
     this.virtualColumns =
       this.showExtraGroupColumn && table.groupedColumns.length > 1
@@ -241,7 +241,7 @@ class IrisGridTreeTableModel extends IrisGridTableModelTemplate<
   textAlignForCell(x: ModelIndex, y: ModelIndex): CanvasTextAlign {
     const column = this.sourceColumn(x, y);
 
-    const customAlignment = this.customColumnAlignmentMap?.get(column.name);
+    const customAlignment = this.columnAlignmentMap?.get(column.name);
     if (customAlignment != null) {
       return customAlignment;
     }

--- a/packages/iris-grid/src/IrisGridTreeTableModel.ts
+++ b/packages/iris-grid/src/IrisGridTreeTableModel.ts
@@ -14,7 +14,7 @@ import {
   EMPTY_ARRAY,
   EventShimCustomEvent,
 } from '@deephaven/utils';
-import { type UIRow, type ColumnName, type TextAlignment } from './CommonTypes';
+import { type UIRow, type ColumnName } from './CommonTypes';
 import IrisGridTableModelTemplate from './IrisGridTableModelTemplate';
 import IrisGridModel, { type DisplayColumn } from './IrisGridModel';
 import { type IrisGridThemeType } from './IrisGridTheme';
@@ -107,7 +107,7 @@ class IrisGridTreeTableModel extends IrisGridTableModelTemplate<
     table: DhType.TreeTable,
     formatter = new Formatter(dh),
     inputTable: DhType.InputTable | null = null,
-    customColumnAlignmentMap = new Map<string, TextAlignment>()
+    customColumnAlignmentMap = new Map<string, CanvasTextAlign>()
   ) {
     super(dh, table, formatter, inputTable, customColumnAlignmentMap);
 

--- a/packages/iris-grid/src/IrisGridTreeTableModel.ts
+++ b/packages/iris-grid/src/IrisGridTreeTableModel.ts
@@ -14,7 +14,7 @@ import {
   EMPTY_ARRAY,
   EventShimCustomEvent,
 } from '@deephaven/utils';
-import { type UIRow, type ColumnName } from './CommonTypes';
+import { type UIRow, type ColumnName, type TextAlignment } from './CommonTypes';
 import IrisGridTableModelTemplate from './IrisGridTableModelTemplate';
 import IrisGridModel, { type DisplayColumn } from './IrisGridModel';
 import { type IrisGridThemeType } from './IrisGridTheme';
@@ -106,9 +106,10 @@ class IrisGridTreeTableModel extends IrisGridTableModelTemplate<
     dh: typeof DhType,
     table: DhType.TreeTable,
     formatter = new Formatter(dh),
-    inputTable: DhType.InputTable | null = null
+    inputTable: DhType.InputTable | null = null,
+    customColumnAlignmentMap = new Map<string, TextAlignment>()
   ) {
-    super(dh, table, formatter, inputTable);
+    super(dh, table, formatter, inputTable, customColumnAlignmentMap);
 
     this.virtualColumns =
       this.showExtraGroupColumn && table.groupedColumns.length > 1
@@ -239,6 +240,12 @@ class IrisGridTreeTableModel extends IrisGridTableModelTemplate<
 
   textAlignForCell(x: ModelIndex, y: ModelIndex): CanvasTextAlign {
     const column = this.sourceColumn(x, y);
+
+    const customAlignment = this.customColumnAlignmentMap?.get(column.name);
+    if (customAlignment != null) {
+      return customAlignment;
+    }
+
     const row = this.row(y);
     assertNotNull(row);
 

--- a/packages/iris-grid/src/IrisGridUtils.test.ts
+++ b/packages/iris-grid/src/IrisGridUtils.test.ts
@@ -676,6 +676,7 @@ describe('dehydration methods', () => {
           showOnTop: false,
         },
         customColumnFormatMap: new Map(),
+        customColumnAlignmentMap: new Map(),
         isFilterBarShown: false,
         quickFilters: new Map(),
         customColumns: [],

--- a/packages/iris-grid/src/IrisGridUtils.test.ts
+++ b/packages/iris-grid/src/IrisGridUtils.test.ts
@@ -676,7 +676,7 @@ describe('dehydration methods', () => {
           showOnTop: false,
         },
         customColumnFormatMap: new Map(),
-        customColumnAlignmentMap: new Map(),
+        columnAlignmentMap: new Map(),
         isFilterBarShown: false,
         quickFilters: new Map(),
         customColumns: [],

--- a/packages/iris-grid/src/IrisGridUtils.ts
+++ b/packages/iris-grid/src/IrisGridUtils.ts
@@ -34,7 +34,6 @@ import {
   type PendingDataMap,
   type UIRow,
   type AdvancedFilterOptions,
-  type TextAlignment,
 } from './CommonTypes';
 import { type UIRollupConfig } from './sidebar/RollupRows';
 import { type AggregationSettings } from './sidebar/aggregations/Aggregations';
@@ -94,7 +93,7 @@ export type DehydratedQuickFilter = [
 
 export type DehydratedCustomColumnFormat = [string, FormattingRule];
 
-export type DehydratedCustomColumnAlignment = [string, TextAlignment];
+export type DehydratedCustomColumnAlignment = [string, CanvasTextAlign];
 
 export type DehydratedUserColumnWidth = [ColumnName, number];
 

--- a/packages/iris-grid/src/IrisGridUtils.ts
+++ b/packages/iris-grid/src/IrisGridUtils.ts
@@ -55,7 +55,7 @@ export type HydratedIrisGridState = Pick<
   | 'advancedFilters'
   | 'aggregationSettings'
   | 'customColumnFormatMap'
-  | 'customColumnAlignmentMap'
+  | 'columnAlignmentMap'
   | 'isFilterBarShown'
   | 'quickFilters'
   | 'customColumns'
@@ -93,7 +93,7 @@ export type DehydratedQuickFilter = [
 
 export type DehydratedCustomColumnFormat = [string, FormattingRule];
 
-export type DehydratedCustomColumnAlignment = [string, CanvasTextAlign];
+export type DehydratedUserColumnAlignment = [string, CanvasTextAlign];
 
 export type DehydratedUserColumnWidth = [ColumnName, number];
 
@@ -127,7 +127,7 @@ export interface DehydratedIrisGridState {
   advancedFilters: readonly DehydratedAdvancedFilter[];
   aggregationSettings: AggregationSettings;
   customColumnFormatMap: readonly DehydratedCustomColumnFormat[];
-  customColumnAlignmentMap: readonly DehydratedCustomColumnAlignment[];
+  columnAlignmentMap: readonly DehydratedUserColumnAlignment[];
   isFilterBarShown: boolean;
   quickFilters: readonly DehydratedQuickFilter[];
   sorts: readonly DehydratedSort[];
@@ -1175,7 +1175,7 @@ class IrisGridUtils {
       aggregationSettings = { aggregations: EMPTY_ARRAY, showOnTop: false },
       advancedFilters,
       customColumnFormatMap,
-      customColumnAlignmentMap,
+      columnAlignmentMap,
       isFilterBarShown,
       metrics: { userColumnWidths, userRowHeights } = {
         userColumnWidths: EMPTY_MAP,
@@ -1207,7 +1207,7 @@ class IrisGridUtils {
       advancedFilters: this.dehydrateAdvancedFilters(columns, advancedFilters),
       aggregationSettings,
       customColumnFormatMap: [...customColumnFormatMap],
-      customColumnAlignmentMap: [...customColumnAlignmentMap],
+      columnAlignmentMap: [...columnAlignmentMap],
       isFilterBarShown,
       quickFilters: IrisGridUtils.dehydrateQuickFilters(quickFilters),
       sorts: IrisGridUtils.dehydrateSort(sorts),
@@ -1259,7 +1259,7 @@ class IrisGridUtils {
       advancedFilters,
       aggregationSettings = { aggregations: [], showOnTop: false },
       customColumnFormatMap,
-      customColumnAlignmentMap,
+      columnAlignmentMap,
       isFilterBarShown,
       quickFilters,
       sorts,
@@ -1292,7 +1292,7 @@ class IrisGridUtils {
       ),
       aggregationSettings,
       customColumnFormatMap: new Map(customColumnFormatMap),
-      customColumnAlignmentMap: new Map(customColumnAlignmentMap),
+      columnAlignmentMap: new Map(columnAlignmentMap),
       isFilterBarShown,
       quickFilters: this.hydrateQuickFilters(
         columns,

--- a/packages/iris-grid/src/IrisGridUtils.ts
+++ b/packages/iris-grid/src/IrisGridUtils.ts
@@ -34,6 +34,7 @@ import {
   type PendingDataMap,
   type UIRow,
   type AdvancedFilterOptions,
+  type TextAlignment,
 } from './CommonTypes';
 import { type UIRollupConfig } from './sidebar/RollupRows';
 import { type AggregationSettings } from './sidebar/aggregations/Aggregations';
@@ -55,6 +56,7 @@ export type HydratedIrisGridState = Pick<
   | 'advancedFilters'
   | 'aggregationSettings'
   | 'customColumnFormatMap'
+  | 'customColumnAlignmentMap'
   | 'isFilterBarShown'
   | 'quickFilters'
   | 'customColumns'
@@ -92,6 +94,8 @@ export type DehydratedQuickFilter = [
 
 export type DehydratedCustomColumnFormat = [string, FormattingRule];
 
+export type DehydratedCustomColumnAlignment = [string, TextAlignment];
+
 export type DehydratedUserColumnWidth = [ColumnName, number];
 
 export type DehydratedUserRowHeight = [number, number];
@@ -124,6 +128,7 @@ export interface DehydratedIrisGridState {
   advancedFilters: readonly DehydratedAdvancedFilter[];
   aggregationSettings: AggregationSettings;
   customColumnFormatMap: readonly DehydratedCustomColumnFormat[];
+  customColumnAlignmentMap: readonly DehydratedCustomColumnAlignment[];
   isFilterBarShown: boolean;
   quickFilters: readonly DehydratedQuickFilter[];
   sorts: readonly DehydratedSort[];
@@ -1171,6 +1176,7 @@ class IrisGridUtils {
       aggregationSettings = { aggregations: EMPTY_ARRAY, showOnTop: false },
       advancedFilters,
       customColumnFormatMap,
+      customColumnAlignmentMap,
       isFilterBarShown,
       metrics: { userColumnWidths, userRowHeights } = {
         userColumnWidths: EMPTY_MAP,
@@ -1202,6 +1208,7 @@ class IrisGridUtils {
       advancedFilters: this.dehydrateAdvancedFilters(columns, advancedFilters),
       aggregationSettings,
       customColumnFormatMap: [...customColumnFormatMap],
+      customColumnAlignmentMap: [...customColumnAlignmentMap],
       isFilterBarShown,
       quickFilters: IrisGridUtils.dehydrateQuickFilters(quickFilters),
       sorts: IrisGridUtils.dehydrateSort(sorts),
@@ -1253,6 +1260,7 @@ class IrisGridUtils {
       advancedFilters,
       aggregationSettings = { aggregations: [], showOnTop: false },
       customColumnFormatMap,
+      customColumnAlignmentMap,
       isFilterBarShown,
       quickFilters,
       sorts,
@@ -1285,6 +1293,7 @@ class IrisGridUtils {
       ),
       aggregationSettings,
       customColumnFormatMap: new Map(customColumnFormatMap),
+      customColumnAlignmentMap: new Map(customColumnAlignmentMap),
       isFilterBarShown,
       quickFilters: this.hydrateQuickFilters(
         columns,

--- a/packages/iris-grid/src/format-context-menus/TextAlignmentFormatContextMenu.ts
+++ b/packages/iris-grid/src/format-context-menus/TextAlignmentFormatContextMenu.ts
@@ -5,11 +5,10 @@ import {
   dhRightAlign,
 } from '@deephaven/icons';
 
-interface TextAlignmentOption {
+interface TextAlignmentOptions {
   title: string;
   alignment: CanvasTextAlign | null;
   group: number;
-  isSelected: boolean;
   icon?: IconDefinition;
 }
 
@@ -18,58 +17,43 @@ class TextAlignmentFormatContextMenu {
 
   static alignmentGroup = 20;
 
+  static readonly alignmentOptions: ReadonlyArray<TextAlignmentOptions> = [
+    {
+      title: 'Default',
+      alignment: null,
+      group: TextAlignmentFormatContextMenu.defaultGroup,
+    },
+    {
+      title: 'Left Align',
+      alignment: 'left',
+      icon: dhLeftAlign,
+      group: TextAlignmentFormatContextMenu.alignmentGroup,
+    },
+    {
+      title: 'Center Align',
+      alignment: 'center',
+      icon: dhCenterAlign,
+      group: TextAlignmentFormatContextMenu.alignmentGroup,
+    },
+    {
+      title: 'Right Align',
+      alignment: 'right',
+      icon: dhRightAlign,
+      group: TextAlignmentFormatContextMenu.alignmentGroup,
+    },
+  ];
+
   /**
    * Gets the associated icon for a given alignment
    * @param alignment The text alignment
    * @returns The corresponding icon definition
    */
   static getIconForAlignment(alignment: CanvasTextAlign): IconDefinition {
-    if (alignment === 'left') return dhLeftAlign;
     if (alignment === 'center') return dhCenterAlign;
+    if (alignment === 'left') return dhLeftAlign;
     return dhRightAlign;
-  }
-
-  /**
-   * Creates list of text alignment options for the context menu
-   * @param currentAlignment The active text alignment
-   * @returns Array of text alignment options for the context menu
-   */
-  static getOptions(
-    currentAlignment?: CanvasTextAlign | null
-  ): TextAlignmentOption[] {
-    const alignmentOptions: TextAlignmentOption[] = [
-      {
-        title: 'Default',
-        alignment: null,
-        isSelected: currentAlignment == null,
-        group: TextAlignmentFormatContextMenu.defaultGroup,
-      },
-      {
-        title: 'Left Align',
-        alignment: 'left',
-        icon: dhLeftAlign,
-        isSelected: currentAlignment === 'left',
-        group: TextAlignmentFormatContextMenu.alignmentGroup,
-      },
-      {
-        title: 'Center Align',
-        alignment: 'center',
-        icon: dhCenterAlign,
-        isSelected: currentAlignment === 'center',
-        group: TextAlignmentFormatContextMenu.alignmentGroup,
-      },
-      {
-        title: 'Right Align',
-        alignment: 'right',
-        icon: dhRightAlign,
-        isSelected: currentAlignment === 'right',
-        group: TextAlignmentFormatContextMenu.alignmentGroup,
-      },
-    ];
-
-    return alignmentOptions;
   }
 }
 
 export default TextAlignmentFormatContextMenu;
-export type { TextAlignmentOption };
+export type { TextAlignmentOptions };

--- a/packages/iris-grid/src/format-context-menus/TextAlignmentFormatContextMenu.ts
+++ b/packages/iris-grid/src/format-context-menus/TextAlignmentFormatContextMenu.ts
@@ -1,0 +1,75 @@
+import {
+  type IconDefinition,
+  dhLeftAlign,
+  dhCenterAlign,
+  dhRightAlign,
+} from '@deephaven/icons';
+
+interface TextAlignmentOption {
+  title: string;
+  alignment: CanvasTextAlign | null;
+  group: number;
+  isSelected: boolean;
+  icon?: IconDefinition;
+}
+
+class TextAlignmentFormatContextMenu {
+  static defaultGroup = 10;
+
+  static alignmentGroup = 20;
+
+  /**
+   * Gets the associated icon for a given alignment
+   * @param alignment The text alignment
+   * @returns The corresponding icon definition
+   */
+  static getIconForAlignment(alignment: CanvasTextAlign): IconDefinition {
+    if (alignment === 'left') return dhLeftAlign;
+    if (alignment === 'center') return dhCenterAlign;
+    return dhRightAlign;
+  }
+
+  /**
+   * Creates list of text alignment options for the context menu
+   * @param currentAlignment The active text alignment
+   * @returns Array of text alignment options for the context menu
+   */
+  static getOptions(
+    currentAlignment?: CanvasTextAlign | null
+  ): TextAlignmentOption[] {
+    const alignmentOptions: TextAlignmentOption[] = [
+      {
+        title: 'Default',
+        alignment: null,
+        isSelected: currentAlignment == null,
+        group: TextAlignmentFormatContextMenu.defaultGroup,
+      },
+      {
+        title: 'Left Align',
+        alignment: 'left',
+        icon: dhLeftAlign,
+        isSelected: currentAlignment === 'left',
+        group: TextAlignmentFormatContextMenu.alignmentGroup,
+      },
+      {
+        title: 'Center Align',
+        alignment: 'center',
+        icon: dhCenterAlign,
+        isSelected: currentAlignment === 'center',
+        group: TextAlignmentFormatContextMenu.alignmentGroup,
+      },
+      {
+        title: 'Right Align',
+        alignment: 'right',
+        icon: dhRightAlign,
+        isSelected: currentAlignment === 'right',
+        group: TextAlignmentFormatContextMenu.alignmentGroup,
+      },
+    ];
+
+    return alignmentOptions;
+  }
+}
+
+export default TextAlignmentFormatContextMenu;
+export type { TextAlignmentOption };

--- a/packages/iris-grid/src/format-context-menus/index.ts
+++ b/packages/iris-grid/src/format-context-menus/index.ts
@@ -1,3 +1,4 @@
 export { default as DateTimeFormatContextMenu } from './DateTimeFormatContextMenu';
 export { default as DecimalFormatContextMenu } from './DecimalFormatContextMenu';
 export { default as IntegerFormatContextMenu } from './IntegerFormatContextMenu';
+export { default as TextAlignmentFormatContextMenu } from './TextAlignmentFormatContextMenu';

--- a/packages/iris-grid/src/mousehandlers/IrisGridContextMenuHandler.tsx
+++ b/packages/iris-grid/src/mousehandlers/IrisGridContextMenuHandler.tsx
@@ -54,6 +54,7 @@ import {
   DateTimeFormatContextMenu,
   DecimalFormatContextMenu,
   IntegerFormatContextMenu,
+  TextAlignmentFormatContextMenu,
 } from '../format-context-menus';
 import './IrisGridContextMenuHandler.scss';
 import SHORTCUTS from '../IrisGridShortcuts';
@@ -375,6 +376,13 @@ class IrisGridContextMenuHandler extends GridMouseHandler {
         actions: this.numberFormatActions(column) ?? undefined,
       });
     }
+
+    actions.push({
+      title: 'Text Alignment',
+      group: IrisGridContextMenuHandler.GROUP_FORMAT,
+      actions: this.textAlignmentFormatActions(column),
+    });
+
     return actions;
   }
 
@@ -1114,6 +1122,28 @@ class IrisGridContextMenuHandler extends GridMouseHandler {
       });
     }
     return actions;
+  }
+
+  textAlignmentFormatActions(column: DhType.Column): ContextAction[] {
+    const { model } = this.irisGrid.props;
+    const { customColumnAlignmentMap } = this.irisGrid.state;
+    const modelIndex = model.getColumnIndexByName(column.name);
+    assertNotNull(modelIndex);
+
+    const currentAlignment = customColumnAlignmentMap.get(column.name);
+
+    const alignmentOptions =
+      TextAlignmentFormatContextMenu.getOptions(currentAlignment);
+
+    return alignmentOptions.map((option, index) => ({
+      title: option.title,
+      icon: option.isSelected ? vsCheck : option.icon,
+      order: index,
+      group: option.group,
+      action: () => {
+        this.irisGrid.handleColumnAlignmentChange(modelIndex, option.alignment);
+      },
+    }));
   }
 
   stringFilterActions(

--- a/packages/iris-grid/src/mousehandlers/IrisGridContextMenuHandler.tsx
+++ b/packages/iris-grid/src/mousehandlers/IrisGridContextMenuHandler.tsx
@@ -1126,11 +1126,11 @@ class IrisGridContextMenuHandler extends GridMouseHandler {
 
   textAlignmentFormatActions(column: DhType.Column): ContextAction[] {
     const { model } = this.irisGrid.props;
-    const { customColumnAlignmentMap } = this.irisGrid.state;
+    const { columnAlignmentMap } = this.irisGrid.state;
     const modelIndex = model.getColumnIndexByName(column.name);
     assertNotNull(modelIndex);
 
-    const currentAlignment = customColumnAlignmentMap.get(column.name);
+    const currentAlignment = columnAlignmentMap.get(column.name);
 
     return TextAlignmentFormatContextMenu.alignmentOptions.map(
       (option, index) => ({

--- a/packages/iris-grid/src/mousehandlers/IrisGridContextMenuHandler.tsx
+++ b/packages/iris-grid/src/mousehandlers/IrisGridContextMenuHandler.tsx
@@ -1132,18 +1132,24 @@ class IrisGridContextMenuHandler extends GridMouseHandler {
 
     const currentAlignment = customColumnAlignmentMap.get(column.name);
 
-    const alignmentOptions =
-      TextAlignmentFormatContextMenu.getOptions(currentAlignment);
-
-    return alignmentOptions.map((option, index) => ({
-      title: option.title,
-      icon: option.isSelected ? vsCheck : option.icon,
-      order: index,
-      group: option.group,
-      action: () => {
-        this.irisGrid.handleColumnAlignmentChange(modelIndex, option.alignment);
-      },
-    }));
+    return TextAlignmentFormatContextMenu.alignmentOptions.map(
+      (option, index) => ({
+        title: option.title,
+        icon:
+          (currentAlignment == null && option.alignment == null) ||
+          currentAlignment === option.alignment
+            ? vsCheck
+            : option.icon,
+        order: index,
+        group: option.group,
+        action: () => {
+          this.irisGrid.handleColumnAlignmentChange(
+            modelIndex,
+            option.alignment
+          );
+        },
+      })
+    );
   }
 
   stringFilterActions(


### PR DESCRIPTION
For DH-10205. Allows users to override the default type-based alignment logic on a per column basis using a context menu.

Text alignment is determined with the following priority order: 1. context menu, 2.ui.table, 3. column type.

TODO:
- [ ] Bump package version in ui plugins
- [ ] Update `UITableModel` to use custom text alignment from the base model