### PR TITLE
fix: DH-20388: VITE_MODULE_PLUGINS_URL path should be relative

### DIFF
--- a/packages/embed-widget/.env
+++ b/packages/embed-widget/.env
@@ -2,7 +2,7 @@
 BASE_URL=./
 # We assume embed-widget is served at a nested path, e.g. '/iframe/widget'
 VITE_CORE_API_URL=../../jsapi
-VITE_MODULE_PLUGINS_URL=/js-plugins
+VITE_MODULE_PLUGINS_URL=../../js-plugins
 VITE_CORE_API_NAME=dh-core.js
 VITE_BUILD_PATH=./build
 VITE_LOG_LEVEL=2


### PR DESCRIPTION
DH-20388: VITE_MODULE_PLUGINS_URL path was set to an absolute path which breaks DH UI in VS code extension when targetting Envoy servers. Changed to a relative path.