### PR TITLE
chore: Set data-testid props on LoadingOverlay instances

### DIFF
--- a/packages/app-utils/src/components/AppDashboards.tsx
+++ b/packages/app-utils/src/components/AppDashboards.tsx
@@ -33,7 +33,7 @@ export function AppDashboards({
   onLayoutInitialized,
   onGoldenLayoutChange,
   plugins,
-  emptyDashboard = <LoadingOverlay />,
+  emptyDashboard = <LoadingOverlay data-testid="app-dashboards-loading" />,
 }: AppDashboardsProps): JSX.Element {
   const fetchObject = useObjectFetcher();
 

--- a/packages/app-utils/src/components/AuthBootstrap.tsx
+++ b/packages/app-utils/src/components/AuthBootstrap.tsx
@@ -88,6 +88,7 @@ export function AuthBootstrap({ children }: AuthBootstrapProps): JSX.Element {
       <LoadingOverlay
         isLoading={isLoading && error == null}
         errorMessage={getErrorMessage(error)}
+        data-testid="auth-bootstrap-loading-error"
       />
     );
   }

--- a/packages/app-utils/src/components/ServerConfigBootstrap.tsx
+++ b/packages/app-utils/src/components/ServerConfigBootstrap.tsx
@@ -54,6 +54,7 @@ export function ServerConfigBootstrap({
   if (isLoading || error != null) {
     return (
       <LoadingOverlay
+        data-testid="server-config-bootstrap-loading"
         isLoading={isLoading && error == null}
         errorMessage={getErrorMessage(error)}
       />

--- a/packages/chart/src/LazyChart.tsx
+++ b/packages/chart/src/LazyChart.tsx
@@ -5,7 +5,7 @@ const Chart = lazy(() => import('./Chart.js'));
 
 function LazyChart(props: React.ComponentProps<typeof Chart>): JSX.Element {
   return (
-    <Suspense fallback={<LoadingOverlay />}>
+    <Suspense fallback={<LoadingOverlay data-testid="lazy-chart-loading" />}>
       {/* eslint-disable-next-line react/jsx-props-no-spreading */}
       <Chart {...props} />
     </Suspense>

--- a/packages/chart/src/plotly/LazyPlot.tsx
+++ b/packages/chart/src/plotly/LazyPlot.tsx
@@ -5,7 +5,7 @@ const PlotBase = lazy(() => import('./Plot.js'));
 
 function Plot(props: React.ComponentProps<typeof PlotBase>): JSX.Element {
   return (
-    <Suspense fallback={<LoadingOverlay />}>
+    <Suspense fallback={<LoadingOverlay data-testid="lazy-plot-loading" />}>
       {/* eslint-disable react/jsx-props-no-spreading */}
       <PlotBase {...props} />
     </Suspense>

--- a/packages/code-studio/src/index.tsx
+++ b/packages/code-studio/src/index.tsx
@@ -67,7 +67,9 @@ async function getCorePlugins() {
 
 ReactDOM.render(
   <ApiBootstrap apiUrl={apiURL.href} setGlobally>
-    <Suspense fallback={<LoadingOverlay />}>
+    <Suspense
+      fallback={<LoadingOverlay data-testid="code-studio-index-loading" />}
+    >
       <Provider store={store}>
         <AppBootstrap
           getCorePlugins={getCorePlugins}

--- a/packages/code-studio/src/main/AppInit.tsx
+++ b/packages/code-studio/src/main/AppInit.tsx
@@ -156,6 +156,7 @@ function AppInit(): JSX.Element {
     <>
       {isLoaded && <App />}
       <LoadingOverlay
+        data-testid="loading-overlay-app-init"
         isLoading={isLoading && errorMessage == null}
         isLoaded={isLoaded}
         errorMessage={errorMessage}

--- a/packages/code-studio/src/main/AppInit.tsx
+++ b/packages/code-studio/src/main/AppInit.tsx
@@ -156,7 +156,7 @@ function AppInit(): JSX.Element {
     <>
       {isLoaded && <App />}
       <LoadingOverlay
-        data-testid="loading-overlay-app-init"
+        data-testid="app-init-loading"
         isLoading={isLoading && errorMessage == null}
         isLoaded={isLoaded}
         errorMessage={errorMessage}

--- a/packages/code-studio/src/main/AppMainContainer.tsx
+++ b/packages/code-studio/src/main/AppMainContainer.tsx
@@ -1049,7 +1049,7 @@ export class AppMainContainer extends Component<
             activeTabKey === DEFAULT_DASHBOARD_ID ? (
               <EmptyDashboard onAutoFillClick={this.handleAutoFillClick} />
             ) : (
-              <LoadingOverlay data-testid="app-dashboards-loading" />
+              <LoadingOverlay data-testid="app-main-container-loading" />
             )
           }
           plugins={[

--- a/packages/code-studio/src/main/AppMainContainer.tsx
+++ b/packages/code-studio/src/main/AppMainContainer.tsx
@@ -1049,7 +1049,7 @@ export class AppMainContainer extends Component<
             activeTabKey === DEFAULT_DASHBOARD_ID ? (
               <EmptyDashboard onAutoFillClick={this.handleAutoFillClick} />
             ) : (
-              <LoadingOverlay />
+              <LoadingOverlay data-testid="app-dashboards-loading" />
             )
           }
           plugins={[

--- a/packages/components/src/ErrorBoundary.tsx
+++ b/packages/components/src/ErrorBoundary.tsx
@@ -59,6 +59,7 @@ export class ErrorBoundary extends Component<
             errorMessage={`${error}`}
             isLoading={false}
             isLoaded={false}
+            data-testid="error-boundary-loading"
           />
         </div>
       );

--- a/packages/console/src/notebook/ScriptEditor.tsx
+++ b/packages/console/src/notebook/ScriptEditor.tsx
@@ -370,6 +370,7 @@ class ScriptEditor extends Component<ScriptEditorProps, ScriptEditorState> {
         {(error || isLoading) && (
           <div className="h-100 w-100 position-relative">
             <LoadingOverlay
+              data-testid="script-editor-loading"
               errorMessage={errorMessage}
               isLoading={isLoading}
               isLoaded={isLoaded}

--- a/packages/dashboard-core-plugins/src/GridWidgetPlugin.tsx
+++ b/packages/dashboard-core-plugins/src/GridWidgetPlugin.tsx
@@ -143,12 +143,15 @@ export function GridWidgetPlugin({
   }, [linkerAlwaysFetchColumns, filterFetchColumns]);
 
   if (fetchResult.status === 'loading') {
-    return <LoadingOverlay isLoading />;
+    return (
+      <LoadingOverlay isLoading data-testid="grid-widget-plugin-loading" />
+    );
   }
 
   if (fetchResult.status === 'error') {
     return (
       <LoadingOverlay
+        data-testid="grid-widget-plugin-loading-error"
         errorMessage={getErrorMessage(fetchResult.error)}
         isLoading={false}
       />

--- a/packages/dashboard-core-plugins/src/PandasWidgetPlugin.tsx
+++ b/packages/dashboard-core-plugins/src/PandasWidgetPlugin.tsx
@@ -12,7 +12,9 @@ export function PandasWidgetPlugin({
   const fetchResult = useIrisGridModel(fetch);
 
   if (fetchResult.status === 'loading') {
-    return <LoadingOverlay isLoading />;
+    return (
+      <LoadingOverlay isLoading data-testid="pandas-widget-plugin-loading" />
+    );
   }
 
   if (fetchResult.status === 'error') {
@@ -20,6 +22,7 @@ export function PandasWidgetPlugin({
       <LoadingOverlay
         errorMessage={getErrorMessage(fetchResult.error)}
         isLoading={false}
+        data-testid="pandas-widget-plugin-loading-error"
       />
     );
   }

--- a/packages/dashboard-core-plugins/src/panels/ConsolePanel.tsx
+++ b/packages/dashboard-core-plugins/src/panels/ConsolePanel.tsx
@@ -387,7 +387,11 @@ export class ConsolePanel extends PureComponent<
 
     if (sessionWrapper == null) {
       return (
-        <LoadingOverlay isLoading={false} errorMessage="Console is disabled." />
+        <LoadingOverlay
+          isLoading={false}
+          errorMessage="Console is disabled."
+          data-testid="console-panel-loading-error"
+        />
       );
     }
 

--- a/packages/dashboard-core-plugins/src/panels/MarkdownPanel.tsx
+++ b/packages/dashboard-core-plugins/src/panels/MarkdownPanel.tsx
@@ -240,7 +240,9 @@ export class MarkdownPanel extends Component<
             isEditing={isEditing}
             onDoubleClick={this.handleContainerDoubleClick}
           >
-            <Suspense fallback={<LoadingOverlay />}>
+            <Suspense
+              fallback={<LoadingOverlay data-testid="markdown-panel-loading" />}
+            >
               <MarkdownEditor
                 ref={markdownEditor => {
                   this.markdownEditor = markdownEditor;

--- a/packages/dashboard-core-plugins/src/panels/NotebookPanel.tsx
+++ b/packages/dashboard-core-plugins/src/panels/NotebookPanel.tsx
@@ -1435,7 +1435,9 @@ class NotebookPanel extends Component<NotebookPanelProps, NotebookPanelState> {
             </>
           )}
           {isMarkdown && (
-            <Suspense fallback={<LoadingOverlay />}>
+            <Suspense
+              fallback={<LoadingOverlay data-testid="notebook-panel-loading" />}
+            >
               <MarkdownNotebook
                 content={settings.value ?? ''}
                 onLinkClick={this.handleLinkClick}

--- a/packages/dashboard/src/BasePanel.tsx
+++ b/packages/dashboard/src/BasePanel.tsx
@@ -298,6 +298,7 @@ class BasePanel extends PureComponent<BasePanelProps, BasePanelState> {
       >
         {children}
         <LoadingOverlay
+          data-testid="base-panel-loading"
           errorMessage={errorMessage}
           isLoaded={isLoaded}
           isLoading={isLoading}

--- a/packages/dashboard/src/LazyDashboard.tsx
+++ b/packages/dashboard/src/LazyDashboard.tsx
@@ -42,7 +42,7 @@ export function LazyDashboard({
   }
 
   if (!isLoaded) {
-    return <LoadingOverlay />;
+    return <LoadingOverlay data-testid="lazy-dashboard-loading" />;
   }
 
   return (

--- a/packages/dashboard/src/PanelErrorBoundary.tsx
+++ b/packages/dashboard/src/PanelErrorBoundary.tsx
@@ -50,6 +50,7 @@ class PanelErrorBoundary extends Component<
       return (
         <div className="panel-error-boundary">
           <LoadingOverlay
+            data-testid="panel-error-boundary-loading-error"
             errorMessage={`${error}`}
             isLoading={false}
             isLoaded={false}

--- a/packages/embed-widget/src/App.scss
+++ b/packages/embed-widget/src/App.scss
@@ -15,6 +15,10 @@
   overflow: hidden;
 }
 
+.loading-overlay-panel {
+  background-color: red !important;
+}
+
 $tab-height: 32px;
 $tab-font-size: 1rem;
 

--- a/packages/embed-widget/src/App.scss
+++ b/packages/embed-widget/src/App.scss
@@ -15,10 +15,6 @@
   overflow: hidden;
 }
 
-.loading-overlay-panel {
-  background-color: red !important;
-}
-
 $tab-height: 32px;
 $tab-font-size: 1rem;
 

--- a/packages/embed-widget/src/App.tsx
+++ b/packages/embed-widget/src/App.tsx
@@ -235,6 +235,7 @@ function App(): JSX.Element {
       )}
       {!isLoaded && (
         <LoadingOverlay
+          data-testid="embed-widget-app-loading"
           isLoaded={isLoaded}
           isLoading={isLoading}
           errorMessage={error ?? null}

--- a/packages/embed-widget/src/index.tsx
+++ b/packages/embed-widget/src/index.tsx
@@ -57,7 +57,9 @@ async function getCorePlugins() {
 
 ReactDOM.render(
   <ApiBootstrap apiUrl={apiURL.href} setGlobally>
-    <Suspense fallback={<LoadingOverlay />}>
+    <Suspense
+      fallback={<LoadingOverlay data-testid="embed-widget-index-loading" />}
+    >
       <AppBootstrap
         getCorePlugins={getCorePlugins}
         serverUrl={apiURL.origin}

--- a/packages/iris-grid/src/LazyIrisGrid.tsx
+++ b/packages/iris-grid/src/LazyIrisGrid.tsx
@@ -14,7 +14,9 @@ const LazyIrisGrid = forwardRef<
     props,
     ref
   ): JSX.Element => (
-    <Suspense fallback={<LoadingOverlay />}>
+    <Suspense
+      fallback={<LoadingOverlay data-testid="lazy-iris-grid-loading" />}
+    >
       {/* eslint-disable-next-line react/jsx-props-no-spreading */}
       <IrisGrid ref={ref} {...props} />
     </Suspense>

--- a/packages/jsapi-bootstrap/src/ApiBootstrap.tsx
+++ b/packages/jsapi-bootstrap/src/ApiBootstrap.tsx
@@ -62,7 +62,7 @@ export function ApiBootstrap({
   }, [apiUrl, setGlobally]);
 
   if (isLoading) {
-    return <LoadingOverlay />;
+    return <LoadingOverlay data-testid="api-bootstrap-loading" />;
   }
   if (api == null) {
     return (

--- a/packages/jsapi-components/src/TableInput.tsx
+++ b/packages/jsapi-components/src/TableInput.tsx
@@ -298,6 +298,7 @@ function TableInput(props: TableInputProps): JSX.Element {
               isLoaded={table != null}
               isLoading={table == null && error == null}
               errorMessage={error?.message ?? null}
+              data-testid="table-input-loading"
             />
           </div>
         ))}


### PR DESCRIPTION
DH-19445: Set data-testid props on LoadingOverlay instances

While I was looking at performance, I set data-testid props to make it possible to identify different loading spinners.