### PR TITLE
fix: DH-23004: fall back to TablePluginLoaderContext in useLoadTablePlugin

### DIFF
--- a/packages/dashboard-core-plugins/src/TablePluginLoaderContext.ts
+++ b/packages/dashboard-core-plugins/src/TablePluginLoaderContext.ts
@@ -1,0 +1,14 @@
+import { createContext } from 'react';
+import { type TablePluginComponent } from '@deephaven/plugin';
+
+/**
+ * Context providing an optional function to load a table plugin by name.
+ * When provided, `useLoadTablePlugin` will call this function before falling
+ * back to the built-in plugin registry lookup.
+ */
+export const TablePluginLoaderContext = createContext<
+  ((name: string) => TablePluginComponent) | null
+>(null);
+TablePluginLoaderContext.displayName = 'TablePluginLoaderContext';
+
+export default TablePluginLoaderContext;

--- a/packages/dashboard-core-plugins/src/index.ts
+++ b/packages/dashboard-core-plugins/src/index.ts
@@ -27,6 +27,7 @@ export * from './useDashboardColumnFilters';
 export * from './useGridLinker';
 export * from './useLoadTablePlugin';
 export * from './useTablePlugin';
+export * from './TablePluginLoaderContext';
 
 export * from './ConsoleEvents';
 export * from './events';

--- a/packages/dashboard-core-plugins/src/useLoadTablePlugin.test.ts
+++ b/packages/dashboard-core-plugins/src/useLoadTablePlugin.test.ts
@@ -1,0 +1,111 @@
+import { renderHook } from '@testing-library/react';
+import React from 'react';
+import {
+  PluginType,
+  type TablePlugin,
+  type LegacyTablePlugin,
+  type TablePluginComponent,
+} from '@deephaven/plugin';
+import { TablePluginLoaderContext } from './TablePluginLoaderContext';
+import { useLoadTablePlugin } from './useLoadTablePlugin';
+
+const mockPlugins = new Map();
+
+jest.mock('@deephaven/plugin', () => ({
+  ...jest.requireActual('@deephaven/plugin'),
+  usePlugins: () => mockPlugins,
+}));
+
+const MockTableComponent = jest.fn() as unknown as TablePluginComponent;
+const MockLegacyTableComponent = jest.fn() as unknown as TablePluginComponent;
+
+const tablePlugin: TablePlugin = {
+  name: 'test-table-plugin',
+  type: PluginType.TABLE_PLUGIN,
+  component: MockTableComponent,
+};
+
+const legacyTablePlugin: LegacyTablePlugin = {
+  TablePlugin: MockLegacyTableComponent,
+};
+
+beforeEach(() => {
+  mockPlugins.clear();
+});
+
+describe('useLoadTablePlugin', () => {
+  it('returns the component from a TablePlugin registered in the plugin map', () => {
+    mockPlugins.set('test-table-plugin', tablePlugin);
+    const { result } = renderHook(() => useLoadTablePlugin());
+    expect(result.current('test-table-plugin')).toBe(MockTableComponent);
+  });
+
+  it('returns the component from a LegacyTablePlugin registered in the plugin map', () => {
+    mockPlugins.set('legacy-plugin', legacyTablePlugin);
+    const { result } = renderHook(() => useLoadTablePlugin());
+    expect(result.current('legacy-plugin')).toBe(MockLegacyTableComponent);
+  });
+
+  it('throws an error when the plugin is not found and no context loader is provided', () => {
+    const { result } = renderHook(() => useLoadTablePlugin());
+    expect(() => result.current('missing-plugin')).toThrow(
+      'Unable to find table plugin missing-plugin.'
+    );
+  });
+
+  it('falls back to the context loader when the plugin is not in the map', () => {
+    const contextComponent = jest.fn() as unknown as TablePluginComponent;
+    const contextLoader = jest.fn(() => contextComponent);
+
+    const wrapper = ({ children }: { children: React.ReactNode }) =>
+      React.createElement(
+        TablePluginLoaderContext.Provider,
+        { value: contextLoader },
+        children
+      );
+
+    const { result } = renderHook(() => useLoadTablePlugin(), { wrapper });
+    const loaded = result.current('context-plugin');
+
+    expect(contextLoader).toHaveBeenCalledWith('context-plugin');
+    expect(loaded).toBe(contextComponent);
+  });
+
+  it('prefers the plugin map over the context loader', () => {
+    mockPlugins.set('test-table-plugin', tablePlugin);
+
+    const contextComponent = jest.fn() as unknown as TablePluginComponent;
+    const contextLoader = jest.fn(() => contextComponent);
+
+    const wrapper = ({ children }: { children: React.ReactNode }) =>
+      React.createElement(
+        TablePluginLoaderContext.Provider,
+        { value: contextLoader },
+        children
+      );
+
+    const { result } = renderHook(() => useLoadTablePlugin(), { wrapper });
+    const loaded = result.current('test-table-plugin');
+
+    expect(contextLoader).not.toHaveBeenCalled();
+    expect(loaded).toBe(MockTableComponent);
+  });
+
+  it('throws an error when the plugin is not found even though a context loader is provided', () => {
+    const contextLoader = jest.fn(() => {
+      throw new Error('Plugin not found in context');
+    });
+
+    const wrapper = ({ children }: { children: React.ReactNode }) =>
+      React.createElement(
+        TablePluginLoaderContext.Provider,
+        { value: contextLoader },
+        children
+      );
+
+    const { result } = renderHook(() => useLoadTablePlugin(), { wrapper });
+    expect(() => result.current('missing-plugin')).toThrow(
+      'Plugin not found in context'
+    );
+  });
+});

--- a/packages/dashboard-core-plugins/src/useLoadTablePlugin.ts
+++ b/packages/dashboard-core-plugins/src/useLoadTablePlugin.ts
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useContext } from 'react';
 import {
   type TablePluginComponent,
   isTablePlugin,
@@ -6,6 +6,7 @@ import {
   usePlugins,
 } from '@deephaven/plugin';
 import Log from '@deephaven/log';
+import { TablePluginLoaderContext } from './TablePluginLoaderContext';
 
 const log = Log.module('@deephaven/app-utils/useTablePlugin');
 
@@ -15,6 +16,7 @@ const log = Log.module('@deephaven/app-utils/useTablePlugin');
  */
 export function useLoadTablePlugin(): (name: string) => TablePluginComponent {
   const plugins = usePlugins();
+  const loaderFromContext = useContext(TablePluginLoaderContext);
 
   const plugin = useCallback(
     (name: string) => {
@@ -29,11 +31,16 @@ export function useLoadTablePlugin(): (name: string) => TablePluginComponent {
         }
       }
 
+      // Fall back to the loader function provided via context, if any.
+      if (loaderFromContext != null) {
+        return loaderFromContext(name);
+      }
+
       const errorMessage = `Unable to find table plugin ${name}.`;
       log.error(errorMessage);
       throw new Error(errorMessage);
     },
-    [plugins]
+    [plugins, loaderFromContext]
   );
 
   return plugin;


### PR DESCRIPTION
- To support loading legacy Enterprise plugins from Enterprise (e.g. plugins built with this template: https://github.com/deephaven/js-plugin-template)
- Used in Enterprise with https://github.com/deephaven-ent/iris/pull/4911
- Deployed to https://bender-dh-23004.int.illumon.com:8123/iriside/, just run a Legacy Groovy studio and run:
```
t=db.t("LearnDeephaven", "StockTrades").where("Date=`2017-08-21`")
t.setAttribute("PluginName", "ExampleTablePlugin")
```