### PR TITLE
fix: DH-18443: Add variableName to ItemContainer

### DIFF
--- a/packages/golden-layout/src/container/ItemContainer.ts
+++ b/packages/golden-layout/src/container/ItemContainer.ts
@@ -26,7 +26,10 @@ export default class ItemContainer<
   tab?: Tab;
 
   // This type is to make TS happy and allow ReactComponentConfig passed to container generic
-  _config: C & { componentState: Record<string, unknown> };
+  _config: C & {
+    componentState: Record<string, unknown>;
+    variableName?: string;
+  };
 
   isHidden = false;
 
@@ -49,7 +52,10 @@ export default class ItemContainer<
     this.parent = parent;
     this.layoutManager = layoutManager;
 
-    this._config = config as C & { componentState: Record<string, unknown> };
+    this._config = config as C & {
+      componentState: Record<string, unknown>;
+      variableName?: string;
+    };
 
     this._contentElement = this._element.find('.lm_content');
 


### PR DESCRIPTION
Adds a variable name in support of https://github.com/deephaven/deephaven-plugins/pull/1226
Currently the title is passed through the container and that can be overriden to not be the variable name, so I thought this would be a simple solution to bundle that information.

Required for https://github.com/deephaven/deephaven-plugins/pull/1226