### PR TITLE
fix: DH-23126: Use Subscription for Update Event with Viewport Options

### DIFF
--- a/packages/jsapi-components/src/useSetPaddedViewportCallback.ts
+++ b/packages/jsapi-components/src/useSetPaddedViewportCallback.ts
@@ -1,10 +1,22 @@
-import { useCallback, useEffect, useRef } from 'react';
+import { type MutableRefObject, useCallback, useEffect, useRef } from 'react';
 import type { dh } from '@deephaven/jsapi-types';
 import {
   getSize,
   padFirstAndLastRow,
   TableUtils,
 } from '@deephaven/jsapi-utils';
+
+/**
+ * The return type of `useSetPaddedViewportCallback`. It is callable as a
+ * function and also exposes `subscriptionRef` so that callers can register
+ * event listeners directly on the underlying `TableViewportSubscription` when
+ * one is in use (required since DH-20800 severed the table→subscription event
+ * propagation).
+ */
+export type UseSetPaddedViewportCallbackResult = {
+  (firstRow: number): void;
+  subscriptionRef: MutableRefObject<dh.TableViewportSubscription | null>;
+};
 
 /**
  * Creates a callback function that will set a Table viewport. The callback has
@@ -17,14 +29,15 @@ import {
  * @param viewportSubscriptionOptions The viewport subscription options to use. If provided and
  * the table is not a `TreeTable`, the data will be requested using a `TableViewportSubscription`.
  * Rows and columns are filled in when the subscription is created if they are missing.
- * @returns A callback function for setting the viewport.
+ * @returns A callable result with a `subscriptionRef` property exposing the
+ * active `TableViewportSubscription` (if any) so callers can attach listeners.
  */
 export function useSetPaddedViewportCallback(
   table: dh.Table | dh.TreeTable | null,
   viewportSize: number,
   viewportPadding: number,
   viewportSubscriptionOptions: Partial<dh.ViewportSubscriptionOptions> | null = null
-): (firstRow: number) => void {
+): UseSetPaddedViewportCallbackResult {
   const subscriptionRef = useRef<dh.TableViewportSubscription | null>(null);
   const prevTableRef = useRef<dh.Table | dh.TreeTable | null>(null);
   const prevViewportOptionsRef =
@@ -48,8 +61,8 @@ export function useSetPaddedViewportCallback(
 
   useEffect(() => cleanupSubscription, []);
 
-  return useCallback(
-    function setPaddedViewport(firstRow: number) {
+  const setPaddedViewport = useCallback(
+    function setPaddedViewportFn(firstRow: number) {
       if (table == null) {
         return;
       }
@@ -91,6 +104,14 @@ export function useSetPaddedViewportCallback(
     },
     [table, viewportPadding, viewportSize, viewportSubscriptionOptions]
   );
+
+  // Attach subscriptionRef as a property of the returned callback so that
+  // useViewportData can register TABLE_UPDATED listeners directly on the
+  // subscription (since DH-20800 severed table→subscription event propagation).
+  const result =
+    setPaddedViewport as unknown as UseSetPaddedViewportCallbackResult;
+  result.subscriptionRef = subscriptionRef;
+  return result;
 }
 
 export default useSetPaddedViewportCallback;

--- a/packages/jsapi-components/src/useViewportData.test.tsx
+++ b/packages/jsapi-components/src/useViewportData.test.tsx
@@ -12,7 +12,10 @@ import { TestUtils } from '@deephaven/test-utils';
 import useViewportData, { type UseViewportDataProps } from './useViewportData';
 import { makeApiContextWrapper } from './HookTestUtils';
 import { useTableSize } from './useTableSize';
-import { useSetPaddedViewportCallback } from './useSetPaddedViewportCallback';
+import {
+  useSetPaddedViewportCallback,
+  type UseSetPaddedViewportCallbackResult,
+} from './useSetPaddedViewportCallback';
 import { SCROLL_DEBOUNCE_MS } from './Constants';
 
 jest.mock('@deephaven/react-hooks', () => ({
@@ -78,12 +81,16 @@ const optionsTableNull: UseViewportDataProps<unknown, DhType.Table> = {
 
 const wrapper: React.FC<DhType.Table> = makeApiContextWrapper(dh);
 
-const useSetPaddedViewportCallbackResultA = jest
-  .fn()
-  .mockName('useSetPaddedViewportCallbackResultA');
-const useSetPaddedViewportCallbackResultB = jest
-  .fn()
-  .mockName('useSetPaddedViewportCallbackResultB');
+const stubSubscriptionRef: React.MutableRefObject<DhType.TableViewportSubscription | null> =
+  { current: null };
+const useSetPaddedViewportCallbackResultA = Object.assign(
+  jest.fn().mockName('useSetPaddedViewportCallbackResultA'),
+  { subscriptionRef: stubSubscriptionRef }
+) as unknown as UseSetPaddedViewportCallbackResult;
+const useSetPaddedViewportCallbackResultB = Object.assign(
+  jest.fn().mockName('useSetPaddedViewportCallbackResultB'),
+  { subscriptionRef: stubSubscriptionRef }
+) as unknown as UseSetPaddedViewportCallbackResult;
 const mockOnScrollCallback = jest.fn().mockName('mockOnScrollCallback');
 
 beforeEach(() => {

--- a/packages/jsapi-components/src/useViewportData.ts
+++ b/packages/jsapi-components/src/useViewportData.ts
@@ -97,6 +97,7 @@ export function useViewportData<TItem, TTable extends dh.Table | dh.TreeTable>({
     viewportPadding,
     viewportSubscriptionOptions
   );
+  const { subscriptionRef } = setPaddedViewport;
 
   const setViewport = useCallback(
     (firstRow: number) => {
@@ -149,7 +150,26 @@ export function useViewportData<TItem, TTable extends dh.Table | dh.TreeTable>({
     // Hydrate the viewport with real data. This will fetch data from index
     // 0 to the end of the viewport + padding.
     setViewport(0);
-  }, [table, setViewport]);
+
+    // Since DH-20800, TABLE_UPDATED events fire on the subscription object
+    // rather than on the table when createViewportSubscription is used.
+    // Register the listener directly on the subscription after setViewport(0)
+    // creates it synchronously above.
+    const subscription = subscriptionRef.current;
+    if (subscription != null) {
+      return subscription.addEventListener(
+        dh.Table.EVENT_UPDATED,
+        onTableUpdated
+      );
+    }
+    return undefined;
+  }, [
+    dh.Table.EVENT_UPDATED,
+    onTableUpdated,
+    setViewport,
+    subscriptionRef,
+    table,
+  ]);
 
   useEffect(() => {
     setViewport(currentViewportFirstRowRef.current);


### PR DESCRIPTION
https://github.com/deephaven/deephaven-core/commit/de3420a8e6dcc3986597429059be719958d20fa7#diff-162aa86fd5cbdd89292447104bd0ce09e4d45907c433bd9d10e41924e66bf4a3R848
Due to the above change, table subscriptions are severed from the table meaning that the TABLE_UPDATE event no longer fires on the table if you have a subscription.

This fix does the following:
- return the subscription ref from useSetPaddedViewportCallback
- in useViewportData, subscribe to events if the subscription is not null