### PR TITLE
fix: DH-20255 Limit maximum depth to serialize redux log data

### DIFF
--- a/packages/log/src/LogExport.test.ts
+++ b/packages/log/src/LogExport.test.ts
@@ -172,4 +172,27 @@ describe('getReduxDataString', () => {
     const result = getReduxDataString(reduxData, [['*']]);
     expect(result).toBe('{}');
   });
+
+  it('should respect maximum depth', () => {
+    const reduxData = {
+      key1: {
+        key2: {
+          key3: 'too deep',
+        },
+        key4: ['too deep'],
+      },
+    };
+    const result = getReduxDataString(reduxData, [], 2);
+    const expected = JSON.stringify(
+      {
+        key1: {
+          key2: '[Object]',
+          key4: '[Array]',
+        },
+      },
+      null,
+      2
+    );
+    expect(result).toBe(expected);
+  });
 });

--- a/packages/log/src/LogExport.ts
+++ b/packages/log/src/LogExport.ts
@@ -14,9 +14,14 @@ export const DEFAULT_PATH_BLACKLIST: string[][] = [
   ['dashboardData', '*', 'openedMap'],
   ['draftManager', 'draftStorage'],
   ['layoutStorage'],
-  ['schemaService', 'client'],
-  ['schemaService', 'schemaStorage'],
   ['storage'],
+
+  // Below are confirmed enterprise specific keys, and will be moved in DH-20410
+  ['schemaService', 'client'],
+  ['schemaService', 'clientUtils'],
+  ['schemaService', 'schemaStorage'],
+  ['corePlusManager', 'dheClient'],
+  ['dheClient'],
 ];
 
 function stringifyReplacer(blacklist: string[][]) {


### PR DESCRIPTION
Follow up PR to https://github.com/deephaven/web-client-ui/pull/2531 which failed testing, with an error from `JSON.stringify()` of `RangeError: Invalid string length`. 

These errors are caused by linked structures such as a Java LinkedHashMap that's included in the Redux data in various API related keys. We use the blacklist to filter out keys containing these structures, but these keys are not stable and will need to be constantly updated to prevent the log export from outright failing. 

To preemptively deal with this, the maximum depth to serialize to can be limited in the [safe-stable-stringify](https://www.npmjs.com/package/safe-stable-stringify) library to avoid linked structures from blowing up the log size. With no blacklist entries, the exported log size is only `1.2MB`.

With an updated blacklist, exporting the logs with or without the limit both yield log files of almost the exact same size, meaning that no useful data has been lost by limiting the depth. However, I'm open to suggestions to the default depth to serialize to, or whether it should be optional to have a limit on the depth instead of mandating a limit (`Infinity` is not accepted by the library).