### PR TITLE
feat: DH-22956: Worker variables context and store

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27568,6 +27568,7 @@
       "dependencies": {
         "@deephaven/components": "file:../components",
         "@deephaven/jsapi-types": "^1.0.0-dev0.40.4",
+        "@deephaven/jsapi-utils": "file:../jsapi-utils",
         "@deephaven/log": "file:../log",
         "@deephaven/react-hooks": "file:../react-hooks",
         "@deephaven/utils": "file:../utils"

--- a/packages/app-utils/src/components/ConnectionBootstrap.tsx
+++ b/packages/app-utils/src/components/ConnectionBootstrap.tsx
@@ -14,9 +14,14 @@ import {
   type UriVariableDescriptor,
   useApi,
   useClient,
+  WorkerVariablesContext,
 } from '@deephaven/jsapi-bootstrap';
 import type { dh } from '@deephaven/jsapi-types';
 import Log from '@deephaven/log';
+import {
+  createWorkerVariablesStore,
+  type WorkerVariablesStore,
+} from '@deephaven/jsapi-utils';
 import { assertNotNull } from '@deephaven/utils';
 import { vsDebugDisconnect } from '@deephaven/icons';
 import ConnectionContext from './ConnectionContext';
@@ -179,6 +184,25 @@ export function ConnectionBootstrap({
     [connection]
   );
 
+  // Push-based worker variable store for DHC. Core exposes a single
+  // connection, so the resolver ignores the worker key.
+  const [workerVariablesStore, setWorkerVariablesStore] =
+    useState<WorkerVariablesStore | null>(null);
+  useEffect(
+    function manageWorkerVariablesStore() {
+      if (connection == null) {
+        setWorkerVariablesStore(null);
+        return undefined;
+      }
+      const store = createWorkerVariablesStore(async () => connection);
+      setWorkerVariablesStore(store);
+      return () => {
+        store.destroy();
+      };
+    },
+    [connection]
+  );
+
   /** We don't really need to do anything fancy in Core to manage an object, just fetch it  */
   const objectManager: ObjectFetchManager = useMemo(
     () => ({
@@ -215,27 +239,29 @@ export function ConnectionBootstrap({
   return (
     <ConnectionContext.Provider value={connection ?? null}>
       <ObjectFetcherContext.Provider value={objectFetcher}>
-        <ObjectFetchManagerContext.Provider value={objectManager}>
-          {children}
-          <DebouncedModal isOpen={isReconnecting} debounceMs={1000}>
-            <InfoModal
-              icon={vsDebugDisconnect}
-              title={
-                <>
-                  <LoadingSpinner /> Attempting to reconnect...
-                </>
-              }
-              subtitle="Please check your network connection."
+        <WorkerVariablesContext.Provider value={workerVariablesStore}>
+          <ObjectFetchManagerContext.Provider value={objectManager}>
+            {children}
+            <DebouncedModal isOpen={isReconnecting} debounceMs={1000}>
+              <InfoModal
+                icon={vsDebugDisconnect}
+                title={
+                  <>
+                    <LoadingSpinner /> Attempting to reconnect...
+                  </>
+                }
+                subtitle="Please check your network connection."
+              />
+            </DebouncedModal>
+            <BasicModal
+              confirmButtonText="Refresh"
+              onConfirm={handleRefresh}
+              isOpen={isAuthFailed}
+              headerText="Authentication failed"
+              bodyText="Credentials are invalid. Please refresh your browser to try and reconnect."
             />
-          </DebouncedModal>
-          <BasicModal
-            confirmButtonText="Refresh"
-            onConfirm={handleRefresh}
-            isOpen={isAuthFailed}
-            headerText="Authentication failed"
-            bodyText="Credentials are invalid. Please refresh your browser to try and reconnect."
-          />
-        </ObjectFetchManagerContext.Provider>
+          </ObjectFetchManagerContext.Provider>
+        </WorkerVariablesContext.Provider>
       </ObjectFetcherContext.Provider>
     </ConnectionContext.Provider>
   );

--- a/packages/jsapi-bootstrap/package.json
+++ b/packages/jsapi-bootstrap/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "@deephaven/components": "file:../components",
     "@deephaven/jsapi-types": "^1.0.0-dev0.40.4",
+    "@deephaven/jsapi-utils": "file:../jsapi-utils",
     "@deephaven/log": "file:../log",
     "@deephaven/react-hooks": "file:../react-hooks",
     "@deephaven/utils": "file:../utils"

--- a/packages/jsapi-bootstrap/src/WorkerVariablesContext.ts
+++ b/packages/jsapi-bootstrap/src/WorkerVariablesContext.ts
@@ -1,0 +1,14 @@
+import { createContext } from 'react';
+import type { WorkerVariablesStore } from '@deephaven/jsapi-utils';
+
+/**
+ * Context providing a {@link WorkerVariablesStore} that delivers push-based,
+ * ref-counted worker variable lists. `null` when the host does not expose
+ * field-update subscriptions; consumers must handle the missing-provider case.
+ */
+export const WorkerVariablesContext =
+  createContext<WorkerVariablesStore | null>(null);
+
+WorkerVariablesContext.displayName = 'WorkerVariablesContext';
+
+export default WorkerVariablesContext;

--- a/packages/jsapi-bootstrap/src/index.ts
+++ b/packages/jsapi-bootstrap/src/index.ts
@@ -7,3 +7,5 @@ export * from './useDeferredApi';
 export * from './useObjectFetch';
 export * from './useObjectFetcher';
 export * from './useWidget';
+export * from './useWorkerVariables';
+export * from './WorkerVariablesContext';

--- a/packages/jsapi-bootstrap/src/useWorkerVariables.test.tsx
+++ b/packages/jsapi-bootstrap/src/useWorkerVariables.test.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import { act, renderHook } from '@testing-library/react';
+import type { dh } from '@deephaven/jsapi-types';
+import type { WorkerVariablesStore } from '@deephaven/jsapi-utils';
+import WorkerVariablesContext from './WorkerVariablesContext';
+import useWorkerVariables from './useWorkerVariables';
+
+function makeStore(initial: dh.ide.VariableDefinition[] | null = null): {
+  store: WorkerVariablesStore;
+  push: (next: dh.ide.VariableDefinition[] | null) => void;
+  subscribeMock: jest.Mock;
+} {
+  let current = initial;
+  const listeners = new Set<() => void>();
+  const subscribeMock = jest.fn((_key: string, listener: () => void) => {
+    listeners.add(listener);
+    return () => {
+      listeners.delete(listener);
+    };
+  });
+  const store: WorkerVariablesStore = {
+    snapshot: () => current,
+    subscribe: subscribeMock as unknown as WorkerVariablesStore['subscribe'],
+    invalidate: jest.fn(),
+    destroy: jest.fn(),
+  };
+  return {
+    store,
+    subscribeMock,
+    push: next => {
+      current = next;
+      listeners.forEach(l => l());
+    },
+  };
+}
+
+function wrapperWith(
+  store: WorkerVariablesStore | null
+): React.FC<{ children: React.ReactNode }> {
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <WorkerVariablesContext.Provider value={store}>
+        {children}
+      </WorkerVariablesContext.Provider>
+    );
+  };
+}
+
+describe('useWorkerVariables', () => {
+  it('returns null with no provider', () => {
+    const { result } = renderHook(() => useWorkerVariables({ type: 'Table' }));
+    expect(result.current).toBeNull();
+  });
+
+  it('returns null when the store has no snapshot yet', () => {
+    const { store } = makeStore();
+    const { result } = renderHook(() => useWorkerVariables({ type: 'Table' }), {
+      wrapper: wrapperWith(store),
+    });
+    expect(result.current).toBeNull();
+  });
+
+  it('re-renders when the store pushes a new snapshot', () => {
+    const { store, push } = makeStore();
+    const { result } = renderHook(() => useWorkerVariables({ type: 'Table' }), {
+      wrapper: wrapperWith(store),
+    });
+    expect(result.current).toBeNull();
+
+    const next = [
+      { id: 'a', name: 'a', type: 'Table' } as dh.ide.VariableDefinition,
+    ];
+    act(() => {
+      push(next);
+    });
+    expect(result.current).toBe(next);
+  });
+
+  it('uses the worker key derived from the descriptor', () => {
+    const { store, subscribeMock } = makeStore();
+    renderHook(
+      () =>
+        useWorkerVariables({ querySerial: 'qs' } as Record<string, unknown>),
+      { wrapper: wrapperWith(store) }
+    );
+    expect(subscribeMock).toHaveBeenCalledWith('q:qs', expect.any(Function));
+  });
+});

--- a/packages/jsapi-bootstrap/src/useWorkerVariables.ts
+++ b/packages/jsapi-bootstrap/src/useWorkerVariables.ts
@@ -1,0 +1,42 @@
+import { useCallback, useContext, useSyncExternalStore } from 'react';
+import type { dh } from '@deephaven/jsapi-types';
+import { getWorkerKey, type WorkerVariables } from '@deephaven/jsapi-utils';
+import WorkerVariablesContext from './WorkerVariablesContext';
+
+/**
+ * Subscribe to the live list of variables on the worker identified by
+ * `descriptor`. Returns `null` while the worker connection is being resolved
+ * or when no {@link WorkerVariablesContext} provider is mounted; returns the
+ * cumulative list (with field-update deltas applied) once the first update
+ * arrives.
+ *
+ * Subscriptions are ref-counted by worker key so multiple consumers targeting
+ * the same worker share a single underlying `subscribeToFieldUpdates` call.
+ */
+export function useWorkerVariables(
+  descriptor:
+    | Partial<dh.ide.VariableDescriptor>
+    | Record<string, unknown>
+    | null
+    | undefined
+): WorkerVariables | null {
+  const store = useContext(WorkerVariablesContext);
+  const key = getWorkerKey(descriptor);
+
+  const subscribe = useCallback(
+    (listener: () => void) => {
+      if (store == null) return () => undefined;
+      return store.subscribe(key, listener);
+    },
+    [store, key]
+  );
+
+  const getSnapshot = useCallback(
+    () => (store == null ? null : store.snapshot(key)),
+    [store, key]
+  );
+
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+}
+
+export default useWorkerVariables;

--- a/packages/jsapi-bootstrap/tsconfig.json
+++ b/packages/jsapi-bootstrap/tsconfig.json
@@ -8,6 +8,7 @@
   "exclude": ["node_modules", "src/**/*.test.*", "src/**/__mocks__/*"],
   "references": [
     { "path": "../components" },
+    { "path": "../jsapi-utils" },
     { "path": "../log" },
     { "path": "../react-hooks" },
     { "path": "../test-utils" },

--- a/packages/jsapi-utils/src/WorkerVariablesStore.test.ts
+++ b/packages/jsapi-utils/src/WorkerVariablesStore.test.ts
@@ -240,4 +240,66 @@ describe('createWorkerVariablesStore', () => {
     expect(listener).not.toHaveBeenCalled();
     expect(store.snapshot('w1')).toBeNull();
   });
+
+  it('isolates a throwing listener so other listeners still run', async () => {
+    const { connection, emit } = makeConnection();
+    const store = createWorkerVariablesStore(async () => connection);
+    const throwing = jest.fn(() => {
+      throw new Error('listener boom');
+    });
+    const other = jest.fn();
+    store.subscribe('w1', throwing);
+    store.subscribe('w1', other);
+    await flushPromises();
+    expect(() => emit({ created: [makeDefinition('v1')] })).not.toThrow();
+    expect(throwing).toHaveBeenCalledTimes(1);
+    expect(other).toHaveBeenCalledTimes(1);
+    expect(store.snapshot('w1')?.map(v => v.id)).toEqual(['v1']);
+  });
+
+  it('swallows errors thrown while unsubscribing from field updates', async () => {
+    const unsubscribeMock = jest.fn(() => {
+      throw new Error('unsubscribe boom');
+    });
+    const subscribeMock = jest.fn(() => unsubscribeMock);
+    const connection = {
+      subscribeToFieldUpdates: subscribeMock,
+    } as unknown as dh.IdeConnection;
+    const store = createWorkerVariablesStore(async () => connection);
+    const off = store.subscribe('w1', jest.fn());
+    await flushPromises();
+    expect(() => off()).not.toThrow();
+    expect(unsubscribeMock).toHaveBeenCalledTimes(1);
+    expect(store.snapshot('w1')).toBeNull();
+  });
+
+  it('does not start a second subscription while one is already resolving', async () => {
+    let resolve: (c: dh.IdeConnection) => void = () => undefined;
+    const connectionPromise = new Promise<dh.IdeConnection>(r => {
+      resolve = r;
+    });
+    const { connection, subscribeMock } = makeConnection();
+    const resolveConnection = jest.fn(() => connectionPromise);
+    const store = createWorkerVariablesStore(resolveConnection);
+    store.subscribe('w1', jest.fn());
+    // First start is mid-flight (resolving); invalidate kicks off a second
+    // start which must bail out early instead of resolving again.
+    store.invalidate('w1');
+    expect(resolveConnection).toHaveBeenCalledTimes(1);
+    resolve(connection);
+    await flushPromises();
+    // The original resolve is stale (generation bumped), so no subscription.
+    expect(subscribeMock).not.toHaveBeenCalled();
+  });
+
+  it('logs and recovers when resolveConnection rejects', async () => {
+    const store = createWorkerVariablesStore(async () => {
+      throw new Error('resolve boom');
+    });
+    const listener = jest.fn();
+    store.subscribe('w1', listener);
+    await flushPromises();
+    expect(listener).not.toHaveBeenCalled();
+    expect(store.snapshot('w1')).toBeNull();
+  });
 });

--- a/packages/jsapi-utils/src/WorkerVariablesStore.test.ts
+++ b/packages/jsapi-utils/src/WorkerVariablesStore.test.ts
@@ -273,7 +273,7 @@ describe('createWorkerVariablesStore', () => {
     expect(store.snapshot('w1')).toBeNull();
   });
 
-  it('does not start a second subscription while one is already resolving', async () => {
+  it('re-resolves after an invalidate that lands mid-resolve, without resolving concurrently', async () => {
     let resolve: (c: dh.IdeConnection) => void = () => undefined;
     const connectionPromise = new Promise<dh.IdeConnection>(r => {
       resolve = r;
@@ -282,14 +282,19 @@ describe('createWorkerVariablesStore', () => {
     const resolveConnection = jest.fn(() => connectionPromise);
     const store = createWorkerVariablesStore(resolveConnection);
     store.subscribe('w1', jest.fn());
-    // First start is mid-flight (resolving); invalidate kicks off a second
-    // start which must bail out early instead of resolving again.
+    // First start is mid-flight (resolving); invalidate must NOT kick off a
+    // concurrent resolve while one is already in flight.
     store.invalidate('w1');
     expect(resolveConnection).toHaveBeenCalledTimes(1);
+    expect(subscribeMock).not.toHaveBeenCalled();
+    // Once the in-flight resolve completes it bails out as stale (generation
+    // bumped) but must trigger a fresh resolve so the entry isn't left stuck.
     resolve(connection);
     await flushPromises();
-    // The original resolve is stale (generation bumped), so no subscription.
-    expect(subscribeMock).not.toHaveBeenCalled();
+    expect(resolveConnection).toHaveBeenCalledTimes(2);
+    expect(subscribeMock).toHaveBeenCalledTimes(1);
+    // Subscription is open again; snapshot stays null until a delta arrives.
+    expect(store.snapshot('w1')).toBeNull();
   });
 
   it('logs and recovers when resolveConnection rejects', async () => {

--- a/packages/jsapi-utils/src/WorkerVariablesStore.test.ts
+++ b/packages/jsapi-utils/src/WorkerVariablesStore.test.ts
@@ -302,4 +302,57 @@ describe('createWorkerVariablesStore', () => {
     expect(listener).not.toHaveBeenCalled();
     expect(store.snapshot('w1')).toBeNull();
   });
+
+  it('matches deltas by name/title when id is absent', async () => {
+    const { connection, emit } = makeConnection();
+    const store = createWorkerVariablesStore(async () => connection);
+    store.subscribe('w1', jest.fn());
+    await flushPromises();
+
+    // Definitions without an id (id omitted) must still be tracked by name.
+    const a = makeDefinition('a', { id: undefined as unknown as string });
+    const b = makeDefinition('b', { id: undefined as unknown as string });
+    emit({ created: [a, b] });
+    expect(store.snapshot('w1')?.map(v => v.name)).toEqual(['a', 'b']);
+
+    // Removing by name (no id) should drop the matching entry, not all.
+    emit({
+      removed: [makeDefinition('a', { id: undefined as unknown as string })],
+    });
+    expect(store.snapshot('w1')?.map(v => v.name)).toEqual(['b']);
+
+    // Updating by name replaces in place and moves to the end.
+    emit({
+      updated: [
+        makeDefinition('b', {
+          id: undefined as unknown as string,
+          title: 'b2',
+        }),
+      ],
+    });
+    const snap = store.snapshot('w1');
+    expect(snap?.map(v => v.name)).toEqual(['b']);
+    expect(snap?.find(v => v.name === 'b')?.title).toBe('b2');
+  });
+
+  it('keeps keyless items instead of dropping them on a delta', async () => {
+    const { connection, emit } = makeConnection();
+    const store = createWorkerVariablesStore(async () => connection);
+    store.subscribe('w1', jest.fn());
+    await flushPromises();
+
+    const keyless = makeDefinition('', {
+      id: undefined as unknown as string,
+      name: '',
+      title: '',
+    });
+    emit({ created: [keyless, makeDefinition('a')] });
+    expect(store.snapshot('w1')).toHaveLength(2);
+
+    // An unrelated delta must not drop the keyless item.
+    emit({ removed: [makeDefinition('a')] });
+    const snap = store.snapshot('w1');
+    expect(snap).toHaveLength(1);
+    expect(snap?.[0]).toBe(keyless);
+  });
 });

--- a/packages/jsapi-utils/src/WorkerVariablesStore.test.ts
+++ b/packages/jsapi-utils/src/WorkerVariablesStore.test.ts
@@ -1,0 +1,244 @@
+import type { dh } from '@deephaven/jsapi-types';
+import {
+  DEFAULT_WORKER_KEY,
+  createWorkerVariablesStore,
+  getWorkerKey,
+} from './WorkerVariablesStore';
+
+type FieldUpdateListener = (changes: dh.ide.VariableChanges) => void;
+
+function makeDefinition(
+  id: string,
+  overrides: Partial<dh.ide.VariableDefinition> = {}
+): dh.ide.VariableDefinition {
+  return {
+    id,
+    name: id,
+    title: id,
+    type: 'Table',
+    description: '',
+    applicationId: '',
+    applicationName: '',
+    ...overrides,
+  } as dh.ide.VariableDefinition;
+}
+
+function makeConnection(): {
+  connection: dh.IdeConnection;
+  emit: (changes: Partial<dh.ide.VariableChanges>) => void;
+  subscribeMock: jest.Mock;
+  unsubscribeMock: jest.Mock;
+} {
+  let listener: FieldUpdateListener | null = null;
+  const unsubscribeMock = jest.fn(() => {
+    listener = null;
+  });
+  const subscribeMock = jest.fn((cb: FieldUpdateListener) => {
+    listener = cb;
+    return unsubscribeMock;
+  });
+  const connection = {
+    subscribeToFieldUpdates: subscribeMock,
+  } as unknown as dh.IdeConnection;
+  return {
+    connection,
+    subscribeMock,
+    unsubscribeMock,
+    emit: (changes: Partial<dh.ide.VariableChanges>) => {
+      listener?.({
+        created: [],
+        removed: [],
+        updated: [],
+        ...changes,
+      } as dh.ide.VariableChanges);
+    },
+  };
+}
+
+describe('getWorkerKey', () => {
+  it('returns default key for null/undefined/plain descriptors', () => {
+    expect(getWorkerKey(null)).toBe(DEFAULT_WORKER_KEY);
+    expect(getWorkerKey(undefined)).toBe(DEFAULT_WORKER_KEY);
+    expect(getWorkerKey({ type: 'Table', name: 'x' })).toBe(DEFAULT_WORKER_KEY);
+  });
+
+  it('prefers querySerial over queryName over sessionId', () => {
+    expect(
+      getWorkerKey({ querySerial: 'qs', queryName: 'qn', sessionId: 'sid' })
+    ).toBe('q:qs');
+    expect(getWorkerKey({ queryName: 'qn', sessionId: 'sid' })).toBe('qn:qn');
+    expect(getWorkerKey({ sessionId: 'sid' })).toBe('s:sid');
+  });
+
+  it('ignores empty-string routing fields', () => {
+    expect(
+      getWorkerKey({ querySerial: '', queryName: '', sessionId: '' })
+    ).toBe(DEFAULT_WORKER_KEY);
+  });
+});
+
+describe('createWorkerVariablesStore', () => {
+  function flushMicrotasks(): Promise<void> {
+    return new Promise(resolve => setTimeout(resolve, 0));
+  }
+
+  it('returns null snapshot before any updates arrive', async () => {
+    const { connection } = makeConnection();
+    const store = createWorkerVariablesStore(async () => connection);
+    const listener = jest.fn();
+    store.subscribe('w1', listener);
+    expect(store.snapshot('w1')).toBeNull();
+  });
+
+  it('opens one subscription and shares it across consumers for the same key', async () => {
+    const { connection, subscribeMock, emit } = makeConnection();
+    const store = createWorkerVariablesStore(async () => connection);
+    const a = jest.fn();
+    const b = jest.fn();
+    store.subscribe('w1', a);
+    store.subscribe('w1', b);
+    await flushMicrotasks();
+    expect(subscribeMock).toHaveBeenCalledTimes(1);
+    emit({ created: [makeDefinition('v1')] });
+    expect(a).toHaveBeenCalledTimes(1);
+    expect(b).toHaveBeenCalledTimes(1);
+    expect(store.snapshot('w1')).toEqual([makeDefinition('v1')]);
+  });
+
+  it('opens separate subscriptions per worker key', async () => {
+    const { connection, subscribeMock } = makeConnection();
+    const store = createWorkerVariablesStore(async () => connection);
+    store.subscribe('w1', jest.fn());
+    store.subscribe('w2', jest.fn());
+    await flushMicrotasks();
+    expect(subscribeMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('applies created/updated/removed deltas with stable snapshot identity per delta', async () => {
+    const { connection, emit } = makeConnection();
+    const store = createWorkerVariablesStore(async () => connection);
+    store.subscribe('w1', jest.fn());
+    await flushMicrotasks();
+
+    emit({ created: [makeDefinition('a'), makeDefinition('b')] });
+    const snap1 = store.snapshot('w1');
+    const snap1Again = store.snapshot('w1');
+    expect(snap1).toBe(snap1Again);
+    expect(snap1?.map(v => v.id)).toEqual(['a', 'b']);
+
+    emit({ created: [makeDefinition('c')] });
+    const snap2 = store.snapshot('w1');
+    expect(snap2).not.toBe(snap1);
+    expect(snap2?.map(v => v.id)).toEqual(['a', 'b', 'c']);
+
+    emit({ removed: [makeDefinition('a')] });
+    expect(store.snapshot('w1')?.map(v => v.id)).toEqual(['b', 'c']);
+
+    emit({ updated: [makeDefinition('b', { title: 'b2' })] });
+    const snap4 = store.snapshot('w1');
+    expect(snap4?.map(v => v.id)).toEqual(['c', 'b']);
+    expect(snap4?.find(v => v.id === 'b')?.title).toBe('b2');
+  });
+
+  it('closes the underlying subscription when the last listener unsubscribes', async () => {
+    const { connection, unsubscribeMock } = makeConnection();
+    const store = createWorkerVariablesStore(async () => connection);
+    const a = jest.fn();
+    const b = jest.fn();
+    const offA = store.subscribe('w1', a);
+    const offB = store.subscribe('w1', b);
+    await flushMicrotasks();
+    offA();
+    expect(unsubscribeMock).not.toHaveBeenCalled();
+    offB();
+    expect(unsubscribeMock).toHaveBeenCalledTimes(1);
+    expect(store.snapshot('w1')).toBeNull();
+  });
+
+  it('unsubscribe is idempotent', async () => {
+    const { connection, unsubscribeMock } = makeConnection();
+    const store = createWorkerVariablesStore(async () => connection);
+    const off = store.subscribe('w1', jest.fn());
+    await flushMicrotasks();
+    off();
+    off();
+    expect(unsubscribeMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('invalidate clears the snapshot, notifies listeners, and re-resolves', async () => {
+    const subscribeMock = jest.fn();
+    let listener: FieldUpdateListener | null = null;
+    const unsubscribeMock = jest.fn(() => {
+      listener = null;
+    });
+    subscribeMock.mockImplementation((cb: FieldUpdateListener) => {
+      listener = cb;
+      return unsubscribeMock;
+    });
+    const connection = {
+      subscribeToFieldUpdates: subscribeMock,
+    } as unknown as dh.IdeConnection;
+    const store = createWorkerVariablesStore(async () => connection);
+
+    const onChange = jest.fn();
+    store.subscribe('w1', onChange);
+    await flushMicrotasks();
+    listener?.({
+      created: [makeDefinition('a')],
+      removed: [],
+      updated: [],
+    });
+    expect(store.snapshot('w1')?.map(v => v.id)).toEqual(['a']);
+    onChange.mockClear();
+
+    store.invalidate('w1');
+    expect(unsubscribeMock).toHaveBeenCalledTimes(1);
+    expect(store.snapshot('w1')).toBeNull();
+    expect(onChange).toHaveBeenCalledTimes(1);
+
+    await flushMicrotasks();
+    expect(subscribeMock).toHaveBeenCalledTimes(2);
+    listener?.({
+      created: [makeDefinition('b')],
+      removed: [],
+      updated: [],
+    });
+    expect(store.snapshot('w1')?.map(v => v.id)).toEqual(['b']);
+  });
+
+  it('destroy tears down all entries and stops further updates', async () => {
+    const { connection, unsubscribeMock, emit } = makeConnection();
+    const store = createWorkerVariablesStore(async () => connection);
+    const listener = jest.fn();
+    store.subscribe('w1', listener);
+    await flushMicrotasks();
+    store.destroy();
+    expect(unsubscribeMock).toHaveBeenCalledTimes(1);
+    emit({ created: [makeDefinition('v1')] });
+    expect(listener).not.toHaveBeenCalled();
+    expect(store.snapshot('w1')).toBeNull();
+  });
+
+  it('skips subscription when all listeners leave before connection resolves', async () => {
+    let resolve: (c: dh.IdeConnection) => void = () => undefined;
+    const connectionPromise = new Promise<dh.IdeConnection>(r => {
+      resolve = r;
+    });
+    const { connection, subscribeMock } = makeConnection();
+    const store = createWorkerVariablesStore(() => connectionPromise);
+    const off = store.subscribe('w1', jest.fn());
+    off();
+    resolve(connection);
+    await flushMicrotasks();
+    expect(subscribeMock).not.toHaveBeenCalled();
+  });
+
+  it('does not subscribe when resolveConnection returns null', async () => {
+    const store = createWorkerVariablesStore(async () => null);
+    const listener = jest.fn();
+    store.subscribe('w1', listener);
+    await flushMicrotasks();
+    expect(listener).not.toHaveBeenCalled();
+    expect(store.snapshot('w1')).toBeNull();
+  });
+});

--- a/packages/jsapi-utils/src/WorkerVariablesStore.test.ts
+++ b/packages/jsapi-utils/src/WorkerVariablesStore.test.ts
@@ -1,9 +1,12 @@
 import type { dh } from '@deephaven/jsapi-types';
+import { TestUtils } from '@deephaven/test-utils';
 import {
   DEFAULT_WORKER_KEY,
   createWorkerVariablesStore,
   getWorkerKey,
 } from './WorkerVariablesStore';
+
+const { flushPromises } = TestUtils;
 
 type FieldUpdateListener = (changes: dh.ide.VariableChanges) => void;
 
@@ -78,10 +81,6 @@ describe('getWorkerKey', () => {
 });
 
 describe('createWorkerVariablesStore', () => {
-  function flushMicrotasks(): Promise<void> {
-    return new Promise(resolve => setTimeout(resolve, 0));
-  }
-
   it('returns null snapshot before any updates arrive', async () => {
     const { connection } = makeConnection();
     const store = createWorkerVariablesStore(async () => connection);
@@ -97,7 +96,7 @@ describe('createWorkerVariablesStore', () => {
     const b = jest.fn();
     store.subscribe('w1', a);
     store.subscribe('w1', b);
-    await flushMicrotasks();
+    await flushPromises();
     expect(subscribeMock).toHaveBeenCalledTimes(1);
     emit({ created: [makeDefinition('v1')] });
     expect(a).toHaveBeenCalledTimes(1);
@@ -110,7 +109,7 @@ describe('createWorkerVariablesStore', () => {
     const store = createWorkerVariablesStore(async () => connection);
     store.subscribe('w1', jest.fn());
     store.subscribe('w2', jest.fn());
-    await flushMicrotasks();
+    await flushPromises();
     expect(subscribeMock).toHaveBeenCalledTimes(2);
   });
 
@@ -118,7 +117,7 @@ describe('createWorkerVariablesStore', () => {
     const { connection, emit } = makeConnection();
     const store = createWorkerVariablesStore(async () => connection);
     store.subscribe('w1', jest.fn());
-    await flushMicrotasks();
+    await flushPromises();
 
     emit({ created: [makeDefinition('a'), makeDefinition('b')] });
     const snap1 = store.snapshot('w1');
@@ -147,7 +146,7 @@ describe('createWorkerVariablesStore', () => {
     const b = jest.fn();
     const offA = store.subscribe('w1', a);
     const offB = store.subscribe('w1', b);
-    await flushMicrotasks();
+    await flushPromises();
     offA();
     expect(unsubscribeMock).not.toHaveBeenCalled();
     offB();
@@ -159,7 +158,7 @@ describe('createWorkerVariablesStore', () => {
     const { connection, unsubscribeMock } = makeConnection();
     const store = createWorkerVariablesStore(async () => connection);
     const off = store.subscribe('w1', jest.fn());
-    await flushMicrotasks();
+    await flushPromises();
     off();
     off();
     expect(unsubscribeMock).toHaveBeenCalledTimes(1);
@@ -182,7 +181,7 @@ describe('createWorkerVariablesStore', () => {
 
     const onChange = jest.fn();
     store.subscribe('w1', onChange);
-    await flushMicrotasks();
+    await flushPromises();
     listener?.({
       created: [makeDefinition('a')],
       removed: [],
@@ -196,7 +195,7 @@ describe('createWorkerVariablesStore', () => {
     expect(store.snapshot('w1')).toBeNull();
     expect(onChange).toHaveBeenCalledTimes(1);
 
-    await flushMicrotasks();
+    await flushPromises();
     expect(subscribeMock).toHaveBeenCalledTimes(2);
     listener?.({
       created: [makeDefinition('b')],
@@ -211,7 +210,7 @@ describe('createWorkerVariablesStore', () => {
     const store = createWorkerVariablesStore(async () => connection);
     const listener = jest.fn();
     store.subscribe('w1', listener);
-    await flushMicrotasks();
+    await flushPromises();
     store.destroy();
     expect(unsubscribeMock).toHaveBeenCalledTimes(1);
     emit({ created: [makeDefinition('v1')] });
@@ -229,7 +228,7 @@ describe('createWorkerVariablesStore', () => {
     const off = store.subscribe('w1', jest.fn());
     off();
     resolve(connection);
-    await flushMicrotasks();
+    await flushPromises();
     expect(subscribeMock).not.toHaveBeenCalled();
   });
 
@@ -237,7 +236,7 @@ describe('createWorkerVariablesStore', () => {
     const store = createWorkerVariablesStore(async () => null);
     const listener = jest.fn();
     store.subscribe('w1', listener);
-    await flushMicrotasks();
+    await flushPromises();
     expect(listener).not.toHaveBeenCalled();
     expect(store.snapshot('w1')).toBeNull();
   });

--- a/packages/jsapi-utils/src/WorkerVariablesStore.ts
+++ b/packages/jsapi-utils/src/WorkerVariablesStore.ts
@@ -60,22 +60,22 @@ export type ResolveConnection = (
  */
 export type WorkerVariablesStore = {
   /** Current list for `key`, or `null` if not yet resolved. */
-  snapshot(key: string): WorkerVariables | null;
+  snapshot: (key: string) => WorkerVariables | null;
   /**
    * Subscribe to changes for `key`. The listener fires after each delta is
    * applied. Returns an unsubscribe function; the underlying field-updates
    * subscription is closed when the last listener for `key` unsubscribes.
    */
-  subscribe(key: string, listener: () => void): () => void;
+  subscribe: (key: string, listener: () => void) => () => void;
   /**
    * Drop the cached list and subscription for `key`. Active subscribers will
    * be notified (snapshot becomes `null`) and a fresh resolve+subscribe will
    * kick off. Use when an external signal indicates the worker behind `key`
    * has been replaced (e.g. DHE query restart).
    */
-  invalidate(key: string): void;
+  invalidate: (key: string) => void;
   /** Tear down all entries. Call when the owning provider unmounts. */
-  destroy(): void;
+  destroy: () => void;
 };
 
 type Entry = {
@@ -121,8 +121,9 @@ export function createWorkerVariablesStore(
     });
   }
 
-  function teardown(entry: Entry): void {
-    if (entry.unsubscribeFieldUpdates != null) {
+  function teardown(key: string): void {
+    const entry = entries.get(key);
+    if (entry?.unsubscribeFieldUpdates != null) {
       try {
         entry.unsubscribeFieldUpdates();
       } catch (e) {
@@ -132,8 +133,15 @@ export function createWorkerVariablesStore(
     }
   }
 
-  async function start(key: string, entry: Entry): Promise<void> {
-    if (entry.resolving || entry.unsubscribeFieldUpdates != null) return;
+  async function start(key: string): Promise<void> {
+    const entry = entries.get(key);
+    if (
+      entry == null ||
+      entry.resolving ||
+      entry.unsubscribeFieldUpdates != null
+    ) {
+      return;
+    }
     entry.resolving = true;
     const gen = entry.generation;
     try {
@@ -181,12 +189,13 @@ export function createWorkerVariablesStore(
       const entry = getOrCreate(key);
       entry.listeners.add(listener);
       if (entry.unsubscribeFieldUpdates == null && !entry.resolving) {
-        void start(key, entry);
+        // start handles its own errors; nothing to do on rejection
+        start(key).catch(() => undefined);
       }
       return () => {
         entry.listeners.delete(listener);
         if (entry.listeners.size === 0) {
-          teardown(entry);
+          teardown(key);
           entry.list = null;
           entries.delete(key);
         }
@@ -196,19 +205,17 @@ export function createWorkerVariablesStore(
       const entry = entries.get(key);
       if (entry == null) return;
       entry.generation += 1;
-      teardown(entry);
+      teardown(key);
       entry.list = null;
       notify(entry);
       if (entry.listeners.size > 0) {
-        void start(key, entry);
+        // start handles its own errors; nothing to do on rejection
+        start(key).catch(() => undefined);
       }
     },
     destroy() {
-      entries.forEach(entry => {
-        teardown(entry);
-        entry.listeners.clear();
-        entry.list = null;
-        entry.generation += 1;
+      Array.from(entries.keys()).forEach(key => {
+        teardown(key);
       });
       entries.clear();
     },

--- a/packages/jsapi-utils/src/WorkerVariablesStore.ts
+++ b/packages/jsapi-utils/src/WorkerVariablesStore.ts
@@ -1,0 +1,216 @@
+import type { dh } from '@deephaven/jsapi-types';
+import Log from '@deephaven/log';
+
+const log = Log.module('@deephaven/jsapi-utils.WorkerVariablesStore');
+
+/**
+ * The current full list of variable definitions on a worker. Snapshot identity
+ * is stable until the next field-update delta is applied, so consumers using
+ * `useSyncExternalStore` will only re-render when the list actually changes.
+ */
+export type WorkerVariables = readonly dh.ide.VariableDefinition[];
+
+/** Default key used when a host exposes a single connection (e.g. DHC). */
+export const DEFAULT_WORKER_KEY = 'default';
+
+/**
+ * Derive a stable string key identifying the worker that owns the variable
+ * described by `descriptor`. Used by {@link WorkerVariablesStore} to dedup
+ * subscriptions across consumers that target the same worker.
+ *
+ * The base `dh.ide.VariableDescriptor` type only carries `type`/`id`/`name`,
+ * but DHE attaches routing fields (`querySerial`, `queryName`, `sessionId`).
+ * Those are read defensively so this helper works in DHC too — where every
+ * descriptor maps to {@link DEFAULT_WORKER_KEY}.
+ */
+export function getWorkerKey(
+  descriptor:
+    | Partial<dh.ide.VariableDescriptor>
+    | Record<string, unknown>
+    | null
+    | undefined
+): string {
+  if (descriptor == null) return DEFAULT_WORKER_KEY;
+  const d = descriptor as Record<string, unknown>;
+  if (typeof d.querySerial === 'string' && d.querySerial.length > 0) {
+    return `q:${d.querySerial}`;
+  }
+  if (typeof d.queryName === 'string' && d.queryName.length > 0) {
+    return `qn:${d.queryName}`;
+  }
+  if (typeof d.sessionId === 'string' && d.sessionId.length > 0) {
+    return `s:${d.sessionId}`;
+  }
+  return DEFAULT_WORKER_KEY;
+}
+
+/**
+ * Resolves the IDE connection that owns the worker identified by `key`. Return
+ * `null` if the worker is not currently reachable (e.g. query is stopped). The
+ * store will retry on the next subscribe or {@link WorkerVariablesStore.invalidate}.
+ */
+export type ResolveConnection = (
+  key: string
+) => Promise<dh.IdeConnection | null>;
+
+/**
+ * A ref-counted store of worker variable lists, keyed by worker. Wraps
+ * `IdeConnection.subscribeToFieldUpdates` so the underlying push subscription
+ * is opened once per worker regardless of the number of React consumers.
+ */
+export type WorkerVariablesStore = {
+  /** Current list for `key`, or `null` if not yet resolved. */
+  snapshot(key: string): WorkerVariables | null;
+  /**
+   * Subscribe to changes for `key`. The listener fires after each delta is
+   * applied. Returns an unsubscribe function; the underlying field-updates
+   * subscription is closed when the last listener for `key` unsubscribes.
+   */
+  subscribe(key: string, listener: () => void): () => void;
+  /**
+   * Drop the cached list and subscription for `key`. Active subscribers will
+   * be notified (snapshot becomes `null`) and a fresh resolve+subscribe will
+   * kick off. Use when an external signal indicates the worker behind `key`
+   * has been replaced (e.g. DHE query restart).
+   */
+  invalidate(key: string): void;
+  /** Tear down all entries. Call when the owning provider unmounts. */
+  destroy(): void;
+};
+
+type Entry = {
+  list: WorkerVariables | null;
+  listeners: Set<() => void>;
+  unsubscribeFieldUpdates: (() => void) | null;
+  resolving: boolean;
+  generation: number;
+};
+
+/**
+ * Create a {@link WorkerVariablesStore} backed by `resolveConnection`. The
+ * store is framework-free; pair it with a React provider/hook (see
+ * `@deephaven/jsapi-bootstrap`'s `WorkerVariablesContext`/`useWorkerVariables`).
+ */
+export function createWorkerVariablesStore(
+  resolveConnection: ResolveConnection
+): WorkerVariablesStore {
+  const entries = new Map<string, Entry>();
+
+  function getOrCreate(key: string): Entry {
+    let entry = entries.get(key);
+    if (entry == null) {
+      entry = {
+        list: null,
+        listeners: new Set(),
+        unsubscribeFieldUpdates: null,
+        resolving: false,
+        generation: 0,
+      };
+      entries.set(key, entry);
+    }
+    return entry;
+  }
+
+  function notify(entry: Entry): void {
+    entry.listeners.forEach(listener => {
+      try {
+        listener();
+      } catch (e) {
+        log.error('WorkerVariables listener threw', e);
+      }
+    });
+  }
+
+  function teardown(entry: Entry): void {
+    if (entry.unsubscribeFieldUpdates != null) {
+      try {
+        entry.unsubscribeFieldUpdates();
+      } catch (e) {
+        log.warn('Error unsubscribing from field updates', e);
+      }
+      entry.unsubscribeFieldUpdates = null;
+    }
+  }
+
+  async function start(key: string, entry: Entry): Promise<void> {
+    if (entry.resolving || entry.unsubscribeFieldUpdates != null) return;
+    entry.resolving = true;
+    const gen = entry.generation;
+    try {
+      const connection = await resolveConnection(key);
+      if (
+        gen !== entry.generation ||
+        entry.listeners.size === 0 ||
+        entries.get(key) !== entry
+      ) {
+        return;
+      }
+      if (connection == null) {
+        log.debug('No connection available for worker', key);
+        return;
+      }
+      // Cumulative list maintained inside the closure; entry.list is replaced
+      // with a fresh array each delta so snapshot identity is stable.
+      const current: dh.ide.VariableDefinition[] = [];
+      const unsubscribe = connection.subscribeToFieldUpdates(changes => {
+        if (gen !== entry.generation) return;
+        const removedIds = new Set(changes.removed.map(v => v.id));
+        const updatedIds = new Set(changes.updated.map(v => v.id));
+        const next = current.filter(
+          v => !removedIds.has(v.id) && !updatedIds.has(v.id)
+        );
+        next.push(...changes.updated, ...changes.created);
+        current.length = 0;
+        current.push(...next);
+        entry.list = next;
+        notify(entry);
+      });
+      entry.unsubscribeFieldUpdates = unsubscribe;
+    } catch (e) {
+      log.error('Failed to resolve worker connection', key, e);
+    } finally {
+      entry.resolving = false;
+    }
+  }
+
+  return {
+    snapshot(key) {
+      return entries.get(key)?.list ?? null;
+    },
+    subscribe(key, listener) {
+      const entry = getOrCreate(key);
+      entry.listeners.add(listener);
+      if (entry.unsubscribeFieldUpdates == null && !entry.resolving) {
+        void start(key, entry);
+      }
+      return () => {
+        entry.listeners.delete(listener);
+        if (entry.listeners.size === 0) {
+          teardown(entry);
+          entry.list = null;
+          entries.delete(key);
+        }
+      };
+    },
+    invalidate(key) {
+      const entry = entries.get(key);
+      if (entry == null) return;
+      entry.generation += 1;
+      teardown(entry);
+      entry.list = null;
+      notify(entry);
+      if (entry.listeners.size > 0) {
+        void start(key, entry);
+      }
+    },
+    destroy() {
+      entries.forEach(entry => {
+        teardown(entry);
+        entry.listeners.clear();
+        entry.list = null;
+        entry.generation += 1;
+      });
+      entries.clear();
+    },
+  };
+}

--- a/packages/jsapi-utils/src/WorkerVariablesStore.ts
+++ b/packages/jsapi-utils/src/WorkerVariablesStore.ts
@@ -96,6 +96,7 @@ export function createWorkerVariablesStore(
 ): WorkerVariablesStore {
   const entries = new Map<string, Entry>();
 
+  /** Get the entry for `key`, creating an empty one if it doesn't exist. */
   function getOrCreate(key: string): Entry {
     let entry = entries.get(key);
     if (entry == null) {
@@ -111,6 +112,7 @@ export function createWorkerVariablesStore(
     return entry;
   }
 
+  /** Invoke every listener on `entry`, isolating listener errors. */
   function notify(entry: Entry): void {
     entry.listeners.forEach(listener => {
       try {
@@ -121,6 +123,7 @@ export function createWorkerVariablesStore(
     });
   }
 
+  /** Close the field-updates subscription for `key`, if any. */
   function teardown(key: string): void {
     const entry = entries.get(key);
     if (entry?.unsubscribeFieldUpdates != null) {
@@ -133,6 +136,7 @@ export function createWorkerVariablesStore(
     }
   }
 
+  /** Resolve the connection for `key` and open its field-updates subscription. */
   async function start(key: string): Promise<void> {
     const entry = entries.get(key);
     if (
@@ -157,19 +161,16 @@ export function createWorkerVariablesStore(
         log.debug('No connection available for worker', key);
         return;
       }
-      // Cumulative list maintained inside the closure; entry.list is replaced
-      // with a fresh array each delta so snapshot identity is stable.
-      const current: dh.ide.VariableDefinition[] = [];
+      // entry.list is replaced with a fresh array each delta so snapshot
+      // identity is stable for `useSyncExternalStore` consumers.
       const unsubscribe = connection.subscribeToFieldUpdates(changes => {
         if (gen !== entry.generation) return;
         const removedIds = new Set(changes.removed.map(v => v.id));
         const updatedIds = new Set(changes.updated.map(v => v.id));
-        const next = current.filter(
+        const next = (entry.list ?? []).filter(
           v => !removedIds.has(v.id) && !updatedIds.has(v.id)
         );
         next.push(...changes.updated, ...changes.created);
-        current.length = 0;
-        current.push(...next);
         entry.list = next;
         notify(entry);
       });
@@ -181,43 +182,50 @@ export function createWorkerVariablesStore(
     }
   }
 
-  return {
-    snapshot(key) {
-      return entries.get(key)?.list ?? null;
-    },
-    subscribe(key, listener) {
-      const entry = getOrCreate(key);
-      entry.listeners.add(listener);
-      if (entry.unsubscribeFieldUpdates == null && !entry.resolving) {
-        // start handles its own errors; nothing to do on rejection
-        start(key).catch(() => undefined);
-      }
-      return () => {
-        entry.listeners.delete(listener);
-        if (entry.listeners.size === 0) {
-          teardown(key);
-          entry.list = null;
-          entries.delete(key);
-        }
-      };
-    },
-    invalidate(key) {
-      const entry = entries.get(key);
-      if (entry == null) return;
-      entry.generation += 1;
-      teardown(key);
-      entry.list = null;
-      notify(entry);
-      if (entry.listeners.size > 0) {
-        // start handles its own errors; nothing to do on rejection
-        start(key).catch(() => undefined);
-      }
-    },
-    destroy() {
-      Array.from(entries.keys()).forEach(key => {
+  /** Current list for `key`, or `null` if not yet resolved. */
+  function snapshot(key: string): WorkerVariables | null {
+    return entries.get(key)?.list ?? null;
+  }
+
+  /** Register `listener` for `key`, starting the subscription on first listener. */
+  function subscribe(key: string, listener: () => void): () => void {
+    const entry = getOrCreate(key);
+    entry.listeners.add(listener);
+    if (entry.unsubscribeFieldUpdates == null && !entry.resolving) {
+      // start handles its own errors; nothing to do on rejection
+      start(key).catch(() => undefined);
+    }
+    return () => {
+      entry.listeners.delete(listener);
+      if (entry.listeners.size === 0) {
         teardown(key);
-      });
-      entries.clear();
-    },
-  };
+        entry.list = null;
+        entries.delete(key);
+      }
+    };
+  }
+
+  /** Drop the cached list/subscription for `key` and re-resolve if observed. */
+  function invalidate(key: string): void {
+    const entry = entries.get(key);
+    if (entry == null) return;
+    entry.generation += 1;
+    teardown(key);
+    entry.list = null;
+    notify(entry);
+    if (entry.listeners.size > 0) {
+      // start handles its own errors; nothing to do on rejection
+      start(key).catch(() => undefined);
+    }
+  }
+
+  /** Tear down every entry and clear all state. */
+  function destroy(): void {
+    Array.from(entries.keys()).forEach(key => {
+      teardown(key);
+    });
+    entries.clear();
+  }
+
+  return { snapshot, subscribe, invalidate, destroy };
 }

--- a/packages/jsapi-utils/src/WorkerVariablesStore.ts
+++ b/packages/jsapi-utils/src/WorkerVariablesStore.ts
@@ -54,6 +54,28 @@ export type ResolveConnection = (
 ) => Promise<dh.IdeConnection | null>;
 
 /**
+ * Identify a variable for delta matching. `dh.ide.VariableDefinition` declares
+ * a non-optional `id`, but at runtime instances are frequently created as just
+ * `{ name, type }` (e.g. field-update payloads and test fixtures), so `id` may
+ * be absent. Fall back to `name`, then `title`, and return `undefined` when no
+ * usable key exists so such items are never matched against a delta. Keys are
+ * namespaced by source field so an `id` of `"x"` never collides with a `name`
+ * of `"x"`.
+ */
+function getVariableKey(v: dh.ide.VariableDefinition): string | undefined {
+  if (typeof v.id === 'string' && v.id.length > 0) {
+    return `id:${v.id}`;
+  }
+  if (typeof v.name === 'string' && v.name.length > 0) {
+    return `name:${v.name}`;
+  }
+  if (typeof v.title === 'string' && v.title.length > 0) {
+    return `title:${v.title}`;
+  }
+  return undefined;
+}
+
+/**
  * A ref-counted store of worker variable lists, keyed by worker. Wraps
  * `IdeConnection.subscribeToFieldUpdates` so the underlying push subscription
  * is opened once per worker regardless of the number of React consumers.
@@ -165,11 +187,18 @@ export function createWorkerVariablesStore(
       // identity is stable for `useSyncExternalStore` consumers.
       const unsubscribe = connection.subscribeToFieldUpdates(changes => {
         if (gen !== entry.generation) return;
-        const removedIds = new Set(changes.removed.map(v => v.id));
-        const updatedIds = new Set(changes.updated.map(v => v.id));
-        const next = (entry.list ?? []).filter(
-          v => !removedIds.has(v.id) && !updatedIds.has(v.id)
+        const removedKeys = new Set(
+          changes.removed.map(getVariableKey).filter(k => k != null)
         );
+        const updatedKeys = new Set(
+          changes.updated.map(getVariableKey).filter(k => k != null)
+        );
+        // Keep keyless items (they can't be matched) and items whose key was
+        // not removed or updated; updated/created items are re-appended below.
+        const next = (entry.list ?? []).filter(v => {
+          const k = getVariableKey(v);
+          return k == null || (!removedKeys.has(k) && !updatedKeys.has(k));
+        });
         next.push(...changes.updated, ...changes.created);
         entry.list = next;
         notify(entry);

--- a/packages/jsapi-utils/src/WorkerVariablesStore.ts
+++ b/packages/jsapi-utils/src/WorkerVariablesStore.ts
@@ -208,6 +208,21 @@ export function createWorkerVariablesStore(
       log.error('Failed to resolve worker connection', key, e);
     } finally {
       entry.resolving = false;
+      // If `invalidate` ran while this resolve was in flight, it bumped
+      // `generation` but couldn't start a fresh resolve (this one was still
+      // marked `resolving`). The in-flight resolve above then bailed out as
+      // stale, so kick off another resolve now that `resolving` is cleared —
+      // otherwise the entry would be stuck with `list === null` and no
+      // subscription until the next `invalidate`/subscribe. `gen` now equals
+      // `entry.generation` when no invalidation occurred, so this never loops.
+      if (
+        entries.get(key) === entry &&
+        gen !== entry.generation &&
+        entry.unsubscribeFieldUpdates == null &&
+        entry.listeners.size > 0
+      ) {
+        start(key).catch(() => undefined);
+      }
     }
   }
 

--- a/packages/jsapi-utils/src/index.ts
+++ b/packages/jsapi-utils/src/index.ts
@@ -12,3 +12,4 @@ export * from './SessionUtils';
 export * from './Settings';
 export * from './TableUtils';
 export * from './ViewportDataUtils';
+export * from './WorkerVariablesStore';


### PR DESCRIPTION
This PR adds subscription-based infrastructure for discovering a worker's variables (for example, whether a worker exposes a PivotService). Plugins subscribe and react as variables appear, including ones that show up only after the worker finishes initializing, rather than relying on a single point-in-time lookup that could run too early.

### Changes

- **`jsapi-bootstrap`**: Adds `WorkerVariablesContext` and the `useWorkerVariables` hook, which subscribes to a worker's field updates and exposes the current set of variables, updating reactively as variables are added or removed.
- **`jsapi-utils`**: Adds `WorkerVariablesStore` to back the subscription and hold the latest variable state.
- **`app-utils`**: Wires the provider into `ConnectionBootstrap` so the variables are available to Core consumers.

### Notes

This PR contains the shared infrastructure only. The DHE client and the pivot-builder plugin adopt `useWorkerVariables` in their respective PRs, which depend on this one being published first.