### PR TITLE
fix: DH-22040: Open Dashboard List global shortcut conflicts

### DIFF
--- a/packages/components/src/shortcuts/GlobalShortcuts.ts
+++ b/packages/components/src/shortcuts/GlobalShortcuts.ts
@@ -68,8 +68,8 @@ const GLOBAL_SHORTCUTS = {
   OPEN_DASHBOARD_LIST: ShortcutRegistry.createAndAdd({
     id: 'GLOBAL.OPEN_DASHBOARD_LIST',
     name: 'Open Dashboard List',
-    shortcut: [MODIFIER.CTRL, MODIFIER.SHIFT, KEY.D],
-    macShortcut: [MODIFIER.CMD, MODIFIER.SHIFT, KEY.D],
+    shortcut: [MODIFIER.ALT, MODIFIER.SHIFT, KEY.D],
+    macShortcut: [MODIFIER.OPTION, MODIFIER.SHIFT, KEY.D],
     isEditable: true,
   }),
   NEXT: ShortcutRegistry.createAndAdd({


### PR DESCRIPTION
"Open Dashboard List" global keyboard shortcut conflicts with Code Studio "Disconnect Console" shortcut

[DH-22040](https://deephaven.atlassian.net/browse/DH-22040)

Testing:

| OS | Browser | Result |
|---|---|---|
| macOS | Chrome | ✅ |
| macOS | Firefox | ✅ |
| macOS | Safari | ✅ |
| Windows | Chrome | ✅ |
| Windows | Firefox | ✅ |
| Linux | Chrome | ✅ |
| Linux | Firefox | ✅ |

[DH-22040]: https://deephaven.atlassian.net/browse/DH-22040?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ