### PR TITLE
fix: DH-22548: Command Selection Overrides Select File Button

### DIFF
--- a/packages/console/src/Console.tsx
+++ b/packages/console/src/Console.tsx
@@ -1096,18 +1096,6 @@ export class Console extends PureComponent<ConsoleProps, ConsoleState> {
             onDragEnter={this.handleDragEnter}
             onDragLeave={this.handleDragLeave}
           >
-            {showCsvOverlay && (
-              <CsvOverlay
-                onCancel={this.handleCsvFileCanceled}
-                onFileOpened={this.handleCsvFileOpened}
-                onPaste={this.handleCsvPaste}
-                clearDragError={this.handleClearDragError}
-                dragError={dragError}
-                onError={this.handleCsvError}
-                uploadInProgress={csvUploadInProgress}
-                allowZip={unzip != null}
-              />
-            )}
             <div
               role="presentation"
               className={classNames('scroll-pane no-scroll-x', {
@@ -1128,6 +1116,18 @@ export class Console extends PureComponent<ConsoleProps, ConsoleState> {
               />
               {historyChildren}
             </div>
+            {showCsvOverlay && (
+              <CsvOverlay
+                onCancel={this.handleCsvFileCanceled}
+                onFileOpened={this.handleCsvFileOpened}
+                onPaste={this.handleCsvPaste}
+                clearDragError={this.handleClearDragError}
+                dragError={dragError}
+                onError={this.handleCsvError}
+                uploadInProgress={csvUploadInProgress}
+                allowZip={unzip != null}
+              />
+            )}
           </div>
           {!showCsvOverlay && (
             <ConsoleInput


### PR DESCRIPTION
[DH-22548](https://deephaven.atlassian.net/browse/DH-22548)

When the CSV upload overlay was open, hovering over the console history would trigger the command action toolbar (`.console-history-actions`), which rendered on top of the overlay and blocked the "Select File..." button from being clickable.

The overlay was rendered before the scroll-pane in the DOM, so the history items — being positioned elements later in the tree — painted on top of it. Fixed by moving the `CsvOverlay` to render after the scroll-pane, so natural DOM stacking order puts it on top without requiring any z-index hacks.

[DH-22548]: https://deephaven.atlassian.net/browse/DH-22548?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ