### PR TITLE
feat: DH-22990: improve clear command behaviour in console input

### DIFF
--- a/packages/console/src/ClearCommands.ts
+++ b/packages/console/src/ClearCommands.ts
@@ -1,0 +1,16 @@
+/**
+ * Special console commands that clear the console output/history. These are
+ * handled entirely client-side (see Console.handleCommandSubmit) and never sent
+ * to the server.
+ */
+export const CLEAR_CONSOLE_COMMANDS: readonly string[] = ['clear', 'cls'];
+
+/**
+ * Whether the given command is a special "clear the console" command.
+ * @param command The trimmed command text
+ */
+export function isClearConsoleCommand(command: string): boolean {
+  return CLEAR_CONSOLE_COMMANDS.includes(command);
+}
+
+export default CLEAR_CONSOLE_COMMANDS;

--- a/packages/console/src/Console.tsx
+++ b/packages/console/src/Console.tsx
@@ -25,6 +25,7 @@ import { assertNotNull, Pending, PromiseUtils } from '@deephaven/utils';
 import ConsoleHistory from './console-history/ConsoleHistory';
 import { type ConsoleHistoryActionItem } from './console-history/ConsoleHistoryTypes';
 import SHORTCUTS from './ConsoleShortcuts';
+import { isClearConsoleCommand } from './ClearCommands';
 import LogLevel from './log/LogLevel';
 import ConsoleInput from './ConsoleInput';
 import CsvOverlay from './csv/CsvOverlay';
@@ -186,7 +187,7 @@ export class Console extends PureComponent<ConsoleProps, ConsoleState> {
     this.handleCommandResult = this.handleCommandResult.bind(this);
     this.handleCommandStarted = this.handleCommandStarted.bind(this);
     this.handleCommandSubmit = this.handleCommandSubmit.bind(this);
-    this.handleClearShortcut = this.handleClearShortcut.bind(this);
+    this.handleClearConsole = this.handleClearConsole.bind(this);
     this.handleFocusHistory = this.handleFocusHistory.bind(this);
     this.handleLogMessage = this.handleLogMessage.bind(this);
     this.handleOverflowActions = this.handleOverflowActions.bind(this);
@@ -332,11 +333,8 @@ export class Console extends PureComponent<ConsoleProps, ConsoleState> {
     return Math.abs(scrollHeight - clientHeight - scrollTop) <= 1;
   }
 
-  handleClearShortcut(event: Event): void {
-    event.preventDefault();
-    event.stopPropagation();
-
-    this.consoleInput.current?.clear();
+  handleClearConsole(): void {
+    this.clearConsoleHistory();
   }
 
   handleCommandStarted(
@@ -927,11 +925,18 @@ export class Console extends PureComponent<ConsoleProps, ConsoleState> {
         group: ContextActions.groups.high + 10,
         order: 40,
       },
+      {
+        title: 'Clear',
+        action: this.handleClearConsole,
+        group: ContextActions.groups.high + 20,
+        order: 50,
+        shortcut: SHORTCUTS.CONSOLE.CLEAR,
+      },
     ];
   }
 
   handleCommandSubmit(command: string): void {
-    if (command === 'clear' || command === 'cls') {
+    if (isClearConsoleCommand(command)) {
       this.clearConsoleHistory();
     } else if (command.length > 0) {
       // Result is handled in this.handleCommandStarted
@@ -977,10 +982,6 @@ export class Console extends PureComponent<ConsoleProps, ConsoleState> {
   getContextActions = memoize(
     (actions: DropdownAction[]): ResolvableContextAction[] => [
       ...actions,
-      {
-        action: this.handleClearShortcut,
-        shortcut: SHORTCUTS.CONSOLE.CLEAR,
-      },
       {
         action: this.handleFocusHistory,
         shortcut: SHORTCUTS.CONSOLE.FOCUS_HISTORY,
@@ -1136,6 +1137,7 @@ export class Console extends PureComponent<ConsoleProps, ConsoleState> {
               language={language}
               scope={scope}
               onSubmit={this.handleCommandSubmit}
+              onClear={this.handleClearConsole}
               maxHeight={inputMaxHeight}
               commandHistoryStorage={commandHistoryStorage}
             />

--- a/packages/console/src/ConsoleInput.tsx
+++ b/packages/console/src/ConsoleInput.tsx
@@ -9,6 +9,7 @@ import {
 } from '@deephaven/utils';
 import { type ViewportData } from '@deephaven/storage';
 import type { dh } from '@deephaven/jsapi-types';
+import { ShortcutRegistry } from '@deephaven/components';
 import {
   type CommandHistoryStorage,
   type CommandHistoryStorageItem,
@@ -63,6 +64,7 @@ export class ConsoleInput extends PureComponent<
     super(props);
 
     this.handleResize = this.handleResize.bind(this);
+    this.updateShortcuts = this.updateShortcuts.bind(this);
 
     this.commandContainer = React.createRef();
     this.commandHistoryIndex = null;
@@ -84,6 +86,9 @@ export class ConsoleInput extends PureComponent<
     this.initCommandEditor();
 
     this.loadMoreHistory();
+
+    // Re-register the clear shortcut when its keybinding changes in settings
+    ShortcutRegistry.addEventListener('onUpdate', this.updateShortcuts);
   }
 
   componentDidUpdate(): void {
@@ -96,6 +101,9 @@ export class ConsoleInput extends PureComponent<
     if (this.loadingPromise != null) {
       this.loadingPromise.cancel();
     }
+
+    ShortcutRegistry.removeEventListener('onUpdate', this.updateShortcuts);
+    this.clearShortcutCleanup?.dispose();
 
     this.destroyCommandEditor();
   }
@@ -111,6 +119,8 @@ export class ConsoleInput extends PureComponent<
   commandHistoryIndex: number | null;
 
   commandSuggestionContainer?: Element | null;
+
+  clearShortcutCleanup?: monaco.IDisposable;
 
   loadingPromise?:
     | CancelablePromise<ViewportData<CommandHistoryStorageItem>>
@@ -200,17 +210,7 @@ export class ConsoleInput extends PureComponent<
 
     this.commandEditor = monaco.editor.create(element, commandSettings);
 
-    // Clear the console output via the keyboard shortcut. Registering on the
-    // editor (rather than a global/ContextActions listener) means it only fires
-    // while the console input is focused and overrides Monaco's built-in
-    // Ctrl/Cmd+L ("expand line selection"), which would otherwise swallow it.
-    this.commandEditor.addCommand(
-      MonacoUtils.getMonacoKeyCodeFromShortcut(SHORTCUTS.CONSOLE.CLEAR),
-      () => {
-        const { onClear } = this.props;
-        onClear?.();
-      }
-    );
+    this.registerClearShortcut();
 
     MonacoUtils.setEOL(this.commandEditor);
     MonacoUtils.openDocument(this.commandEditor, session);
@@ -327,6 +327,37 @@ export class ConsoleInput extends PureComponent<
       this.commandEditor.dispose();
       this.commandEditor = undefined;
     }
+  }
+
+  /**
+   * Registers the "clear console" keyboard shortcut on the editor. Registering
+   * it on the editor (rather than a global/ContextActions listener) means it
+   * only fires while the console input is focused and overrides Monaco's
+   * built-in Ctrl/Cmd+L ("expand line selection"), which would otherwise
+   * swallow it. Returns a disposable so it can be re-registered when the
+   * shortcut's keybinding changes (see updateShortcuts).
+   */
+  registerClearShortcut(): void {
+    this.clearShortcutCleanup = this.commandEditor?.addAction({
+      id: 'console-clear',
+      label: 'Clear',
+      keybindings: [
+        MonacoUtils.getMonacoKeyCodeFromShortcut(SHORTCUTS.CONSOLE.CLEAR),
+      ],
+      run: () => {
+        const { onClear } = this.props;
+        onClear?.();
+      },
+    });
+  }
+
+  /**
+   * Re-registers shortcuts so edits made in the shortcut settings take effect
+   * without a reload. Fired by ShortcutRegistry's `onUpdate` event.
+   */
+  updateShortcuts(): void {
+    this.clearShortcutCleanup?.dispose();
+    this.registerClearShortcut();
   }
 
   handleResize(): void {

--- a/packages/console/src/ConsoleInput.tsx
+++ b/packages/console/src/ConsoleInput.tsx
@@ -15,6 +15,8 @@ import {
   type CommandHistoryTable,
 } from './command-history';
 import { MonacoProviders, MonacoTheme, MonacoUtils } from './monaco';
+import SHORTCUTS from './ConsoleShortcuts';
+import { isClearConsoleCommand } from './ClearCommands';
 import './ConsoleInput.scss';
 
 const log = Log.module('ConsoleInput');
@@ -31,6 +33,7 @@ interface ConsoleInputProps {
   scope?: string;
   commandHistoryStorage: CommandHistoryStorage;
   onSubmit: (command: string) => void;
+  onClear?: () => void;
   maxHeight?: number;
   disabled?: boolean;
 }
@@ -197,6 +200,18 @@ export class ConsoleInput extends PureComponent<
 
     this.commandEditor = monaco.editor.create(element, commandSettings);
 
+    // Clear the console output via the keyboard shortcut. Registering on the
+    // editor (rather than a global/ContextActions listener) means it only fires
+    // while the console input is focused and overrides Monaco's built-in
+    // Ctrl/Cmd+L ("expand line selection"), which would otherwise swallow it.
+    this.commandEditor.addCommand(
+      MonacoUtils.getMonacoKeyCodeFromShortcut(SHORTCUTS.CONSOLE.CLEAR),
+      () => {
+        const { onClear } = this.props;
+        onClear?.();
+      }
+    );
+
     MonacoUtils.setEOL(this.commandEditor);
     MonacoUtils.openDocument(this.commandEditor, session);
 
@@ -262,14 +277,25 @@ export class ConsoleInput extends PureComponent<
           return;
         }
 
-        if (
-          keyEvent.keyCode === monaco.KeyCode.Enter &&
-          !this.isSuggestionMenuPopulated()
-        ) {
+        if (keyEvent.keyCode === monaco.KeyCode.Enter) {
+          const command = this.commandEditor?.getValue().trim();
+
+          // The suggest widget normally claims Enter to accept a completion, so
+          // we only submit when it's closed. The exception is clear/cls: always
+          // submit those so an open widget can't hijack them with a fuzzy match
+          // (see ClearCommands).
+          const isClearCommand =
+            command !== undefined && isClearConsoleCommand(command);
+
+          if (this.isSuggestionMenuPopulated() && !isClearCommand) {
+            return;
+          }
+
           keyEvent.stopPropagation();
           keyEvent.preventDefault();
+          // Dismiss the suggest widget so it can't alter the command
+          this.commandEditor?.trigger('keyboard', 'hideSuggestWidget', {});
 
-          const command = this.commandEditor?.getValue().trim();
           if (command !== undefined) {
             this.processCommand(command);
             this.commandEditor?.setValue('');

--- a/packages/console/src/ConsoleShortcuts.ts
+++ b/packages/console/src/ConsoleShortcuts.ts
@@ -6,7 +6,7 @@ const CONSOLE = {
     id: 'CONSOLE.CLEAR',
     name: 'Clear',
     shortcut: [MODIFIER.CTRL, KEY.L],
-    macShortcut: [MODIFIER.CTRL, KEY.C],
+    macShortcut: [MODIFIER.CMD, KEY.L],
   }),
   FOCUS_HISTORY: ShortcutRegistry.createAndAdd({
     id: 'CONSOLE.FOCUS_HISTORY',

--- a/packages/console/src/index.ts
+++ b/packages/console/src/index.ts
@@ -5,6 +5,7 @@ export { Console };
 export type { Settings as ConsoleSettings } from './Console';
 export { default as ConsoleInput } from './ConsoleInput';
 export { default as SHORTCUTS } from './ConsoleShortcuts';
+export * from './ClearCommands';
 export { default as ConsoleStatusBar } from './ConsoleStatusBar';
 export * from './monaco/MonacoThemeProvider';
 export { default as MonacoUtils } from './monaco/MonacoUtils';

--- a/packages/console/src/monaco/MonacoProviders.tsx
+++ b/packages/console/src/monaco/MonacoProviders.tsx
@@ -8,6 +8,7 @@ import type { dh } from '@deephaven/jsapi-types';
 import init, { Workspace, type Diagnostic } from '@astral-sh/ruff-wasm-web';
 import RUFF_DEFAULT_SETTINGS from './RuffDefaultSettings';
 import MonacoUtils from './MonacoUtils';
+import { CLEAR_CONSOLE_COMMANDS } from '../ClearCommands';
 
 const log = Log.module('MonacoCompletionProvider');
 
@@ -440,6 +441,45 @@ class MonacoProviders extends PureComponent<
         text: MonacoProviders.ruffWorkspace.format(model.getValue()),
       },
     ];
+  }
+
+  /**
+   * Provides the special client-side console commands (clear/cls) as completion
+   * items for the console input. Registered with the '*' selector so it shares
+   * Monaco's low-priority word-based completion group rather than the
+   * higher-priority language provider: Monaco stops at the first provider group
+   * that returns results, so returning these from the language group on every
+   * keystroke would suppress word-based suggestions entirely. Only contributes
+   * for the console model.
+   */
+  static provideConsoleCommandCompletions(
+    model: monaco.editor.ITextModel,
+    position: monaco.Position
+  ): monaco.languages.ProviderResult<monaco.languages.CompletionList> {
+    if (!MonacoUtils.isConsoleModel(model)) {
+      return undefined;
+    }
+
+    const word = model.getWordUntilPosition(position);
+    const range = {
+      startLineNumber: position.lineNumber,
+      startColumn: word.startColumn,
+      endLineNumber: position.lineNumber,
+      endColumn: word.endColumn,
+    };
+
+    return {
+      suggestions: CLEAR_CONSOLE_COMMANDS.map(command => ({
+        label: command,
+        kind: monaco.languages.CompletionItemKind.Keyword,
+        detail: 'Clear the console',
+        // Leading low character ranks the exact match above fuzzy matches
+        sortText: `\x00${command}`,
+        filterText: command,
+        insertText: command,
+        range,
+      })),
+    };
   }
 
   constructor(props: MonacoProviderProps) {

--- a/packages/console/src/monaco/MonacoUtils.ts
+++ b/packages/console/src/monaco/MonacoUtils.ts
@@ -56,6 +56,13 @@ class MonacoUtils {
 
     registerLanguages([DbLang, PyLang, GroovyLang, LogLang, ScalaLang]);
 
+    // Register the special console commands (clear/cls) as completions. Uses the
+    // '*' selector so it shares Monaco's low-priority word-based completion group
+    // and coexists with it, instead of suppressing word-based suggestions.
+    monaco.languages.registerCompletionItemProvider('*', {
+      provideCompletionItems: MonacoProviders.provideConsoleCommandCompletions,
+    });
+
     monaco.languages.onLanguage('python', () => {
       monaco.languages.registerCodeActionProvider(
         'python',


### PR DESCRIPTION
Typing `clear`/`cls` in the console was unreliable — Monaco autocomplete would hijack Enter with a fuzzy match instead of running the command. This makes clearing the console reliable and discoverable.

- a single enter now always runs `clear`/`cls` even with the suggest widget open
- `clear`/`cls` now show in autocomplete (without suppressing word-based suggestions).
- added "Clear" to the console overflow menu
- added cmd/ctrl+l shortcut (updates live when rebound in settings), replacing previous shortcut that was supposed to clear the input but didn't actually do anything because monaco ate it

Not tested on mac. Please test.

Not sure how much gets reused in enterprise of this.