### PR TITLE
feat: close maximized panels with escape key

### DIFF
--- a/packages/golden-layout/src/LayoutManager.ts
+++ b/packages/golden-layout/src/LayoutManager.ts
@@ -1049,10 +1049,7 @@ export class LayoutManager extends EventEmitter {
    * @param e The keydown event
    */
   _windowKeydown(e: JQuery.KeyDownEvent) {
-    if (
-      (e.key === 'Escape' || e.key === 'Esc') &&
-      this._maximisedItem !== null
-    ) {
+    if (e.key === 'Escape' && this._maximisedItem !== null) {
       const active = document.activeElement;
       if (
         active &&

--- a/packages/grid/src/key-handlers/SelectionKeyHandler.ts
+++ b/packages/grid/src/key-handlers/SelectionKeyHandler.ts
@@ -96,10 +96,10 @@ class SelectionKeyHandler extends KeyHandler {
         return true;
       }
       case 'Escape':
+        if (grid.state.selectedRanges.length === 0) return false;
         grid.clearSelectedRanges();
-        // Event consumed, but propagation not stopped
-        // so the shortcut could be handled by the global handler
-        return { preventDefault: false, stopPropagation: false };
+        // consume the event, and stop propagation only if there were selected ranges to clear
+        return { preventDefault: false, stopPropagation: true };
       case 'Enter':
         if (grid.state.selectedRanges.length > 0) {
           grid.moveCursorInDirection(


### PR DESCRIPTION
fixes: #1165

Was annoyed with this while working on something, add handling to escape close maximize fields.

Exclude if inputs are focused (ex. monaco uses escape to deselect, but doesn't consume it, native searches clear field but don't consume it either).