### PR TITLE
fix: DH-20500: Links without operators not working

### DIFF
--- a/packages/dashboard-core-plugins/src/linker/Linker.tsx
+++ b/packages/dashboard-core-plugins/src/linker/Linker.tsx
@@ -562,7 +562,7 @@ export class Linker extends Component<LinkerProps, LinkerState> {
     // combine them so they could be set in a single call per target panel
     for (let i = 0; i < links.length; i += 1) {
       const { start, end, operator } = links[i];
-      if (start.panelId === sourceId && end != null && operator != null) {
+      if (start.panelId === sourceId && end != null) {
         const { panelId: endPanelId, columnName, columnType } = end;
         // Map of column name to column type and filter value
         const existingFilterMap = panelFilterMap.get(endPanelId);

--- a/packages/dashboard-core-plugins/src/linker/LinkerUtils.ts
+++ b/packages/dashboard-core-plugins/src/linker/LinkerUtils.ts
@@ -36,7 +36,7 @@ export type LinkColumn = {
 };
 
 export type LinkDataValue<T = unknown> = {
-  operator: FilterTypeValue;
+  operator?: FilterTypeValue; // Default behavior treats no operator as equals
   text: string;
   value: T;
   startColumnIndex: number;

--- a/packages/iris-grid/src/IrisGrid.tsx
+++ b/packages/iris-grid/src/IrisGrid.tsx
@@ -253,7 +253,7 @@ function isEmptyConfig({
 }
 
 export type FilterData = {
-  operator: FilterTypeValue;
+  operator?: FilterTypeValue; // Default behavior treats no operator as equals
   text: string;
   value: unknown;
   startColumnIndex: number;


### PR DESCRIPTION
This check was added [here](https://github.com/deephaven/web-client-ui/pull/2459/files#diff-8ecaa9ac05eff8c4e7d211121d0a67985caab90a4e0756cc8658fd9b4ff84673R565) and caused links created before we had an operator to not function. We have logic that defaults to equals effectively if the operator does not exist.

We may want to clean that up and add a default in the future to migrate any old links, but this is the simple fix for now and there's not much harm in it