### PR TITLE
fix: DH-22965: Use unique pre-release id for canary publishes

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -46,7 +46,7 @@ jobs:
         if: ${{ github.event_name == 'workflow_dispatch' }}
         run: |
           PREID="${{ github.event.inputs.preid }}.$(git rev-parse --short HEAD)"
-          ./node_modules/.bin/lerna publish --canary --preid "$PREID" --dist-tag canary --yes
+          ./node_modules/.bin/lerna publish --canary --preid "$PREID" --force-publish=\* --dist-tag canary --yes
       - name: Publish production packages
         if: ${{ github.event_name == 'release' }}
         run: ./node_modules/.bin/lerna publish from-package --yes

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -37,8 +37,26 @@ jobs:
       - name: Build production
         run: npm run build
       - name: Publish canary packages
+        # lerna's `--canary` only differentiates runs via `+<sha>` build metadata,
+        # which npm strips on publish, so every canary run for the same base
+        # version collides on the same published version
+        # (e.g. 1.22.2-alpha-pivot-builder.0). Instead, set an explicit,
+        # npm-visible prerelease version (run_number keeps it unique per run) and
+        # publish what's on disk with `from-package`.
         if: ${{ github.event_name == 'workflow_dispatch' }}
-        run: ./node_modules/.bin/lerna publish --canary --force-publish=\* --preid ${{ github.event.inputs.preid }} --dist-tag canary --yes
+        run: |
+          BASE=$(node -p "require('./lerna.json').version")
+          NEXT=$(node -p "require('semver').inc('$BASE', 'patch')")
+          VERSION="${NEXT}-${{ github.event.inputs.preid }}.${{ github.run_number }}"
+          echo "Publishing canary version $VERSION"
+          ./node_modules/.bin/lerna version "$VERSION" \
+            --exact \
+            --force-publish=\* \
+            --no-push \
+            --no-git-tag-version \
+            --no-changelog \
+            --yes
+          ./node_modules/.bin/lerna publish from-package --dist-tag canary --yes
       - name: Publish production packages
         if: ${{ github.event_name == 'release' }}
         run: ./node_modules/.bin/lerna publish from-package --yes

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -37,26 +37,16 @@ jobs:
       - name: Build production
         run: npm run build
       - name: Publish canary packages
-        # lerna's `--canary` only differentiates runs via `+<sha>` build metadata,
+        # lerna's `--canary` differentiates runs via `+<sha>` build metadata,
         # which npm strips on publish, so every canary run for the same base
-        # version collides on the same published version
-        # (e.g. 1.22.2-alpha-pivot-builder.0). Instead, set an explicit,
-        # npm-visible prerelease version (run_number keeps it unique per run) and
-        # publish what's on disk with `from-package`.
+        # version would otherwise collide on the same published version
+        # (e.g. 1.22.2-alpha.0). Folding the short SHA into the preid moves it
+        # into the npm-visible prerelease segment, keeping versions unique
+        # (e.g. 1.22.2-alpha.a1b2c3d.0). Matches the deephaven-plugins workflow.
         if: ${{ github.event_name == 'workflow_dispatch' }}
         run: |
-          BASE=$(node -p "require('./lerna.json').version")
-          NEXT=$(node -p "require('semver').inc('$BASE', 'patch')")
-          VERSION="${NEXT}-${{ github.event.inputs.preid }}.${{ github.run_number }}"
-          echo "Publishing canary version $VERSION"
-          ./node_modules/.bin/lerna version "$VERSION" \
-            --exact \
-            --force-publish=\* \
-            --no-push \
-            --no-git-tag-version \
-            --no-changelog \
-            --yes
-          ./node_modules/.bin/lerna publish from-package --dist-tag canary --yes
+          PREID="${{ github.event.inputs.preid }}.$(git rev-parse --short HEAD)"
+          ./node_modules/.bin/lerna publish --canary --preid "$PREID" --dist-tag canary --yes
       - name: Publish production packages
         if: ${{ github.event_name == 'release' }}
         run: ./node_modules/.bin/lerna publish from-package --yes


### PR DESCRIPTION
Lerna's --canary differentiates runs via `+<sha>` build metadata, which npm strips on publish — so every canary run for the same base version collided on the same published version (e.g. 1.22.2-alpha.0). This folds the short commit SHA into the preid so it lands in the npm-visible prerelease segment, keeping canary versions unique (e.g. 1.22.2-alpha.a1b2c3d.0). Aligns the canary publish step with the deephaven-plugins workflow.

Tested by running the updated action from the `vlad-DH-22965` branch. Canary packages published successfully - https://github.com/deephaven/web-client-ui/actions/runs/28121228123/job/83273413307