### PR TITLE
fix: DH-16187: send imploded value to AutoResizeTextarea parent

### DIFF
--- a/packages/components/src/AutoResizeTextarea.test.tsx
+++ b/packages/components/src/AutoResizeTextarea.test.tsx
@@ -5,13 +5,27 @@ import AutoResizeTextarea from './AutoResizeTextarea';
 function renderTextarea(
   props: Partial<React.ComponentProps<typeof AutoResizeTextarea>> = {}
 ) {
-  const { value = '', onChange = jest.fn(), ...rest } = props;
+  const {
+    value = '',
+    onChange = jest.fn(),
+    className,
+    spellCheck,
+    placeholder,
+    disabled,
+    delimiter,
+    id,
+  } = props;
   return render(
     <AutoResizeTextarea
       value={value}
       onChange={onChange}
+      className={className}
+      spellCheck={spellCheck}
+      placeholder={placeholder}
+      disabled={disabled}
+      delimiter={delimiter}
+      id={id}
       data-testid="auto-resize-textarea"
-      {...rest}
     />
   );
 }

--- a/packages/components/src/AutoResizeTextarea.test.tsx
+++ b/packages/components/src/AutoResizeTextarea.test.tsx
@@ -1,16 +1,19 @@
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 import AutoResizeTextarea from './AutoResizeTextarea';
 
-const DEFAULT_PROPS = {
-  value: '',
-  onChange: jest.fn(),
-  'data-testid': 'auto-resize-textarea',
-};
-
-function renderTextarea(props = {}) {
-  return render(<AutoResizeTextarea {...DEFAULT_PROPS} {...props} />);
+function renderTextarea(
+  props: Partial<React.ComponentProps<typeof AutoResizeTextarea>> = {}
+) {
+  const { value = '', onChange = jest.fn(), ...rest } = props;
+  return render(
+    <AutoResizeTextarea
+      value={value}
+      onChange={onChange}
+      data-testid="auto-resize-textarea"
+      {...rest}
+    />
+  );
 }
 
 function getTextarea() {
@@ -124,10 +127,10 @@ describe('AutoResizeTextarea', () => {
       const onChange = jest.fn();
       const { rerender } = render(
         <AutoResizeTextarea
-          {...DEFAULT_PROPS}
           value={IMPLODED_VALUE}
-          delimiter={DELIMITER}
           onChange={onChange}
+          delimiter={DELIMITER}
+          data-testid="auto-resize-textarea"
         />
       );
       const textarea = getTextarea();
@@ -144,10 +147,10 @@ describe('AutoResizeTextarea', () => {
       const implodedFromOnChange = onChange.mock.calls[0][0];
       rerender(
         <AutoResizeTextarea
-          {...DEFAULT_PROPS}
           value={implodedFromOnChange}
-          delimiter={DELIMITER}
           onChange={onChange}
+          delimiter={DELIMITER}
+          data-testid="auto-resize-textarea"
         />
       );
 
@@ -200,11 +203,22 @@ describe('AutoResizeTextarea', () => {
 
   describe('syncs with prop changes', () => {
     it('updates internal value when prop value changes', () => {
+      const onChange = jest.fn();
       const { rerender } = render(
-        <AutoResizeTextarea {...DEFAULT_PROPS} value="initial" />
+        <AutoResizeTextarea
+          value="initial"
+          onChange={onChange}
+          data-testid="auto-resize-textarea"
+        />
       );
 
-      rerender(<AutoResizeTextarea {...DEFAULT_PROPS} value="updated" />);
+      rerender(
+        <AutoResizeTextarea
+          value="updated"
+          onChange={onChange}
+          data-testid="auto-resize-textarea"
+        />
+      );
 
       expect(getTextarea()).toHaveValue('updated');
     });

--- a/packages/components/src/AutoResizeTextarea.test.tsx
+++ b/packages/components/src/AutoResizeTextarea.test.tsx
@@ -172,6 +172,104 @@ describe('AutoResizeTextarea', () => {
       expect(textarea).toHaveValue(editedExploded);
     });
 
+    it('explodes new prop value received while focused', () => {
+      const onChange = jest.fn();
+      const { rerender } = render(
+        <AutoResizeTextarea
+          value="-Xmx512m -Xms256m"
+          onChange={onChange}
+          delimiter={DELIMITER}
+          data-testid="auto-resize-textarea"
+        />
+      );
+      const textarea = getTextarea();
+
+      fireEvent.focus(textarea);
+      expect(textarea).toHaveValue('-Xmx512m\n-Xms256m');
+
+      // Parent provides an entirely new value while still focused
+      rerender(
+        <AutoResizeTextarea
+          value="-Xmx1024m -Xms512m -Dfoo=bar"
+          onChange={onChange}
+          delimiter={DELIMITER}
+          data-testid="auto-resize-textarea"
+        />
+      );
+
+      // Display should show the exploded version of the new prop value
+      expect(textarea).toHaveValue('-Xmx1024m\n-Xms512m\n-Dfoo=bar');
+    });
+
+    it('does not strip a partially-typed delimiter when parent re-renders', () => {
+      const onChange = jest.fn();
+      const { rerender } = render(
+        <AutoResizeTextarea
+          value="-Xmx512m -Xms256m"
+          onChange={onChange}
+          delimiter={DELIMITER}
+          data-testid="auto-resize-textarea"
+        />
+      );
+      const textarea = getTextarea();
+
+      fireEvent.focus(textarea);
+
+      // User types " -" at the end to start a new arg — display has a trailing delimiter
+      const withPartialArg = '-Xmx512m\n-Xms256m\n-';
+      fireEvent.change(textarea, { target: { value: withPartialArg } });
+
+      // onChange reports the imploded form: "-Xmx512m -Xms256m -"
+      const implodedWithPartial = onChange.mock.calls[0][0];
+      expect(implodedWithPartial).toBe('-Xmx512m -Xms256m -');
+
+      // Parent re-renders with that value
+      rerender(
+        <AutoResizeTextarea
+          value={implodedWithPartial}
+          onChange={onChange}
+          delimiter={DELIMITER}
+          data-testid="auto-resize-textarea"
+        />
+      );
+
+      // The trailing "-" must NOT be stripped from the display
+      expect(textarea).toHaveValue(withPartialArg);
+    });
+
+    it('does not clobber a trailing newline when parent re-renders', () => {
+      const onChange = jest.fn();
+      const { rerender } = render(
+        <AutoResizeTextarea
+          value="-Xmx512m -Xms256m"
+          onChange={onChange}
+          delimiter={DELIMITER}
+          data-testid="auto-resize-textarea"
+        />
+      );
+      const textarea = getTextarea();
+
+      fireEvent.focus(textarea);
+
+      // User presses Enter to start typing a new arg
+      const withTrailingNewline = '-Xmx512m\n-Xms256m\n';
+      fireEvent.change(textarea, { target: { value: withTrailingNewline } });
+
+      // Parent re-renders with the onChange value
+      const implodedValue = onChange.mock.calls[0][0];
+      rerender(
+        <AutoResizeTextarea
+          value={implodedValue}
+          onChange={onChange}
+          delimiter={DELIMITER}
+          data-testid="auto-resize-textarea"
+        />
+      );
+
+      // The trailing newline must NOT be stripped from the display
+      expect(textarea).toHaveValue(withTrailingNewline);
+    });
+
     it('explodes pasted content', () => {
       const onChange = jest.fn();
       renderTextarea({

--- a/packages/components/src/AutoResizeTextarea.test.tsx
+++ b/packages/components/src/AutoResizeTextarea.test.tsx
@@ -1,0 +1,212 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import AutoResizeTextarea from './AutoResizeTextarea';
+
+const DEFAULT_PROPS = {
+  value: '',
+  onChange: jest.fn(),
+  'data-testid': 'auto-resize-textarea',
+};
+
+function renderTextarea(props = {}) {
+  return render(<AutoResizeTextarea {...DEFAULT_PROPS} {...props} />);
+}
+
+function getTextarea() {
+  return screen.getByTestId('auto-resize-textarea') as HTMLTextAreaElement;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('AutoResizeTextarea', () => {
+  it('renders with the provided value', () => {
+    renderTextarea({ value: 'hello world' });
+    expect(getTextarea()).toHaveValue('hello world');
+  });
+
+  it('calls onChange when text is typed', async () => {
+    const onChange = jest.fn();
+    renderTextarea({ onChange });
+    const textarea = getTextarea();
+
+    fireEvent.change(textarea, { target: { value: 'new text' } });
+
+    expect(onChange).toHaveBeenCalledWith('new text');
+  });
+
+  it('applies custom className', () => {
+    renderTextarea({ className: 'my-class' });
+    expect(getTextarea()).toHaveClass('my-class');
+  });
+
+  it('renders with placeholder', () => {
+    renderTextarea({ placeholder: 'Enter text...' });
+    expect(getTextarea()).toHaveAttribute('placeholder', 'Enter text...');
+  });
+
+  it('renders disabled when disabled prop is true', () => {
+    renderTextarea({ disabled: true });
+    expect(getTextarea()).toBeDisabled();
+  });
+
+  describe('with delimiter', () => {
+    const DELIMITER = ' -';
+    const IMPLODED_VALUE = '-Xmx512m -Xms256m -Dfoo=bar';
+    const EXPLODED_VALUE = '-Xmx512m\n-Xms256m\n-Dfoo=bar';
+
+    it('explodes value on focus', () => {
+      renderTextarea({ value: IMPLODED_VALUE, delimiter: DELIMITER });
+      const textarea = getTextarea();
+
+      fireEvent.focus(textarea);
+
+      expect(textarea).toHaveValue(EXPLODED_VALUE);
+    });
+
+    it('implodes value on blur', () => {
+      const onChange = jest.fn();
+      renderTextarea({
+        value: IMPLODED_VALUE,
+        delimiter: DELIMITER,
+        onChange,
+      });
+      const textarea = getTextarea();
+
+      fireEvent.focus(textarea);
+      fireEvent.blur(textarea);
+
+      expect(onChange).toHaveBeenCalledWith(IMPLODED_VALUE);
+    });
+
+    it('calls onChange with imploded value during editing (not exploded)', () => {
+      const onChange = jest.fn();
+      renderTextarea({
+        value: IMPLODED_VALUE,
+        delimiter: DELIMITER,
+        onChange,
+      });
+      const textarea = getTextarea();
+
+      // Focus to explode
+      fireEvent.focus(textarea);
+
+      // Simulate editing the exploded value
+      const editedExploded = '-Xmx1024m\n-Xms256m\n-Dfoo=bar';
+      fireEvent.change(textarea, { target: { value: editedExploded } });
+
+      // onChange should receive the imploded version, not the exploded one
+      expect(onChange).toHaveBeenCalledWith('-Xmx1024m -Xms256m -Dfoo=bar');
+    });
+
+    it('never passes exploded value to onChange on change events', () => {
+      const onChange = jest.fn();
+      renderTextarea({
+        value: '-Xmx512m -Xms256m',
+        delimiter: DELIMITER,
+        onChange,
+      });
+      const textarea = getTextarea();
+
+      fireEvent.focus(textarea);
+      fireEvent.change(textarea, {
+        target: { value: '-Xmx512m\n-Xms256m\n-Dnew=val' },
+      });
+
+      // The onChange value should never contain newlines when delimiter is set
+      const calledWith = onChange.mock.calls[0][0];
+      expect(calledWith).not.toContain('\n');
+    });
+
+    it('does not collapse exploded display when parent re-renders with imploded value', () => {
+      const onChange = jest.fn();
+      const { rerender } = render(
+        <AutoResizeTextarea
+          {...DEFAULT_PROPS}
+          value={IMPLODED_VALUE}
+          delimiter={DELIMITER}
+          onChange={onChange}
+        />
+      );
+      const textarea = getTextarea();
+
+      // Focus to explode
+      fireEvent.focus(textarea);
+      expect(textarea).toHaveValue(EXPLODED_VALUE);
+
+      // Simulate typing a new arg (parent gets imploded value and re-renders)
+      const editedExploded = '-Xmx512m\n-Xms256m\n-Dfoo=bar\n-Dnew=val';
+      fireEvent.change(textarea, { target: { value: editedExploded } });
+
+      // Parent re-renders with the imploded value from onChange
+      const implodedFromOnChange = onChange.mock.calls[0][0];
+      rerender(
+        <AutoResizeTextarea
+          {...DEFAULT_PROPS}
+          value={implodedFromOnChange}
+          delimiter={DELIMITER}
+          onChange={onChange}
+        />
+      );
+
+      // The display should still show the exploded (multi-line) value, not collapse
+      expect(textarea).toHaveValue(editedExploded);
+    });
+
+    it('explodes pasted content', () => {
+      const onChange = jest.fn();
+      renderTextarea({
+        value: '',
+        delimiter: DELIMITER,
+        onChange,
+      });
+      const textarea = getTextarea();
+
+      fireEvent.focus(textarea);
+      fireEvent.paste(textarea);
+      fireEvent.change(textarea, {
+        target: { value: '-Xmx512m -Xms256m' },
+      });
+
+      // Display value should be exploded
+      expect(textarea).toHaveValue('-Xmx512m\n-Xms256m');
+      // onChange should still get imploded value
+      expect(onChange).toHaveBeenCalledWith('-Xmx512m -Xms256m');
+    });
+  });
+
+  describe('without delimiter', () => {
+    it('does not transform value on focus', () => {
+      renderTextarea({ value: 'no transform' });
+      const textarea = getTextarea();
+
+      fireEvent.focus(textarea);
+
+      expect(textarea).toHaveValue('no transform');
+    });
+
+    it('passes value directly to onChange without transformation', () => {
+      const onChange = jest.fn();
+      renderTextarea({ onChange });
+      const textarea = getTextarea();
+
+      fireEvent.change(textarea, { target: { value: 'line1\nline2' } });
+
+      expect(onChange).toHaveBeenCalledWith('line1\nline2');
+    });
+  });
+
+  describe('syncs with prop changes', () => {
+    it('updates internal value when prop value changes', () => {
+      const { rerender } = render(
+        <AutoResizeTextarea {...DEFAULT_PROPS} value="initial" />
+      );
+
+      rerender(<AutoResizeTextarea {...DEFAULT_PROPS} value="updated" />);
+
+      expect(getTextarea()).toHaveValue('updated');
+    });
+  });
+});

--- a/packages/components/src/AutoResizeTextarea.tsx
+++ b/packages/components/src/AutoResizeTextarea.tsx
@@ -41,7 +41,7 @@ function AutoResizeTextarea({
     function syncStateWithProp() {
       // keep state value in sync with prop changes
       // but not while focused, as the display value is exploded
-      // and the prop value is often imploded
+      // and the prop value might not be
       if (!isFocused.current) {
         setValue(propsValue);
       }

--- a/packages/components/src/AutoResizeTextarea.tsx
+++ b/packages/components/src/AutoResizeTextarea.tsx
@@ -36,7 +36,7 @@ function explode(input: string, delimiter: string): string {
 
 /**
  * Makes a textarea that auto resizes based on contents, its height grows with new lines.
- * If a delimeter is set, such as " -" or " ", as used by jvm args or env vars
+ * If a delimiter is set, such as " -" or " ", as used by jvm args or env vars
  * then the field will also "explode" the value by the delimiter over new lines
  * on focus, and implode on blur. By default, it doesn't word wrap.
  */
@@ -60,13 +60,12 @@ function AutoResizeTextarea({
 
   useEffect(
     function syncStateWithProp() {
-      if (!isFocused.current) {
-        // When not focused, always sync to the new prop value.
+      if (!isFocused.current || !delimiter) {
+        // When not focused (or no delimiter), always sync to the new prop value.
         setValue(propsValue);
       } else if (implode(valueRef.current) !== implode(propsValue)) {
-        // When focused, only update if the imploded value changed
-        // to prevent clobbering delimiters
-        setValue(delimiter ? explode(propsValue, delimiter) : propsValue);
+        // When focused with delimiter, only update if the imploded value changed to prevent clobbering delimiters
+        setValue(explode(propsValue, delimiter));
       }
     },
     [propsValue, delimiter]

--- a/packages/components/src/AutoResizeTextarea.tsx
+++ b/packages/components/src/AutoResizeTextarea.tsx
@@ -35,11 +35,16 @@ function AutoResizeTextarea({
   const [value, setValue] = useState(propsValue);
   const [isPastedChange, setIsPastedChange] = useState(false);
   const element = useRef<HTMLTextAreaElement>(null);
+  const isFocused = useRef(false);
 
   useEffect(
     function syncStateWithProp() {
       // keep state value in sync with prop changes
-      setValue(propsValue);
+      // but not while focused, as the display value is exploded
+      // and the prop value is often imploded
+      if (!isFocused.current) {
+        setValue(propsValue);
+      }
     },
     [propsValue]
   );
@@ -81,13 +86,17 @@ function AutoResizeTextarea({
       setIsPastedChange(false);
     }
     setValue(newValue);
-    onChange(newValue);
+    // If there is a delimiter, the onChange value should always be the imploded version
+    // to prevent mismatch when exiting without triggering onBlur
+    // The exploded version is display only
+    onChange(delimiter ? implode(newValue) : newValue);
   }
 
   function handleFocus(): void {
     if (!element.current) {
       return;
     }
+    isFocused.current = true;
     if (delimiter) {
       setValue(explode(value));
       reCalculateLayout();
@@ -106,6 +115,7 @@ function AutoResizeTextarea({
   }
 
   function handleBlur(): void {
+    isFocused.current = false;
     if (delimiter) {
       setValue(implode(value));
       onChange(implode(value));

--- a/packages/components/src/AutoResizeTextarea.tsx
+++ b/packages/components/src/AutoResizeTextarea.tsx
@@ -15,6 +15,25 @@ interface AutoResizeTextareaProps {
   'data-testid'?: string;
 }
 
+function implode(input: string): string {
+  return input
+    .split('\n')
+    .map(string => string.trim())
+    .filter(string => string) // remove empty strings (e.g. from trailing newlines)
+    .join(' ');
+}
+
+function explode(input: string, delimiter: string): string {
+  // split by delimiter, commonly " " or " -"
+  // strip empty strings (if delimiter is space, and there are multiple spaces in a row)
+  // and join with new line and a trimmed delimiter (get rid of leading spaces)
+  return input
+    .trim()
+    .split(delimiter)
+    .filter(string => string) // remove empty strings
+    .join(`\n${delimiter.trim()}`);
+}
+
 /**
  * Makes a textarea that auto resizes based on contents, its height grows with new lines.
  * If a delimeter is set, such as " -" or " ", as used by jvm args or env vars
@@ -36,36 +55,22 @@ function AutoResizeTextarea({
   const [isPastedChange, setIsPastedChange] = useState(false);
   const element = useRef<HTMLTextAreaElement>(null);
   const isFocused = useRef(false);
+  const valueRef = useRef(value);
+  valueRef.current = value;
 
   useEffect(
     function syncStateWithProp() {
-      // keep state value in sync with prop changes
-      // but not while focused, as the display value is exploded
-      // and the prop value might not be
       if (!isFocused.current) {
+        // When not focused, always sync to the new prop value.
         setValue(propsValue);
+      } else if (implode(valueRef.current) !== implode(propsValue)) {
+        // When focused, only update if the imploded value changed
+        // to prevent clobbering delimiters
+        setValue(delimiter ? explode(propsValue, delimiter) : propsValue);
       }
     },
-    [propsValue]
+    [propsValue, delimiter]
   );
-
-  function explode(input: string): string {
-    // split by delimiter, commonly " " or " -"
-    // strip empty strings (if delimiter is space, and there are multiple spaces in a row)
-    // and join with new line and a trimmed delimeter (get rid of leading spaces)
-    return input
-      .trim()
-      .split(delimiter)
-      .filter(string => string) // remove empty strings
-      .join(`\n${delimiter.trim()}`);
-  }
-
-  function implode(input: string): string {
-    return input
-      .split('\n')
-      .map(string => string.trim())
-      .join(' ');
-  }
 
   function reCalculateLayout(): void {
     if (!element.current) {
@@ -82,7 +87,7 @@ function AutoResizeTextarea({
   function handleChange(event: React.ChangeEvent<HTMLTextAreaElement>): void {
     let newValue = event.target.value;
     if (isPastedChange) {
-      if (delimiter) newValue = explode(newValue);
+      if (delimiter) newValue = explode(newValue, delimiter);
       setIsPastedChange(false);
     }
     setValue(newValue);
@@ -98,7 +103,7 @@ function AutoResizeTextarea({
     }
     isFocused.current = true;
     if (delimiter) {
-      setValue(explode(value));
+      setValue(explode(value, delimiter));
       reCalculateLayout();
     }
     element.current.scrollLeft = 0;


### PR DESCRIPTION
Previously, when editing an `AutoResizeTextarea`, the possibly exploded value would be sent as the value to the `onChange`, and the imploded value was sent `onBlur`. In cases that bypassed blur, such as saving with a keyboard shortcut, this meant the value was kept as the exploded one in the parent. In an `AutoResizeTextarea` that relies on the `onChange` prop to manage history, this meant that a field would show as updated upon next blur, even though it wasn't updated by the user, only by the implode. 
This change makes it so the imploded value is the one sent to the parent as the source of truth, and the exploded values are kept local to the `AutoResizeTextarea`.