### PR TITLE
fix: peerDependencies in iris-grid should just use react >=16

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30574,8 +30574,8 @@
         "node": ">=10"
       },
       "peerDependencies": {
-        "react": ">=18.0.0",
-        "react-dom": ">=18.0.0"
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
       }
     },
     "packages/jsapi-bootstrap": {

--- a/packages/iris-grid/package.json
+++ b/packages/iris-grid/package.json
@@ -62,8 +62,8 @@
     "react-transition-group": "^4.4.2"
   },
   "peerDependencies": {
-    "react": ">=18.0.0",
-    "react-dom": ">=18.0.0"
+    "react": ">=16.8.0",
+    "react-dom": ">=16.8.0"
   },
   "devDependencies": {
     "@deephaven/jsapi-shim": "file:../jsapi-shim",


### PR DESCRIPTION
- This change was introduced with PR https://github.com/deephaven/web-client-ui/pull/2555/changes#diff-f952417e448401752610b573dafc9c136ac4ae7b0734afad22382babe6608dff
- The only other changes to `package.json` were to @dnd-kit/modifiers and @dnd-kit/sortable, both of which also have a peer dep of react >=16
- Setting it to >= 18 is unnecessarily restrictive
