### PR TITLE
fix: DH-22547: ESC cancels background row position

### DIFF
--- a/packages/iris-grid/src/IrisGrid.tsx
+++ b/packages/iris-grid/src/IrisGrid.tsx
@@ -4184,6 +4184,7 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
     this.setState({
       showOverflowModal: false,
     });
+    this.grid?.focus(); // Focus on the grid after closing the overflow modal
   }
 
   handleOpenNoPastePermissionModal(errorMessage: string): void {

--- a/packages/iris-grid/src/IrisGridCellOverflowModal.tsx
+++ b/packages/iris-grid/src/IrisGridCellOverflowModal.tsx
@@ -117,6 +117,7 @@ export default function IrisGridCellOverflowModal({
       setHeight(contentHeight)
     );
     autoSetLineNumbers();
+    (document.activeElement as HTMLElement)?.blur();
   }
 
   if (!isOpen && !isOpened) {

--- a/packages/iris-grid/src/mousehandlers/IrisGridCellOverflowMouseHandler.ts
+++ b/packages/iris-grid/src/mousehandlers/IrisGridCellOverflowMouseHandler.ts
@@ -131,6 +131,7 @@ class IrisGridCellOverflowMouseHandler extends GridMouseHandler {
         showOverflowModal: true,
         overflowText: this.irisGrid.getValueForCell(column, row) as string,
       });
+      return true; // Consume the event so GridSelectionMouseHandler doesn't clear the row selection
     }
 
     return false;


### PR DESCRIPTION
**fix: ESC closes cell overflow modal without clearing row selection**

Focuses the modal’s editor when opened so ESC is handled by the Modal’s window key handler.
Restores grid focus after the modal closes for keyboard navigation.