### PR TITLE
fix: DH-15773: Coerce string to numeric for input filter

### DIFF
--- a/packages/chart/src/FigureChartModel.test.ts
+++ b/packages/chart/src/FigureChartModel.test.ts
@@ -590,3 +590,149 @@ it('handles axes min and max properly', () => {
 
   expect(layout.yaxis2?.autorangeoptions?.maxallowed).toEqual(undefined);
 });
+
+describe('setFilter', () => {
+  function makeOneClickModel({ columnName = 'Z', columnType = 'int' } = {}) {
+    const oneClick = {
+      columns: [{ name: columnName, type: columnType }],
+      requireAllFiltersToDisplay: false,
+      setValueForColumn: jest.fn(),
+    };
+
+    const series = chartTestUtils.makeSeries({ name: 'S1' });
+    // Attach oneClick to the series
+    (series as unknown as Record<string, unknown>).oneClick = oneClick;
+
+    const chart = chartTestUtils.makeChart({ series: [series] });
+    const figure = chartTestUtils.makeFigure({ charts: [chart] });
+    const model = new FigureChartModel(dh, figure);
+    model.subscribe(jest.fn());
+
+    return { model, oneClick };
+  }
+
+  describe('coerceFilterValue', () => {
+    it('coerces string to number for int column type', () => {
+      const { model, oneClick } = makeOneClickModel({ columnType: 'int' });
+      const filterMap = new Map([['Z', '1']]);
+
+      model.setFilter(filterMap);
+
+      expect(oneClick.setValueForColumn).toHaveBeenCalledWith('Z', 1);
+    });
+
+    it('coerces string to number for long column type', () => {
+      const { model, oneClick } = makeOneClickModel({ columnType: 'long' });
+      const filterMap = new Map([['Z', '42']]);
+
+      model.setFilter(filterMap);
+
+      expect(oneClick.setValueForColumn).toHaveBeenCalledWith('Z', 42);
+    });
+
+    it('coerces string to number for double column type', () => {
+      const { model, oneClick } = makeOneClickModel({ columnType: 'double' });
+      const filterMap = new Map([['Z', '3.14']]);
+
+      model.setFilter(filterMap);
+
+      expect(oneClick.setValueForColumn).toHaveBeenCalledWith('Z', 3.14);
+    });
+
+    it('coerces string "0" to number 0', () => {
+      const { model, oneClick } = makeOneClickModel({ columnType: 'int' });
+      const filterMap = new Map([['Z', '0']]);
+
+      model.setFilter(filterMap);
+
+      expect(oneClick.setValueForColumn).toHaveBeenCalledWith('Z', 0);
+    });
+
+    it('passes numeric value through unchanged', () => {
+      const { model, oneClick } = makeOneClickModel({ columnType: 'int' });
+      const filterMap = new Map<string, unknown>([['Z', 5]]);
+
+      model.setFilter(filterMap);
+
+      expect(oneClick.setValueForColumn).toHaveBeenCalledWith('Z', 5);
+    });
+
+    it('does not coerce string for string column type', () => {
+      const { model, oneClick } = makeOneClickModel({
+        columnType: 'java.lang.String',
+      });
+      const filterMap = new Map([['Z', '1']]);
+
+      model.setFilter(filterMap);
+
+      expect(oneClick.setValueForColumn).toHaveBeenCalledWith('Z', '1');
+    });
+
+    it('does not coerce non-numeric strings for number column type', () => {
+      const { model, oneClick } = makeOneClickModel({ columnType: 'int' });
+      const filterMap = new Map([['Z', 'abc']]);
+
+      model.setFilter(filterMap);
+
+      expect(oneClick.setValueForColumn).toHaveBeenCalledWith('Z', 'abc');
+    });
+
+    it('passes null/undefined to clear filter', () => {
+      const { model, oneClick } = makeOneClickModel({ columnType: 'int' });
+
+      // First set a value
+      model.setFilter(new Map<string, unknown>([['Z', '1']]));
+      // Then clear it
+      model.setFilter(new Map<string, unknown>([['Z', undefined]]));
+
+      expect(oneClick.setValueForColumn).toHaveBeenLastCalledWith(
+        'Z',
+        undefined
+      );
+    });
+  });
+
+  it('only calls setValueForColumn when value changes', () => {
+    const { model, oneClick } = makeOneClickModel();
+
+    model.setFilter(new Map([['Z', '1']]));
+    expect(oneClick.setValueForColumn).toHaveBeenCalledTimes(1);
+
+    // Same value again should not call
+    model.setFilter(new Map([['Z', '1']]));
+    expect(oneClick.setValueForColumn).toHaveBeenCalledTimes(1);
+
+    // Different value should call
+    model.setFilter(new Map([['Z', '2']]));
+    expect(oneClick.setValueForColumn).toHaveBeenCalledTimes(2);
+  });
+
+  it('clears filter when column removed from filterMap', () => {
+    const { model, oneClick } = makeOneClickModel();
+
+    model.setFilter(new Map([['Z', '1']]));
+    // Remove the key entirely
+    model.setFilter(new Map());
+
+    expect(oneClick.setValueForColumn).toHaveBeenLastCalledWith('Z', undefined);
+  });
+
+  it('ignores columns not in oneClick', () => {
+    const { model, oneClick } = makeOneClickModel({ columnName: 'Z' });
+
+    model.setFilter(new Map([['NotAColumn', '1']]));
+
+    expect(oneClick.setValueForColumn).not.toHaveBeenCalled();
+  });
+
+  it('warns when no oneClicks exist', () => {
+    const series = chartTestUtils.makeSeries({ name: 'S1' });
+    const chart = chartTestUtils.makeChart({ series: [series] });
+    const figure = chartTestUtils.makeFigure({ charts: [chart] });
+    const model = new FigureChartModel(dh, figure);
+    model.subscribe(jest.fn());
+
+    // Should not throw, just warn
+    expect(() => model.setFilter(new Map([['Z', '1']]))).not.toThrow();
+  });
+});

--- a/packages/chart/src/FigureChartModel.ts
+++ b/packages/chart/src/FigureChartModel.ts
@@ -12,9 +12,10 @@ import type {
   XAxisName,
   YAxisName,
 } from 'plotly.js';
-import type {
-  DateTimeColumnFormatter,
-  Formatter,
+import {
+  TableUtils,
+  type DateTimeColumnFormatter,
+  type Formatter,
 } from '@deephaven/jsapi-utils';
 import ChartModel, {
   type ChartEvent,
@@ -789,6 +790,24 @@ class FigureChartModel extends ChartModel {
   }
 
   /**
+   * Coerce a filter value to the appropriate type based on column type.
+   * Input filters always provide string values, but OneClick expects the
+   * native type (e.g. number for numeric columns) to match partition keys.
+   */
+  private coerceFilterValue(value: unknown, columnType: string): unknown {
+    if (value == null) {
+      return value;
+    }
+    if (typeof value === 'string' && TableUtils.isNumberType(columnType)) {
+      const num = Number(value);
+      if (!Number.isNaN(num)) {
+        return num;
+      }
+    }
+    return value;
+  }
+
+  /**
    * Sets the filter on the model. Will only set the values that have changed.
    * @param filterMap Map of filter column names to values
    */
@@ -806,11 +825,13 @@ class FigureChartModel extends ChartModel {
       // Need to get all the keys in case a filter was removed
       const keys = new Set([...filterMap.keys(), ...this.lastFilter.keys()]);
       keys.forEach(key => {
-        const value = filterMap.get(key);
-        if (
-          this.lastFilter.get(key) !== value &&
-          columns.find(column => column.name === key) != null
-        ) {
+        const rawValue = filterMap.get(key);
+        const column = columns.find(c => c.name === key);
+        if (this.lastFilter.get(key) !== rawValue && column != null) {
+          const value =
+            rawValue != null
+              ? this.coerceFilterValue(rawValue, column.type)
+              : rawValue;
           oneClick.setValueForColumn(key, value);
         }
       });

--- a/packages/chart/src/FigureChartModel.ts
+++ b/packages/chart/src/FigureChartModel.ts
@@ -791,8 +791,9 @@ class FigureChartModel extends ChartModel {
 
   /**
    * Coerce a filter value to the appropriate type based on column type.
-   * Input filters always provide string values, but OneClick expects the
+   * Input filter controls always provide string values, but OneClick expects the
    * native type (e.g. number for numeric columns) to match partition keys.
+   * Linkers provide the raw value, so that value should be returned as is.
    */
   private coerceFilterValue(value: unknown, columnType: string): unknown {
     if (value == null) {


### PR DESCRIPTION
Input filters always return a string. When passed to the one click back end, this comparison does not work when a partition is on a numeric column.
Note that the linker tool works (at least for the first filter, see https://github.com/deephaven/deephaven-core/pull/8100) as it properly passes through a number.

This code now works with an input filter:
```
from deephaven import empty_table
from deephaven.plot.selectable_dataset import one_click
from deephaven.plot.figure import Figure
source = empty_table(10).update(["X = i", "Y = Math.random()", "Z = i % 2"])
oc = one_click(t=source, by=["Z"])
plot = Figure().plot_xy(series_name="Plot", t=oc, x="X", y="Y").show()
```