### PR TITLE
fix: DH-19948: increase max dashboard tab title width

### DIFF
--- a/packages/components/src/navigation/NavTabList.scss
+++ b/packages/components/src/navigation/NavTabList.scss
@@ -38,7 +38,7 @@ $tab-control-btn-offset: -8px;
     .btn-nav-tab {
       line-height: $tab-height - $tab-drag-border-width * 2; // subtract top and bottom borders, and focus border
       width: auto;
-      max-width: 200px;
+      max-width: max(200px, 40vw);
       overflow: hidden;
       padding: 0 $tab-link-side-padding;
       position: relative;


### PR DESCRIPTION
Adjust the maximum width of dashboard tab titles to accommodate longer titles. Cap at 40vw seems reasonably long, and makes use of more space, the more space is available.