### PR TITLE
feat: DH-19720: Make Web Advanced Filter Dialog Maximizable

### DIFF
--- a/packages/components/src/popper/Popper.scss
+++ b/packages/components/src/popper/Popper.scss
@@ -13,6 +13,15 @@ $animation-offset: 10px;
   }
 }
 
+// Override popper.js inline positioning when a maximized popper should be
+// centered and fixed in the viewport.
+.popper-container.maximized {
+  position: fixed !important;
+  top: 50% !important;
+  left: 50% !important;
+  transform: translate(-50%, -50%) !important;
+}
+
 .popper.popper-tooltip {
   --background-color: var(--dh-color-tooltip-bg);
 }

--- a/packages/components/src/popper/Popper.tsx
+++ b/packages/components/src/popper/Popper.tsx
@@ -166,7 +166,7 @@ class Popper extends Component<PopperProps, PopperState> {
   // This is the request animation frame handle number
   rAF: number;
 
-  updateContainerClassName(
+  private updateContainerClassName(
     containerClassName: string,
     isMaximized: boolean
   ): void {

--- a/packages/components/src/popper/Popper.tsx
+++ b/packages/components/src/popper/Popper.tsx
@@ -60,6 +60,7 @@ interface PopperProps {
   children: React.ReactNode;
   options: PopperOptions;
   className: string;
+  containerClassName: string;
   timeout: number;
   onEntered: () => void;
   onExited: () => void;
@@ -81,6 +82,7 @@ class Popper extends Component<PopperProps, PopperState> {
   static defaultProps = {
     options: {},
     className: '',
+    containerClassName: '',
     timeout: ThemeExport.transitionMs,
     onEntered(): void {
       // no-op
@@ -106,7 +108,7 @@ class Popper extends Component<PopperProps, PopperState> {
     this.handleExit = this.handleExit.bind(this);
     this.handleBlur = this.handleBlur.bind(this);
     this.element = document.createElement('div');
-    this.element.className = 'popper-container';
+    this.updateContainerClassName(props.containerClassName);
     this.container = React.createRef<HTMLDivElement>();
 
     // cancelAnimationFrame does nothing if the handle isn't recognized
@@ -122,8 +124,12 @@ class Popper extends Component<PopperProps, PopperState> {
   }
 
   componentDidUpdate(prevProps: PopperProps): void {
-    const { isShown } = this.props;
+    const { isShown, containerClassName } = this.props;
     const { popper } = this.state;
+
+    if (prevProps.containerClassName !== containerClassName) {
+      this.updateContainerClassName(containerClassName);
+    }
 
     if (prevProps.isShown !== isShown) {
       cancelAnimationFrame(this.rAF);
@@ -153,6 +159,10 @@ class Popper extends Component<PopperProps, PopperState> {
 
   // This is the request animation frame handle number
   rAF: number;
+
+  updateContainerClassName(containerClassName: string): void {
+    this.element.className = classNames('popper-container', containerClassName);
+  }
 
   /** Goes through an element and it's parents until the first visible element is found */
   getVisibleElement(element: HTMLElement | null): HTMLElement | null {

--- a/packages/components/src/popper/Popper.tsx
+++ b/packages/components/src/popper/Popper.tsx
@@ -25,6 +25,7 @@ import './Popper.scss';
 import { SpectrumThemeProvider } from '../theme/SpectrumThemeProvider';
 
 const POPPER_CLASS_NAME = 'popper';
+const POPPER_CONTAINER_CLASS_NAME = 'popper-container';
 
 const KEEP_IN_PARENT_OPTIONS: PopperOptions = {
   placement: 'bottom-end',
@@ -170,7 +171,7 @@ class Popper extends Component<PopperProps, PopperState> {
     isMaximized: boolean
   ): void {
     this.element.className = classNames(
-      'popper-container',
+      POPPER_CONTAINER_CLASS_NAME,
       containerClassName,
       {
         maximized: isMaximized,

--- a/packages/components/src/popper/Popper.tsx
+++ b/packages/components/src/popper/Popper.tsx
@@ -61,6 +61,7 @@ interface PopperProps {
   options: PopperOptions;
   className: string;
   containerClassName: string;
+  isMaximized: boolean;
   timeout: number;
   onEntered: () => void;
   onExited: () => void;
@@ -83,6 +84,7 @@ class Popper extends Component<PopperProps, PopperState> {
     options: {},
     className: '',
     containerClassName: '',
+    isMaximized: false,
     timeout: ThemeExport.transitionMs,
     onEntered(): void {
       // no-op
@@ -108,7 +110,7 @@ class Popper extends Component<PopperProps, PopperState> {
     this.handleExit = this.handleExit.bind(this);
     this.handleBlur = this.handleBlur.bind(this);
     this.element = document.createElement('div');
-    this.updateContainerClassName(props.containerClassName);
+    this.updateContainerClassName(props.containerClassName, props.isMaximized);
     this.container = React.createRef<HTMLDivElement>();
 
     // cancelAnimationFrame does nothing if the handle isn't recognized
@@ -124,11 +126,14 @@ class Popper extends Component<PopperProps, PopperState> {
   }
 
   componentDidUpdate(prevProps: PopperProps): void {
-    const { isShown, containerClassName } = this.props;
+    const { isShown, containerClassName, isMaximized } = this.props;
     const { popper } = this.state;
 
-    if (prevProps.containerClassName !== containerClassName) {
-      this.updateContainerClassName(containerClassName);
+    if (
+      prevProps.containerClassName !== containerClassName ||
+      prevProps.isMaximized !== isMaximized
+    ) {
+      this.updateContainerClassName(containerClassName, isMaximized);
     }
 
     if (prevProps.isShown !== isShown) {
@@ -160,8 +165,17 @@ class Popper extends Component<PopperProps, PopperState> {
   // This is the request animation frame handle number
   rAF: number;
 
-  updateContainerClassName(containerClassName: string): void {
-    this.element.className = classNames('popper-container', containerClassName);
+  updateContainerClassName(
+    containerClassName: string,
+    isMaximized: boolean
+  ): void {
+    this.element.className = classNames(
+      'popper-container',
+      containerClassName,
+      {
+        maximized: isMaximized,
+      }
+    );
   }
 
   /** Goes through an element and it's parents until the first visible element is found */

--- a/packages/iris-grid/src/AdvancedFilterCreator.scss
+++ b/packages/iris-grid/src/AdvancedFilterCreator.scss
@@ -170,14 +170,8 @@ $advanced-filter-maximized-height: 85vh;
   }
 }
 
-// Maximized state: override popper.js inline position so the dialog fills the viewport.
-// !important is required because popper.js sets position/top/left/transform as inline styles.
-.popper-container.advanced-filter-menu-popper-maximized {
-  position: fixed !important;
-  top: 50% !important;
-  left: 50% !important;
-  transform: translate(-50%, -50%) !important;
-
+// Maximized state dimensions for the advanced filter dialog.
+.popper-container.maximized {
   .advanced-filter-creator {
     width: $advanced-filter-maximized-width !important;
     height: $advanced-filter-maximized-height !important;

--- a/packages/iris-grid/src/AdvancedFilterCreator.scss
+++ b/packages/iris-grid/src/AdvancedFilterCreator.scss
@@ -124,6 +124,50 @@ $advanced-filter-maximized-height: 85vh;
       }
     }
   }
+
+  // The component renders a <form> wrapping all interactive content; make it
+  // the flex column so the values list can claim remaining vertical space.
+  > form {
+    display: flex;
+    flex-direction: column;
+    flex: 1 1 auto;
+    min-height: 0;
+    overflow: hidden;
+
+    > .advanced-filter-values-group {
+      display: flex;
+      flex-direction: column;
+      flex: 1 1 auto;
+      min-height: 0;
+    }
+  }
+
+  .advanced-filter-creator-select-value {
+    display: flex;
+    flex-direction: column;
+    flex: 1 1 auto;
+    min-height: 0;
+
+    .select-value-list-wrapper {
+      flex: 1 1 auto;
+      min-height: 120px;
+      // Establishes a containing block for the absolutely-positioned scroll
+      // pane so it cannot grow to fit the (huge) virtual list content.
+      position: relative;
+      overflow: hidden;
+    }
+
+    // Pin the scroll pane to fill its wrapper. Without this, the fixed
+    // height: 120px rule or the inner virtual list's intrinsic height
+    // (itemCount × rowHeight) would size the pane and defeat virtualization.
+    .select-value-list-scroll-pane {
+      position: absolute;
+      inset: 0;
+      height: auto;
+      max-height: none;
+      min-height: 0;
+    }
+  }
 }
 
 // Maximized state: override popper.js inline position so the dialog fills the viewport.
@@ -142,49 +186,5 @@ $advanced-filter-maximized-height: 85vh;
     overflow: hidden;
     display: flex;
     flex-direction: column;
-
-    // The component renders a <form> wrapping all interactive content; make it
-    // the flex column so the values list can claim the remaining vertical space.
-    > form {
-      display: flex;
-      flex-direction: column;
-      flex: 1 1 auto;
-      min-height: 0;
-      overflow: hidden;
-
-      > .advanced-filter-values-group {
-        display: flex;
-        flex-direction: column;
-        flex: 1 1 auto;
-        min-height: 0;
-      }
-    }
-
-    .advanced-filter-creator-select-value {
-      display: flex;
-      flex-direction: column;
-      flex: 1 1 auto;
-      min-height: 0;
-
-      .select-value-list-wrapper {
-        flex: 1 1 auto;
-        min-height: 120px;
-        // Establishes a containing block for the absolutely-positioned scroll
-        // pane so it cannot grow to fit the (huge) virtual list content.
-        position: relative;
-        overflow: hidden;
-      }
-
-      // Pin the scroll pane to fill its wrapper. Without this, the fixed
-      // height: 120px rule or the inner virtual list's intrinsic height
-      // (itemCount × rowHeight) would size the pane and defeat virtualization.
-      .select-value-list-scroll-pane {
-        position: absolute;
-        inset: 0;
-        height: auto;
-        max-height: none;
-        min-height: 0;
-      }
-    }
   }
 }

--- a/packages/iris-grid/src/AdvancedFilterCreator.scss
+++ b/packages/iris-grid/src/AdvancedFilterCreator.scss
@@ -122,3 +122,66 @@
     }
   }
 }
+
+// Maximized state: override popper.js inline position so the dialog fills the viewport.
+// !important is required because popper.js sets position/top/left/transform as inline styles.
+.popper-container.advanced-filter-menu-popper-maximized {
+  position: fixed !important;
+  top: 50% !important;
+  left: 50% !important;
+  transform: translate(-50%, -50%) !important;
+
+  .advanced-filter-creator {
+    width: min(94vw, 2200px) !important;
+    height: 85vh !important;
+    max-width: none !important;
+    max-height: none !important;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+
+    // The component renders a <form> wrapping all interactive content; make it
+    // the flex column so the values list can claim the remaining vertical space.
+    > form {
+      display: flex;
+      flex-direction: column;
+      flex: 1 1 auto;
+      min-height: 0;
+      overflow: hidden;
+
+      > .advanced-filter-values-group {
+        display: flex;
+        flex-direction: column;
+        flex: 1 1 auto;
+        min-height: 0;
+      }
+    }
+
+    .advanced-filter-creator-select-value {
+      display: flex;
+      flex-direction: column;
+      flex: 1 1 auto;
+      min-height: 0;
+
+      .select-value-list-wrapper {
+        flex: 1 1 auto;
+        min-height: 120px;
+        // Establishes a containing block for the absolutely-positioned scroll
+        // pane so it cannot grow to fit the (huge) virtual list content.
+        position: relative;
+        overflow: hidden;
+      }
+
+      // Pin the scroll pane to fill its wrapper. Without this, the fixed
+      // height: 120px rule or the inner virtual list's intrinsic height
+      // (itemCount × rowHeight) would size the pane and defeat virtualization.
+      .select-value-list-scroll-pane {
+        position: absolute;
+        inset: 0;
+        height: auto;
+        max-height: none;
+        min-height: 0;
+      }
+    }
+  }
+}

--- a/packages/iris-grid/src/AdvancedFilterCreator.scss
+++ b/packages/iris-grid/src/AdvancedFilterCreator.scss
@@ -1,5 +1,8 @@
 @import '@deephaven/components/scss/custom.scss';
 
+$advanced-filter-maximized-width: min(94vw, 2200px);
+$advanced-filter-maximized-height: 85vh;
+
 .advanced-filter-creator {
   padding: $popover-body-padding-y $popover-body-padding-x;
 
@@ -132,8 +135,8 @@
   transform: translate(-50%, -50%) !important;
 
   .advanced-filter-creator {
-    width: min(94vw, 2200px) !important;
-    height: 85vh !important;
+    width: $advanced-filter-maximized-width !important;
+    height: $advanced-filter-maximized-height !important;
     max-width: none !important;
     max-height: none !important;
     overflow: hidden;

--- a/packages/iris-grid/src/AdvancedFilterCreator.test.tsx
+++ b/packages/iris-grid/src/AdvancedFilterCreator.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Formatter, TableUtils } from '@deephaven/jsapi-utils';
-import { render } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 import type { Column } from '@deephaven/jsapi-types';
 // import userEvent from '@testing-library/user-event';
 import dh from '@deephaven/jsapi-shim';
@@ -33,18 +33,24 @@ const irisGridTestUtils = new IrisGridTestUtils(dh);
 // );
 
 function makeAdvancedFilterCreatorWrapper(
-  {
+  overrides: {
+    tableUtils?: TableUtils;
+    options?: AdvancedFilterOptions;
+    model?: IrisGridModel;
+    column?: Column;
+    formatter?: Formatter;
+    isMaximized?: boolean;
+    onToggleMaximize?: () => void;
+  } = {}
+) {
+  const {
     tableUtils,
     options,
     model,
     column,
     formatter,
-  }: {
-    tableUtils: TableUtils;
-    options: AdvancedFilterOptions;
-    model: IrisGridModel;
-    column: Column;
-    formatter: Formatter;
+    isMaximized,
+    onToggleMaximize,
   } = {
     tableUtils: new TableUtils(dh),
     options: {
@@ -56,8 +62,11 @@ function makeAdvancedFilterCreatorWrapper(
     model: irisGridTestUtils.makeModel(),
     column: irisGridTestUtils.makeColumn('0'), // needs to match column name in makeModel so that columnIndex can be found when rendering
     formatter: new Formatter(dh),
-  }
-) {
+    isMaximized: false,
+    onToggleMaximize: () => null,
+    ...overrides,
+  };
+
   const wrapper = render(
     <AdvancedFilterCreator
       model={model}
@@ -68,6 +77,8 @@ function makeAdvancedFilterCreatorWrapper(
       onDone={() => null}
       options={options}
       tableUtils={tableUtils}
+      isMaximized={isMaximized}
+      onToggleMaximize={onToggleMaximize}
     />
   );
 
@@ -87,6 +98,31 @@ function makeAdvancedFilterCreatorWrapper(
 
 it('renders without crashing', () => {
   makeAdvancedFilterCreatorWrapper();
+});
+
+it('calls onToggleMaximize when maximize button is clicked', () => {
+  const onToggleMaximize = jest.fn();
+  const { container } = makeAdvancedFilterCreatorWrapper({ onToggleMaximize });
+
+  const maximizeButton = container.querySelector<HTMLButtonElement>(
+    '.advanced-filter-menu-buttons .sort-operator:last-child'
+  );
+
+  expect(maximizeButton).not.toBeNull();
+  fireEvent.click(maximizeButton as HTMLButtonElement);
+
+  expect(onToggleMaximize).toHaveBeenCalledTimes(1);
+});
+
+it('marks maximize button active when isMaximized is true', () => {
+  const { container } = makeAdvancedFilterCreatorWrapper({ isMaximized: true });
+
+  const maximizeButton = container.querySelector<HTMLButtonElement>(
+    '.advanced-filter-menu-buttons .sort-operator:last-child'
+  );
+
+  expect(maximizeButton).not.toBeNull();
+  expect(maximizeButton?.classList.contains('active')).toBe(true);
 });
 
 // jest.mock('./AdvancedFilterCreatorFilterItem', () =>

--- a/packages/iris-grid/src/AdvancedFilterCreator.tsx
+++ b/packages/iris-grid/src/AdvancedFilterCreator.tsx
@@ -11,7 +11,12 @@ import {
   type TypeValue as FilterTypeValue,
   assertOperatorValue as assertFilterOperatorValue,
 } from '@deephaven/filters';
-import { dhSortAmountDown, dhNewCircleLargeFilled } from '@deephaven/icons';
+import {
+  dhSortAmountDown,
+  dhNewCircleLargeFilled,
+  vsScreenFull,
+  vsScreenNormal,
+} from '@deephaven/icons';
 import {
   type Formatter,
   TableUtils,
@@ -58,6 +63,8 @@ interface AdvancedFilterCreatorProps {
   sortDirection: SortDirection;
   formatter: Formatter;
   tableUtils: TableUtils;
+  isMaximized: boolean;
+  onToggleMaximize: () => void;
 }
 
 interface AdvancedFilterItem {
@@ -459,7 +466,15 @@ class AdvancedFilterCreator extends PureComponent<
   }
 
   render(): JSX.Element {
-    const { column, model, sortDirection, formatter, tableUtils } = this.props;
+    const {
+      column,
+      model,
+      sortDirection,
+      formatter,
+      tableUtils,
+      isMaximized,
+      onToggleMaximize,
+    } = this.props;
     const {
       filterItems,
       filterOperators,
@@ -597,6 +612,17 @@ class AdvancedFilterCreator extends PureComponent<
                 }
                 disabled={!isSortable}
               />
+              <Button
+                kind="ghost"
+                className={classNames('sort-operator', {
+                  active: isMaximized,
+                })}
+                onClick={onToggleMaximize}
+                icon={isMaximized ? vsScreenNormal : vsScreenFull}
+                tooltip={
+                  isMaximized ? 'Restore dialog size' : 'Maximize dialog'
+                }
+              />
             </div>
           </div>
           <hr />
@@ -608,7 +634,7 @@ class AdvancedFilterCreator extends PureComponent<
           {isValuesTableAvailable && valuesTableError == null && (
             <>
               {!isBoolean && <hr />}
-              <div className="form-group">
+              <div className="form-group advanced-filter-values-group">
                 <AdvancedFilterCreatorSelectValue
                   dh={dh}
                   table={valuesTable}

--- a/packages/iris-grid/src/IrisGrid.tsx
+++ b/packages/iris-grid/src/IrisGrid.tsx
@@ -408,6 +408,7 @@ export interface IrisGridState {
   quickFilters: ReadonlyQuickFilterMap;
   advancedFilters: ReadonlyAdvancedFilterMap;
   shownAdvancedFilter: number | null;
+  maximizedAdvancedFilter: number | null;
   hoverAdvancedFilter: number | null;
 
   sorts: readonly SortDescriptor[];
@@ -587,6 +588,8 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
     this.handleAdvancedFilterSortChange =
       this.handleAdvancedFilterSortChange.bind(this);
     this.handleAdvancedFilterDone = this.handleAdvancedFilterDone.bind(this);
+    this.handleAdvancedFilterToggleMaximize =
+      this.handleAdvancedFilterToggleMaximize.bind(this);
     this.handleAdvancedMenuOpened = this.handleAdvancedMenuOpened.bind(this);
     this.handleGotoRowOpened = this.handleGotoRowOpened.bind(this);
     this.handleGotoRowClosed = this.handleGotoRowClosed.bind(this);
@@ -851,6 +854,7 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
       quickFilters: quickFilters ? new Map(quickFilters) : new Map(),
       advancedFilters: new Map(advancedFilters),
       shownAdvancedFilter: null,
+      maximizedAdvancedFilter: null,
       hoverAdvancedFilter: null,
       sorts: [],
       reverse: false,
@@ -1142,13 +1146,21 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
     { max: 100 }
   );
 
+  getAdvancedMenuToggleMaximizeHandler = memoize(
+    (column: ModelIndex) =>
+      this.handleAdvancedFilterToggleMaximize.bind(this, column),
+    { max: 100 }
+  );
+
   getCachedAdvancedFilterMenuActions = memoize(
     (
       model: IrisGridModel,
       column: DhType.Column,
       advancedFilterOptions: AdvancedFilterOptions | undefined,
       sortDirection: SortDirection | undefined,
-      formatter: Formatter
+      formatter: Formatter,
+      isMaximized: boolean,
+      onToggleMaximize: () => void
     ) => (
       <AdvancedFilterCreator
         model={model}
@@ -1160,6 +1172,8 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
         sortDirection={sortDirection}
         formatter={formatter}
         tableUtils={this.tableUtils}
+        isMaximized={isMaximized}
+        onToggleMaximize={onToggleMaximize}
       />
     ),
     { max: 50 }
@@ -3177,8 +3191,18 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
     this.grid?.focus();
   }
 
+  handleAdvancedFilterToggleMaximize(column: GridRangeIndex): void {
+    this.setState(({ maximizedAdvancedFilter }) => ({
+      maximizedAdvancedFilter:
+        maximizedAdvancedFilter === column ? null : column,
+    }));
+  }
+
   handleAdvancedMenuOpened(column: GridRangeIndex): void {
-    this.setState({ shownAdvancedFilter: column });
+    this.setState({
+      shownAdvancedFilter: column,
+      maximizedAdvancedFilter: null,
+    });
   }
 
   handleGotoRowOpened(): void {
@@ -3197,11 +3221,15 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
       this.filterInputRef?.current !== null
     ) {
       this.filterInputRef?.current.focus();
-      this.setState({ shownAdvancedFilter: null });
+      this.setState({
+        shownAdvancedFilter: null,
+        maximizedAdvancedFilter: null,
+      });
     } else {
       this.setState({
         focusedFilterBarColumn: null,
         shownAdvancedFilter: null,
+        maximizedAdvancedFilter: null,
       });
     }
   }
@@ -4681,6 +4709,7 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
       shownColumnTooltip,
       hoverAdvancedFilter,
       shownAdvancedFilter,
+      maximizedAdvancedFilter,
       hoverSelectColumn,
       quickFilters,
       advancedFilters,
@@ -4884,7 +4913,10 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
                       }
                     )}
                     onClick={() => {
-                      this.setState({ shownAdvancedFilter: columnIndex });
+                      this.setState({
+                        shownAdvancedFilter: columnIndex,
+                        maximizedAdvancedFilter: null,
+                      });
                     }}
                     onContextMenu={event => {
                       this.grid?.handleContextMenu(event);
@@ -4974,6 +5006,11 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
               >
                 <Popper
                   className="advanced-filter-menu-popper"
+                  containerClassName={classNames({
+                    'advanced-filter-menu-popper-maximized':
+                      shownAdvancedFilter === columnIndex &&
+                      maximizedAdvancedFilter === columnIndex,
+                  })}
                   onEntered={this.getAdvancedMenuOpenedHandler(columnIndex)}
                   onExited={() => {
                     this.handleAdvancedMenuClosed(columnIndex);
@@ -4990,7 +5027,10 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
                     column,
                     advancedFilterOptions,
                     sortDirection,
-                    formatter
+                    formatter,
+                    shownAdvancedFilter === columnIndex &&
+                      maximizedAdvancedFilter === columnIndex,
+                    this.getAdvancedMenuToggleMaximizeHandler(columnIndex)
                   )}
                 </Popper>
               </div>

--- a/packages/iris-grid/src/IrisGrid.tsx
+++ b/packages/iris-grid/src/IrisGrid.tsx
@@ -5006,11 +5006,10 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
               >
                 <Popper
                   className="advanced-filter-menu-popper"
-                  containerClassName={classNames({
-                    'advanced-filter-menu-popper-maximized':
-                      shownAdvancedFilter === columnIndex &&
-                      maximizedAdvancedFilter === columnIndex,
-                  })}
+                  isMaximized={
+                    shownAdvancedFilter === columnIndex &&
+                    maximizedAdvancedFilter === columnIndex
+                  }
                   onEntered={this.getAdvancedMenuOpenedHandler(columnIndex)}
                   onExited={() => {
                     this.handleAdvancedMenuClosed(columnIndex);


### PR DESCRIPTION
Adds a maximize/restore control to the Web Advanced Filter dialog and applies the corresponding layout updates for the maximized state.

Tested in Chrome, Safari, and Firefox.

Has tooltips with "Maximize" and "Restore Size" text.

# Demo:

<img width="1280" height="720" alt="2026-06-05 17-05-49" src="https://github.com/user-attachments/assets/f40b0cc0-e3a9-4dea-bd66-506ab2d4e28c" />

The state is in the IrisGrid React class component (Field: maximizedAdvancedFilter). IrisGrid is the owner component that renders the popper and holds shownAdvancedFilter and maximizedAdvancedFilter. Maximize button is inside AdvancedFilterCreator, AdvancedFilterCreator is rendered by IrisGrid as Popper content, Popper component is rendered by IrisGrid (IrisGrid (state owner) → Popper → AdvancedFilterCreator → maximize Button). IrisGrid computes whether this specific menu is maximized, then passes class advanced-filter-menu-popper-maximized into Popper containerClassName. The AdvancedFilterCreator.scss is then applied to maximize that modal.

# How this works:

1. IrisGrid owns which advanced filter popper is open and which one is maximized in IrisGrid.tsx.
2. IrisGrid passes isMaximized to Popper (for container layout) in IrisGrid.tsx.
3. IrisGrid passes isMaximized and onToggleMaximize to AdvancedFilterCreator (for button UI + user intent) in IrisGrid.tsx.
4. AdvancedFilterCreator is a controlled child in AdvancedFilterCreator.tsx.