### PR TITLE
fix: DH-22803: Update AutoResizeTextarea to handle quoted values

### DIFF
--- a/packages/components/src/AutoResizeTextarea.test.tsx
+++ b/packages/components/src/AutoResizeTextarea.test.tsx
@@ -482,6 +482,50 @@ describe('AutoResizeTextarea', () => {
       expect(onChange).toHaveBeenCalledWith('FOO="hello world" BAZ=qux');
     });
 
+    it('keeps a double-quoted span containing a single quote on one line', () => {
+      // "it's" contains a single quote inside double quotes — must not break the span
+      renderTextarea({
+        value: `FOO="it's fine" BAZ=qux`,
+        delimiter: DELIMITER,
+      });
+      fireEvent.focus(getTextarea());
+      expect(getTextarea()).toHaveValue(`FOO="it's fine"\nBAZ=qux`);
+    });
+
+    it('round-trips: double-quoted span containing a single quote', () => {
+      const onChange = jest.fn();
+      renderTextarea({
+        value: `FOO="it's fine" BAZ=qux`,
+        delimiter: DELIMITER,
+        onChange,
+      });
+      fireEvent.focus(getTextarea());
+      fireEvent.blur(getTextarea());
+      expect(onChange).toHaveBeenCalledWith(`FOO="it's fine" BAZ=qux`);
+    });
+
+    it('keeps a single-quoted span containing a double quote on one line', () => {
+      // 'say "hello"' contains double quotes inside single quotes — must not break the span
+      renderTextarea({
+        value: `FOO='say "hello"' BAZ=qux`,
+        delimiter: DELIMITER,
+      });
+      fireEvent.focus(getTextarea());
+      expect(getTextarea()).toHaveValue(`FOO='say "hello"'\nBAZ=qux`);
+    });
+
+    it('round-trips: single-quoted span containing a double quote', () => {
+      const onChange = jest.fn();
+      renderTextarea({
+        value: `FOO='say "hello"' BAZ=qux`,
+        delimiter: DELIMITER,
+        onChange,
+      });
+      fireEvent.focus(getTextarea());
+      fireEvent.blur(getTextarea());
+      expect(onChange).toHaveBeenCalledWith(`FOO='say "hello"' BAZ=qux`);
+    });
+
     it('unbalanced quote: splits on the delimiter as if no quote, does not throw', () => {
       const onChange = jest.fn();
       renderTextarea({

--- a/packages/components/src/AutoResizeTextarea.test.tsx
+++ b/packages/components/src/AutoResizeTextarea.test.tsx
@@ -337,9 +337,7 @@ describe('AutoResizeTextarea', () => {
   });
 
   // ─── Quoted-value use-case coverage ───────────────────────────────────────
-  // Tests marked it.failing are expected to fail until the implementation is
-  // updated to handle quoted values. Once the feature is implemented, change
-  // those to plain it() calls.
+  // Tests for quote-aware splitting behaviour.
 
   describe('JVM arguments, with quotes – delimiter " -"', () => {
     const DELIMITER = ' -';
@@ -353,17 +351,14 @@ describe('AutoResizeTextarea', () => {
       expect(getTextarea()).toHaveValue('-Dfoo="bar baz"\n-Xmx512m');
     });
 
-    it.failing(
-      'keeps a quoted value containing the delimiter on one line when exploding',
-      () => {
-        renderTextarea({
-          value: '-Dfoo="has -dash inside" -Xmx512m',
-          delimiter: DELIMITER,
-        });
-        fireEvent.focus(getTextarea());
-        expect(getTextarea()).toHaveValue('-Dfoo="has -dash inside"\n-Xmx512m');
-      }
-    );
+    it('keeps a quoted value containing the delimiter on one line when exploding', () => {
+      renderTextarea({
+        value: '-Dfoo="has -dash inside" -Xmx512m',
+        delimiter: DELIMITER,
+      });
+      fireEvent.focus(getTextarea());
+      expect(getTextarea()).toHaveValue('-Dfoo="has -dash inside"\n-Xmx512m');
+    });
 
     it('round-trips: implode(explode(value)) === value for quoted arg containing delimiter', () => {
       const onChange = jest.fn();
@@ -457,29 +452,23 @@ describe('AutoResizeTextarea', () => {
   describe('environment variables, with quotes – delimiter " "', () => {
     const DELIMITER = ' ';
 
-    it.failing(
-      'keeps a double-quoted value containing a space on one line',
-      () => {
-        renderTextarea({
-          value: 'FOO="hello world" BAZ=qux',
-          delimiter: DELIMITER,
-        });
-        fireEvent.focus(getTextarea());
-        expect(getTextarea()).toHaveValue('FOO="hello world"\nBAZ=qux');
-      }
-    );
+    it('keeps a double-quoted value containing a space on one line', () => {
+      renderTextarea({
+        value: 'FOO="hello world" BAZ=qux',
+        delimiter: DELIMITER,
+      });
+      fireEvent.focus(getTextarea());
+      expect(getTextarea()).toHaveValue('FOO="hello world"\nBAZ=qux');
+    });
 
-    it.failing(
-      'keeps a single-quoted value containing a space on one line',
-      () => {
-        renderTextarea({
-          value: "FOO='hello world' BAZ=qux",
-          delimiter: DELIMITER,
-        });
-        fireEvent.focus(getTextarea());
-        expect(getTextarea()).toHaveValue("FOO='hello world'\nBAZ=qux");
-      }
-    );
+    it('keeps a single-quoted value containing a space on one line', () => {
+      renderTextarea({
+        value: "FOO='hello world' BAZ=qux",
+        delimiter: DELIMITER,
+      });
+      fireEvent.focus(getTextarea());
+      expect(getTextarea()).toHaveValue("FOO='hello world'\nBAZ=qux");
+    });
 
     it('round-trips: implode(explode(value)) === value for quoted env vars', () => {
       const onChange = jest.fn();
@@ -590,17 +579,14 @@ describe('AutoResizeTextarea', () => {
   describe('extra classpaths, with quotes – delimiter " "', () => {
     const DELIMITER = ' ';
 
-    it.failing(
-      'keeps a quoted path containing spaces on one line when exploding',
-      () => {
-        renderTextarea({
-          value: '"/a/path with spaces" /c/d',
-          delimiter: DELIMITER,
-        });
-        fireEvent.focus(getTextarea());
-        expect(getTextarea()).toHaveValue('"/a/path with spaces"\n/c/d');
-      }
-    );
+    it('keeps a quoted path containing spaces on one line when exploding', () => {
+      renderTextarea({
+        value: '"/a/path with spaces" /c/d',
+        delimiter: DELIMITER,
+      });
+      fireEvent.focus(getTextarea());
+      expect(getTextarea()).toHaveValue('"/a/path with spaces"\n/c/d');
+    });
 
     it('round-trips: implode(explode(value)) === value for quoted paths', () => {
       const onChange = jest.fn();

--- a/packages/components/src/AutoResizeTextarea.test.tsx
+++ b/packages/components/src/AutoResizeTextarea.test.tsx
@@ -335,4 +335,355 @@ describe('AutoResizeTextarea', () => {
       expect(getTextarea()).toHaveValue('updated');
     });
   });
+
+  // ─── Use-case coverage (TC-1 through TC-8) ────────────────────────────────
+  // Tests marked it.failing are expected to fail until the implementation is
+  // updated to handle quoted values. Once the feature is implemented, change
+  // those to plain it() calls.
+
+  describe('TC-1: JVM arguments, no quotes – delimiter " -"', () => {
+    const DELIMITER = ' -';
+
+    it('explodes args on focus', () => {
+      renderTextarea({
+        value: '-Xmx512m -Xms256m -Dfoo=bar',
+        delimiter: DELIMITER,
+      });
+      fireEvent.focus(getTextarea());
+      expect(getTextarea()).toHaveValue('-Xmx512m\n-Xms256m\n-Dfoo=bar');
+    });
+
+    it('implodes on blur', () => {
+      const onChange = jest.fn();
+      renderTextarea({
+        value: '-Xmx512m -Xms256m -Dfoo=bar',
+        delimiter: DELIMITER,
+        onChange,
+      });
+      fireEvent.focus(getTextarea());
+      fireEvent.blur(getTextarea());
+      expect(onChange).toHaveBeenCalledWith('-Xmx512m -Xms256m -Dfoo=bar');
+    });
+
+    it('round-trips: implode(explode(value)) === value', () => {
+      const onChange = jest.fn();
+      renderTextarea({
+        value: '-Xmx512m -Xms256m -Dfoo=bar',
+        delimiter: DELIMITER,
+        onChange,
+      });
+      fireEvent.focus(getTextarea());
+      fireEvent.blur(getTextarea());
+      expect(onChange).toHaveBeenCalledWith('-Xmx512m -Xms256m -Dfoo=bar');
+    });
+  });
+
+  describe('TC-2: JVM arguments, with quotes – delimiter " -"', () => {
+    const DELIMITER = ' -';
+
+    it('keeps a quoted value containing a space on one line when exploding', () => {
+      renderTextarea({
+        value: '-Dfoo="bar baz" -Xmx512m',
+        delimiter: DELIMITER,
+      });
+      fireEvent.focus(getTextarea());
+      expect(getTextarea()).toHaveValue('-Dfoo="bar baz"\n-Xmx512m');
+    });
+
+    it.failing(
+      'keeps a quoted value containing the delimiter on one line when exploding',
+      () => {
+        renderTextarea({
+          value: '-Dfoo="has -dash inside" -Xmx512m',
+          delimiter: DELIMITER,
+        });
+        fireEvent.focus(getTextarea());
+        expect(getTextarea()).toHaveValue('-Dfoo="has -dash inside"\n-Xmx512m');
+      }
+    );
+
+    it('round-trips: implode(explode(value)) === value for quoted arg containing delimiter', () => {
+      const onChange = jest.fn();
+      renderTextarea({
+        value: '-Dfoo="has -dash inside" -Xmx512m',
+        delimiter: DELIMITER,
+        onChange,
+      });
+      fireEvent.focus(getTextarea());
+      fireEvent.blur(getTextarea());
+      expect(onChange).toHaveBeenCalledWith(
+        '-Dfoo="has -dash inside" -Xmx512m'
+      );
+    });
+
+    it('round-trips: implode(explode(value)) === value for quoted args', () => {
+      const onChange = jest.fn();
+      renderTextarea({
+        value: '-Dfoo="bar baz" -Xmx512m',
+        delimiter: DELIMITER,
+        onChange,
+      });
+      fireEvent.focus(getTextarea());
+      fireEvent.blur(getTextarea());
+      expect(onChange).toHaveBeenCalledWith('-Dfoo="bar baz" -Xmx512m');
+    });
+
+    it('unbalanced quote: splits on the delimiter as if no quote, does not throw', () => {
+      const onChange = jest.fn();
+      renderTextarea({
+        value: '-Dfoo="bad -Xmx512m',
+        delimiter: DELIMITER,
+        onChange,
+      });
+      fireEvent.focus(getTextarea());
+      // Unbalanced quote is treated as a literal character; split proceeds normally
+      expect(getTextarea()).toHaveValue('-Dfoo="bad\n-Xmx512m');
+      fireEvent.blur(getTextarea());
+      // Round-trip: original value is preserved
+      expect(onChange).toHaveBeenCalledWith('-Dfoo="bad -Xmx512m');
+    });
+
+    it('pasted JVM args with quoted value explode correctly', () => {
+      const onChange = jest.fn();
+      renderTextarea({ value: '', delimiter: DELIMITER, onChange });
+      const textarea = getTextarea();
+      fireEvent.focus(textarea);
+      fireEvent.paste(textarea);
+      fireEvent.change(textarea, {
+        target: { value: '-Dfoo="bar baz" -Xmx512m' },
+      });
+      expect(textarea).toHaveValue('-Dfoo="bar baz"\n-Xmx512m');
+      expect(onChange).toHaveBeenCalledWith('-Dfoo="bar baz" -Xmx512m');
+    });
+  });
+
+  describe('TC-3: environment variables, no quotes – delimiter " "', () => {
+    const DELIMITER = ' ';
+
+    it('explodes env vars on focus', () => {
+      renderTextarea({ value: 'FOO=bar BAZ=qux', delimiter: DELIMITER });
+      fireEvent.focus(getTextarea());
+      expect(getTextarea()).toHaveValue('FOO=bar\nBAZ=qux');
+    });
+
+    it('implodes on blur', () => {
+      const onChange = jest.fn();
+      renderTextarea({
+        value: 'FOO=bar BAZ=qux',
+        delimiter: DELIMITER,
+        onChange,
+      });
+      fireEvent.focus(getTextarea());
+      fireEvent.blur(getTextarea());
+      expect(onChange).toHaveBeenCalledWith('FOO=bar BAZ=qux');
+    });
+
+    it('round-trips: implode(explode(value)) === value', () => {
+      const onChange = jest.fn();
+      renderTextarea({
+        value: 'FOO=bar BAZ=qux',
+        delimiter: DELIMITER,
+        onChange,
+      });
+      fireEvent.focus(getTextarea());
+      fireEvent.blur(getTextarea());
+      expect(onChange).toHaveBeenCalledWith('FOO=bar BAZ=qux');
+    });
+  });
+
+  describe('TC-4: environment variables, with quotes – delimiter " "', () => {
+    const DELIMITER = ' ';
+
+    it.failing(
+      'keeps a double-quoted value containing a space on one line',
+      () => {
+        renderTextarea({
+          value: 'FOO="hello world" BAZ=qux',
+          delimiter: DELIMITER,
+        });
+        fireEvent.focus(getTextarea());
+        expect(getTextarea()).toHaveValue('FOO="hello world"\nBAZ=qux');
+      }
+    );
+
+    it.failing(
+      'keeps a single-quoted value containing a space on one line',
+      () => {
+        renderTextarea({
+          value: "FOO='hello world' BAZ=qux",
+          delimiter: DELIMITER,
+        });
+        fireEvent.focus(getTextarea());
+        expect(getTextarea()).toHaveValue("FOO='hello world'\nBAZ=qux");
+      }
+    );
+
+    it('round-trips: implode(explode(value)) === value for quoted env vars', () => {
+      const onChange = jest.fn();
+      renderTextarea({
+        value: 'FOO="hello world" BAZ=qux',
+        delimiter: DELIMITER,
+        onChange,
+      });
+      fireEvent.focus(getTextarea());
+      fireEvent.blur(getTextarea());
+      expect(onChange).toHaveBeenCalledWith('FOO="hello world" BAZ=qux');
+    });
+
+    it('unbalanced quote: splits on the delimiter as if no quote, does not throw', () => {
+      const onChange = jest.fn();
+      renderTextarea({
+        value: 'FOO="bad BAZ=qux',
+        delimiter: DELIMITER,
+        onChange,
+      });
+      fireEvent.focus(getTextarea());
+      // Unbalanced quote is treated as a literal character; split proceeds normally
+      expect(getTextarea()).toHaveValue('FOO="bad\nBAZ=qux');
+      fireEvent.blur(getTextarea());
+      // Round-trip: original value is preserved
+      expect(onChange).toHaveBeenCalledWith('FOO="bad BAZ=qux');
+    });
+  });
+
+  describe('TC-5: Python packages, no quotes – delimiter " "', () => {
+    const DELIMITER = ' ';
+
+    it('explodes package list on focus', () => {
+      renderTextarea({
+        value: 'numpy==1.24 pandas>=2.0 scipy[extra]',
+        delimiter: DELIMITER,
+      });
+      fireEvent.focus(getTextarea());
+      expect(getTextarea()).toHaveValue(
+        'numpy==1.24\npandas>=2.0\nscipy[extra]'
+      );
+    });
+
+    it('implodes on blur', () => {
+      const onChange = jest.fn();
+      renderTextarea({
+        value: 'numpy==1.24 pandas>=2.0 scipy[extra]',
+        delimiter: DELIMITER,
+        onChange,
+      });
+      fireEvent.focus(getTextarea());
+      fireEvent.blur(getTextarea());
+      expect(onChange).toHaveBeenCalledWith(
+        'numpy==1.24 pandas>=2.0 scipy[extra]'
+      );
+    });
+
+    it('does not treat square brackets as quotes', () => {
+      renderTextarea({
+        value: 'scipy[extra] numpy',
+        delimiter: DELIMITER,
+      });
+      fireEvent.focus(getTextarea());
+      expect(getTextarea()).toHaveValue('scipy[extra]\nnumpy');
+    });
+
+    it('round-trips: implode(explode(value)) === value', () => {
+      const onChange = jest.fn();
+      renderTextarea({
+        value: 'numpy==1.24 pandas>=2.0 scipy[extra]',
+        delimiter: DELIMITER,
+        onChange,
+      });
+      fireEvent.focus(getTextarea());
+      fireEvent.blur(getTextarea());
+      expect(onChange).toHaveBeenCalledWith(
+        'numpy==1.24 pandas>=2.0 scipy[extra]'
+      );
+    });
+  });
+
+  describe('TC-6: extra classpaths, no quotes – delimiter " "', () => {
+    const DELIMITER = ' ';
+
+    it('explodes classpath entries on focus', () => {
+      renderTextarea({ value: '/a/b /c/d', delimiter: DELIMITER });
+      fireEvent.focus(getTextarea());
+      expect(getTextarea()).toHaveValue('/a/b\n/c/d');
+    });
+
+    it('implodes on blur', () => {
+      const onChange = jest.fn();
+      renderTextarea({ value: '/a/b /c/d', delimiter: DELIMITER, onChange });
+      fireEvent.focus(getTextarea());
+      fireEvent.blur(getTextarea());
+      expect(onChange).toHaveBeenCalledWith('/a/b /c/d');
+    });
+
+    it('round-trips: implode(explode(value)) === value', () => {
+      const onChange = jest.fn();
+      renderTextarea({ value: '/a/b /c/d', delimiter: DELIMITER, onChange });
+      fireEvent.focus(getTextarea());
+      fireEvent.blur(getTextarea());
+      expect(onChange).toHaveBeenCalledWith('/a/b /c/d');
+    });
+  });
+
+  describe('TC-7: extra classpaths, with quotes – delimiter " "', () => {
+    const DELIMITER = ' ';
+
+    it.failing(
+      'keeps a quoted path containing spaces on one line when exploding',
+      () => {
+        renderTextarea({
+          value: '"/a/path with spaces" /c/d',
+          delimiter: DELIMITER,
+        });
+        fireEvent.focus(getTextarea());
+        expect(getTextarea()).toHaveValue('"/a/path with spaces"\n/c/d');
+      }
+    );
+
+    it('round-trips: implode(explode(value)) === value for quoted paths', () => {
+      const onChange = jest.fn();
+      renderTextarea({
+        value: '"/a/path with spaces" /c/d',
+        delimiter: DELIMITER,
+        onChange,
+      });
+      fireEvent.focus(getTextarea());
+      fireEvent.blur(getTextarea());
+      expect(onChange).toHaveBeenCalledWith('"/a/path with spaces" /c/d');
+    });
+
+    it('unbalanced quote: splits on the delimiter as if no quote, does not throw', () => {
+      const onChange = jest.fn();
+      renderTextarea({ value: '"/bad /c/d', delimiter: DELIMITER, onChange });
+      fireEvent.focus(getTextarea());
+      // Unbalanced quote is treated as a literal character; split proceeds normally
+      expect(getTextarea()).toHaveValue('"/bad\n/c/d');
+      fireEvent.blur(getTextarea());
+      // Round-trip: original value is preserved
+      expect(onChange).toHaveBeenCalledWith('"/bad /c/d');
+    });
+  });
+
+  describe('TC-8: no delimiter', () => {
+    it('does not transform value on focus', () => {
+      renderTextarea({ value: 'assignment policy params' });
+      fireEvent.focus(getTextarea());
+      expect(getTextarea()).toHaveValue('assignment policy params');
+    });
+
+    it('passes quoted values through to onChange unchanged', () => {
+      const onChange = jest.fn();
+      renderTextarea({ onChange });
+      fireEvent.change(getTextarea(), {
+        target: { value: 'KEY="value with spaces"' },
+      });
+      expect(onChange).toHaveBeenCalledWith('KEY="value with spaces"');
+    });
+
+    it('passes newlines through to onChange unchanged', () => {
+      const onChange = jest.fn();
+      renderTextarea({ onChange });
+      fireEvent.change(getTextarea(), { target: { value: 'line1\nline2' } });
+      expect(onChange).toHaveBeenCalledWith('line1\nline2');
+    });
+  });
 });

--- a/packages/components/src/AutoResizeTextarea.test.tsx
+++ b/packages/components/src/AutoResizeTextarea.test.tsx
@@ -336,47 +336,10 @@ describe('AutoResizeTextarea', () => {
     });
   });
 
-  // ─── Use-case coverage (TC-1 through TC-8) ────────────────────────────────
+  // ─── Quoted-value use-case coverage (TC-2 through TC-7) ──────────────────
   // Tests marked it.failing are expected to fail until the implementation is
   // updated to handle quoted values. Once the feature is implemented, change
   // those to plain it() calls.
-
-  describe('TC-1: JVM arguments, no quotes – delimiter " -"', () => {
-    const DELIMITER = ' -';
-
-    it('explodes args on focus', () => {
-      renderTextarea({
-        value: '-Xmx512m -Xms256m -Dfoo=bar',
-        delimiter: DELIMITER,
-      });
-      fireEvent.focus(getTextarea());
-      expect(getTextarea()).toHaveValue('-Xmx512m\n-Xms256m\n-Dfoo=bar');
-    });
-
-    it('implodes on blur', () => {
-      const onChange = jest.fn();
-      renderTextarea({
-        value: '-Xmx512m -Xms256m -Dfoo=bar',
-        delimiter: DELIMITER,
-        onChange,
-      });
-      fireEvent.focus(getTextarea());
-      fireEvent.blur(getTextarea());
-      expect(onChange).toHaveBeenCalledWith('-Xmx512m -Xms256m -Dfoo=bar');
-    });
-
-    it('round-trips: implode(explode(value)) === value', () => {
-      const onChange = jest.fn();
-      renderTextarea({
-        value: '-Xmx512m -Xms256m -Dfoo=bar',
-        delimiter: DELIMITER,
-        onChange,
-      });
-      fireEvent.focus(getTextarea());
-      fireEvent.blur(getTextarea());
-      expect(onChange).toHaveBeenCalledWith('-Xmx512m -Xms256m -Dfoo=bar');
-    });
-  });
 
   describe('TC-2: JVM arguments, with quotes – delimiter " -"', () => {
     const DELIMITER = ' -';
@@ -660,30 +623,6 @@ describe('AutoResizeTextarea', () => {
       fireEvent.blur(getTextarea());
       // Round-trip: original value is preserved
       expect(onChange).toHaveBeenCalledWith('"/bad /c/d');
-    });
-  });
-
-  describe('TC-8: no delimiter', () => {
-    it('does not transform value on focus', () => {
-      renderTextarea({ value: 'assignment policy params' });
-      fireEvent.focus(getTextarea());
-      expect(getTextarea()).toHaveValue('assignment policy params');
-    });
-
-    it('passes quoted values through to onChange unchanged', () => {
-      const onChange = jest.fn();
-      renderTextarea({ onChange });
-      fireEvent.change(getTextarea(), {
-        target: { value: 'KEY="value with spaces"' },
-      });
-      expect(onChange).toHaveBeenCalledWith('KEY="value with spaces"');
-    });
-
-    it('passes newlines through to onChange unchanged', () => {
-      const onChange = jest.fn();
-      renderTextarea({ onChange });
-      fireEvent.change(getTextarea(), { target: { value: 'line1\nline2' } });
-      expect(onChange).toHaveBeenCalledWith('line1\nline2');
     });
   });
 });

--- a/packages/components/src/AutoResizeTextarea.test.tsx
+++ b/packages/components/src/AutoResizeTextarea.test.tsx
@@ -336,12 +336,12 @@ describe('AutoResizeTextarea', () => {
     });
   });
 
-  // ─── Quoted-value use-case coverage (TC-2 through TC-7) ──────────────────
+  // ─── Quoted-value use-case coverage ───────────────────────────────────────
   // Tests marked it.failing are expected to fail until the implementation is
   // updated to handle quoted values. Once the feature is implemented, change
   // those to plain it() calls.
 
-  describe('TC-2: JVM arguments, with quotes – delimiter " -"', () => {
+  describe('JVM arguments, with quotes – delimiter " -"', () => {
     const DELIMITER = ' -';
 
     it('keeps a quoted value containing a space on one line when exploding', () => {
@@ -420,7 +420,7 @@ describe('AutoResizeTextarea', () => {
     });
   });
 
-  describe('TC-3: environment variables, no quotes – delimiter " "', () => {
+  describe('environment variables, no quotes – delimiter " "', () => {
     const DELIMITER = ' ';
 
     it('explodes env vars on focus', () => {
@@ -454,7 +454,7 @@ describe('AutoResizeTextarea', () => {
     });
   });
 
-  describe('TC-4: environment variables, with quotes – delimiter " "', () => {
+  describe('environment variables, with quotes – delimiter " "', () => {
     const DELIMITER = ' ';
 
     it.failing(
@@ -509,7 +509,7 @@ describe('AutoResizeTextarea', () => {
     });
   });
 
-  describe('TC-5: Python packages, no quotes – delimiter " "', () => {
+  describe('Python packages, no quotes – delimiter " "', () => {
     const DELIMITER = ' ';
 
     it('explodes package list on focus', () => {
@@ -561,7 +561,7 @@ describe('AutoResizeTextarea', () => {
     });
   });
 
-  describe('TC-6: extra classpaths, no quotes – delimiter " "', () => {
+  describe('extra classpaths, no quotes – delimiter " "', () => {
     const DELIMITER = ' ';
 
     it('explodes classpath entries on focus', () => {
@@ -587,7 +587,7 @@ describe('AutoResizeTextarea', () => {
     });
   });
 
-  describe('TC-7: extra classpaths, with quotes – delimiter " "', () => {
+  describe('extra classpaths, with quotes – delimiter " "', () => {
     const DELIMITER = ' ';
 
     it.failing(

--- a/packages/components/src/AutoResizeTextarea.tsx
+++ b/packages/components/src/AutoResizeTextarea.tsx
@@ -23,14 +23,57 @@ function implode(input: string): string {
     .join(' ');
 }
 
+function splitOnDelimiter(input: string, delimiter: string): string[] {
+  // Walk the string character by character, tracking quoted spans so that
+  // delimiters inside "..." or '...' are not treated as split points.
+  // Quotes are preserved in the output (not stripped) so the round-trip is lossless.
+  // An unbalanced quote is treated as a literal character — splitting continues normally.
+  const tokens: string[] = [];
+  let current = '';
+  let quoteChar: '"' | "'" | null = null;
+  let i = 0;
+
+  while (i < input.length) {
+    const ch = input[i];
+
+    if (quoteChar !== null) {
+      // Inside a quoted span — accumulate until we hit the matching closing quote
+      current += ch;
+      if (ch === quoteChar) {
+        quoteChar = null;
+      }
+      i += 1;
+    } else if (ch === '"' || ch === "'") {
+      // Only treat as a quoted span if there is a matching closing quote ahead.
+      // An unbalanced quote is treated as a literal character so the delimiter
+      // logic continues to work normally.
+      const closingIdx = input.indexOf(ch, i + 1);
+      if (closingIdx !== -1) {
+        quoteChar = ch;
+      }
+      current += ch;
+      i += 1;
+    } else if (input.startsWith(delimiter, i)) {
+      // Delimiter found outside a quoted span — emit the current token and advance
+      tokens.push(current);
+      current = '';
+      i += delimiter.length;
+    } else {
+      current += ch;
+      i += 1;
+    }
+  }
+
+  tokens.push(current);
+  return tokens;
+}
+
 function explode(input: string, delimiter: string): string {
-  // split by delimiter, commonly " " or " -"
-  // strip empty strings (if delimiter is space, and there are multiple spaces in a row)
-  // and join with new line and a trimmed delimiter (get rid of leading spaces)
-  return input
-    .trim()
-    .split(delimiter)
-    .filter(string => string) // remove empty strings
+  // Split by delimiter (commonly " " or " -") respecting quoted spans, then
+  // join with newline + trimmed delimiter so each token appears on its own line.
+  // Empty tokens (e.g. from multiple consecutive delimiters) are filtered out.
+  return splitOnDelimiter(input.trim(), delimiter)
+    .filter(token => token !== '') // remove empty strings
     .join(`\n${delimiter.trim()}`);
 }
 

--- a/packages/components/src/AutoResizeTextarea.tsx
+++ b/packages/components/src/AutoResizeTextarea.tsx
@@ -23,6 +23,20 @@ function implode(input: string): string {
     .join(' ');
 }
 
+/**
+ * Splits a string on a delimiter, respecting quoted spans.
+ * Delimiters that appear inside `"..."` or `'...'` are treated as literal
+ * characters and do not cause a split. Quotes are preserved in the returned
+ * tokens so the operation is lossless (suitable for display-only transformations
+ * where the original text must be recoverable).
+ *
+ * An unbalanced opening quote (no matching closing quote found ahead) is treated
+ * as a literal character and splitting proceeds normally.
+ *
+ * @param input The string to split.
+ * @param delimiter The delimiter to split on.
+ * @returns An array of tokens. Always contains at least one element.
+ */
 function splitOnDelimiter(input: string, delimiter: string): string[] {
   // Walk the string character by character, tracking quoted spans so that
   // delimiters inside "..." or '...' are not treated as split points.
@@ -59,6 +73,7 @@ function splitOnDelimiter(input: string, delimiter: string): string[] {
       current = '';
       i += delimiter.length;
     } else {
+      // Plain character outside any quoted span and not part of the delimiter — accumulate it
       current += ch;
       i += 1;
     }


### PR DESCRIPTION
- add a splitOnDelimiter function to AutoResizeTextarea that handles quoted values correctly (doesn't split inside quotes)
- added unit tests for existing use cases with and without quotes