### PR TITLE
fix: DH-20910: Don't log an error when loading a widget

### DIFF
--- a/packages/jsapi-bootstrap/src/useWidget.ts
+++ b/packages/jsapi-bootstrap/src/useWidget.ts
@@ -97,7 +97,8 @@ export function useWidget<T extends WidgetTypes = dh.Widget>(
           if (isCancelled) {
             return;
           }
-          log.error('loadWidgetInternal error', descriptor, e);
+          // We shouldn't log an error from the hook. The onus is on the consumer to log the error from the hook if they want to. However, we can log a debug message for troubleshooting.
+          log.debug('loadWidgetInternal error', descriptor, e);
           setWrapper({ widget: null, error: e ?? new Error('Null error') });
         }
       }


### PR DESCRIPTION
- The useWidget hook was always logging an error if there was an error loading the widget
  - Instead of logging the error, just report the error back. The consumer should log the error if necessary (or catch it and ignore it)
- Tested using the steps in the ticket
