### PR TITLE
fix: DH-20403: Persist user column widths by name in IrisGrid

### DIFF
--- a/packages/dashboard-core-plugins/src/panels/IrisGridPanel.tsx
+++ b/packages/dashboard-core-plugins/src/panels/IrisGridPanel.tsx
@@ -202,6 +202,7 @@ interface IrisGridPanelState {
   quickFilters: ReadonlyQuickFilterMap;
   sorts: readonly SortDescriptor[];
   userColumnWidths: ModelSizeMap;
+  userColumnWidthsByName: Map<ColumnName, number>;
   userRowHeights: ModelSizeMap;
   reverse: boolean;
   movedColumns: readonly MoveOperation[];
@@ -313,6 +314,7 @@ export class IrisGridPanel extends PureComponent<
       quickFilters: new Map(),
       sorts: [],
       userColumnWidths: new Map(),
+      userColumnWidthsByName: new Map(),
       userRowHeights: new Map(),
       reverse: false,
       movedColumns: [],
@@ -1032,9 +1034,8 @@ export class IrisGridPanel extends PureComponent<
         rollupConfig,
         aggregationSettings,
         sorts,
-        // TODO:
-        // DH-20403: IrisGrid should persist user column widths when the model initializes with a partial column list
         userColumnWidths,
+        userColumnWidthsByName,
         userRowHeights,
         showSearchBar,
         searchValue,
@@ -1074,6 +1075,7 @@ export class IrisGridPanel extends PureComponent<
         aggregationSettings,
         sorts,
         userColumnWidths,
+        userColumnWidthsByName,
         userRowHeights,
         showSearchBar,
         searchValue,
@@ -1180,6 +1182,7 @@ export class IrisGridPanel extends PureComponent<
       rollupConfig,
       sorts,
       userColumnWidths,
+      userColumnWidthsByName,
       userRowHeights,
       showSearchBar,
       searchValue,
@@ -1264,6 +1267,7 @@ export class IrisGridPanel extends PureComponent<
             settings={settings}
             sorts={sorts}
             userColumnWidths={userColumnWidths}
+            userColumnWidthsByName={userColumnWidthsByName}
             userRowHeights={userRowHeights}
             model={model}
             showSearchBar={showSearchBar}

--- a/packages/dashboard-core-plugins/src/panels/IrisGridPanel.tsx
+++ b/packages/dashboard-core-plugins/src/panels/IrisGridPanel.tsx
@@ -202,7 +202,7 @@ interface IrisGridPanelState {
   quickFilters: ReadonlyQuickFilterMap;
   sorts: readonly SortDescriptor[];
   userColumnWidths: ModelSizeMap;
-  userColumnWidthsByName: Map<ColumnName, number>;
+  userColumnWidthsByName: ReadonlyMap<ColumnName, number>;
   userRowHeights: ModelSizeMap;
   reverse: boolean;
   movedColumns: readonly MoveOperation[];

--- a/packages/iris-grid/src/IrisGrid.test.tsx
+++ b/packages/iris-grid/src/IrisGrid.test.tsx
@@ -289,38 +289,6 @@ describe('handleRollupChange', () => {
     // The by-index map should not include it (no model index).
     expect([...metricCalculator.getUserColumnWidths().entries()]).toEqual([]);
   });
-
-  it('un-hides a group-by column that is absent from the current (already rolled-up) model', () => {
-    // Simulates editing an existing rollup where a newly-added group-by
-    // column is not present in the current model (e.g. non-aggregated columns
-    // are hidden), so a model-index lookup against this.props.model would
-    // miss it. Resetting by name must still clear its hidden width.
-    const columns = irisGridTestUtils.makeColumns(3);
-    const model = irisGridTestUtils.makeModel(
-      irisGridTestUtils.makeTable({ columns })
-    );
-    const irisGrid = makeComponent(model);
-    const { metricCalculator } = irisGrid.state;
-
-    // Simulate the column having been hidden previously (width 0 stored by name).
-    const newGroupByName = 'NotInCurrentModel';
-    metricCalculator.userColumnWidthsByName.set(newGroupByName, 0);
-
-    // Spy AFTER seeding so the spy still calls through.
-    jest.spyOn(model, 'getColumnIndexByName').mockReturnValue(undefined);
-
-    act(() => {
-      irisGrid.handleRollupChange({
-        columns: [newGroupByName],
-        showConstituents: false,
-        showNonAggregatedColumns: false,
-      });
-    });
-
-    expect(metricCalculator.userColumnWidthsByName.has(newGroupByName)).toBe(
-      false
-    );
-  });
 });
 
 // auto resize -> reset user width and set calculated width to content width

--- a/packages/iris-grid/src/IrisGrid.test.tsx
+++ b/packages/iris-grid/src/IrisGrid.test.tsx
@@ -265,6 +265,64 @@ describe('handleResizeColumn', () => {
   });
 });
 
+describe('handleRollupChange', () => {
+  it('seeds metric calculator from userColumnWidthsByName prop and preserves widths for columns absent from the current model', () => {
+    // Current (rolled-up) model only contains the group-by column.
+    const fullColumns = irisGridTestUtils.makeColumns(3);
+    const currentColumns = [fullColumns[0]];
+    const currentModel = irisGridTestUtils.makeModel(
+      irisGridTestUtils.makeTable({ columns: currentColumns })
+    );
+
+    // Persisted state includes a hidden width for a column not in the
+    // currently displayed (rolled-up) model.
+    const hiddenName = fullColumns[2].name;
+    const irisGrid = makeComponent(currentModel, DEFAULT_SETTINGS, {
+      userColumnWidthsByName: new Map([[hiddenName, 0]]),
+    });
+
+    const { metricCalculator } = irisGrid.state;
+    // The by-name map carries the entry even though it isn't in the model.
+    expect(metricCalculator.getUserColumnWidthsByName().get(hiddenName)).toBe(
+      0
+    );
+    // The by-index map should not include it (no model index).
+    expect([...metricCalculator.getUserColumnWidths().entries()]).toEqual([]);
+  });
+
+  it('un-hides a group-by column that is absent from the current (already rolled-up) model', () => {
+    // Simulates editing an existing rollup where a newly-added group-by
+    // column is not present in the current model (e.g. non-aggregated columns
+    // are hidden), so a model-index lookup against this.props.model would
+    // miss it. Resetting by name must still clear its hidden width.
+    const columns = irisGridTestUtils.makeColumns(3);
+    const model = irisGridTestUtils.makeModel(
+      irisGridTestUtils.makeTable({ columns })
+    );
+    const irisGrid = makeComponent(model);
+    const { metricCalculator } = irisGrid.state;
+
+    // Simulate the column having been hidden previously (width 0 stored by name).
+    const newGroupByName = 'NotInCurrentModel';
+    metricCalculator.userColumnWidthsByName.set(newGroupByName, 0);
+
+    // Spy AFTER seeding so the spy still calls through.
+    jest.spyOn(model, 'getColumnIndexByName').mockReturnValue(undefined);
+
+    act(() => {
+      irisGrid.handleRollupChange({
+        columns: [newGroupByName],
+        showConstituents: false,
+        showNonAggregatedColumns: false,
+      });
+    });
+
+    expect(metricCalculator.userColumnWidthsByName.has(newGroupByName)).toBe(
+      false
+    );
+  });
+});
+
 // auto resize -> reset user width and set calculated width to content width
 // manual resize -> set user width to content width
 describe('handleResizeAllColumns', () => {

--- a/packages/iris-grid/src/IrisGrid.tsx
+++ b/packages/iris-grid/src/IrisGrid.tsx
@@ -322,7 +322,20 @@ export interface IrisGridProps {
   customColumns: readonly ColumnName[];
   selectDistinctColumns: readonly ColumnName[];
   settings?: Settings;
+  /**
+   * @deprecated Pass `userColumnWidthsByName` instead. The by-index map is
+   * lossy across model swaps because column indices change when the model
+   * is replaced (e.g. when applying or removing a rollup). Kept for
+   * back-compat with consumers that have not migrated.
+   */
   userColumnWidths: ReadonlyMap<ModelIndex, number>;
+  /**
+   * Map of user-set column widths keyed by column name. Source of truth
+   * for hidden/manually-sized columns across model swaps and persistence
+   * boundaries. Takes precedence over `userColumnWidths` when both are
+   * provided.
+   */
+  userColumnWidthsByName?: ReadonlyMap<ColumnName, number>;
   userRowHeights: ReadonlyMap<ModelIndex, number>;
   onSelectionChanged: (gridRanges: readonly GridRange[]) => void;
   rollupConfig?: UIRollupConfig;
@@ -524,6 +537,7 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
     aggregationSettings: DEFAULT_AGGREGATION_SETTINGS,
     rollupConfig: undefined,
     userColumnWidths: EMPTY_MAP,
+    userColumnWidthsByName: undefined,
     userRowHeights: EMPTY_MAP,
     onSelectionChanged: (): void => undefined,
     isSelectingColumn: false,
@@ -744,6 +758,7 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
       movedRows: movedRowsProp,
       rollupConfig,
       userColumnWidths,
+      userColumnWidthsByName,
       userRowHeights,
       showSearchBar,
       searchValue,
@@ -791,6 +806,10 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
 
     const metricCalculator = getMetricCalculator({
       userColumnWidths: new Map(userColumnWidths),
+      userColumnWidthsByName:
+        userColumnWidthsByName != null
+          ? new Map(userColumnWidthsByName)
+          : undefined,
       userRowHeights: new Map(userRowHeights),
       movedColumns,
       initialColumnWidths: new Map(

--- a/packages/iris-grid/src/IrisGridCacheUtils.ts
+++ b/packages/iris-grid/src/IrisGridCacheUtils.ts
@@ -71,6 +71,7 @@ function areIrisGridStatesEqual(
     irisGridStateA === irisGridStateB ||
     (irisGridStateA.metrics != null &&
       irisGridStateB.metrics != null &&
+      irisGridStateA.metricCalculator === irisGridStateB.metricCalculator &&
       irisGridStateA.metrics.userColumnWidths ===
         irisGridStateB.metrics.userColumnWidths &&
       irisGridStateA.metrics.userRowHeights ===

--- a/packages/iris-grid/src/IrisGridMetricCalculator.test.ts
+++ b/packages/iris-grid/src/IrisGridMetricCalculator.test.ts
@@ -111,6 +111,55 @@ describe('IrisGridMetricCalculator', () => {
     expect(calculator.getUserColumnWidths().get(0)).toBe(150);
   });
 
+  it('seeds userColumnWidthsByName from constructor options and projects to current model', () => {
+    const seeded = new IrisGridMetricCalculator({
+      userColumnWidthsByName: new Map([
+        ['Column2', 0],
+        ['NotInModel', 0],
+      ]),
+    });
+
+    expect([...seeded.getUserColumnWidthsByName().entries()]).toEqual([
+      ['Column2', 0],
+      ['NotInModel', 0],
+    ]);
+
+    // Force a model swap so updateUserColumnWidths runs and projects to the
+    // current model. The entry for `NotInModel` is preserved in the by-name
+    // map but does not appear in the by-index map.
+    seeded.getMetrics(state);
+
+    expect([...seeded.getUserColumnWidths().entries()]).toEqual([[1, 0]]);
+    expect([...seeded.getUserColumnWidthsByName().entries()]).toEqual([
+      ['Column2', 0],
+      ['NotInModel', 0],
+    ]);
+  });
+
+  it('preserves widths for columns absent from the current model across model swaps', () => {
+    const seeded = new IrisGridMetricCalculator({
+      userColumnWidthsByName: new Map([['Column2', 0]]),
+    });
+
+    // Initial model: 5 columns, Column2 is hidden.
+    seeded.getMetrics(state);
+    expect(seeded.getUserColumnWidths().get(1)).toBe(0);
+
+    // Swap to a smaller model that no longer contains Column2 (e.g. a rollup).
+    columns = columns.filter(col => col.name !== 'Column2');
+    seeded.getMetrics(state);
+    expect([...seeded.getUserColumnWidths().entries()]).toEqual([]);
+    // The by-name map preserves the hidden width for re-projection later.
+    expect([...seeded.getUserColumnWidthsByName().entries()]).toEqual([
+      ['Column2', 0],
+    ]);
+
+    // Restore the original model. Column2 should be hidden again.
+    columns = makeColumns();
+    seeded.getMetrics(state);
+    expect([...seeded.getUserColumnWidths().entries()]).toEqual([[1, 0]]);
+  });
+
   describe('getFilterInputCoordinates', () => {
     it.each([
       {

--- a/packages/iris-grid/src/IrisGridMetricCalculator.ts
+++ b/packages/iris-grid/src/IrisGridMetricCalculator.ts
@@ -36,7 +36,7 @@ export type IrisGridMetricCalculatorOptions = GridMetricCalculatorOptions & {
 };
 
 export class IrisGridMetricCalculator extends GridMetricCalculator {
-  // Column widths by name to keep track of columns going in and out of viewport
+  // Column widths by name to keep track of columns going in and out of viewport.
   private userColumnWidthsByName: Map<ColumnName, number>;
 
   // Cached model column names to detect when the column width map update is necessary
@@ -46,6 +46,12 @@ export class IrisGridMetricCalculator extends GridMetricCalculator {
 
   // Cached padding maps for column header groups
   private cachedPaddingMaps: Map<string, Map<string, number>> = new Map();
+
+  constructor(options: IrisGridMetricCalculatorOptions = {}) {
+    const { userColumnWidthsByName, ...rest } = options;
+    super(rest);
+    this.userColumnWidthsByName = userColumnWidthsByName ?? new Map();
+  }
 
   static getModelColumnRoot(
     model: IrisGridModel,
@@ -106,12 +112,6 @@ export class IrisGridMetricCalculator extends GridMetricCalculator {
       children: [],
       value: getLeafValue(name) ?? 0,
     };
-  }
-
-  constructor(options: IrisGridMetricCalculatorOptions = {}) {
-    const { userColumnWidthsByName, ...rest } = options;
-    super(rest);
-    this.userColumnWidthsByName = userColumnWidthsByName ?? new Map();
   }
 
   /**

--- a/packages/iris-grid/src/IrisGridMetricCalculator.ts
+++ b/packages/iris-grid/src/IrisGridMetricCalculator.ts
@@ -19,9 +19,25 @@ import { rebalanceTree, type TreeNode } from './TreeRebalanceUtil';
 
 export type IrisGridMetricState = GridMetricState & IrisGridStateOverride;
 
+type GridMetricCalculatorOptions = NonNullable<
+  ConstructorParameters<typeof GridMetricCalculator>[0]
+>;
+
+export type IrisGridMetricCalculatorOptions = GridMetricCalculatorOptions & {
+  /**
+   * Map of user-set column widths keyed by column name. This is the source
+   * of truth for hidden/manually-sized columns across model swaps (e.g.
+   * applying or removing a rollup), where the model's column indices
+   * change but names are stable. Entries for columns absent from the
+   * current model are preserved and re-projected onto the by-index map
+   * whenever the model swaps.
+   */
+  userColumnWidthsByName?: Map<ColumnName, number>;
+};
+
 export class IrisGridMetricCalculator extends GridMetricCalculator {
   // Column widths by name to keep track of columns going in and out of viewport
-  private userColumnWidthsByName: Map<ColumnName, number> = new Map();
+  private userColumnWidthsByName: Map<ColumnName, number>;
 
   // Cached model column names to detect when the column width map update is necessary
   private cachedModelColumnNames: readonly ColumnName[] | undefined;
@@ -90,6 +106,12 @@ export class IrisGridMetricCalculator extends GridMetricCalculator {
       children: [],
       value: getLeafValue(name) ?? 0,
     };
+  }
+
+  constructor(options: IrisGridMetricCalculatorOptions = {}) {
+    const { userColumnWidthsByName, ...rest } = options;
+    super(rest);
+    this.userColumnWidthsByName = userColumnWidthsByName ?? new Map();
   }
 
   /**
@@ -197,6 +219,7 @@ export class IrisGridMetricCalculator extends GridMetricCalculator {
     const modelColumnNames = this.getCachedCurrentModelColumnNames(
       model.columns
     );
+    const isFirstCall = this.cachedModelColumnNames == null;
     if (
       this.cachedModelColumnNames != null &&
       this.cachedModelColumnNames !== modelColumnNames &&
@@ -206,6 +229,10 @@ export class IrisGridMetricCalculator extends GridMetricCalculator {
       this.updateCalculatedColumnWidths(model);
       this.updateUserColumnWidths(model);
       this.cachedPaddingMaps.clear();
+    } else if (isFirstCall && this.userColumnWidthsByName.size > 0) {
+      // On the first call, project the seeded by-name widths into the
+      // by-index map for the current model.
+      this.updateUserColumnWidths(model);
     }
     this.cachedModelColumnNames = modelColumnNames;
 
@@ -321,6 +348,16 @@ export class IrisGridMetricCalculator extends GridMetricCalculator {
   getUserColumnWidths(): ModelSizeMap {
     // This might return stale data if getMetrics hasn't been called
     return this.userColumnWidths;
+  }
+
+  /**
+   * Gets the user column widths keyed by column name. This is the source
+   * of truth for hidden/manually-sized columns across model swaps and
+   * persistence boundaries.
+   * @returns A map of user column widths keyed by column name
+   */
+  getUserColumnWidthsByName(): ReadonlyMap<ColumnName, number> {
+    return this.userColumnWidthsByName;
   }
 
   getCalculatedColumnWidths(): ModelSizeMap {

--- a/packages/iris-grid/src/IrisGridUtils.test.ts
+++ b/packages/iris-grid/src/IrisGridUtils.test.ts
@@ -11,6 +11,7 @@ import { type TypeValue as FilterTypeValue } from '@deephaven/filters';
 import { DateUtils } from '@deephaven/jsapi-utils';
 import type { AdvancedFilter } from './CommonTypes';
 import { type FilterData } from './IrisGrid';
+import { IrisGridMetricCalculator } from './IrisGridMetricCalculator';
 import IrisGridTestUtils from './IrisGridTestUtils';
 import IrisGridUtils, {
   type DehydratedSort,
@@ -921,5 +922,99 @@ describe('textAlignForValue', () => {
       IrisGridUtils.textAlignForValue('java.lang.String', 'TestColumn')
     ).toBe('left');
     expect(IrisGridUtils.textAlignForValue('char', 'TestColumn')).toBe('left');
+  });
+});
+
+describe('user column widths persistence by name', () => {
+  it('preserves widths for columns absent from the current model across a dehydrate/hydrate/dehydrate round-trip', () => {
+    // Original (un-rolled-up) model has 5 columns named name_0..name_4.
+    const originalColumns = irisGridTestUtils.makeColumns(5, 'name_');
+    const originalModel = irisGridTestUtils.makeModel(
+      irisGridTestUtils.makeTable({ columns: originalColumns })
+    );
+
+    // Current model is a "rolled-up" subset that only includes name_0 (the
+    // group-by column). The other four columns are absent from the model.
+    const currentColumns = [originalColumns[0]];
+    const currentModel = irisGridTestUtils.makeModel(
+      irisGridTestUtils.makeTable({ columns: currentColumns })
+    );
+
+    // Metric calculator carries widths for columns that aren't in the current
+    // model — e.g. name_2 was hidden by the user before the rollup.
+    const metricCalculator = new IrisGridMetricCalculator({
+      userColumnWidthsByName: new Map([['name_2', 0]]),
+    });
+
+    // First dehydrate against the current (rolled-up) model.
+    const firstDehydrated = irisGridUtils.dehydrateIrisGridState(currentModel, {
+      advancedFilters: new Map(),
+      aggregationSettings: { aggregations: [], showOnTop: false },
+      customColumnFormatMap: new Map(),
+      columnAlignmentMap: new Map(),
+      isFilterBarShown: false,
+      quickFilters: new Map(),
+      customColumns: [],
+      reverse: false,
+      rollupConfig: undefined,
+      showSearchBar: false,
+      searchValue: '',
+      selectDistinctColumns: [],
+      selectedSearchColumns: [],
+      sorts: [],
+      invertSearchColumns: false,
+      pendingDataMap: new Map(),
+      frozenColumns: [],
+      conditionalFormats: [],
+      columnHeaderGroups: [],
+      partitionConfig: undefined,
+      metricCalculator,
+      metrics: {
+        userColumnWidths: new Map(),
+        userRowHeights: new Map(),
+      } as Partial<GridMetrics>,
+    });
+
+    expect(firstDehydrated.userColumnWidths).toEqual([['name_2', 0]]);
+
+    // Hydrate against the current (rolled-up) model. The by-name map should
+    // preserve the entry even though name_2 is absent from currentModel.
+    const hydrated = irisGridUtils.hydrateIrisGridState(currentModel, {
+      ...firstDehydrated,
+      userColumnWidths: firstDehydrated.userColumnWidths,
+    });
+    expect(hydrated.userColumnWidthsByName.get('name_2')).toBe(0);
+    expect(hydrated.userColumnWidths.size).toBe(0);
+
+    // Re-seed the metric calculator with the hydrated by-name map (this
+    // simulates IrisGrid passing `userColumnWidthsByName` through to its
+    // metric calculator constructor) and dehydrate again.
+    const reseeded = new IrisGridMetricCalculator({
+      userColumnWidthsByName: hydrated.userColumnWidthsByName,
+    });
+    const secondDehydrated = irisGridUtils.dehydrateIrisGridState(
+      currentModel,
+      {
+        ...firstDehydrated,
+        metricCalculator: reseeded,
+        metrics: {
+          userColumnWidths: new Map(),
+          userRowHeights: new Map(),
+        } as Partial<GridMetrics>,
+      }
+    );
+
+    // The entry for name_2 must survive the second save.
+    expect(secondDehydrated.userColumnWidths).toEqual([['name_2', 0]]);
+
+    // After removing the rollup (model swap back to originalColumns),
+    // hydrating against the original model yields a by-index map with the
+    // hidden width re-applied to name_2.
+    const restored = irisGridUtils.hydrateIrisGridState(
+      originalModel,
+      secondDehydrated
+    );
+    expect(restored.userColumnWidthsByName.get('name_2')).toBe(0);
+    expect(restored.userColumnWidths.get(2)).toBe(0);
   });
 });

--- a/packages/iris-grid/src/IrisGridUtils.ts
+++ b/packages/iris-grid/src/IrisGridUtils.ts
@@ -79,6 +79,11 @@ export type HydratedIrisGridState = Pick<
   | 'partitionConfig'
 > & {
   metrics?: Partial<GridMetrics>;
+  /**
+   * The metric calculator instance, used to access the by-name user column
+   * widths map (the source of truth across model swaps).
+   */
+  metricCalculator?: IrisGridState['metricCalculator'];
 };
 
 export type DehydratedPendingDataMap<T> = [number, { data: [string, T][] }][];
@@ -1194,6 +1199,7 @@ class IrisGridUtils {
       customColumnFormatMap,
       columnAlignmentMap = EMPTY_MAP,
       isFilterBarShown,
+      metricCalculator,
       metrics: {
         userColumnWidths = new Map<ModelIndex, number>(),
         userRowHeights = new Map<ModelIndex, number>(),
@@ -1219,6 +1225,23 @@ class IrisGridUtils {
       ? model.partitionColumns
       : [];
 
+    // Prefer the by-name map from the metric calculator: it preserves entries
+    // for columns absent from the current model (e.g. while a rollup is
+    // active), so reload-then-save round-trips don't drop them.
+    // Fall back to projecting the by-index map against the current model for
+    // callers that didn't pass a metric calculator.
+    const dehydratedUserColumnWidths: DehydratedUserColumnWidth[] =
+      metricCalculator != null
+        ? [...metricCalculator.getUserColumnWidthsByName()]
+        : [...userColumnWidths]
+            .filter(
+              ([columnIndex]) =>
+                columnIndex != null &&
+                columnIndex >= 0 &&
+                columnIndex < columns.length
+            )
+            .map(([columnIndex, width]) => [columns[columnIndex].name, width]);
+
     // Return value will be serialized, should not contain undefined
     return {
       advancedFilters: this.dehydrateAdvancedFilters(columns, advancedFilters),
@@ -1228,14 +1251,7 @@ class IrisGridUtils {
       isFilterBarShown,
       quickFilters: IrisGridUtils.dehydrateQuickFilters(quickFilters),
       sorts: IrisGridUtils.dehydrateSort(sorts),
-      userColumnWidths: [...userColumnWidths]
-        .filter(
-          ([columnIndex]) =>
-            columnIndex != null &&
-            columnIndex >= 0 &&
-            columnIndex < columns.length
-        )
-        .map(([columnIndex, width]) => [columns[columnIndex].name, width]),
+      userColumnWidths: dehydratedUserColumnWidths,
       userRowHeights: [...userRowHeights],
       customColumns: [...customColumns],
       conditionalFormats: [...conditionalFormats],
@@ -1268,8 +1284,9 @@ class IrisGridUtils {
   hydrateIrisGridState(
     model: IrisGridModel,
     irisGridState: DehydratedIrisGridState
-  ): Omit<HydratedIrisGridState, 'metrics'> & {
+  ): Omit<HydratedIrisGridState, 'metrics' | 'metricCalculator'> & {
     userColumnWidths: ModelSizeMap;
+    userColumnWidthsByName: Map<ColumnName, number>;
     userRowHeights: ModelSizeMap;
   } {
     const {
@@ -1301,6 +1318,22 @@ class IrisGridUtils {
     const partitionColumns = isPartitionedGridModelProvider(model)
       ? model.partitionColumns
       : [];
+
+    // Build a name-keyed map preserving every persisted entry, including
+    // entries for columns absent from the current model. Then derive the
+    // by-index map from that for back-compat with consumers that read
+    // widths immediately after hydrate.
+    const userColumnWidthsByName = new Map<ColumnName, number>();
+    userColumnWidths.forEach(([column, width]) => {
+      const name =
+        typeof column === 'string' || (column as unknown) instanceof String
+          ? (column as ColumnName)
+          : columns[column as number]?.name;
+      if (name != null) {
+        userColumnWidthsByName.set(name, width);
+      }
+    });
+
     return {
       advancedFilters: this.hydrateAdvancedFilters(
         columns,
@@ -1317,22 +1350,13 @@ class IrisGridUtils {
         formatter.timeZone
       ),
       sorts: this.hydrateSort(columns, sorts, true),
+      userColumnWidthsByName,
       userColumnWidths: new Map(
-        userColumnWidths
-          .map(
-            ([column, width]: [string | number, number]): [number, number] => {
-              if (
-                typeof column === 'string' ||
-                (column as unknown) instanceof String
-              ) {
-                return [
-                  columns.findIndex(({ name }) => name === column),
-                  width,
-                ];
-              }
-              return [column, width];
-            }
-          )
+        [...userColumnWidthsByName]
+          .map(([name, width]): [number, number] => [
+            columns.findIndex(c => c.name === name),
+            width,
+          ])
           .filter(
             ([column]) =>
               column != null && column >= 0 && column < columns.length

--- a/packages/iris-grid/src/IrisGridUtils.ts
+++ b/packages/iris-grid/src/IrisGridUtils.ts
@@ -1228,8 +1228,8 @@ class IrisGridUtils {
     // Prefer the by-name map from the metric calculator: it preserves entries
     // for columns absent from the current model (e.g. while a rollup is
     // active), so reload-then-save round-trips don't drop them.
-    // Fall back to projecting the by-index map against the current model for
-    // callers that didn't pass a metric calculator.
+    // Fall back to projecting the by-index map from `metrics` against the
+    // current model for callers that didn't pass a metric calculator.
     const dehydratedUserColumnWidths: DehydratedUserColumnWidth[] =
       metricCalculator != null
         ? [...metricCalculator.getUserColumnWidthsByName()]

--- a/plans/DH-20403-persist-user-column-widths-by-name.md
+++ b/plans/DH-20403-persist-user-column-widths-by-name.md
@@ -1,0 +1,168 @@
+# DH-20403 — Persist hidden-column widths by name end-to-end
+
+Folded into PR [#2668](https://github.com/deephaven/web-client-ui/pull/2668).
+
+## Problem
+
+Reproduction:
+
+1. Open the stocks table, hide all columns except `Random`.
+2. Apply a rollup grouping by `Sym` → only `Sym` and `Random` are visible.
+3. Reload the browser → the rollup with two visible columns is restored correctly.
+4. Remove the `Sym` grouping in the rollup settings.
+
+Expected: `Sym` and `Random` remain the only visible columns.
+Actual: every column becomes visible.
+
+## Root cause
+
+Hidden state is stored in `IrisGridMetricCalculator` in two maps:
+
+- `userColumnWidths: Map<ModelIndex, number>` — derived view, regenerated on
+  every model swap.
+- `userColumnWidthsByName: Map<ColumnName, number>` — source of truth that
+  survives model swaps (rollup apply/remove, select-distinct, etc.).
+  `updateUserColumnWidths(model)` re-projects from this map on every metrics
+  pass.
+
+The persistence boundary in `IrisGridUtils` only knows about the by-index map:
+
+- `dehydrateIrisGridState` reads `metrics.userColumnWidths` (by index) and
+  serializes `[columnName, width][]` against the **current** model's
+  `columns`. While a rollup is active, columns absent from the rolled-up
+  model are missing from the by-index map and therefore dropped.
+- `hydrateIrisGridState` re-projects the persisted `[name, width][]` array
+  back into a `Map<ModelIndex, number>` against the **current** model.
+  Names that don't resolve get filtered out. The metric calculator's
+  constructor only sees the by-index map, so `userColumnWidthsByName` starts
+  empty after a reload.
+
+Net effect: when the rollup is removed, `updateUserColumnWidths` rebuilds the
+by-index map from an empty by-name map → all hidden columns become visible.
+This is data loss at the persistence boundary, not a runtime calculation bug.
+
+## Approach: thread `userColumnWidthsByName` end-to-end
+
+Make column **names** the source of truth across the persistence boundary.
+The persisted form is already `[ColumnName, number][]`, so no schema bump is
+needed. We just need to stop discarding entries during hydrate, and read
+from the by-name map during dehydrate.
+
+### Steps
+
+1. **Extend `IrisGridMetricCalculator`** ([packages/iris-grid/src/IrisGridMetricCalculator.ts](packages/iris-grid/src/IrisGridMetricCalculator.ts))
+   - Accept an optional `userColumnWidthsByName: Map<ColumnName, number>` in
+     the constructor; initialize the field from it when supplied.
+   - Add `getUserColumnWidthsByName(): ReadonlyMap<ColumnName, number>`.
+   - No changes to the projection logic — `updateUserColumnWidths` (L180)
+     already projects by-name → by-index on every model swap.
+
+2. **Add `userColumnWidthsByName` prop to `IrisGrid`** ([packages/iris-grid/src/IrisGrid.tsx](packages/iris-grid/src/IrisGrid.tsx))
+   - Type as `ReadonlyMap<ColumnName, number>`, optional, default `EMPTY_MAP`.
+   - Pass into `getMetricCalculator({...})` at L792.
+   - Keep the existing `userColumnWidths` prop as a back-compat fallback for
+     callers that haven't migrated; mark deprecated in JSDoc.
+
+3. **Update `IrisGridUtils.hydrateIrisGridState`** ([packages/iris-grid/src/IrisGridUtils.ts](packages/iris-grid/src/IrisGridUtils.ts), L1268)
+   - Stop dropping name entries that don't resolve in `model.columns`.
+   - Return both `userColumnWidths` (the index-projected, current-model
+     subset, kept for back-compat with consumers reading widths immediately
+     after hydrate) **and** `userColumnWidthsByName` (the full preserved
+     map). Update `HydratedIrisGridState` accordingly.
+
+4. **Update `IrisGridUtils.dehydrateIrisGridState`** ([packages/iris-grid/src/IrisGridUtils.ts](packages/iris-grid/src/IrisGridUtils.ts), L1187)
+   - Read widths from `metrics.userColumnWidthsByName` when present, falling
+     back to deriving from `metrics.userColumnWidths` against `model.columns`
+     (current behavior). This closes the loop — saved state stops shrinking
+     on every save.
+
+5. **Plumb through panel hosts**
+   - [packages/dashboard-core-plugins/src/panels/IrisGridPanel.tsx](packages/dashboard-core-plugins/src/panels/IrisGridPanel.tsx):
+     destructure `userColumnWidthsByName` from `hydrateIrisGridState`
+     (L1049), store in state alongside `userColumnWidths`, pass as prop at
+     L1266. Initial state defaults to an empty map (L315).
+   - [packages/dashboard-core-plugins/src/GridWidgetPlugin.tsx](packages/dashboard-core-plugins/src/GridWidgetPlugin.tsx):
+     `hydrateIrisGridState` already spreads its return into `hydratedState`
+     (L59), so confirm the new field flows to `IrisGrid`.
+
+### Tests
+
+- `IrisGridMetricCalculator.test.ts`
+  - Constructor seeds `userColumnWidthsByName`.
+  - `updateUserColumnWidths` projects to the current model and preserves
+    entries for absent names across a model swap.
+
+- `IrisGridUtils.test.ts`
+  - dehydrate → hydrate → dehydrate round-trip preserves a width entry for a
+    column **not present** in the current model (the regression).
+
+- `IrisGrid.test.tsx`
+  - Existing `handleRollupChange` tests still pass.
+  - Construct `IrisGrid` with `userColumnWidthsByName` containing a hidden
+    column not present in the current rolled-up model; assert it remains
+    hidden after a model swap.
+
+### Verification
+
+1. Manual repro of the user's scenario via DevTools MCP: open stocks, hide
+   all but `Random`, rollup on `Sym`, reload, remove rollup → only `Sym` and
+   `Random` visible.
+2. Unit tests above pass; existing tests remain green.
+3. `npx tsc -p packages/iris-grid/tsconfig.json --noEmit` and
+   `npx tsc -p packages/dashboard-core-plugins/tsconfig.json --noEmit` clean.
+4. `eslint` clean on modified files.
+
+## Decisions / scope guardrails
+
+- Single source of truth for hidden-column state in memory =
+  `userColumnWidthsByName` on `IrisGridMetricCalculator`. The by-index map is
+  a derived view, repopulated by `updateUserColumnWidths` on every model
+  swap (already true today).
+- Persisted form stays `[ColumnName, number][]` — no schema bump.
+- Out of scope: reworking `userRowHeights` (rows aren't subject to model
+  column swaps).
+- Out of scope: hard-removing the legacy `userColumnWidths` prop on
+  `IrisGrid` — kept as a deprecated back-compat path.
+- No data migration needed: existing persisted state is already by name.
+
+## Alternatives considered
+
+### Hydrate against `originalColumns`
+
+Use `(model as IrisGridProxyModel).originalColumns ?? model.columns` for the
+name-to-index lookup in `hydrateIrisGridState`.
+
+- Pros: ~5 lines, no prop plumbing.
+- Cons:
+  - Doesn't fix dehydrate. With a rollup active, the by-index map still
+    misses absent columns, so save-after-reload still drops them.
+  - `originalColumns` is `IrisGridProxyModel`-specific. Surfacing it in
+    `IrisGridUtils` leaks rollup semantics into model-agnostic code.
+  - Doesn't help select-distinct or other future model-swap features whose
+    `originalColumns` is the post-swap set.
+
+### Hybrid: hydrate against `originalColumns` + dehydrate from by-name
+
+Equivalent in correctness to the chosen approach but still leaks
+`originalColumns` into utils. The metric calculator's by-name map is still
+the right source for dehydrate, so we'd still need to expose it; at that
+point the marginal cost of adding the prop to `IrisGrid` is tiny and
+future-proofs against further model swaps.
+
+### Drop the by-index map from props entirely
+
+`hydrateIrisGridState` returns only `userColumnWidthsByName`. Simpler mental
+model, but a breaking change for the panel and any external consumers
+reading `userColumnWidths` from props. Out of scope for this PR (kept as a
+back-compat path); see "Future work" below.
+
+## Future work
+
+Once this PR ships and the deprecation has been advertised for a release,
+follow up with the cleanup: remove the by-index `userColumnWidths` prop on
+`IrisGrid` and the matching field from `HydratedIrisGridState`, leaving
+`userColumnWidthsByName` as the only width prop. This eliminates the dual
+representation that motivated the by-name plumbing in the first place and
+removes the back-compat fallback in the metric calculator constructor and
+`dehydrateIrisGridState`. Tracked separately to keep this PR focused and to
+give downstream consumers a release window to migrate.

--- a/plans/DH-20403-persist-user-column-widths-by-name.md
+++ b/plans/DH-20403-persist-user-column-widths-by-name.md
@@ -1,6 +1,10 @@
-# DH-20403 — Persist hidden-column widths by name end-to-end
+# DH-20403 — Persist user column widths by name end-to-end
 
-Folded into PR [#2668](https://github.com/deephaven/web-client-ui/pull/2668).
+Follow-up split out of [PR #2668](https://github.com/deephaven/web-client-ui/pull/2668)
+(DH-22326). That PR's "Future work" section called out the dual
+by-index / by-name representation as the next thing to address; this PR
+threads `userColumnWidthsByName` end-to-end through the persistence boundary
+so saved layouts retain hidden-column state across model swaps.
 
 ## Problem
 


### PR DESCRIPTION
Persist user column widths by name end-to-end so hidden/resized columns survive layouts where the underlying model doesn't currently expose them (e.g. while a rollup is active and non-aggregated columns are hidden).

`IrisGridMetricCalculator` already tracked widths by name internally, but state was saved and restored only via the by-index map projected against the current model — entries for columns not present in the model were silently dropped on every dehydrate. `dehydrateIrisGridState` now prefers `metricCalculator.getUserColumnWidthsByName()` when available, falling back to the previous by-index projection only for callers that don't pass a metric calculator. `hydrateIrisGridState` returns a `userColumnWidthsByName` map alongside the back-compat by-index map, and `IrisGridPanel` / `GridWidgetPlugin` thread it through to `IrisGrid`, which seeds the metric calculator's by-name map at construction.

Unit tests cover the round-trip: a width entry for a column absent from the rolled-up model survives dehydrate → hydrate → dehydrate, and is re-applied to the by-index map once the original (un-rolled-up) model is hydrated against.