### PR TITLE
fix: Allow undefined for useTablePlugin irisGridUtils

### DIFF
--- a/packages/dashboard-core-plugins/src/useTablePlugin.tsx
+++ b/packages/dashboard-core-plugins/src/useTablePlugin.tsx
@@ -26,7 +26,7 @@ interface UseTablePluginProps {
   /**
    * A IrisGridUtils instance.
    */
-  irisGridUtils: IrisGridUtils;
+  irisGridUtils: IrisGridUtils | undefined;
   /**
    * The currently selected ranges in the grid.
    */
@@ -56,7 +56,9 @@ export function useTablePlugin({
   const [pluginFilters, setPluginFilters] = useState<InputFilter[]>([]);
   const customFilters = useMemo(
     () =>
-      model != null && isIrisGridTableModelTemplate(model)
+      model != null &&
+      irisGridUtils != null &&
+      isIrisGridTableModelTemplate(model)
         ? irisGridUtils.getFiltersFromInputFilters(
             model.table.columns,
             pluginFilters,


### PR DESCRIPTION
Small thing needed for ui.resolve b/c the JS API may not be available on mount of `UITable`, so `irisGridUtils` may be null

This won't affect any rendering of table plugins since `model` is also required and possibly undefined until the JS API and table are loaded.