### PR TITLE
fix: Add explicit refs to react-transition-group for React 19 support

### DIFF
--- a/@types/react-transition-group/index.d.ts
+++ b/@types/react-transition-group/index.d.ts
@@ -1,0 +1,10 @@
+/* eslint-disable */
+export * from '../../node_modules/@types/react-transition-group';
+
+// Require nodeRef in CSSTransition to support React 19 (no findDOMNode)
+import { Component } from 'react';
+import { CSSTransitionProps } from '../../node_modules/@types/react-transition-group/CSSTransition';
+declare class CSSTransition<Ref extends HTMLElement> extends Component<
+  CSSTransitionProps<Ref> & { nodeRef: React.Ref<Ref> }
+> {}
+export { CSSTransition };

--- a/packages/components/src/Collapse.tsx
+++ b/packages/components/src/Collapse.tsx
@@ -27,26 +27,6 @@ class Collapse extends Component<CollapseProps> {
     'data-testid': undefined,
   };
 
-  static handleEnter(elemParam: HTMLElement): void {
-    const elem = elemParam;
-    elem.style.height = '0';
-  }
-
-  static handleEntering(elemParam: HTMLElement): void {
-    const elem = elemParam;
-    elem.style.height = `${Collapse.getHeight(elem)}px`;
-  }
-
-  static handleExiting(elemParam: HTMLElement): void {
-    const elem = elemParam;
-    elem.style.height = '0';
-  }
-
-  static handleExit(elemParam: HTMLElement): void {
-    const elem = elemParam;
-    elem.style.height = `${Collapse.getHeight(elem)}px`;
-  }
-
   static getHeight(elem: HTMLElement): number {
     const scrollBarWidth = elem.scrollWidth - elem.clientWidth;
     return elem.scrollHeight - scrollBarWidth;
@@ -58,8 +38,13 @@ class Collapse extends Component<CollapseProps> {
     this.handleEntered = this.handleEntered.bind(this);
   }
 
-  handleEntered(elemParam: HTMLElement): void {
-    const elem = elemParam;
+  nodeRef = React.createRef<HTMLDivElement>();
+
+  handleEntered(): void {
+    const elem = this.nodeRef.current;
+    if (!elem) {
+      return;
+    }
     elem.style.height = '';
 
     const { autoFocusOnShow } = this.props;
@@ -72,6 +57,38 @@ class Collapse extends Component<CollapseProps> {
         input.focus();
       }
     }
+  }
+
+  handleEnter(): void {
+    const elem = this.nodeRef.current;
+    if (!elem) {
+      return;
+    }
+    elem.style.height = '0';
+  }
+
+  handleEntering(): void {
+    const elem = this.nodeRef.current;
+    if (!elem) {
+      return;
+    }
+    elem.style.height = `${Collapse.getHeight(elem)}px`;
+  }
+
+  handleExiting(): void {
+    const elem = this.nodeRef.current;
+    if (!elem) {
+      return;
+    }
+    elem.style.height = '0';
+  }
+
+  handleExit(): void {
+    const elem = this.nodeRef.current;
+    if (!elem) {
+      return;
+    }
+    elem.style.height = `${Collapse.getHeight(elem)}px`;
   }
 
   render(): JSX.Element {
@@ -90,15 +107,17 @@ class Collapse extends Component<CollapseProps> {
           exitActive: 'collapsing',
           exitDone: 'collapse',
         }}
-        onEnter={Collapse.handleEnter}
-        onEntering={Collapse.handleEntering}
+        onEnter={this.handleEnter}
+        onEntering={this.handleEntering}
         onEntered={this.handleEntered}
-        onExit={Collapse.handleExit}
-        onExiting={Collapse.handleExiting}
+        onExit={this.handleExit}
+        onExiting={this.handleExiting}
         timeout={350}
+        nodeRef={this.nodeRef}
       >
         {state => (
           <div
+            ref={this.nodeRef}
             className={classNames({ collapse: state === 'exited' }, className)}
             data-testid={dataTestId}
           >

--- a/packages/components/src/LoadingOverlay.tsx
+++ b/packages/components/src/LoadingOverlay.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { CSSTransition } from 'react-transition-group';
 import classNames from 'classnames';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -29,6 +29,7 @@ function LoadingOverlay({
   timeout = ThemeExport.transitionMs,
   'data-testid': dataTestId,
 }: LoadingOverlayProps): JSX.Element {
+  const nodeRef = useRef<HTMLDivElement>(null);
   const messageTestId =
     dataTestId != null ? `${dataTestId}-message` : undefined;
   const spinnerTestId =
@@ -41,8 +42,13 @@ function LoadingOverlay({
       classNames={classNames(className, { fade: isLoaded })}
       mountOnEnter
       unmountOnExit
+      nodeRef={nodeRef}
     >
-      <div className="fill-parent-absolute" data-testid={dataTestId}>
+      <div
+        ref={nodeRef}
+        className="fill-parent-absolute"
+        data-testid={dataTestId}
+      >
         <div
           className={classNames(
             'iris-panel-message-overlay',

--- a/packages/components/src/ToastNotification.tsx
+++ b/packages/components/src/ToastNotification.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import classNames from 'classnames';
 import { CSSTransition } from 'react-transition-group';
 import { vsClose } from '@deephaven/icons';
@@ -31,6 +31,7 @@ function ToastNotification({
   onDismiss,
   'data-testid': dataTestId,
 }: ToastNotificationProps): JSX.Element {
+  const nodeRef = useRef<HTMLDivElement>(null);
   const hasButtons = buttons && buttons.length !== 0;
 
   return (
@@ -40,8 +41,10 @@ function ToastNotification({
       classNames="toast-notification-slide-up"
       mountOnEnter
       unmountOnExit
+      nodeRef={nodeRef}
     >
       <div
+        ref={nodeRef}
         className={classNames('toast-notification', classNamesProp, type)}
         role="presentation"
         onClick={onClick}

--- a/packages/components/src/modal/Modal.tsx
+++ b/packages/components/src/modal/Modal.tsx
@@ -42,6 +42,7 @@ function Modal({
 }: ModalProps): React.ReactElement | null {
   const element = useRef<HTMLElement>();
   const background = useRef<HTMLDivElement>(null);
+  const backdropFade = useRef<HTMLDivElement>(null);
   const [backgroundClicked, setBackgroundClicked] = useState(false);
 
   const handleKeyDown = useCallback(
@@ -118,8 +119,10 @@ function Modal({
             }}
             timeout={ThemeExport.transitionMs}
             onExited={onExited}
+            nodeRef={backdropFade}
           >
             <div
+              ref={backdropFade}
               className={classNames('modal-backdrop fade')}
               style={{ zIndex: 1050 }}
             />
@@ -134,6 +137,7 @@ function Modal({
             }}
             timeout={ThemeExport.transitionMs}
             onExited={onExited}
+            nodeRef={background}
           >
             <div
               ref={background}

--- a/packages/components/src/popper/Popper.tsx
+++ b/packages/components/src/popper/Popper.tsx
@@ -122,6 +122,8 @@ class Popper extends Component<PopperProps, PopperState> {
 
   container: React.RefObject<HTMLDivElement>;
 
+  nodeRef = React.createRef<HTMLDivElement>();
+
   // This is the request animation frame handle number
   rAF: number;
 
@@ -259,8 +261,10 @@ class Popper extends Component<PopperProps, PopperState> {
           classNames="popper-transition"
           onEntered={this.handleEnter}
           onExited={this.handleExit}
+          nodeRef={this.nodeRef}
         >
           <div
+            ref={this.nodeRef}
             onClick={e => {
               // stop click events from escaping popper
               e.stopPropagation();

--- a/packages/components/src/transitions/FadeTransition.tsx
+++ b/packages/components/src/transitions/FadeTransition.tsx
@@ -1,32 +1,46 @@
+import { useRef } from 'react';
 import { CSSTransition } from 'react-transition-group';
 import type { CSSTransitionProps } from 'react-transition-group/CSSTransition';
 import type { EndHandler } from 'react-transition-group/Transition';
 import classNames from 'classnames';
+import type { RemoveIndexSignature } from '@deephaven/utils';
 import ThemeExport from '../ThemeExport';
 
-type FadeTransitionProps<Ref extends undefined | HTMLElement = undefined> =
+type FadeTransitionProps =
   // We default the timeout, so user doesn't need to provide it
   // However, CSSTransitionProps get confused if you don't provide a timeout, it requires an endHandler
   // We're just making the endHandler optional here, as the timeout has a default
-  Omit<CSSTransitionProps<Ref>, 'addEndHandler'> & {
-    addEndHandler?: EndHandler<Ref> | undefined;
+  Omit<
+    RemoveIndexSignature<CSSTransitionProps<HTMLDivElement>>,
+    'addEndHandler' | 'children'
+  > & {
+    addEndHandler?: EndHandler<HTMLDivElement> | undefined;
+    children?: React.ReactNode;
   };
 
 /**
  * Fade between two components. Defaults to 150ms transition.
  */
-function FadeTransition<Ref extends undefined | HTMLElement = undefined>({
-  className,
+function FadeTransition({
+  classNames: classNamesProp,
   timeout = ThemeExport.transitionMs,
+  children,
   ...props
-}: FadeTransitionProps<Ref>): JSX.Element {
+}: FadeTransitionProps): JSX.Element {
+  const nodeRef = useRef<HTMLDivElement>(null);
+
   return (
     <CSSTransition
+      nodeRef={nodeRef}
       timeout={timeout}
-      classNames={classNames('fade', className)}
+      classNames={classNames('fade', classNamesProp)}
       // eslint-disable-next-line react/jsx-props-no-spreading
       {...props}
-    />
+    >
+      <div ref={nodeRef} style={{ display: 'contents' }}>
+        {children}
+      </div>
+    </CSSTransition>
   );
 }
 

--- a/packages/components/src/transitions/FadeTransition.tsx
+++ b/packages/components/src/transitions/FadeTransition.tsx
@@ -1,7 +1,10 @@
-import { useRef } from 'react';
+import { useCallback, useRef } from 'react';
 import { CSSTransition } from 'react-transition-group';
 import type { CSSTransitionProps } from 'react-transition-group/CSSTransition';
-import type { EndHandler } from 'react-transition-group/Transition';
+import type {
+  EndHandler,
+  EnterHandler,
+} from 'react-transition-group/Transition';
 import classNames from 'classnames';
 import type { RemoveIndexSignature } from '@deephaven/utils';
 import ThemeExport from '../ThemeExport';
@@ -11,10 +14,11 @@ type FadeTransitionProps =
   // However, CSSTransitionProps get confused if you don't provide a timeout, it requires an endHandler
   // We're just making the endHandler optional here, as the timeout has a default
   Omit<
-    RemoveIndexSignature<CSSTransitionProps<HTMLDivElement>>,
-    'addEndHandler' | 'children'
+    RemoveIndexSignature<CSSTransitionProps<HTMLElement>>,
+    'addEndHandler' | 'children' | 'onEnter'
   > & {
-    addEndHandler?: EndHandler<HTMLDivElement> | undefined;
+    addEndHandler?: EndHandler<HTMLElement> | undefined;
+    onEnter?: EnterHandler<undefined>;
     children?: React.ReactNode;
   };
 
@@ -25,19 +29,37 @@ function FadeTransition({
   classNames: classNamesProp,
   timeout = ThemeExport.transitionMs,
   children,
+  onEnter,
   ...props
 }: FadeTransitionProps): JSX.Element {
-  const nodeRef = useRef<HTMLDivElement>(null);
+  const nodeRef = useRef<HTMLElement | null>(null);
+  const handleOnEnter = useCallback(
+    (isAppearing: boolean) => {
+      const elem = nodeRef.current;
+      if (!elem) {
+        return;
+      }
+      onEnter?.(elem, isAppearing);
+    },
+    [onEnter]
+  );
+
+  // Mimics findDOMNode for CSSTransition
+  // The ref should be set before CSSTransition does anything with it
+  const setRef = useCallback((node: HTMLElement | null) => {
+    nodeRef.current = node?.firstElementChild as HTMLElement;
+  }, []);
 
   return (
     <CSSTransition
       nodeRef={nodeRef}
       timeout={timeout}
       classNames={classNames('fade', classNamesProp)}
+      onEnter={handleOnEnter}
       // eslint-disable-next-line react/jsx-props-no-spreading
       {...props}
     >
-      <div ref={nodeRef} style={{ display: 'contents' }}>
+      <div ref={setRef} style={{ display: 'contents' }}>
         {children}
       </div>
     </CSSTransition>

--- a/packages/components/src/transitions/SlideTransition.tsx
+++ b/packages/components/src/transitions/SlideTransition.tsx
@@ -1,21 +1,24 @@
 // SlideTransition class uses CSSTransition with slide-left and slide-right classNames, depending on the prop direction. The transition is 250ms long.
-//
+import { useRef } from 'react';
 import { CSSTransition } from 'react-transition-group';
 import type { CSSTransitionProps } from 'react-transition-group/CSSTransition';
 import type { EndHandler } from 'react-transition-group/Transition';
-
 import classNames from 'classnames';
+import type { RemoveIndexSignature } from '@deephaven/utils';
 import ThemeExport from '../ThemeExport';
 
 type SlideDirection = 'left' | 'right';
 
-type SlideTransitionProps<Ref extends undefined | HTMLElement = undefined> =
+type SlideTransitionProps =
   // We default the timeout, so user doesn't need to provide it
   // However, CSSTransitionProps get confused if you don't provide a timeout, it requires an endHandler
   // We're just making the endHandler optional here, as the timeout has a default
-  Omit<CSSTransitionProps<Ref>, 'addEndHandler'> & {
-    addEndHandler?: EndHandler<Ref> | undefined;
-  } & {
+  Omit<
+    RemoveIndexSignature<CSSTransitionProps<HTMLDivElement>>,
+    'addEndHandler'
+  > & {
+    addEndHandler?: EndHandler<HTMLDivElement> | undefined;
+    children?: React.ReactNode;
     /**
      * The direction of the slide transition. Defaults to left.
      */
@@ -31,19 +34,27 @@ type SlideTransitionProps<Ref extends undefined | HTMLElement = undefined> =
  */
 function SlideTransition({
   direction = 'left',
-  className,
+  classNames: classNamesProp,
+  children,
 
   /** Defaults to mid */
   timeout = ThemeExport.transitionMidMs,
   ...props
 }: SlideTransitionProps): JSX.Element {
+  const nodeRef = useRef<HTMLDivElement>(null);
+
   return (
     <CSSTransition
+      nodeRef={nodeRef}
       timeout={timeout}
-      classNames={classNames(`slide-${direction}`, className)}
+      classNames={classNames(`slide-${direction}`, classNamesProp)}
       // eslint-disable-next-line react/jsx-props-no-spreading
       {...props}
-    />
+    >
+      <div ref={nodeRef} style={{ display: 'contents' }}>
+        {children}
+      </div>
+    </CSSTransition>
   );
 }
 

--- a/packages/components/src/transitions/SlideTransition.tsx
+++ b/packages/components/src/transitions/SlideTransition.tsx
@@ -1,5 +1,5 @@
 // SlideTransition class uses CSSTransition with slide-left and slide-right classNames, depending on the prop direction. The transition is 250ms long.
-import { useRef } from 'react';
+import { useCallback, useRef } from 'react';
 import { CSSTransition } from 'react-transition-group';
 import type { CSSTransitionProps } from 'react-transition-group/CSSTransition';
 import type { EndHandler } from 'react-transition-group/Transition';
@@ -14,10 +14,10 @@ type SlideTransitionProps =
   // However, CSSTransitionProps get confused if you don't provide a timeout, it requires an endHandler
   // We're just making the endHandler optional here, as the timeout has a default
   Omit<
-    RemoveIndexSignature<CSSTransitionProps<HTMLDivElement>>,
+    RemoveIndexSignature<CSSTransitionProps<HTMLElement>>,
     'addEndHandler'
   > & {
-    addEndHandler?: EndHandler<HTMLDivElement> | undefined;
+    addEndHandler?: EndHandler<HTMLElement> | undefined;
     children?: React.ReactNode;
     /**
      * The direction of the slide transition. Defaults to left.
@@ -41,7 +41,13 @@ function SlideTransition({
   timeout = ThemeExport.transitionMidMs,
   ...props
 }: SlideTransitionProps): JSX.Element {
-  const nodeRef = useRef<HTMLDivElement>(null);
+  const nodeRef = useRef<HTMLElement | null>(null);
+
+  // Mimics findDOMNode for CSSTransition
+  // The ref should be set before CSSTransition does anything with it
+  const setRef = useCallback((node: HTMLElement | null) => {
+    nodeRef.current = node?.firstElementChild as HTMLElement;
+  }, []);
 
   return (
     <CSSTransition
@@ -51,7 +57,7 @@ function SlideTransition({
       // eslint-disable-next-line react/jsx-props-no-spreading
       {...props}
     >
-      <div ref={nodeRef} style={{ display: 'contents' }}>
+      <div ref={setRef} style={{ display: 'contents' }}>
         {children}
       </div>
     </CSSTransition>

--- a/packages/iris-grid/src/IrisGrid.tsx
+++ b/packages/iris-grid/src/IrisGrid.tsx
@@ -1094,6 +1094,10 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
 
   mouseHandlers: readonly GridMouseHandler[];
 
+  slideTransitionRef: React.RefObject<HTMLDivElement> = React.createRef();
+
+  bottomTransitionRef: React.RefObject<HTMLDivElement> = React.createRef();
+
   get gridWrapper(): HTMLDivElement | null {
     return this.grid?.canvasWrapper.current ?? null;
   }
@@ -4940,8 +4944,12 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
             onExited={this.handleAnimationEnd}
             mountOnEnter
             unmountOnExit
+            nodeRef={this.slideTransitionRef}
           >
-            <div className="iris-grid-partition-selector-wrapper iris-grid-bar iris-grid-bar-primary">
+            <div
+              ref={this.slideTransitionRef}
+              className="iris-grid-partition-selector-wrapper iris-grid-bar iris-grid-bar-primary"
+            >
               {isPartitionedGridModel(model) && model.isPartitionRequired && (
                 <IrisGridPartitionSelector
                   model={model}
@@ -4961,8 +4969,9 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
             onExited={this.handleAnimationEnd}
             mountOnEnter
             unmountOnExit
+            nodeRef={this.bottomTransitionRef}
           >
-            <div className="iris-grid-bar">
+            <div ref={this.bottomTransitionRef} className="iris-grid-bar">
               <CrossColumnSearch
                 value={searchValue}
                 selectedColumns={selectedSearchColumns}

--- a/packages/iris-grid/src/IrisGridBottomBar.tsx
+++ b/packages/iris-grid/src/IrisGridBottomBar.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import classNames from 'classnames';
 import { CSSTransition } from 'react-transition-group';
 import { ThemeExport } from '@deephaven/components';
@@ -27,6 +27,7 @@ export function IrisGridBottomBar({
   onExiting,
   onExited,
 }: IrisGridBottomBarProps): JSX.Element {
+  const nodeRef = useRef<HTMLDivElement>(null);
   return (
     <CSSTransition
       in={isShown}
@@ -38,8 +39,10 @@ export function IrisGridBottomBar({
       onExited={onExited}
       mountOnEnter
       unmountOnExit
+      nodeRef={nodeRef}
     >
       <div
+        ref={nodeRef}
         className={classNames('iris-grid-bottom-bar', className)}
         role="presentation"
         onClick={onClick}

--- a/packages/utils/src/TypeUtils.ts
+++ b/packages/utils/src/TypeUtils.ts
@@ -65,3 +65,17 @@ export type UndoPartial<T> = T extends Partial<infer U> ? U : never;
  * type A = typeof x[keyof typeof x]; // 1 | 2 | 3
  */
 export type ValueOf<T> = T[keyof T];
+
+/**
+ * Removes the index signature from a type.
+ * This can be useful if you want to Omit a key from a type,
+ * but the type has an index signature. Otherwise, the index signature
+ * is the only thing that remains after Omit.
+ */
+export type RemoveIndexSignature<T> = {
+  [K in keyof T as string extends K
+    ? never
+    : number extends K
+    ? never
+    : K]: T[K];
+};


### PR DESCRIPTION
Tested with Settings menu slide out, sections collapse/expand. On a grid the copy handler tests the slide up and then the message fades out

Can also test the styleguide modal and toasts (the toasts must be dismissed by clicking the button, they don't auto-dismiss)

Also added a type override that should throw a type error if you remove `nodeRef` from any of the `CSSTransition` components. That way we don't accidentally introduce it in the future until we move off of `react-transition-group`.