### PR TITLE
fix: Add default values for columnAlignmentMap in hydrate/dehydrate methods

### DIFF
--- a/packages/iris-grid/src/IrisGridUtils.ts
+++ b/packages/iris-grid/src/IrisGridUtils.ts
@@ -1175,7 +1175,7 @@ class IrisGridUtils {
       aggregationSettings = { aggregations: EMPTY_ARRAY, showOnTop: false },
       advancedFilters,
       customColumnFormatMap,
-      columnAlignmentMap,
+      columnAlignmentMap = EMPTY_MAP,
       isFilterBarShown,
       metrics: { userColumnWidths, userRowHeights } = {
         userColumnWidths: EMPTY_MAP,
@@ -1259,7 +1259,7 @@ class IrisGridUtils {
       advancedFilters,
       aggregationSettings = { aggregations: [], showOnTop: false },
       customColumnFormatMap,
-      columnAlignmentMap,
+      columnAlignmentMap = [],
       isFilterBarShown,
       quickFilters,
       sorts,


### PR DESCRIPTION
For DH-10205. The current implementation breaks enterprise code that uses  hydration/dehydration without providing a `columnAlignmentMap` (such as `QueryMonitorGridPanel`).

We could update the few places that call hydrate/dehydrate iris grid when updating packages in DHE. But it is probably better to set defaults as Matt suggested. 