### PR TITLE
docs: update quickstart link

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ For details on how to contribute to this repository, please see the [contributin
 
 We are using node 24.x and npm 11.x. If you are [using nvm](https://github.com/nvm-sh/nvm#installing-and-updating), there is an [.nvmrc](.nvmrc) file, so just run `nvm install` to get the latest 24.x/11.x versions (or set up your environment to [automatically switch](https://github.com/nvm-sh/nvm#deeper-shell-integration)). Otherwise, download from the [node homepage](https://nodejs.org/en/download/).
 
-In order to use the UI, you must also be running a [deephaven-core](https://github.com/deephaven/deephaven-core) server on port 10000. The server provides APIs that the web-client-ui depends upon. An easy way to get started is to launch a Deephaven container from the [quick start guide](https://deephaven.io/core/docs/tutorials/quickstart/).
+In order to use the UI, you must also be running a [deephaven-core](https://github.com/deephaven/deephaven-core) server on port 10000. The server provides APIs that the web-client-ui depends upon. An easy way to get started is to launch a Deephaven container from the [quick start guide](https://deephaven.io/core/docs/getting-started/quickstart/).
 
 ## Recommended Environment
 

--- a/packages/code-studio/README.md
+++ b/packages/code-studio/README.md
@@ -1,6 +1,6 @@
 # Introduction
 
-Code Studio is a web application that connects to a running [deephaven-core](https://github.com/deephaven/deephaven-core/) instance. You can quickly bring up a [Deephaven backend from pre-built images](https://deephaven.io/core/docs/tutorials/quickstart/#tldr). A few notes to get developers quickly up and running.
+Code Studio is a web application that connects to a running [deephaven-core](https://github.com/deephaven/deephaven-core/) instance. You can quickly bring up a [Deephaven backend from pre-built images](https://deephaven.io/core/docs/getting-started/quickstart/#1-install-and-launch-deephaven). A few notes to get developers quickly up and running.
 
 ## Running
 


### PR DESCRIPTION
Updates Deephaven docker quickstart links to point to the current getting-started quickstart page.