### PR TITLE
feat: DH-21757: Allow widget plugins to register types as dashboard types

### DIFF
--- a/packages/dashboard-core-plugins/src/panels/ConsolePanel.test.tsx
+++ b/packages/dashboard-core-plugins/src/panels/ConsolePanel.test.tsx
@@ -1,6 +1,10 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import { type CommandHistoryStorage } from '@deephaven/console';
+import {
+  CREATE_DASHBOARD,
+  PanelEvent,
+} from '@deephaven/dashboard';
 import type { Container, EventEmitter } from '@deephaven/golden-layout';
 import type { IdeConnection, IdeSession } from '@deephaven/jsapi-types';
 import { dh } from '@deephaven/jsapi-shim';
@@ -8,6 +12,12 @@ import {
   type SessionConfig,
   type SessionWrapper,
 } from '@deephaven/jsapi-utils';
+import {
+  PluginType,
+  type PluginModuleMap,
+  type WidgetDashboardPlugin,
+  type WidgetPlugin,
+} from '@deephaven/plugin';
 import { TestUtils } from '@deephaven/test-utils';
 import { ConsolePanel } from './ConsolePanel';
 
@@ -61,16 +71,27 @@ function renderConsolePanel({
   commandHistoryStorage = makeCommandHistoryStorage(),
   timeZone = 'MockTimeZone',
   sessionWrapper = makeSessionWrapper(),
+  plugins = new Map() as PluginModuleMap,
+  ref,
+}: {
+  eventHub?: EventEmitter;
+  container?: Container;
+  commandHistoryStorage?: CommandHistoryStorage;
+  timeZone?: string;
+  sessionWrapper?: SessionWrapper;
+  plugins?: PluginModuleMap;
+  ref?: React.Ref<ConsolePanel>;
 } = {}) {
   return render(
     <ConsolePanel
+      ref={ref}
       glEventHub={eventHub}
       glContainer={container}
       commandHistoryStorage={commandHistoryStorage}
       timeZone={timeZone}
       sessionWrapper={sessionWrapper}
       localDashboardId="mock-localDashboardId"
-      plugins={new Map()}
+      plugins={plugins}
     />
   );
 }
@@ -87,4 +108,80 @@ beforeEach(() => {
 it('renders without crashing', () => {
   const { unmount } = renderConsolePanel();
   unmount();
+});
+
+describe('openWidget', () => {
+  function TestWidget() {
+    return null;
+  }
+
+  const widgetPlugin: WidgetPlugin = {
+    name: 'test-widget-plugin',
+    type: PluginType.WIDGET_PLUGIN,
+    component: TestWidget,
+    supportedTypes: 'test-widget',
+  };
+
+  const dashboardPayload = {
+    pluginId: 'test-widget-dashboard-plugin',
+    title: 'Test Dashboard',
+    data: { foo: 'bar' },
+  };
+
+  const widgetDashboardPlugin: WidgetDashboardPlugin = {
+    name: 'test-widget-dashboard-plugin',
+    type: PluginType.WIDGET_PLUGIN,
+    component: TestWidget,
+    supportedTypes: 'test-widget',
+    dashboardTypes: 'test-dashboard',
+    createDashboardPayload: jest.fn(() => dashboardPayload),
+  };
+
+  it('emits CREATE_DASHBOARD when a matching widget dashboard plugin is found', () => {
+    const eventHub = TestUtils.createMockProxy<EventEmitter>();
+    const ref = React.createRef<ConsolePanel>();
+    const plugins: PluginModuleMap = new Map([
+      [widgetDashboardPlugin.name, widgetDashboardPlugin],
+    ]);
+    renderConsolePanel({ eventHub, plugins, ref });
+
+    const widget = { type: 'test-dashboard', name: 'test', title: 'Test' };
+    ref.current?.openWidget(widget);
+
+    expect(widgetDashboardPlugin.createDashboardPayload).toHaveBeenCalledWith(
+      widget
+    );
+    expect(eventHub.emit).toHaveBeenCalledWith(
+      CREATE_DASHBOARD,
+      dashboardPayload
+    );
+    expect(eventHub.emit).not.toHaveBeenCalledWith(
+      PanelEvent.OPEN,
+      expect.anything()
+    );
+  });
+
+  it('emits PanelEvent.OPEN when no widget dashboard plugin matches', () => {
+    const eventHub = TestUtils.createMockProxy<EventEmitter>();
+    const ref = React.createRef<ConsolePanel>();
+    const plugins: PluginModuleMap = new Map([
+      [widgetPlugin.name, widgetPlugin],
+      [widgetDashboardPlugin.name, widgetDashboardPlugin],
+    ]);
+    renderConsolePanel({ eventHub, plugins, ref });
+
+    const widget = { type: 'test-widget', name: 'test', title: 'Test' };
+    ref.current?.openWidget(widget);
+
+    expect(eventHub.emit).toHaveBeenCalledWith(
+      PanelEvent.OPEN,
+      expect.objectContaining({
+        widget: expect.objectContaining({ type: 'test-widget' }),
+      })
+    );
+    expect(eventHub.emit).not.toHaveBeenCalledWith(
+      CREATE_DASHBOARD,
+      expect.anything()
+    );
+  });
 });

--- a/packages/dashboard-core-plugins/src/panels/ConsolePanel.test.tsx
+++ b/packages/dashboard-core-plugins/src/panels/ConsolePanel.test.tsx
@@ -1,10 +1,7 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import { type CommandHistoryStorage } from '@deephaven/console';
-import {
-  CREATE_DASHBOARD,
-  PanelEvent,
-} from '@deephaven/dashboard';
+import { CREATE_DASHBOARD, PanelEvent } from '@deephaven/dashboard';
 import type { Container, EventEmitter } from '@deephaven/golden-layout';
 import type { IdeConnection, IdeSession } from '@deephaven/jsapi-types';
 import { dh } from '@deephaven/jsapi-shim';

--- a/packages/dashboard-core-plugins/src/panels/ConsolePanel.tsx
+++ b/packages/dashboard-core-plugins/src/panels/ConsolePanel.tsx
@@ -223,6 +223,10 @@ export class ConsolePanel extends PureComponent<
     return id;
   }
 
+  /**
+   * Removes the item ID mapping from state by its ID value.
+   * @param id The item ID to delete from the itemIds map.
+   */
   private deleteItemId(id: string): void {
     this.setState(({ itemIds }) => {
       log.debug('Delete item', id, itemIds);
@@ -256,6 +260,12 @@ export class ConsolePanel extends PureComponent<
     }
   }
 
+  /**
+   * Handles a panel closed event. Removes the panel's item ID mapping unless
+   * the panel was replaced (i.e. a panel with the same ID still exists in the layout),
+   * in which case the mapping is retained for the replacement panel.
+   * @param panelId The ID of the panel that was closed.
+   */
   handlePanelClosed(panelId: string): void {
     // When replacing a panel, LayoutUtils.openComponent adds the new panel before removing the old
     // one, so the old panel's CLOSED event fires with the same panelId as the new panel.

--- a/packages/dashboard-core-plugins/src/panels/ConsolePanel.tsx
+++ b/packages/dashboard-core-plugins/src/panels/ConsolePanel.tsx
@@ -15,7 +15,9 @@ import {
 import {
   type DashboardPanelProps,
   emitCloseDashboard,
+  emitCreateDashboard,
   emitPanelOpen,
+  emitPanelClose,
   LayoutManagerContext,
   LayoutUtils,
   PanelEvent,
@@ -33,6 +35,7 @@ import {
 import { assertNotNull } from '@deephaven/utils';
 import {
   getIconForPlugin,
+  getWidgetDashboardPlugin,
   pluginSupportsType,
   type PluginModuleMap,
 } from '@deephaven/plugin';
@@ -220,6 +223,19 @@ export class ConsolePanel extends PureComponent<
     return id;
   }
 
+  private deleteItemId(id: string): void {
+    this.setState(({ itemIds }) => {
+      log.debug('Delete item', id, itemIds);
+      const key = [...itemIds.keys()].find(k => itemIds.get(k) === id);
+      if (key === undefined) {
+        return null;
+      }
+      const newItemIds = new Map(itemIds);
+      newItemIds.delete(key);
+      return { itemIds: newItemIds };
+    });
+  }
+
   handleTabFocus(): void {
     this.consoleRef.current?.focus();
   }
@@ -238,6 +254,22 @@ export class ConsolePanel extends PureComponent<
         this.setItemId(panelId, panelId);
       }
     }
+  }
+
+  handlePanelClosed(panelId: string): void {
+    // When replacing a panel, LayoutUtils.openComponent adds the new panel before removing the old
+    // one, so the old panel's CLOSED event fires with the same panelId as the new panel.
+    // If a panel with panelId still exists, it was replaced and we should not delete the itemId.
+    const { glContainer } = this.props;
+    const root = LayoutUtils.getRootFromContainer(glContainer);
+    const stack = LayoutUtils.getStackForConfig(root, { id: panelId });
+    if (
+      stack !== null &&
+      LayoutUtils.getContentItemInStack(stack, { id: panelId }) !== null
+    ) {
+      return;
+    }
+    this.deleteItemId(panelId);
   }
 
   handleFocusCommandHistory(): void {
@@ -282,7 +314,7 @@ export class ConsolePanel extends PureComponent<
       const id = this.getItemId(title, false);
       if (id != null) {
         const { glEventHub } = this.props;
-        glEventHub.emit(PanelEvent.CLOSE, id);
+        emitPanelClose(glEventHub, id);
         // Just emit for all panels since there shouldn't be dashboard and panel name conflicts
         emitCloseDashboard(glEventHub, title);
       }
@@ -302,23 +334,45 @@ export class ConsolePanel extends PureComponent<
    * @param widget The widget to open
    */
   openWidget(widget: dh.ide.VariableDescriptor & { title?: string }): void {
+    const { glEventHub, plugins } = this.props;
+    const { type } = widget;
+    const widgetDashboardPlugin = getWidgetDashboardPlugin(plugins, type);
+    if (widgetDashboardPlugin != null) {
+      // If it can be opened as a dashboard, open it as a dashboard. Otherwise, open it as a panel.
+      const dashboardPayload =
+        widgetDashboardPlugin.createDashboardPayload(widget);
+      log.debug('openDashboardWidget', dashboardPayload);
+      emitCreateDashboard(glEventHub, dashboardPayload);
+    } else {
+      this.openPanelWidget(widget);
+    }
+  }
+
+  /**
+   * Open the given widget in a new panel. This is used for all widget types except "widget dashboard" types, which are widgets that should be opened in a new dashboard instead of a panel.
+   * @param widget The widget to open
+   */
+  private openPanelWidget(
+    widget: dh.ide.VariableDescriptor & { title?: string }
+  ): void {
     const { glEventHub, sessionWrapper } = this.props;
     assertNotNull(sessionWrapper);
 
     const { config, session } = sessionWrapper;
     const { title = widget.name } = widget;
     assertNotNull(title);
-    const panelId = this.getItemId(title);
+    const itemId = this.getItemId(title);
+    assertNotNull(itemId);
     const openOptions = {
       fetch: () => session.getObject(widget),
-      panelId,
+      panelId: itemId,
       widget: {
         ...getVariableDescriptor(widget),
         sessionId: config.id,
       },
     };
 
-    log.debug('openWidget', openOptions);
+    log.debug('openPanelWidget', openOptions);
 
     emitPanelOpen(glEventHub, openOptions);
   }
@@ -341,7 +395,7 @@ export class ConsolePanel extends PureComponent<
     const panelIdsToClose = [...itemIds.values()];
     const { glEventHub } = this.props;
     panelIdsToClose.forEach(panelId => {
-      glEventHub.emit(PanelEvent.CLOSE, panelId);
+      emitPanelClose(glEventHub, panelId);
     });
 
     this.setState({ itemIds: new Map() });

--- a/packages/dashboard/src/PanelEvent.ts
+++ b/packages/dashboard/src/PanelEvent.ts
@@ -78,6 +78,12 @@ export const {
   useListener: usePanelOpenListener,
 } = makeEventFunctions<[detail: PanelOpenEventDetail]>(PanelEvent.OPEN);
 
+export const {
+  listen: listenForPanelClose,
+  emit: emitPanelClose,
+  useListener: usePanelCloseListener,
+} = makeEventFunctions<[panelId: string]>(PanelEvent.CLOSE);
+
 // TODO (#2147): Add the rest of the event functions here. Need to create the correct types for all of them.
 
 export default PanelEvent;

--- a/packages/plugin/src/PluginTypes.test.ts
+++ b/packages/plugin/src/PluginTypes.test.ts
@@ -11,8 +11,28 @@ import {
   type Plugin,
   type WidgetPlugin,
   type WidgetMiddlewarePlugin,
+  isWidgetDashboardPlugin,
+  type WidgetDashboardPlugin,
   isPlugin,
 } from './PluginTypes';
+
+function TestComponent() {
+  return null;
+}
+
+const widgetPlugin: WidgetPlugin = {
+  name: 'test-widget-plugin',
+  type: PluginType.WIDGET_PLUGIN,
+  component: TestComponent,
+  supportedTypes: 'test-widget',
+};
+
+const widgetDashboardPlugin: WidgetDashboardPlugin = {
+  ...widgetPlugin,
+  name: 'test-widget-dashboard-plugin',
+  dashboardTypes: 'test-dashboard',
+  createDashboardPayload: jest.fn(),
+};
 
 const pluginTypeToTypeGuardMap = [
   [PluginType.AUTH_PLUGIN, isAuthPlugin],
@@ -84,6 +104,45 @@ describe('isWidgetMiddlewarePlugin', () => {
       isWidgetMiddlewarePlugin({
         name: 'test',
         type: PluginType.DASHBOARD_PLUGIN,
+      })
+    ).toBe(false);
+  });
+});
+
+describe('isWidgetDashboardPlugin', () => {
+  it('returns true for a widget plugin with dashboardTypes set', () => {
+    expect(isWidgetDashboardPlugin(widgetDashboardPlugin)).toBe(true);
+  });
+
+  it('returns true when dashboardTypes is an array', () => {
+    expect(
+      isWidgetDashboardPlugin({
+        ...widgetDashboardPlugin,
+        dashboardTypes: ['test-dashboard', 'test-dashboard-two'],
+      })
+    ).toBe(true);
+  });
+
+  it('returns false for a widget plugin without dashboardTypes', () => {
+    expect(isWidgetDashboardPlugin(widgetPlugin)).toBe(false);
+  });
+
+  it('returns false for non-widget plugins', () => {
+    expect(
+      isWidgetDashboardPlugin({
+        name: 'test',
+        type: PluginType.DASHBOARD_PLUGIN,
+        component: TestComponent,
+      })
+    ).toBe(false);
+  });
+
+  it('returns false when dashboardTypes is null', () => {
+    expect(
+      isWidgetDashboardPlugin({
+        ...widgetPlugin,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        dashboardTypes: null as any,
       })
     ).toBe(false);
   });

--- a/packages/plugin/src/PluginTypes.ts
+++ b/packages/plugin/src/PluginTypes.ts
@@ -1,5 +1,8 @@
 import type { BaseThemeType } from '@deephaven/components';
-import type { WidgetDescriptor } from '@deephaven/dashboard';
+import type {
+  CreateDashboardPayload,
+  WidgetDescriptor,
+} from '@deephaven/dashboard';
 import {
   type EventEmitter,
   type ItemContainer,
@@ -261,10 +264,41 @@ export interface WidgetPlugin<T = unknown> extends Plugin {
   icon?: IconDefinition | React.ReactElement<unknown>;
 }
 
+/**
+ * Special type of WidgetPlugin that supports opening a widget as a dashboard instead of a panel.
+ */
+export interface WidgetDashboardPlugin<T = unknown> extends WidgetPlugin<T> {
+  /**
+   * The widget dashboard types that this plugin can handle.
+   * Widgets of these types can be opened by this plugin as a dashboard using the `createDashboardPayload` function.
+   * Can overlap with `supportedTypes` for widgets that can be opened as either a panel or a dashboard (e.g. nested dashboards).
+   */
+  dashboardTypes: string | string[];
+
+  /**
+   * A function to generate the dashboard payload for creating a new dashboard when a widget of widget is opened.
+   * @param widget Widget to get the create dashboard payload for
+   * @returns The dashboard payload for creating a new dashboard
+   */
+  createDashboardPayload<D extends WidgetDescriptor>(
+    widget: D
+  ): CreateDashboardPayload;
+}
+
 export function isWidgetPlugin(
   plugin: PluginModuleExport
 ): plugin is WidgetPlugin {
   return 'type' in plugin && plugin.type === PluginType.WIDGET_PLUGIN;
+}
+
+export function isWidgetDashboardPlugin(
+  plugin: PluginModuleExport
+): plugin is WidgetDashboardPlugin {
+  return (
+    isWidgetPlugin(plugin) &&
+    'dashboardTypes' in plugin &&
+    plugin.dashboardTypes != null
+  );
 }
 
 export interface TablePlugin extends Plugin {

--- a/packages/plugin/src/PluginTypes.ts
+++ b/packages/plugin/src/PluginTypes.ts
@@ -280,9 +280,7 @@ export interface WidgetDashboardPlugin<T = unknown> extends WidgetPlugin<T> {
    * @param widget Widget to get the create dashboard payload for
    * @returns The dashboard payload for creating a new dashboard
    */
-  createDashboardPayload<D extends WidgetDescriptor>(
-    widget: D
-  ): CreateDashboardPayload;
+  createDashboardPayload: (widget: WidgetDescriptor) => CreateDashboardPayload;
 }
 
 export function isWidgetPlugin(

--- a/packages/plugin/src/PluginUtils.test.tsx
+++ b/packages/plugin/src/PluginUtils.test.tsx
@@ -14,15 +14,12 @@ import {
   PluginType,
   type ThemePlugin,
   type WidgetPlugin,
-<<<<<<< HEAD
   type WidgetMiddlewarePlugin,
   type WidgetComponentProps,
   type WidgetMiddlewareComponentProps,
   type WidgetPanelProps,
   type WidgetMiddlewarePanelProps,
-=======
   type WidgetDashboardPlugin,
->>>>>>> fdfefce4e1 (feat: DH-21757: Allow widget plugins to register types as dashboard types)
 } from './PluginTypes';
 import {
   pluginSupportsType,
@@ -30,15 +27,12 @@ import {
   getIconForPlugin,
   getThemeDataFromPlugins,
   getPluginsElementMap,
-<<<<<<< HEAD
   getPluginModuleValue,
   processLoadedModule,
   registerPlugin,
   createChainedComponent,
   createChainedPanelComponent,
-=======
   getWidgetDashboardPlugin,
->>>>>>> fdfefce4e1 (feat: DH-21757: Allow widget plugins to register types as dashboard types)
 } from './PluginUtils';
 
 function TestWidget() {
@@ -163,9 +157,7 @@ describe('getWidgetDashboardPlugin', () => {
   });
 
   it('returns null for an empty plugin map', () => {
-    expect(
-      getWidgetDashboardPlugin(new Map(), 'test-dashboard')
-    ).toBeNull();
+    expect(getWidgetDashboardPlugin(new Map(), 'test-dashboard')).toBeNull();
   });
 });
 

--- a/packages/plugin/src/PluginUtils.test.tsx
+++ b/packages/plugin/src/PluginUtils.test.tsx
@@ -14,22 +14,31 @@ import {
   PluginType,
   type ThemePlugin,
   type WidgetPlugin,
+<<<<<<< HEAD
   type WidgetMiddlewarePlugin,
   type WidgetComponentProps,
   type WidgetMiddlewareComponentProps,
   type WidgetPanelProps,
   type WidgetMiddlewarePanelProps,
+=======
+  type WidgetDashboardPlugin,
+>>>>>>> fdfefce4e1 (feat: DH-21757: Allow widget plugins to register types as dashboard types)
 } from './PluginTypes';
 import {
   pluginSupportsType,
+  pluginSupportsTypeAsDashboard,
   getIconForPlugin,
   getThemeDataFromPlugins,
   getPluginsElementMap,
+<<<<<<< HEAD
   getPluginModuleValue,
   processLoadedModule,
   registerPlugin,
   createChainedComponent,
   createChainedPanelComponent,
+=======
+  getWidgetDashboardPlugin,
+>>>>>>> fdfefce4e1 (feat: DH-21757: Allow widget plugins to register types as dashboard types)
 } from './PluginUtils';
 
 function TestWidget() {
@@ -72,6 +81,92 @@ test('pluginSupportsType', () => {
   expect(pluginSupportsType(widgetPlugin, 'test-widget-three')).toBe(false);
   expect(pluginSupportsType(dashboardPlugin, 'test-widget')).toBe(false);
   expect(pluginSupportsType(undefined, 'test-widget')).toBe(false);
+});
+
+const widgetDashboardPlugin: WidgetDashboardPlugin = {
+  name: 'test-widget-dashboard-plugin',
+  type: PluginType.WIDGET_PLUGIN,
+  component: TestWidget,
+  supportedTypes: ['test-widget'],
+  dashboardTypes: ['test-dashboard', 'test-dashboard-two'],
+  createDashboardPayload: jest.fn(),
+};
+
+const widgetDashboardPluginSingleType: WidgetDashboardPlugin = {
+  ...widgetDashboardPlugin,
+  name: 'test-widget-dashboard-plugin-single',
+  dashboardTypes: 'test-dashboard-single',
+};
+
+describe('pluginSupportsTypeAsDashboard', () => {
+  it('returns true for matching dashboard types', () => {
+    expect(
+      pluginSupportsTypeAsDashboard(widgetDashboardPlugin, 'test-dashboard')
+    ).toBe(true);
+    expect(
+      pluginSupportsTypeAsDashboard(widgetDashboardPlugin, 'test-dashboard-two')
+    ).toBe(true);
+    expect(
+      pluginSupportsTypeAsDashboard(
+        widgetDashboardPluginSingleType,
+        'test-dashboard-single'
+      )
+    ).toBe(true);
+  });
+
+  it('returns false for non-matching dashboard types', () => {
+    expect(
+      pluginSupportsTypeAsDashboard(widgetDashboardPlugin, 'unknown')
+    ).toBe(false);
+    // supportedTypes should not satisfy dashboard types
+    expect(
+      pluginSupportsTypeAsDashboard(widgetDashboardPlugin, 'test-widget')
+    ).toBe(false);
+  });
+
+  it('returns false for non-widget-dashboard plugins', () => {
+    expect(pluginSupportsTypeAsDashboard(widgetPlugin, 'test-widget')).toBe(
+      false
+    );
+    expect(
+      pluginSupportsTypeAsDashboard(dashboardPlugin, 'test-dashboard')
+    ).toBe(false);
+    expect(pluginSupportsTypeAsDashboard(undefined, 'test-dashboard')).toBe(
+      false
+    );
+  });
+});
+
+describe('getWidgetDashboardPlugin', () => {
+  const pluginMap = new Map<string, PluginModule>([
+    [widgetPlugin.name, widgetPlugin],
+    [dashboardPlugin.name, dashboardPlugin],
+    [widgetDashboardPlugin.name, widgetDashboardPlugin],
+    [widgetDashboardPluginSingleType.name, widgetDashboardPluginSingleType],
+  ]);
+
+  it('returns the plugin matching the dashboard type', () => {
+    expect(getWidgetDashboardPlugin(pluginMap, 'test-dashboard')).toBe(
+      widgetDashboardPlugin
+    );
+    expect(getWidgetDashboardPlugin(pluginMap, 'test-dashboard-two')).toBe(
+      widgetDashboardPlugin
+    );
+    expect(getWidgetDashboardPlugin(pluginMap, 'test-dashboard-single')).toBe(
+      widgetDashboardPluginSingleType
+    );
+  });
+
+  it('returns null when no plugin matches', () => {
+    expect(getWidgetDashboardPlugin(pluginMap, 'test-widget')).toBeNull();
+    expect(getWidgetDashboardPlugin(pluginMap, 'unknown')).toBeNull();
+  });
+
+  it('returns null for an empty plugin map', () => {
+    expect(
+      getWidgetDashboardPlugin(new Map(), 'test-dashboard')
+    ).toBeNull();
+  });
 });
 
 const DEFAULT_ICON = <FontAwesomeIcon icon={vsPreview} />;

--- a/packages/plugin/src/PluginUtils.tsx
+++ b/packages/plugin/src/PluginUtils.tsx
@@ -21,6 +21,8 @@ import {
   isPlugin,
   type LegacyPlugin,
   type Plugin,
+  type WidgetDashboardPlugin,
+  isWidgetDashboardPlugin,
 } from './PluginTypes';
 
 const log = Log.module('@deephaven/plugin.PluginUtils');
@@ -46,6 +48,23 @@ export function pluginSupportsType(
   }
 
   return [plugin.supportedTypes].flat().some(t => t === type);
+}
+
+/**
+ * Check if the given plugin supports opening a widget of the given type as a dashboard.
+ * @param plugin Plugin to check
+ * @param type Widget type
+ * @returns True if plugin supports opening it as a dashboard
+ */
+export function pluginSupportsTypeAsDashboard(
+  plugin: PluginModule | undefined,
+  type: string
+): boolean {
+  if (plugin == null || !isWidgetDashboardPlugin(plugin)) {
+    return false;
+  }
+
+  return [plugin.dashboardTypes].flat().some(t => t === type);
 }
 
 export function getIconForPlugin(plugin: PluginModule): React.ReactElement {
@@ -489,4 +508,23 @@ export function sortPluginsByDependency<
   }
 
   return sorted;
+}
+
+/**
+ * Get the WidgetPlugin that supports opening a widget of the given type as a dashboard.
+ * @param pluginMap Map of available plugins
+ * @param type Type of widget to check
+ * @returns The WidgetPlugin that supports opening this widget as a dashboard
+ */
+export function getWidgetDashboardPlugin(
+  pluginMap: PluginModuleMap,
+  type: string
+): WidgetDashboardPlugin | null {
+  return (
+    [...pluginMap.values()].find(
+      (entry): entry is WidgetDashboardPlugin =>
+        isWidgetDashboardPlugin(entry) &&
+        [entry.dashboardTypes].flat().some(t => t === type)
+    ) ?? null
+  );
 }

--- a/packages/plugin/src/PluginUtils.tsx
+++ b/packages/plugin/src/PluginUtils.tsx
@@ -514,7 +514,7 @@ export function sortPluginsByDependency<
  * Get the WidgetPlugin that supports opening a widget of the given type as a dashboard.
  * @param pluginMap Map of available plugins
  * @param type Type of widget to check
- * @returns The WidgetPlugin that supports opening this widget as a dashboard
+ * @returns The WidgetPlugin that supports opening this widget as a dashboard, or null if no matching plugin is found
  */
 export function getWidgetDashboardPlugin(
   pluginMap: PluginModuleMap,


### PR DESCRIPTION
- Allows widget plugins to register a type as a dashboard type, and create the dashboard payload
  - Avoids the current hack where the ui DashboardPlugin intercepts the panel open and then emits a dashboard creation, is more explicit about how it's handled
  - Also allows other plugins to potential register dashboard types
- Used by https://github.com/deephaven/deephaven-plugins/pull/1341, Enterprise draft at https://github.com/deephaven-ent/iris/pull/4653
- Leaves the door open for if we want to have an option for allowing dashboards to open as a panel by default (for now, you can just wrap a dashboard in a `ui.panel`)