### PR TITLE
fix: DH-22976: re-apply the quickFilters prop on change

### DIFF
--- a/packages/iris-grid/src/IrisGrid.test.tsx
+++ b/packages/iris-grid/src/IrisGrid.test.tsx
@@ -12,6 +12,7 @@ import IrisGrid from './IrisGrid';
 import IrisGridTestUtils from './IrisGridTestUtils';
 import type IrisGridProxyModel from './IrisGridProxyModel';
 import { isPartitionedGridModel } from './PartitionedGridModel';
+import { type ReadonlyQuickFilterMap } from './CommonTypes';
 
 jest.mock('@deephaven/grid', () => ({
   ...jest.requireActual('@deephaven/grid'),
@@ -649,4 +650,101 @@ describe('Advanced Filter', () => {
       expect(advancedFilterButtons.length > 0).toBe(expectedVisibility);
     }
   );
+});
+
+describe('updateQuickFilters', () => {
+  it('stores the map reference directly (no cloning) when called with a map', () => {
+    const component = makeComponent();
+    const filterMap: ReadonlyQuickFilterMap = new Map([
+      [0, { text: 'foo', filter: null }],
+    ]);
+    act(() => {
+      component.updateQuickFilters(filterMap);
+    });
+    expect(component.state.quickFilters).toBe(filterMap);
+  });
+
+  it('stores EMPTY_MAP when called with null', () => {
+    const component = makeComponent();
+    // Seed a non-empty map first so we can confirm it is replaced
+    act(() => {
+      component.updateQuickFilters(
+        new Map([[0, { text: 'foo', filter: null }]])
+      );
+    });
+    act(() => {
+      component.updateQuickFilters(null);
+    });
+    expect(component.state.quickFilters.size).toBe(0);
+  });
+
+  it('re-applies quickFilters when the prop reference changes', () => {
+    const model = irisGridTestUtils.makeModel();
+    const ref = React.createRef<IrisGrid>();
+    const filter1: ReadonlyQuickFilterMap = new Map([
+      [0, { text: 'a', filter: null }],
+    ]);
+    const filter2: ReadonlyQuickFilterMap = new Map([
+      [0, { text: 'b', filter: null }],
+    ]);
+
+    const { rerender } = render(
+      <IrisGrid
+        ref={ref}
+        model={model}
+        settings={DEFAULT_SETTINGS}
+        quickFilters={filter1}
+      />
+    );
+
+    act(() => undefined); // flush
+
+    // Swap to a new reference — componentDidUpdate should call updateQuickFilters
+    jest.spyOn(ref.current!, 'updateQuickFilters');
+
+    rerender(
+      <IrisGrid
+        ref={ref}
+        model={model}
+        settings={DEFAULT_SETTINGS}
+        quickFilters={filter2}
+      />
+    );
+
+    expect(ref.current!.updateQuickFilters).toHaveBeenCalledWith(filter2);
+    expect(ref.current!.state.quickFilters).toBe(filter2);
+  });
+
+  it('does NOT re-apply quickFilters when the same reference is passed again', () => {
+    const model = irisGridTestUtils.makeModel();
+    const ref = React.createRef<IrisGrid>();
+    const filter: ReadonlyQuickFilterMap = new Map([
+      [0, { text: 'a', filter: null }],
+    ]);
+
+    const { rerender } = render(
+      <IrisGrid
+        ref={ref}
+        model={model}
+        settings={DEFAULT_SETTINGS}
+        quickFilters={filter}
+      />
+    );
+
+    act(() => undefined);
+
+    jest.spyOn(ref.current!, 'updateQuickFilters');
+
+    // Re-render with the exact same reference — should be a no-op
+    rerender(
+      <IrisGrid
+        ref={ref}
+        model={model}
+        settings={DEFAULT_SETTINGS}
+        quickFilters={filter}
+      />
+    );
+
+    expect(ref.current!.updateQuickFilters).not.toHaveBeenCalled();
+  });
 });

--- a/packages/iris-grid/src/IrisGrid.tsx
+++ b/packages/iris-grid/src/IrisGrid.tsx
@@ -1001,6 +1001,7 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
       settings,
       model,
       customFilters,
+      quickFilters,
       sorts,
       getMetricCalculator,
     } = this.props;
@@ -1057,6 +1058,9 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
     }
     if (sorts !== prevProps.sorts) {
       this.updateSorts(sorts);
+    }
+    if (quickFilters !== prevProps.quickFilters) {
+      this.updateQuickFilters(quickFilters);
     }
     const { loadingScrimStartTime, loadingScrimFinishTime } = this;
     if (loadingScrimStartTime != null && loadingScrimFinishTime != null) {
@@ -3013,6 +3017,14 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
   updateSorts(sorts: readonly SortDescriptor[]): void {
     this.startLoading('Sorting...');
     this.setState({ sorts });
+    this.grid?.forceUpdate();
+  }
+
+  updateQuickFilters(quickFilters: ReadonlyQuickFilterMap | null): void {
+    this.startLoading('Filtering...', { resetRanges: true });
+    this.setState({
+      quickFilters: quickFilters != null ? new Map(quickFilters) : new Map(),
+    });
     this.grid?.forceUpdate();
   }
 

--- a/packages/iris-grid/src/IrisGrid.tsx
+++ b/packages/iris-grid/src/IrisGrid.tsx
@@ -3021,10 +3021,17 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
   }
 
   updateQuickFilters(quickFilters: ReadonlyQuickFilterMap | null): void {
+    const { quickFilters: currentQuickFilters } = this.state;
+    if (quickFilters == null) {
+      if (currentQuickFilters.size === 0) {
+        return;
+      }
+    } else if (quickFilters === currentQuickFilters) {
+      return;
+    }
+
     this.startLoading('Filtering...', { resetRanges: true });
-    this.setState({
-      quickFilters: quickFilters ?? EMPTY_MAP,
-    });
+    this.setState({ quickFilters: quickFilters ?? EMPTY_MAP });
     this.grid?.forceUpdate();
   }
 

--- a/packages/iris-grid/src/IrisGrid.tsx
+++ b/packages/iris-grid/src/IrisGrid.tsx
@@ -9,6 +9,7 @@ import memoize from 'memoizee';
 import classNames from 'classnames';
 import { CSSTransition } from 'react-transition-group';
 import deepEqual from 'fast-deep-equal';
+import deepEqualEs6 from 'fast-deep-equal/es6';
 import Log from '@deephaven/log';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import {
@@ -1056,10 +1057,13 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
     if (customFilters !== prevProps.customFilters) {
       this.startLoading('Filtering...', { resetRanges: true });
     }
-    if (sorts !== prevProps.sorts) {
+    if (sorts !== prevProps.sorts && !deepEqualEs6(sorts, prevProps.sorts)) {
       this.updateSorts(sorts);
     }
-    if (quickFilters !== prevProps.quickFilters) {
+    if (
+      quickFilters !== prevProps.quickFilters &&
+      !deepEqualEs6(quickFilters, prevProps.quickFilters)
+    ) {
       this.updateQuickFilters(quickFilters);
     }
     const { loadingScrimStartTime, loadingScrimFinishTime } = this;

--- a/packages/iris-grid/src/IrisGrid.tsx
+++ b/packages/iris-grid/src/IrisGrid.tsx
@@ -9,7 +9,6 @@ import memoize from 'memoizee';
 import classNames from 'classnames';
 import { CSSTransition } from 'react-transition-group';
 import deepEqual from 'fast-deep-equal';
-import deepEqualEs6 from 'fast-deep-equal/es6';
 import Log from '@deephaven/log';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import {
@@ -1057,13 +1056,10 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
     if (customFilters !== prevProps.customFilters) {
       this.startLoading('Filtering...', { resetRanges: true });
     }
-    if (sorts !== prevProps.sorts && !deepEqualEs6(sorts, prevProps.sorts)) {
+    if (sorts !== prevProps.sorts) {
       this.updateSorts(sorts);
     }
-    if (
-      quickFilters !== prevProps.quickFilters &&
-      !deepEqualEs6(quickFilters, prevProps.quickFilters)
-    ) {
+    if (quickFilters !== prevProps.quickFilters) {
       this.updateQuickFilters(quickFilters);
     }
     const { loadingScrimStartTime, loadingScrimFinishTime } = this;

--- a/packages/iris-grid/src/IrisGrid.tsx
+++ b/packages/iris-grid/src/IrisGrid.tsx
@@ -3023,7 +3023,7 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
   updateQuickFilters(quickFilters: ReadonlyQuickFilterMap | null): void {
     this.startLoading('Filtering...', { resetRanges: true });
     this.setState({
-      quickFilters: quickFilters != null ? new Map(quickFilters) : new Map(),
+      quickFilters: quickFilters ?? EMPTY_MAP,
     });
     this.grid?.forceUpdate();
   }


### PR DESCRIPTION
Make IrisGrid re-apply the quickFilters prop on change, so the parent can own/control it. Same as with sorts.