### PR TITLE
fix: DH-22918: Pass ref through middleware chain, export createWidgetMiddleware helpers

### DIFF
--- a/packages/dashboard-core-plugins/src/WidgetLoaderPlugin.test.tsx
+++ b/packages/dashboard-core-plugins/src/WidgetLoaderPlugin.test.tsx
@@ -31,9 +31,11 @@ function TestWidgetTwo() {
   return <div>TestWidgetTwo</div>;
 }
 
-function TestPanel() {
+const TestPanel = React.forwardRef<unknown>((props, ref) => {
+  React.useImperativeHandle(ref, () => ({}));
   return <div>TestPanel</div>;
-}
+});
+TestPanel.displayName = 'TestPanel';
 
 class TestForwardRef extends React.PureComponent<WidgetComponentProps> {
   render() {
@@ -460,18 +462,17 @@ describe('middleware plugin chaining', () => {
   });
 
   it('chains panel middleware around base panelComponent', async () => {
-    function TestPanelMiddleware({
-      Component,
-      ...props
-    }: WidgetMiddlewarePanelProps) {
-      return (
-        <div data-testid="panel-middleware">
-          <span>PanelMiddleware</span>
-          {/* eslint-disable-next-line react/jsx-props-no-spreading */}
-          <Component {...props} />
-        </div>
-      );
-    }
+    const TestPanelMiddleware = React.forwardRef<
+      unknown,
+      WidgetMiddlewarePanelProps
+    >(({ Component, ...props }, ref) => (
+      <div data-testid="panel-middleware">
+        <span>PanelMiddleware</span>
+        {/* eslint-disable-next-line react/jsx-props-no-spreading */}
+        <Component ref={ref} {...props} />
+      </div>
+    ));
+    TestPanelMiddleware.displayName = 'TestPanelMiddleware';
 
     const panelMiddleware: WidgetMiddlewarePlugin = {
       name: 'panel-middleware',

--- a/packages/plugin/src/PluginTypes.ts
+++ b/packages/plugin/src/PluginTypes.ts
@@ -170,8 +170,17 @@ export interface WidgetMiddlewarePanelProps<T = unknown>
   /**
    * The next panel component in the middleware chain.
    * Middleware should render this component to continue the chain.
+   *
+   * This is ref-capable: middleware that transparently wraps a single inner
+   * panel should forward its own `ref` to this component. Golden-layout binds
+   * a ref to the registered panel to persist class-component state into its
+   * `componentState`; if a middleware swallows the ref, the wrapped panel's
+   * state (sorts, filters, column moves, etc.) is never serialized and is lost
+   * on reload.
    */
-  Component: React.ComponentType<WidgetPanelProps<T>>;
+  Component: React.ForwardRefExoticComponent<
+    WidgetPanelProps<T> & React.RefAttributes<unknown>
+  >;
 }
 
 /**
@@ -207,8 +216,17 @@ export interface WidgetMiddlewarePlugin<T = unknown> extends Plugin {
   /**
    * The middleware panel component that wraps the base panel component.
    * If omitted, only the component middleware will be applied.
+   *
+   * Must be a `React.forwardRef` component: middleware that transparently
+   * wraps a single inner panel has to forward its own `ref` to the wrapped
+   * `Component`. Golden-layout binds a ref to the registered panel to persist
+   * class-component state into its `componentState`; if a middleware swallows
+   * the ref, the wrapped panel's state (sorts, filters, column moves, etc.) is
+   * never serialized and is lost on reload.
    */
-  panelComponent?: React.ComponentType<WidgetMiddlewarePanelProps<T>>;
+  panelComponent?: React.ForwardRefExoticComponent<
+    WidgetMiddlewarePanelProps<T> & React.RefAttributes<unknown>
+  >;
 }
 
 /**

--- a/packages/plugin/src/PluginUtils.test.tsx
+++ b/packages/plugin/src/PluginUtils.test.tsx
@@ -32,6 +32,8 @@ import {
   registerPlugin,
   createChainedComponent,
   createChainedPanelComponent,
+  createPanelMiddleware,
+  createWidgetMiddleware,
   getWidgetDashboardPlugin,
 } from './PluginUtils';
 
@@ -814,15 +816,16 @@ describe('createChainedPanelComponent', () => {
       );
     }
 
-    function PanelComp({ Component, ...props }: WidgetMiddlewarePanelProps) {
-      return (
+    const PanelComp = React.forwardRef<unknown, WidgetMiddlewarePanelProps>(
+      ({ Component, ...props }, ref) => (
         <div data-testid={`${name}-panel`}>
           <span>{name}</span>
           {/* eslint-disable-next-line react/jsx-props-no-spreading */}
-          <Component {...props} />
+          <Component ref={ref} {...props} />
         </div>
-      );
-    }
+      )
+    );
+    PanelComp.displayName = `${name}PanelComp`;
 
     return {
       name,
@@ -922,5 +925,174 @@ describe('createChainedPanelComponent', () => {
     // Middleware should be applied
     expect(screen.getByTestId('table-panel-mw-panel')).toBeInTheDocument();
     expect(screen.getByTestId('base-panel')).toBeInTheDocument();
+  });
+
+  it('forwards the golden-layout ref through middleware to the base panel', () => {
+    // A ref-capable base panel, mirroring a class panel golden-layout binds a
+    // ref to for componentState persistence.
+    const RefBasePanel = React.forwardRef<{ marker: string }, WidgetPanelProps>(
+      (props, ref) => {
+        React.useImperativeHandle(ref, () => ({
+          marker: 'base-panel-instance',
+        }));
+        return <div data-testid="ref-base-panel">RefBasePanel</div>;
+      }
+    );
+    RefBasePanel.displayName = 'RefBasePanel';
+
+    const mw = makePanelMiddleware('ref-mw');
+    const Chained = createChainedPanelComponent(RefBasePanel, [
+      mw,
+    ]) as React.ForwardRefExoticComponent<
+      WidgetPanelProps & React.RefAttributes<unknown>
+    >;
+
+    const panelProps = {
+      fetch: jest.fn(),
+      metadata: { type: 'test-type' },
+      localDashboardId: 'test',
+      glContainer: {} as WidgetPanelProps['glContainer'],
+      glEventHub: {} as WidgetPanelProps['glEventHub'],
+    };
+
+    const ref = React.createRef<{ marker: string }>();
+    render(
+      // eslint-disable-next-line react/jsx-props-no-spreading
+      <Chained ref={ref} {...panelProps} />
+    );
+
+    // The ref must reach the base panel through the middleware layer, otherwise
+    // golden-layout cannot persist the wrapped panel's state.
+    expect(screen.getByTestId('ref-mw-panel')).toBeInTheDocument();
+    expect(ref.current).toEqual({ marker: 'base-panel-instance' });
+  });
+});
+
+describe('createPanelMiddleware', () => {
+  it('forwards the ref to the wrapped Component', () => {
+    const RefBasePanelBase = React.forwardRef<
+      { marker: string },
+      WidgetPanelProps
+    >((props, ref) => {
+      React.useImperativeHandle(ref, () => ({ marker: 'base-instance' }));
+      return <div data-testid="base-panel">RefBasePanel</div>;
+    });
+    RefBasePanelBase.displayName = 'RefBasePanel';
+    const RefBasePanel = RefBasePanelBase as React.ForwardRefExoticComponent<
+      WidgetPanelProps & React.RefAttributes<unknown>
+    >;
+
+    const Middleware = createPanelMiddleware(() => ({}), 'TestPanelMiddleware');
+
+    const ref = React.createRef<{ marker: string }>();
+    render(
+      <Middleware
+        ref={ref}
+        Component={RefBasePanel}
+        fetch={jest.fn()}
+        metadata={{ type: 'test-type' }}
+        localDashboardId="test"
+        glContainer={{} as WidgetPanelProps['glContainer']}
+        glEventHub={{} as WidgetPanelProps['glEventHub']}
+      />
+    );
+
+    expect(screen.getByTestId('base-panel')).toBeInTheDocument();
+    expect(ref.current).toEqual({ marker: 'base-instance' });
+  });
+
+  it('injects props and wraps the wrapped Component', () => {
+    let received: Record<string, unknown> | undefined;
+    const BasePanelBase = React.forwardRef<unknown, WidgetPanelProps>(
+      (props, ref) => {
+        received = props as unknown as Record<string, unknown>;
+        return <div data-testid="base-panel">BasePanel</div>;
+      }
+    );
+    BasePanelBase.displayName = 'BasePanel';
+    const BasePanel = BasePanelBase as React.ForwardRefExoticComponent<
+      WidgetPanelProps & React.RefAttributes<unknown>
+    >;
+
+    const marker = jest.fn();
+    const Middleware = createPanelMiddleware(() => ({
+      inject: { extraProp: marker },
+      wrap: child => <div data-testid="wrapper">{child}</div>,
+    }));
+
+    render(
+      <Middleware
+        Component={BasePanel}
+        fetch={jest.fn()}
+        metadata={{ type: 'test-type' }}
+        localDashboardId="test"
+        glContainer={{} as WidgetPanelProps['glContainer']}
+        glEventHub={{} as WidgetPanelProps['glEventHub']}
+      />
+    );
+
+    expect(screen.getByTestId('wrapper')).toBeInTheDocument();
+    expect(screen.getByTestId('base-panel')).toBeInTheDocument();
+    expect(received?.extraProp).toBe(marker);
+  });
+
+  it('passes the incoming props (minus Component) to the body hook', () => {
+    const useBody = jest.fn(() => ({}));
+    const BasePanelBase = React.forwardRef<unknown, WidgetPanelProps>(() => (
+      <div data-testid="base-panel">BasePanel</div>
+    ));
+    BasePanelBase.displayName = 'BasePanel';
+    const BasePanel = BasePanelBase as React.ForwardRefExoticComponent<
+      WidgetPanelProps & React.RefAttributes<unknown>
+    >;
+    const Middleware = createPanelMiddleware(useBody);
+
+    render(
+      <Middleware
+        Component={BasePanel}
+        fetch={jest.fn()}
+        metadata={{ type: 'test-type' }}
+        localDashboardId="test"
+        glContainer={{} as WidgetPanelProps['glContainer']}
+        glEventHub={{} as WidgetPanelProps['glEventHub']}
+      />
+    );
+
+    expect(useBody).toHaveBeenCalledTimes(1);
+    const bodyProps = useBody.mock.calls[0][0] as Record<string, unknown>;
+    expect(bodyProps).not.toHaveProperty('Component');
+    expect(bodyProps).toMatchObject({
+      localDashboardId: 'test',
+      metadata: { type: 'test-type' },
+    });
+  });
+});
+
+describe('createWidgetMiddleware', () => {
+  it('injects props and wraps the wrapped Component', () => {
+    let received: Record<string, unknown> | undefined;
+    function BaseWidget(props: WidgetComponentProps): JSX.Element {
+      received = props as unknown as Record<string, unknown>;
+      return <div data-testid="base-widget">BaseWidget</div>;
+    }
+    BaseWidget.displayName = 'BaseWidget';
+
+    const marker = jest.fn();
+    const Middleware = createWidgetMiddleware(() => ({
+      inject: { extraProp: marker },
+      wrap: child => <div data-testid="wrapper">{child}</div>,
+    }));
+
+    render(
+      <Middleware
+        Component={BaseWidget}
+        fetch={jest.fn()}
+        metadata={{ type: 'test-type' }}
+      />
+    );
+
+    expect(screen.getByTestId('wrapper')).toBeInTheDocument();
+    expect(screen.getByTestId('base-widget')).toBeInTheDocument();
+    expect(received?.extraProp).toBe(marker);
   });
 });

--- a/packages/plugin/src/PluginUtils.tsx
+++ b/packages/plugin/src/PluginUtils.tsx
@@ -13,9 +13,10 @@ import {
   type ElementPlugin,
   type ElementMap,
   type WidgetMiddlewarePlugin,
+  type WidgetMiddlewareComponentProps,
+  type WidgetMiddlewarePanelProps,
   type WidgetComponentProps,
   type WidgetPanelProps,
-  type WidgetMiddlewarePanelProps,
   isLegacyPlugin,
   isMultiPlugin,
   isPlugin,
@@ -200,14 +201,24 @@ export function createChainedComponent<T>(
 /**
  * Creates a panel component that chains middleware around a base panel component.
  * Each middleware panel wraps the next, with the base panel at the innermost layer.
+ *
+ * The chain forwards the `ref` injected by golden-layout (on the registered
+ * panel) all the way down to `basePanelComponent`. Golden-layout uses that ref
+ * to bind a class panel's React state into its serialized `componentState`;
+ * forwarding it keeps that persistence working through transparent middleware,
+ * so wrapped panels still restore sorts/filters/column moves on reload.
  */
 export function createChainedPanelComponent<T>(
   basePanelComponent: React.ComponentType<WidgetPanelProps<T>>,
   middleware: WidgetMiddlewarePlugin<T>[]
 ): React.ComponentType<WidgetPanelProps<T>> {
+  type RefCapablePanel = React.ForwardRefExoticComponent<
+    WidgetPanelProps<T> & React.RefAttributes<unknown>
+  >;
+
   // Filter to middleware that has a panelComponent and extract just the panel components
   type MiddlewareWithPanel = WidgetMiddlewarePlugin<T> & {
-    panelComponent: React.ComponentType<WidgetMiddlewarePanelProps<T>>;
+    panelComponent: NonNullable<WidgetMiddlewarePlugin<T>['panelComponent']>;
   };
   const panelMiddleware = middleware.filter(
     (m): m is MiddlewareWithPanel => m.panelComponent != null
@@ -230,20 +241,28 @@ export function createChainedPanelComponent<T>(
   // Build the chain from inside out (base panel is innermost)
   return [...panelMiddleware]
     .reverse()
-    .reduce<React.ComponentType<WidgetPanelProps<T>>>(
-      (WrappedPanel, middlewarePlugin) => {
-        const { panelComponent: MiddlewarePanelComponent } = middlewarePlugin;
-        const supported = [middlewarePlugin.supportedTypes].flat();
+    .reduce<RefCapablePanel>((WrappedPanel, middlewarePlugin) => {
+      const MiddlewarePanelComponent = middlewarePlugin.panelComponent;
+      const supported = [middlewarePlugin.supportedTypes].flat();
 
-        function ChainedPanel({ metadata, ...rest }: WidgetPanelProps<T>) {
+      const ChainedPanel = React.forwardRef<unknown, WidgetPanelProps<T>>(
+        ({ metadata, ...rest }, ref) => {
+          // Only forward the ref when golden-layout actually provides one.
+          // Spreading an empty object (rather than passing `ref={null}`) keeps
+          // a plain function-component base panel on a non-golden-layout render
+          // path from being handed a ref prop it can't accept.
+          const refProps = ref != null ? { ref } : {};
           // Skip middleware if the widget type doesn't match its supportedTypes
           if (metadata?.type != null && !supported.includes(metadata.type)) {
-            // eslint-disable-next-line react/jsx-props-no-spreading
-            return <WrappedPanel {...rest} metadata={metadata} />;
+            return (
+              // eslint-disable-next-line react/jsx-props-no-spreading
+              <WrappedPanel {...refProps} {...rest} metadata={metadata} />
+            );
           }
           return (
-            // eslint-disable-next-line react/jsx-props-no-spreading
             <MiddlewarePanelComponent
+              // eslint-disable-next-line react/jsx-props-no-spreading
+              {...refProps}
               // eslint-disable-next-line react/jsx-props-no-spreading
               {...rest}
               metadata={metadata}
@@ -251,13 +270,110 @@ export function createChainedPanelComponent<T>(
             />
           );
         }
-        ChainedPanel.displayName = `${
-          middlewarePlugin.name
-        }Panel(${getComponentName(WrappedPanel, 'Panel')})`;
-        return ChainedPanel;
-      },
-      basePanelComponent
+      );
+      ChainedPanel.displayName = `${
+        middlewarePlugin.name
+      }Panel(${getComponentName(WrappedPanel, 'Panel')})`;
+      return ChainedPanel;
+    }, basePanelComponent as RefCapablePanel);
+}
+
+/**
+ * What a middleware body hook returns. Both fields are optional:
+ *
+ * - `inject`: extra props merged onto the wrapped `Component`, threaded down
+ *   the middleware chain. Use it to forward IrisGrid-aware props (e.g.
+ *   `transformModel`, `transformTableOptions`, `onModelChanged`) without
+ *   hand-writing the widening cast on `Component`.
+ * - `wrap`: an optional wrapper placed *around* the wrapped component (e.g. a
+ *   context provider). Receives the already-rendered child element and must
+ *   return an element that renders it.
+ */
+export interface MiddlewareBodyResult {
+  inject?: Record<string, unknown>;
+  wrap?: (child: React.ReactElement) => React.ReactElement;
+}
+
+/**
+ * A hook implementing the body of a middleware. Receives the incoming props
+ * (without `Component`) and returns an optional set of props to inject plus an
+ * optional wrapper. The same body hook can back both a panel and a widget
+ * middleware (see {@link createPanelMiddleware} / {@link createWidgetMiddleware}),
+ * so a plugin expresses its behavior once.
+ *
+ * Type the `props` parameter as wide as the middleware needs (e.g. intersect
+ * with `IrisGridTableOptionsWidgetProps`) — the factory passes the runtime
+ * props through unchanged.
+ */
+export type MiddlewareBody<P> = (props: P) => MiddlewareBodyResult;
+
+/**
+ * Builds a panel-path middleware component from a single body hook, owning the
+ * `React.forwardRef` ceremony and ref forwarding that golden-layout state
+ * persistence depends on.
+ *
+ * The returned component is ref-capable and always forwards its `ref` to the
+ * wrapped `Component`, so a middleware author can never accidentally drop it
+ * (which would silently break `componentState` persistence — sorts, filters,
+ * column moves — on reload). The body hook only decides what to inject and how
+ * to wrap; it never sees the ref.
+ */
+export function createPanelMiddleware<
+  T = unknown,
+  P extends WidgetPanelProps<T> = WidgetPanelProps<T>,
+>(
+  useBody: MiddlewareBody<P>,
+  displayName = 'PanelMiddleware'
+): React.ForwardRefExoticComponent<
+  WidgetMiddlewarePanelProps<T> & React.RefAttributes<unknown>
+> {
+  const PanelMiddleware = React.forwardRef<
+    unknown,
+    WidgetMiddlewarePanelProps<T>
+  >(({ Component, ...rest }, ref) => {
+    const { inject, wrap } = useBody(rest as unknown as P);
+    const Next = Component as unknown as React.ForwardRefExoticComponent<
+      Record<string, unknown> & React.RefAttributes<unknown>
+    >;
+    const child = (
+      // eslint-disable-next-line react/jsx-props-no-spreading
+      <Next ref={ref} {...rest} {...inject} />
     );
+    return wrap != null ? wrap(child) : child;
+  });
+  PanelMiddleware.displayName = displayName;
+  return PanelMiddleware;
+}
+
+/**
+ * Builds a widget-path middleware component from a single body hook. The widget
+ * path takes no ref, so this is a plain function component; otherwise it mirrors
+ * {@link createPanelMiddleware} (same `inject` / `wrap` contract), letting a
+ * plugin reuse one body hook for both paths.
+ */
+export function createWidgetMiddleware<
+  T = unknown,
+  P extends WidgetComponentProps<T> = WidgetComponentProps<T>,
+>(
+  useBody: MiddlewareBody<P>,
+  displayName = 'WidgetMiddleware'
+): React.ComponentType<WidgetMiddlewareComponentProps<T>> {
+  function WidgetMiddleware({
+    Component,
+    ...rest
+  }: WidgetMiddlewareComponentProps<T>): React.ReactElement {
+    const { inject, wrap } = useBody(rest as unknown as P);
+    const Next = Component as unknown as React.ComponentType<
+      Record<string, unknown>
+    >;
+    const child = (
+      // eslint-disable-next-line react/jsx-props-no-spreading
+      <Next {...rest} {...inject} />
+    );
+    return wrap != null ? wrap(child) : child;
+  }
+  WidgetMiddleware.displayName = displayName;
+  return WidgetMiddleware;
 }
 
 export type PluginManifestPluginInfo = {


### PR DESCRIPTION
Plugin package changes implementing `createWidgetMiddleware` and `createPanelMiddleware` helpers, passing ref through middleware chain.

Split out of #2688