### PR TITLE
fix: DH-22961: Content toolbar buttons overflow

### DIFF
--- a/packages/dashboard-core-plugins/src/panels/NotebookPanel.scss
+++ b/packages/dashboard-core-plugins/src/panels/NotebookPanel.scss
@@ -19,12 +19,22 @@ $toolbar-bg: $content-bg;
 
   .notebook-toolbar {
     display: flex;
-    justify-content: center;
+    justify-content: flex-start;
     flex-direction: row;
     background: $toolbar-bg;
     border-bottom: 2px solid $background;
     padding: $spacer-1 $spacer-2;
     gap: $spacer-1;
+    container-type: inline-size;
+    overflow: hidden;
+
+    .notebook-toolbar-actions {
+      display: contents;
+    }
+
+    .btn-overflow {
+      margin-left: auto;
+    }
 
     .btn-play:hover,
     .btn-play-selected:hover {
@@ -34,5 +44,26 @@ $toolbar-bg: $content-bg;
     .icon-create-pq {
       transform: translate(0, -4px);
     }
+  }
+}
+
+// Hide toolbar action buttons one-by-one as the toolbar narrows.
+// Each button is ~32px; breakpoints account for padding (16px) and gaps (4px each).
+// The overflow (⋮) button is always visible.
+@container (width < 128px) {
+  .notebook-toolbar .btn-save {
+    display: none;
+  }
+}
+
+@container (width < 96px) {
+  .notebook-toolbar .btn-run-selected {
+    display: none;
+  }
+}
+
+@container (width < 64px) {
+  .notebook-toolbar .btn-run {
+    display: none;
   }
 }

--- a/packages/dashboard-core-plugins/src/panels/NotebookPanel.tsx
+++ b/packages/dashboard-core-plugins/src/panels/NotebookPanel.tsx
@@ -136,6 +136,8 @@ interface NotebookPanelState {
   itemName?: string;
 
   formatOnSave: boolean;
+
+  isNarrowToolbar: boolean;
 }
 
 class NotebookPanel extends Component<NotebookPanelProps, NotebookPanelState> {
@@ -148,6 +150,10 @@ class NotebookPanel extends Component<NotebookPanelProps, NotebookPanelState> {
   static UNSAVED_INDICATOR_CLASS_NAME = 'editor-unsaved-indicator';
 
   static UNSAVED_STATUS_CLASS_NAME = 'is-unsaved';
+
+  // Minimum toolbar width (px) to show Run, Run Selected, and Save buttons inline.
+  // 4 buttons × ~32px + 2×8px padding + 3×4px gaps ≈ 156px, rounded up.
+  static NARROW_TOOLBAR_THRESHOLD = 160;
 
   static handleError(error: unknown): void {
     if (PromiseUtils.isCanceled(error)) {
@@ -252,6 +258,10 @@ class NotebookPanel extends Component<NotebookPanelProps, NotebookPanelState> {
 
     this.tabInitOnce = false;
 
+    this.toolbarRef = React.createRef();
+
+    this.toolbarResizeObserver = null;
+
     const { isDashboardActive, session, sessionLanguage, panelState } = props;
 
     let settings: editor.IStandaloneEditorConstructionOptions = {
@@ -309,6 +319,8 @@ class NotebookPanel extends Component<NotebookPanelProps, NotebookPanelState> {
       scriptCode: '',
 
       formatOnSave: false,
+
+      isNarrowToolbar: true,
     };
 
     log.debug('constructor', props, this.state);
@@ -325,6 +337,19 @@ class NotebookPanel extends Component<NotebookPanelProps, NotebookPanelState> {
       NotebookEvent.PROMOTE_FROM_PREVIEW,
       this.handlePreviewPromotion
     );
+    const toolbar = this.toolbarRef.current;
+    if (toolbar != null) {
+      this.toolbarResizeObserver = new ResizeObserver(entries => {
+        const entry = entries[0];
+        if (entry != null) {
+          this.setState({
+            isNarrowToolbar:
+              entry.contentRect.width < NotebookPanel.NARROW_TOOLBAR_THRESHOLD,
+          });
+        }
+      });
+      this.toolbarResizeObserver.observe(toolbar);
+    }
   }
 
   componentDidUpdate(
@@ -352,6 +377,7 @@ class NotebookPanel extends Component<NotebookPanelProps, NotebookPanelState> {
   componentWillUnmount(): void {
     this.debouncedSavePanelState.flush();
     this.pending.cancel();
+    this.toolbarResizeObserver?.disconnect();
 
     const { glEventHub, glContainer } = this.props;
 
@@ -378,6 +404,10 @@ class NotebookPanel extends Component<NotebookPanelProps, NotebookPanelState> {
   tabInitOnce: boolean;
 
   editor?: editor.IStandaloneCodeEditor;
+
+  toolbarRef: React.RefObject<HTMLDivElement>;
+
+  toolbarResizeObserver: ResizeObserver | null;
 
   // Called by TabEvent. Happens once when created, but also each time its moved.
   // when moved, need to re-init the unsaved indicators on title elements
@@ -579,9 +609,40 @@ class NotebookPanel extends Component<NotebookPanelProps, NotebookPanelState> {
     (
       isMinimapEnabled: boolean,
       isWordWrapEnabled: boolean,
-      formatOnSave: boolean
+      formatOnSave: boolean,
+      isNarrowToolbar: boolean,
+      runButtonsDisabled: boolean,
+      toolbarDisabled: boolean
     ) => {
       const actions: DropdownAction[] = [
+        ...(isNarrowToolbar
+          ? [
+              {
+                title: 'Run',
+                icon: vsPlay,
+                action: this.handleRunAll,
+                disabled: runButtonsDisabled,
+                group: ContextActions.groups.high,
+                order: 1,
+              },
+              {
+                title: 'Run Selected',
+                icon: dhRunSelection,
+                action: this.handleRunSelected,
+                disabled: runButtonsDisabled,
+                group: ContextActions.groups.high,
+                order: 2,
+              },
+              {
+                title: 'Save',
+                icon: vsSave,
+                action: this.handleSave,
+                disabled: toolbarDisabled,
+                group: ContextActions.groups.high,
+                order: 3,
+              },
+            ]
+          : []),
         {
           title: 'Find',
           icon: dhFileSearch,
@@ -1228,12 +1289,29 @@ class NotebookPanel extends Component<NotebookPanelProps, NotebookPanelState> {
   getDropdownOverflowActions(): DropdownAction[] {
     const { notebookSettings } = this.props;
     const { isMinimapEnabled, formatOnSave } = notebookSettings;
-    const { settings: initialSettings } = this.state;
+    const {
+      settings: initialSettings,
+      isNarrowToolbar,
+      session,
+      sessionLanguage,
+      isLoaded,
+    } = this.state;
+    const settings = this.getSettings(
+      initialSettings,
+      isMinimapEnabled ?? false
+    );
+    const isSessionConnected = session != null;
+    const isLanguageMatching = sessionLanguage === settings.language;
+    const runButtonsDisabled =
+      !isLoaded || !isSessionConnected || !isLanguageMatching;
+    const toolbarDisabled = !isLoaded;
     return this.getOverflowActions(
       isMinimapEnabled ?? false,
-      this.getSettings(initialSettings, isMinimapEnabled ?? false).wordWrap ===
-        'on',
-      formatOnSave ?? false
+      settings.wordWrap === 'on',
+      formatOnSave ?? false,
+      isNarrowToolbar,
+      runButtonsDisabled,
+      toolbarDisabled
     );
   }
 
@@ -1276,6 +1354,7 @@ class NotebookPanel extends Component<NotebookPanelProps, NotebookPanelState> {
     const runButtonsDisabled =
       !isLoaded || !isSessionConnected || !isLanguageMatching;
     const toolbarDisabled = !isLoaded;
+    const { isNarrowToolbar } = this.state;
     const contextActions = [
       {
         action: this.handleSave,
@@ -1355,52 +1434,60 @@ class NotebookPanel extends Component<NotebookPanelProps, NotebookPanelState> {
         >
           {!isMarkdown && (
             <>
-              <div className="notebook-toolbar">
-                <span>
-                  <Button
-                    kind="ghost"
-                    className="btn-play"
-                    onClick={this.handleRunAll}
-                    disabled={runButtonsDisabled}
-                    icon={<FontAwesomeIcon icon={vsPlay} transform="grow-4" />}
-                    tooltip={`Run ${SHORTCUTS.NOTEBOOK.RUN.getDisplayText()}`}
-                    aria-label="Run"
-                  />
-                  {disabledRunButtonTooltip != null && (
-                    <Tooltip>{disabledRunButtonTooltip}</Tooltip>
-                  )}
-                </span>
-                <span>
-                  <Button
-                    kind="ghost"
-                    className="btn-play"
-                    onClick={this.handleRunSelected}
-                    disabled={runButtonsDisabled}
-                    icon={
-                      <FontAwesomeIcon
-                        icon={dhRunSelection}
-                        transform="grow-4"
+              <div className="notebook-toolbar" ref={this.toolbarRef}>
+                {!isNarrowToolbar && (
+                  <>
+                    <span>
+                      <Button
+                        kind="ghost"
+                        className="btn-play"
+                        onClick={this.handleRunAll}
+                        disabled={runButtonsDisabled}
+                        icon={
+                          <FontAwesomeIcon icon={vsPlay} transform="grow-4" />
+                        }
+                        tooltip={`Run ${SHORTCUTS.NOTEBOOK.RUN.getDisplayText()}`}
+                        aria-label="Run"
                       />
-                    }
-                    tooltip={`Run Selected ${SHORTCUTS.NOTEBOOK.RUN_SELECTED.getDisplayText()}`}
-                    aria-label="Run Selected"
-                  />
-                  {disabledRunSelectedButtonTooltip != null && (
-                    <Tooltip>{disabledRunSelectedButtonTooltip}</Tooltip>
-                  )}
-                </span>
+                      {disabledRunButtonTooltip != null && (
+                        <Tooltip>{disabledRunButtonTooltip}</Tooltip>
+                      )}
+                    </span>
+                    <span>
+                      <Button
+                        kind="ghost"
+                        className="btn-play"
+                        onClick={this.handleRunSelected}
+                        disabled={runButtonsDisabled}
+                        icon={
+                          <FontAwesomeIcon
+                            icon={dhRunSelection}
+                            transform="grow-4"
+                          />
+                        }
+                        tooltip={`Run Selected ${SHORTCUTS.NOTEBOOK.RUN_SELECTED.getDisplayText()}`}
+                        aria-label="Run Selected"
+                      />
+                      {disabledRunSelectedButtonTooltip != null && (
+                        <Tooltip>{disabledRunSelectedButtonTooltip}</Tooltip>
+                      )}
+                    </span>
+                    <Button
+                      kind="ghost"
+                      className="mr-auto"
+                      disabled={toolbarDisabled}
+                      onClick={this.handleSave}
+                      icon={vsSave}
+                      tooltip={`Save ${GLOBAL_SHORTCUTS.SAVE.getDisplayText()}`}
+                      aria-label="Save"
+                    />
+                  </>
+                )}
                 <Button
                   kind="ghost"
-                  className="mr-auto"
-                  disabled={toolbarDisabled}
-                  onClick={this.handleSave}
-                  icon={vsSave}
-                  tooltip={`Save ${GLOBAL_SHORTCUTS.SAVE.getDisplayText()}`}
-                  aria-label="Save"
-                />
-                <Button
-                  kind="ghost"
-                  className="btn-overflow"
+                  className={classNames('btn-overflow', {
+                    'ml-auto': isNarrowToolbar,
+                  })}
                   disabled={toolbarDisabled}
                   icon={vsKebabVertical}
                   tooltip="More Actions..."

--- a/packages/dashboard-core-plugins/src/panels/NotebookPanel.tsx
+++ b/packages/dashboard-core-plugins/src/panels/NotebookPanel.tsx
@@ -136,8 +136,6 @@ interface NotebookPanelState {
   itemName?: string;
 
   formatOnSave: boolean;
-
-  isNarrowToolbar: boolean;
 }
 
 class NotebookPanel extends Component<NotebookPanelProps, NotebookPanelState> {
@@ -150,10 +148,6 @@ class NotebookPanel extends Component<NotebookPanelProps, NotebookPanelState> {
   static UNSAVED_INDICATOR_CLASS_NAME = 'editor-unsaved-indicator';
 
   static UNSAVED_STATUS_CLASS_NAME = 'is-unsaved';
-
-  // Minimum toolbar width (px) to show Run, Run Selected, and Save buttons inline.
-  // 4 buttons × ~32px + 2×8px padding + 3×4px gaps ≈ 156px, rounded up.
-  static NARROW_TOOLBAR_THRESHOLD = 160;
 
   static handleError(error: unknown): void {
     if (PromiseUtils.isCanceled(error)) {
@@ -258,10 +252,6 @@ class NotebookPanel extends Component<NotebookPanelProps, NotebookPanelState> {
 
     this.tabInitOnce = false;
 
-    this.toolbarRef = React.createRef();
-
-    this.toolbarResizeObserver = null;
-
     const { isDashboardActive, session, sessionLanguage, panelState } = props;
 
     let settings: editor.IStandaloneEditorConstructionOptions = {
@@ -319,8 +309,6 @@ class NotebookPanel extends Component<NotebookPanelProps, NotebookPanelState> {
       scriptCode: '',
 
       formatOnSave: false,
-
-      isNarrowToolbar: true,
     };
 
     log.debug('constructor', props, this.state);
@@ -337,19 +325,6 @@ class NotebookPanel extends Component<NotebookPanelProps, NotebookPanelState> {
       NotebookEvent.PROMOTE_FROM_PREVIEW,
       this.handlePreviewPromotion
     );
-    const toolbar = this.toolbarRef.current;
-    if (toolbar != null) {
-      this.toolbarResizeObserver = new ResizeObserver(entries => {
-        const entry = entries[0];
-        if (entry != null) {
-          this.setState({
-            isNarrowToolbar:
-              entry.contentRect.width < NotebookPanel.NARROW_TOOLBAR_THRESHOLD,
-          });
-        }
-      });
-      this.toolbarResizeObserver.observe(toolbar);
-    }
   }
 
   componentDidUpdate(
@@ -377,7 +352,6 @@ class NotebookPanel extends Component<NotebookPanelProps, NotebookPanelState> {
   componentWillUnmount(): void {
     this.debouncedSavePanelState.flush();
     this.pending.cancel();
-    this.toolbarResizeObserver?.disconnect();
 
     const { glEventHub, glContainer } = this.props;
 
@@ -404,10 +378,6 @@ class NotebookPanel extends Component<NotebookPanelProps, NotebookPanelState> {
   tabInitOnce: boolean;
 
   editor?: editor.IStandaloneCodeEditor;
-
-  toolbarRef: React.RefObject<HTMLDivElement>;
-
-  toolbarResizeObserver: ResizeObserver | null;
 
   // Called by TabEvent. Happens once when created, but also each time its moved.
   // when moved, need to re-init the unsaved indicators on title elements
@@ -610,39 +580,37 @@ class NotebookPanel extends Component<NotebookPanelProps, NotebookPanelState> {
       isMinimapEnabled: boolean,
       isWordWrapEnabled: boolean,
       formatOnSave: boolean,
-      isNarrowToolbar: boolean,
       runButtonsDisabled: boolean,
       toolbarDisabled: boolean
     ) => {
       const actions: DropdownAction[] = [
-        ...(isNarrowToolbar
-          ? [
-              {
-                title: 'Run',
-                icon: vsPlay,
-                action: this.handleRunAll,
-                disabled: runButtonsDisabled,
-                group: ContextActions.groups.high,
-                order: 1,
-              },
-              {
-                title: 'Run Selected',
-                icon: dhRunSelection,
-                action: this.handleRunSelected,
-                disabled: runButtonsDisabled,
-                group: ContextActions.groups.high,
-                order: 2,
-              },
-              {
-                title: 'Save',
-                icon: vsSave,
-                action: this.handleSave,
-                disabled: toolbarDisabled,
-                group: ContextActions.groups.high,
-                order: 3,
-              },
-            ]
-          : []),
+        {
+          title: 'Run',
+          icon: vsPlay,
+          action: this.handleRunAll,
+          disabled: runButtonsDisabled,
+          shortcut: SHORTCUTS.NOTEBOOK.RUN,
+          group: ContextActions.groups.high,
+          order: 1,
+        },
+        {
+          title: 'Run Selected',
+          icon: dhRunSelection,
+          action: this.handleRunSelected,
+          disabled: runButtonsDisabled,
+          shortcut: SHORTCUTS.NOTEBOOK.RUN_SELECTED,
+          group: ContextActions.groups.high,
+          order: 2,
+        },
+        {
+          title: 'Save',
+          icon: vsSave,
+          action: this.handleSave,
+          disabled: toolbarDisabled,
+          shortcut: GLOBAL_SHORTCUTS.SAVE,
+          group: ContextActions.groups.high,
+          order: 3,
+        },
         {
           title: 'Find',
           icon: dhFileSearch,
@@ -1291,7 +1259,6 @@ class NotebookPanel extends Component<NotebookPanelProps, NotebookPanelState> {
     const { isMinimapEnabled, formatOnSave } = notebookSettings;
     const {
       settings: initialSettings,
-      isNarrowToolbar,
       session,
       sessionLanguage,
       isLoaded,
@@ -1309,7 +1276,6 @@ class NotebookPanel extends Component<NotebookPanelProps, NotebookPanelState> {
       isMinimapEnabled ?? false,
       settings.wordWrap === 'on',
       formatOnSave ?? false,
-      isNarrowToolbar,
       runButtonsDisabled,
       toolbarDisabled
     );
@@ -1354,7 +1320,6 @@ class NotebookPanel extends Component<NotebookPanelProps, NotebookPanelState> {
     const runButtonsDisabled =
       !isLoaded || !isSessionConnected || !isLanguageMatching;
     const toolbarDisabled = !isLoaded;
-    const { isNarrowToolbar } = this.state;
     const contextActions = [
       {
         action: this.handleSave,
@@ -1434,60 +1399,56 @@ class NotebookPanel extends Component<NotebookPanelProps, NotebookPanelState> {
         >
           {!isMarkdown && (
             <>
-              <div className="notebook-toolbar" ref={this.toolbarRef}>
-                {!isNarrowToolbar && (
-                  <>
-                    <span>
-                      <Button
-                        kind="ghost"
-                        className="btn-play"
-                        onClick={this.handleRunAll}
-                        disabled={runButtonsDisabled}
-                        icon={
-                          <FontAwesomeIcon icon={vsPlay} transform="grow-4" />
-                        }
-                        tooltip={`Run ${SHORTCUTS.NOTEBOOK.RUN.getDisplayText()}`}
-                        aria-label="Run"
-                      />
-                      {disabledRunButtonTooltip != null && (
-                        <Tooltip>{disabledRunButtonTooltip}</Tooltip>
-                      )}
-                    </span>
-                    <span>
-                      <Button
-                        kind="ghost"
-                        className="btn-play"
-                        onClick={this.handleRunSelected}
-                        disabled={runButtonsDisabled}
-                        icon={
-                          <FontAwesomeIcon
-                            icon={dhRunSelection}
-                            transform="grow-4"
-                          />
-                        }
-                        tooltip={`Run Selected ${SHORTCUTS.NOTEBOOK.RUN_SELECTED.getDisplayText()}`}
-                        aria-label="Run Selected"
-                      />
-                      {disabledRunSelectedButtonTooltip != null && (
-                        <Tooltip>{disabledRunSelectedButtonTooltip}</Tooltip>
-                      )}
-                    </span>
+              <div className="notebook-toolbar">
+                <div className="notebook-toolbar-actions">
+                  <span>
                     <Button
                       kind="ghost"
-                      className="mr-auto"
-                      disabled={toolbarDisabled}
-                      onClick={this.handleSave}
-                      icon={vsSave}
-                      tooltip={`Save ${GLOBAL_SHORTCUTS.SAVE.getDisplayText()}`}
-                      aria-label="Save"
+                      className="btn-play btn-run"
+                      onClick={this.handleRunAll}
+                      disabled={runButtonsDisabled}
+                      icon={
+                        <FontAwesomeIcon icon={vsPlay} transform="grow-4" />
+                      }
+                      tooltip={`Run ${SHORTCUTS.NOTEBOOK.RUN.getDisplayText()}`}
+                      aria-label="Run"
                     />
-                  </>
-                )}
+                    {disabledRunButtonTooltip != null && (
+                      <Tooltip>{disabledRunButtonTooltip}</Tooltip>
+                    )}
+                  </span>
+                  <span>
+                    <Button
+                      kind="ghost"
+                      className="btn-play btn-run-selected"
+                      onClick={this.handleRunSelected}
+                      disabled={runButtonsDisabled}
+                      icon={
+                        <FontAwesomeIcon
+                          icon={dhRunSelection}
+                          transform="grow-4"
+                        />
+                      }
+                      tooltip={`Run Selected ${SHORTCUTS.NOTEBOOK.RUN_SELECTED.getDisplayText()}`}
+                      aria-label="Run Selected"
+                    />
+                    {disabledRunSelectedButtonTooltip != null && (
+                      <Tooltip>{disabledRunSelectedButtonTooltip}</Tooltip>
+                    )}
+                  </span>
+                  <Button
+                    kind="ghost"
+                    className="btn-save"
+                    disabled={toolbarDisabled}
+                    onClick={this.handleSave}
+                    icon={vsSave}
+                    tooltip={`Save ${GLOBAL_SHORTCUTS.SAVE.getDisplayText()}`}
+                    aria-label="Save"
+                  />
+                </div>
                 <Button
                   kind="ghost"
-                  className={classNames('btn-overflow', {
-                    'ml-auto': isNarrowToolbar,
-                  })}
+                  className="btn-overflow"
                   disabled={toolbarDisabled}
                   icon={vsKebabVertical}
                   tooltip="More Actions..."


### PR DESCRIPTION
Toolbar buttons overflow outside panel when narrow

When a script editor panel is resized to a small width, the toolbar buttons (Run, Run Selected, Save) now hide and move into the overflow (⋮) menu instead of rendering outside the panel boundary. A `ResizeObserver` tracks the toolbar width and collapses the buttons when it drops below 160px.

Demo Video:

https://github.com/user-attachments/assets/354f8bc6-ce6f-41e2-b706-f5569c93409b



