### PR TITLE
fix: DH-21869: Fix Conditional Formatting on Timestamp

### DIFF
--- a/packages/iris-grid/src/sidebar/conditional-formatting/ConditionalFormattingUtils.ts
+++ b/packages/iris-grid/src/sidebar/conditional-formatting/ConditionalFormattingUtils.ts
@@ -569,17 +569,17 @@ export function getTextForDateCondition(
 ): string {
   switch (condition) {
     case DateCondition.IS_EXACTLY:
-      return `${columnName} == convertDateTime("${value}")`;
+      return `${columnName} == '${value}'`;
     case DateCondition.IS_NOT_EXACTLY:
-      return `${columnName} != convertDateTime(\`${value}\`)`;
+      return `${columnName} != '${value}'`;
     case DateCondition.IS_BEFORE:
-      return `${columnName} < convertDateTime(\`${value}\`)`;
+      return `${columnName} < '${value}'`;
     case DateCondition.IS_BEFORE_OR_EQUAL:
-      return `${columnName} <=  convertDateTime("${value}")`;
+      return `${columnName} <=  '${value}'`;
     case DateCondition.IS_AFTER:
-      return `${columnName} > convertDateTime(\`${value}\`)`;
+      return `${columnName} > '${value}'`;
     case DateCondition.IS_AFTER_OR_EQUAL:
-      return `${columnName} >=  convertDateTime(\`${value}\`)`;
+      return `${columnName} >=  '${value}'`;
     case DateCondition.IS_NULL:
       return `${columnName} == null`;
     case DateCondition.IS_NOT_NULL:

--- a/packages/iris-grid/src/sidebar/conditional-formatting/ConditionalFormattingUtils.ts
+++ b/packages/iris-grid/src/sidebar/conditional-formatting/ConditionalFormattingUtils.ts
@@ -745,6 +745,16 @@ export function isDateConditionValid(
         return false;
       }
 
+      // The backend timestamp parsing does not support timezones that end with ST or DT (e.g. EST, EDT)
+      // Passing these to the backend will cause the table to fail.
+      if (
+        tzCode.toUpperCase().endsWith('ST') ||
+        tzCode.toUpperCase().endsWith('DT')
+      ) {
+        log.debug('Timezone ending with ST or DT not supported', tzCode);
+        return false;
+      }
+
       return true;
     }
   }


### PR DESCRIPTION
- the time stamps need to be single quoted as date-time liters per our docs: https://deephaven.io/core/docs/how-to-guides/date-time-literals/
- The backend parsing fails on timezone abbreviations ending with ST or DT. If you have EST or EDT, you need to pass in ET. I have updated the validation to prevent passing these to the backend.