### PR TITLE
fix: DH-22677: Adjust dotted line position in upload screen UI

### DIFF
--- a/packages/console/src/csv/CsvOverlay.scss
+++ b/packages/console/src/csv/CsvOverlay.scss
@@ -1,7 +1,7 @@
 @import '@deephaven/components/scss/custom.scss';
 
 .csv-overlay {
-  margin: $spacer-2;
+  margin: $spacer-0 $spacer-3 $spacer-0;
   background: color-mix(in srgb, var(--dh-color-content-bg) 70%, transparent);
   text-align: center;
   display: flex;


### PR DESCRIPTION
Fix upload screen dotted border to fully encompass content and reach container edges, preventing text from sticking out.