### PR TITLE
fix: IrisGridModelUpdater causes "cannot update during an existing state transition" warning

### DIFF
--- a/packages/iris-grid/src/IrisGridModelUpdater.tsx
+++ b/packages/iris-grid/src/IrisGridModelUpdater.tsx
@@ -181,14 +181,6 @@ function IrisGridModelUpdater({
     [model, isTotalsAvailable, totalsConfig]
   );
   useOnChange(
-    function updateFrozenColumns() {
-      if (frozenColumns) {
-        model.updateFrozenColumns(frozenColumns);
-      }
-    },
-    [model, frozenColumns]
-  );
-  useOnChange(
     function updateColumnHeaderGroups() {
       model.columnHeaderGroups = columnHeaderGroups;
     },
@@ -204,6 +196,14 @@ function IrisGridModelUpdater({
   );
   // These setters are wrapped in useEffect instead of useOnChange because they emit an event
   // that potentially causes side effects, violating the rule that render should be a pure function.
+  useEffect(
+    function updateFrozenColumns() {
+      if (frozenColumns) {
+        model.updateFrozenColumns(frozenColumns);
+      }
+    },
+    [model, frozenColumns]
+  );
   useEffect(
     function updatePendingRowCount() {
       model.pendingRowCount = pendingRowCount;


### PR DESCRIPTION
`IrisGridModelUpdater` displays an error/warning in the browser console when
- The reset button is clicked in the organize columns tab in the sidebar of the grid
- A rollup is added to the table using the sidebar tab

These warnings were causing two e2e tests to fail locally. Full logs can be found in the ticket.

Similar to https://github.com/deephaven/web-client-ui/pull/2249, it looks like the `frozenColumns` setter in `IrisGridModelUpdater` was also emitting an event in the render cycle that caused a React warning about the render not being a pure function, because the event triggered a state update in `IrisGrid`. The setter is now wrapped in `useEffect` instead of `useOnChange` so the events are emitted after the render.