### PR TITLE
ci: Change distTag from 'v0.99' to 'release-v0.99'

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -3,7 +3,7 @@
   "version": "0.99.2",
   "command": {
     "publish": {
-      "distTag": "v0.99"
+      "distTag": "release-v0.99"
     },
     "version": {
       "changelogPreset": "conventionalcommits"


### PR DESCRIPTION
From https://docs.npmjs.com/adding-dist-tags-to-packages
> We recommend avoiding dist-tags that start with a number or the letter "v".

This is now in line with what we do with v0.85 as well.