### PR TITLE
fix: DH-13522: exclude some aggs for arrays

### DIFF
--- a/packages/iris-grid/src/sidebar/aggregations/AggregationUtils.test.ts
+++ b/packages/iris-grid/src/sidebar/aggregations/AggregationUtils.test.ts
@@ -15,10 +15,11 @@ describe('isValidOperation', () => {
     ];
 
     it.each(ops)('%s returns true for any column type', op => {
-      expect(isValidOperation(op, 'int')).toBe(true);
-      expect(isValidOperation(op, 'java.lang.String')).toBe(true);
-      expect(isValidOperation(op, 'boolean')).toBe(true);
-      expect(isValidOperation(op, 'int[]')).toBe(true);
+      [...numberTypes, ...dateTypes, ...textTypes, ...arrayTypes].forEach(
+        type => {
+          expect(isValidOperation(op, type)).toBe(true);
+        }
+      );
     });
   });
 
@@ -30,9 +31,9 @@ describe('isValidOperation', () => {
     ];
 
     it.each(ops)('%s returns true for non-array types', op => {
-      expect(isValidOperation(op, 'int')).toBe(true);
-      expect(isValidOperation(op, 'java.lang.String')).toBe(true);
-      expect(isValidOperation(op, 'boolean')).toBe(true);
+      [...numberTypes, ...dateTypes, ...textTypes].forEach(type => {
+        expect(isValidOperation(op, type)).toBe(true);
+      });
     });
 
     it.each(ops)('%s returns false for array types', op => {
@@ -88,17 +89,19 @@ describe('isValidOperation', () => {
     });
 
     it.each(ops)('%s returns false for non-number types', op => {
-      expect(isValidOperation(op, 'java.lang.String')).toBe(false);
-      expect(isValidOperation(op, 'boolean')).toBe(false);
+      [...textTypes, ...dateTypes, ...arrayTypes].forEach(type => {
+        expect(isValidOperation(op, type)).toBe(false);
+      });
     });
   });
 
   describe('SKIP', () => {
     it('returns false for any type', () => {
-      expect(isValidOperation(AggregationOperation.SKIP, 'int')).toBe(false);
-      expect(
-        isValidOperation(AggregationOperation.SKIP, 'java.lang.String')
-      ).toBe(false);
+      [...numberTypes, ...dateTypes, ...textTypes, ...arrayTypes].forEach(
+        type => {
+          expect(isValidOperation(AggregationOperation.SKIP, type)).toBe(false);
+        }
+      );
     });
   });
 });

--- a/packages/iris-grid/src/sidebar/aggregations/AggregationUtils.test.ts
+++ b/packages/iris-grid/src/sidebar/aggregations/AggregationUtils.test.ts
@@ -1,0 +1,104 @@
+import AggregationOperation from './AggregationOperation';
+import { isValidOperation } from './AggregationUtils';
+
+describe('isValidOperation', () => {
+  const numberTypes = ['int', 'long', 'double', 'float', 'short', 'byte'];
+  const dateTypes = ['java.time.Instant', 'java.time.ZonedDateTime'];
+  const textTypes = ['java.lang.String', 'char'];
+  const arrayTypes = ['int[]', 'java.lang.String[]', 'double[]'];
+
+  describe('COUNT, FIRST, LAST', () => {
+    const ops = [
+      AggregationOperation.COUNT,
+      AggregationOperation.FIRST,
+      AggregationOperation.LAST,
+    ];
+
+    it.each(ops)('%s returns true for any column type', op => {
+      expect(isValidOperation(op, 'int')).toBe(true);
+      expect(isValidOperation(op, 'java.lang.String')).toBe(true);
+      expect(isValidOperation(op, 'boolean')).toBe(true);
+      expect(isValidOperation(op, 'int[]')).toBe(true);
+    });
+  });
+
+  describe('COUNT_DISTINCT, DISTINCT, UNIQUE', () => {
+    const ops = [
+      AggregationOperation.COUNT_DISTINCT,
+      AggregationOperation.DISTINCT,
+      AggregationOperation.UNIQUE,
+    ];
+
+    it.each(ops)('%s returns true for non-array types', op => {
+      expect(isValidOperation(op, 'int')).toBe(true);
+      expect(isValidOperation(op, 'java.lang.String')).toBe(true);
+      expect(isValidOperation(op, 'boolean')).toBe(true);
+    });
+
+    it.each(ops)('%s returns false for array types', op => {
+      arrayTypes.forEach(type => {
+        expect(isValidOperation(op, type)).toBe(false);
+      });
+    });
+  });
+
+  describe('MEDIAN, MIN, MAX', () => {
+    const ops = [
+      AggregationOperation.MEDIAN,
+      AggregationOperation.MIN,
+      AggregationOperation.MAX,
+    ];
+
+    it.each(ops)('%s returns true for number types', op => {
+      numberTypes.forEach(type => {
+        expect(isValidOperation(op, type)).toBe(true);
+      });
+    });
+
+    it.each(ops)('%s returns true for date types', op => {
+      dateTypes.forEach(type => {
+        expect(isValidOperation(op, type)).toBe(true);
+      });
+    });
+
+    it.each(ops)('%s returns true for text types', op => {
+      textTypes.forEach(type => {
+        expect(isValidOperation(op, type)).toBe(true);
+      });
+    });
+
+    it.each(ops)('%s returns false for boolean type', op => {
+      expect(isValidOperation(op, 'boolean')).toBe(false);
+    });
+  });
+
+  describe('SUM, ABS_SUM, VAR, AVG, STD', () => {
+    const ops = [
+      AggregationOperation.SUM,
+      AggregationOperation.ABS_SUM,
+      AggregationOperation.VAR,
+      AggregationOperation.AVG,
+      AggregationOperation.STD,
+    ];
+
+    it.each(ops)('%s returns true for number types', op => {
+      numberTypes.forEach(type => {
+        expect(isValidOperation(op, type)).toBe(true);
+      });
+    });
+
+    it.each(ops)('%s returns false for non-number types', op => {
+      expect(isValidOperation(op, 'java.lang.String')).toBe(false);
+      expect(isValidOperation(op, 'boolean')).toBe(false);
+    });
+  });
+
+  describe('SKIP', () => {
+    it('returns false for any type', () => {
+      expect(isValidOperation(AggregationOperation.SKIP, 'int')).toBe(false);
+      expect(
+        isValidOperation(AggregationOperation.SKIP, 'java.lang.String')
+      ).toBe(false);
+    });
+  });
+});

--- a/packages/iris-grid/src/sidebar/aggregations/AggregationUtils.ts
+++ b/packages/iris-grid/src/sidebar/aggregations/AggregationUtils.ts
@@ -59,10 +59,11 @@ export const isValidOperation = (
     case AggregationOperation.COUNT:
     case AggregationOperation.FIRST:
     case AggregationOperation.LAST:
+      return true;
     case AggregationOperation.COUNT_DISTINCT:
     case AggregationOperation.DISTINCT:
     case AggregationOperation.UNIQUE:
-      return true;
+      return !TableUtils.isArrayType(columnType);
     case AggregationOperation.MEDIAN:
     case AggregationOperation.MIN:
     case AggregationOperation.MAX:

--- a/packages/jsapi-utils/src/TableUtils.test.ts
+++ b/packages/jsapi-utils/src/TableUtils.test.ts
@@ -3633,6 +3633,20 @@ describe('isBigIntegerType', () => {
   });
 });
 
+describe('isArrayType', () => {
+  it('should return true for array types', () => {
+    expect(TableUtils.isArrayType('int[]')).toBe(true);
+    expect(TableUtils.isArrayType('java.lang.String[]')).toBe(true);
+    expect(TableUtils.isArrayType('double[]')).toBe(true);
+  });
+
+  it('should return false for non-array types', () => {
+    expect(TableUtils.isArrayType('int')).toBe(false);
+    expect(TableUtils.isArrayType('java.lang.String')).toBe(false);
+    expect(TableUtils.isArrayType('double')).toBe(false);
+  });
+});
+
 describe('getBaseType', () => {
   it('should return the base column type', () => {
     expect(TableUtils.getBaseType('test')).toBe('test');

--- a/packages/jsapi-utils/src/TableUtils.ts
+++ b/packages/jsapi-utils/src/TableUtils.ts
@@ -530,6 +530,10 @@ export class TableUtils {
     return this.isStringType(columnType) || this.isCharType(columnType);
   }
 
+  static isArrayType(columnType: string): boolean {
+    return columnType.includes('[]');
+  }
+
   /**
    * Get base column type
    * @param columnType Column type


### PR DESCRIPTION
CountDistinct, Distinct, Unique aggs now are empty for array columns instead of throwing an error