### PR TITLE
fix: DH-23126: Use Subscription for Update Event with Viewport Options

### DIFF
--- a/packages/jsapi-components/src/useSetPaddedViewportCallback.test.ts
+++ b/packages/jsapi-components/src/useSetPaddedViewportCallback.test.ts
@@ -1,25 +1,25 @@
 import { renderHook } from '@testing-library/react';
-import type { dh } from '@deephaven/jsapi-types';
+import type { dh as DhType } from '@deephaven/jsapi-types';
 import dh from '@deephaven/jsapi-shim';
 import { TestUtils } from '@deephaven/test-utils';
 import { TableUtils } from '@deephaven/jsapi-utils';
 import useSetPaddedViewportCallback from './useSetPaddedViewportCallback';
 import { makeApiContextWrapper } from './HookTestUtils';
 
-let table: dh.Table;
-let table2: dh.Table;
-let viewportOptions: dh.ViewportSubscriptionOptions;
-let viewportOptionsMissingRows: Partial<dh.ViewportSubscriptionOptions>;
-let viewportOptionsMissingColumns: Partial<dh.ViewportSubscriptionOptions>;
-let viewportOptionsMissingBoth: Partial<dh.ViewportSubscriptionOptions>;
+let table: DhType.Table;
+let table2: DhType.Table;
+let viewportOptions: DhType.ViewportSubscriptionOptions;
+let viewportOptionsMissingRows: Partial<DhType.ViewportSubscriptionOptions>;
+let viewportOptionsMissingColumns: Partial<DhType.ViewportSubscriptionOptions>;
+let viewportOptionsMissingBoth: Partial<DhType.ViewportSubscriptionOptions>;
 const viewportSize = 10;
 const viewportPadding = 4;
 const wrapper = makeApiContextWrapper(dh);
 
 beforeEach(() => {
   jest.clearAllMocks();
-  table = TestUtils.createMockProxy<dh.Table>({ size: 100 });
-  table2 = TestUtils.createMockProxy<dh.Table>({ size: 101 });
+  table = TestUtils.createMockProxy<DhType.Table>({ size: 100 });
+  table2 = TestUtils.createMockProxy<DhType.Table>({ size: 101 });
   viewportOptions = {
     rows: {
       first: 0,
@@ -65,6 +65,7 @@ it('should use TableViewportSubscription if viewport options are provided', () =
   jest.spyOn(TableUtils, 'isTreeTable').mockReturnValue(false);
 
   const mockSubscription = {
+    addEventListener: jest.fn().mockReturnValue(() => undefined),
     update: jest.fn(),
     close: jest.fn(),
   };
@@ -115,6 +116,7 @@ it('should fill missing rows and columns when creating a subscription', () => {
   jest.spyOn(TableUtils, 'isTreeTable').mockReturnValue(false);
 
   const mockSubscription = {
+    addEventListener: jest.fn().mockReturnValue(() => undefined),
     update: jest.fn(),
     close: jest.fn(),
   };
@@ -206,10 +208,12 @@ it('should set update viewport subscription if called in same render as the hook
   jest.spyOn(TableUtils, 'isTreeTable').mockReturnValue(false);
 
   const mockSubscription = {
+    addEventListener: jest.fn().mockReturnValue(() => undefined),
     update: jest.fn(),
     close: jest.fn(),
   };
   const mockSubscription2 = {
+    addEventListener: jest.fn().mockReturnValue(() => undefined),
     update: jest.fn(),
     close: jest.fn(),
   };
@@ -259,11 +263,13 @@ it('should create a new subscription when viewportSubscriptionOptions or table c
   jest.spyOn(TableUtils, 'isTreeTable').mockReturnValue(false);
 
   const mockSubscription1 = {
+    addEventListener: jest.fn().mockReturnValue(() => undefined),
     update: jest.fn(),
     close: jest.fn(),
   };
 
   const mockSubscription2 = {
+    addEventListener: jest.fn().mockReturnValue(() => undefined),
     update: jest.fn(),
     close: jest.fn(),
   };
@@ -311,7 +317,15 @@ it('should create a new subscription when viewportSubscriptionOptions or table c
   expect(mockSubscription2.update).toHaveBeenCalled();
 
   // Change table and rerender
-  const newTable = TestUtils.createMockProxy<dh.Table>({ size: 100 });
+  const mockSubscription3 = {
+    addEventListener: jest.fn().mockReturnValue(() => undefined),
+    update: jest.fn(),
+    close: jest.fn(),
+  };
+  const newTable = TestUtils.createMockProxy<DhType.Table>({ size: 100 });
+  (newTable.createViewportSubscription as jest.Mock).mockReturnValue(
+    mockSubscription3
+  );
   rerender({ table: newTable, options: newViewportOptions });
   expect(mockSubscription2.close).toHaveBeenCalled();
 
@@ -328,6 +342,7 @@ it('should close subscription on unmount', () => {
   jest.spyOn(TableUtils, 'isTreeTable').mockReturnValue(false);
 
   const mockSubscription = {
+    addEventListener: jest.fn().mockReturnValue(() => undefined),
     update: jest.fn(),
     close: jest.fn(),
   };

--- a/packages/jsapi-components/src/useSetPaddedViewportCallback.test.ts
+++ b/packages/jsapi-components/src/useSetPaddedViewportCallback.test.ts
@@ -1,8 +1,10 @@
 import { renderHook } from '@testing-library/react';
 import type { dh } from '@deephaven/jsapi-types';
+import dh from '@deephaven/jsapi-shim';
 import { TestUtils } from '@deephaven/test-utils';
 import { TableUtils } from '@deephaven/jsapi-utils';
 import useSetPaddedViewportCallback from './useSetPaddedViewportCallback';
+import { makeApiContextWrapper } from './HookTestUtils';
 
 let table: dh.Table;
 let table2: dh.Table;
@@ -12,6 +14,7 @@ let viewportOptionsMissingColumns: Partial<dh.ViewportSubscriptionOptions>;
 let viewportOptionsMissingBoth: Partial<dh.ViewportSubscriptionOptions>;
 const viewportSize = 10;
 const viewportPadding = 4;
+const wrapper = makeApiContextWrapper(dh);
 
 beforeEach(() => {
   jest.clearAllMocks();
@@ -37,8 +40,10 @@ beforeEach(() => {
 });
 
 it('should create a callback that sets a padded viewport', () => {
-  const { result } = renderHook(() =>
-    useSetPaddedViewportCallback(table, viewportSize, viewportPadding, null)
+  const { result } = renderHook(
+    () =>
+      useSetPaddedViewportCallback(table, viewportSize, viewportPadding, null),
+    { wrapper }
   );
 
   // Call our `setPaddedViewport` callback.
@@ -68,13 +73,15 @@ it('should use TableViewportSubscription if viewport options are provided', () =
     mockSubscription
   );
 
-  const { result } = renderHook(() =>
-    useSetPaddedViewportCallback(
-      table,
-      viewportSize,
-      viewportPadding,
-      viewportOptions
-    )
+  const { result } = renderHook(
+    () =>
+      useSetPaddedViewportCallback(
+        table,
+        viewportSize,
+        viewportPadding,
+        viewportOptions
+      ),
+    { wrapper }
   );
 
   // Call callback for the first time, which should create a subscription
@@ -124,7 +131,7 @@ it('should fill missing rows and columns when creating a subscription', () => {
         viewportPadding,
         options
       ),
-    { initialProps: viewportOptionsMissingRows }
+    { initialProps: viewportOptionsMissingRows, wrapper }
   );
 
   const firstRow = 30;
@@ -169,13 +176,15 @@ it('should fill missing rows and columns when creating a subscription', () => {
 it('should use setViewport if provided a tree table', () => {
   jest.spyOn(TableUtils, 'isTreeTable').mockReturnValue(true);
 
-  const { result } = renderHook(() =>
-    useSetPaddedViewportCallback(
-      table,
-      viewportSize,
-      viewportPadding,
-      viewportOptions
-    )
+  const { result } = renderHook(
+    () =>
+      useSetPaddedViewportCallback(
+        table,
+        viewportSize,
+        viewportPadding,
+        viewportOptions
+      ),
+    { wrapper }
   );
 
   // Call our `setPaddedViewport` callback.
@@ -221,7 +230,7 @@ it('should set update viewport subscription if called in same render as the hook
       // Call the callback in same render
       callback(30);
     },
-    { initialProps: viewportOptions }
+    { initialProps: viewportOptions, wrapper }
   );
 
   expect(table.createViewportSubscription).toHaveBeenCalledWith(
@@ -273,6 +282,7 @@ it('should create a new subscription when viewportSubscriptionOptions or table c
       ),
     {
       initialProps: { table, options: viewportOptions },
+      wrapper,
     }
   );
 
@@ -326,13 +336,15 @@ it('should close subscription on unmount', () => {
     mockSubscription
   );
 
-  const { result, unmount } = renderHook(() =>
-    useSetPaddedViewportCallback(
-      table,
-      viewportSize,
-      viewportPadding,
-      viewportOptions
-    )
+  const { result, unmount } = renderHook(
+    () =>
+      useSetPaddedViewportCallback(
+        table,
+        viewportSize,
+        viewportPadding,
+        viewportOptions
+      ),
+    { wrapper }
   );
 
   result.current(30);

--- a/packages/jsapi-components/src/useSetPaddedViewportCallback.ts
+++ b/packages/jsapi-components/src/useSetPaddedViewportCallback.ts
@@ -4,7 +4,13 @@ import {
   getSize,
   padFirstAndLastRow,
   TableUtils,
+  type OnTableUpdatedEvent,
 } from '@deephaven/jsapi-utils';
+import { useApi } from '@deephaven/jsapi-bootstrap';
+import useTableListener from './useTableListener';
+
+// Stable no-op used as the useTableListener callback when onTableUpdated is null
+const noopUpdatedHandler = (_event: OnTableUpdatedEvent): void => undefined;
 
 /**
  * Creates a callback function that will set a Table viewport. The callback has
@@ -17,20 +23,27 @@ import {
  * @param viewportSubscriptionOptions The viewport subscription options to use. If provided and
  * the table is not a `TreeTable`, the data will be requested using a `TableViewportSubscription`.
  * Rows and columns are filled in when the subscription is created if they are missing.
+ * @param onUpdated Optional handler for TABLE_UPDATED events. When provided, it is
+ * registered on the table or directly on the subscription
  * @returns A callback function for setting the viewport.
  */
 export function useSetPaddedViewportCallback(
   table: dh.Table | dh.TreeTable | null,
   viewportSize: number,
   viewportPadding: number,
-  viewportSubscriptionOptions: Partial<dh.ViewportSubscriptionOptions> | null = null
+  viewportSubscriptionOptions: Partial<dh.ViewportSubscriptionOptions> | null = null,
+  onUpdated: (event: OnTableUpdatedEvent) => void = noopUpdatedHandler
 ): (firstRow: number) => void {
+  const dh = useApi();
   const subscriptionRef = useRef<dh.TableViewportSubscription | null>(null);
+  const removeSubscriptionListenerRef = useRef<(() => void) | null>(null);
   const prevTableRef = useRef<dh.Table | dh.TreeTable | null>(null);
   const prevViewportOptionsRef =
     useRef<Partial<dh.ViewportSubscriptionOptions> | null>(null);
 
   const cleanupSubscription = () => {
+    removeSubscriptionListenerRef.current?.();
+    removeSubscriptionListenerRef.current = null;
     if (subscriptionRef.current) {
       subscriptionRef.current.close();
       subscriptionRef.current = null;
@@ -48,6 +61,23 @@ export function useSetPaddedViewportCallback(
 
   useEffect(() => cleanupSubscription, []);
 
+  // Only use a subscription when options are provided AND the table is not a
+  // TreeTable (which does not support createViewportSubscription).
+  const needsSubscription =
+    viewportSubscriptionOptions != null &&
+    table != null &&
+    !TableUtils.isTreeTable(table);
+
+  // For the setViewport path (including TreeTable + options), register
+  // TABLE_UPDATED on the table directly.
+  // For the subscription path the listener is registered on the subscription
+  // inside setPaddedViewport when it is first created.
+  useTableListener(
+    needsSubscription ? null : table,
+    dh.Table.EVENT_UPDATED,
+    onUpdated
+  );
+
   return useCallback(
     function setPaddedViewport(firstRow: number) {
       if (table == null) {
@@ -61,11 +91,7 @@ export function useSetPaddedViewportCallback(
         getSize(table)
       );
 
-      if (
-        subscriptionRef.current == null &&
-        viewportSubscriptionOptions != null &&
-        !TableUtils.isTreeTable(table)
-      ) {
+      if (subscriptionRef.current == null && needsSubscription) {
         const subscriptionOptions: dh.ViewportSubscriptionOptions = {
           ...viewportSubscriptionOptions,
           rows: viewportSubscriptionOptions.rows ?? { first, last },
@@ -74,6 +100,14 @@ export function useSetPaddedViewportCallback(
 
         subscriptionRef.current =
           table.createViewportSubscription(subscriptionOptions);
+
+        // TABLE_UPDATED fires on the subscription rather than
+        // the table. Register the listener directly on the subscription.
+        removeSubscriptionListenerRef.current =
+          subscriptionRef.current.addEventListener(
+            dh.Table.EVENT_UPDATED,
+            onUpdated
+          );
       }
 
       if (subscriptionRef.current == null) {
@@ -89,7 +123,15 @@ export function useSetPaddedViewportCallback(
         columns: table.columns,
       });
     },
-    [table, viewportPadding, viewportSize, viewportSubscriptionOptions]
+    [
+      table,
+      viewportPadding,
+      viewportSize,
+      viewportSubscriptionOptions,
+      needsSubscription,
+      onUpdated,
+      dh.Table.EVENT_UPDATED,
+    ]
   );
 }
 

--- a/packages/jsapi-components/src/useViewportData.test.tsx
+++ b/packages/jsapi-components/src/useViewportData.test.tsx
@@ -13,6 +13,7 @@ import useViewportData, { type UseViewportDataProps } from './useViewportData';
 import { makeApiContextWrapper } from './HookTestUtils';
 import { useTableSize } from './useTableSize';
 import { useSetPaddedViewportCallback } from './useSetPaddedViewportCallback';
+import useTableListener from './useTableListener';
 import { SCROLL_DEBOUNCE_MS } from './Constants';
 
 jest.mock('@deephaven/react-hooks', () => ({
@@ -93,10 +94,20 @@ beforeEach(() => {
     .mockImplementation(t => t?.size ?? 0);
   TestUtils.asMock(useSetPaddedViewportCallback)
     .mockName('useSetPaddedViewportCallback')
-    .mockImplementation(t =>
-      t === table
-        ? useSetPaddedViewportCallbackResultA
-        : useSetPaddedViewportCallbackResultB
+    .mockImplementation(
+      (t, _size, _padding, viewportSubscriptionOptions, onUpdated) => {
+        // Simulate the listener registration that the real hook performs
+        useTableListener(
+          viewportSubscriptionOptions == null ? t : null,
+          dh.Table.EVENT_UPDATED,
+          onUpdated
+        );
+        return (
+          t === table
+            ? useSetPaddedViewportCallbackResultA
+            : useSetPaddedViewportCallbackResultB
+        ) as UseSetPaddedViewportCallbackResult;
+      }
     );
   TestUtils.asMock(useOnScrollOffsetChangeCallback)
     .mockName('useOnScrollOffsetChangeCallback')

--- a/packages/jsapi-components/src/useViewportData.ts
+++ b/packages/jsapi-components/src/useViewportData.ts
@@ -8,7 +8,6 @@ import {
   type OnTableUpdatedEvent,
 } from '@deephaven/jsapi-utils';
 import Log from '@deephaven/log';
-import { useApi } from '@deephaven/jsapi-bootstrap';
 import {
   useOnScrollOffsetChangeCallback,
   type WindowedListData,
@@ -17,7 +16,6 @@ import { type KeyedItem } from '@deephaven/utils';
 import useInitializeViewportData from './useInitializeViewportData';
 import useSetPaddedViewportCallback from './useSetPaddedViewportCallback';
 import useTableSize from './useTableSize';
-import useTableListener from './useTableListener';
 import { SCROLL_DEBOUNCE_MS } from './Constants';
 
 const log = Log.module('useViewportData');
@@ -91,11 +89,26 @@ export function useViewportData<TItem, TTable extends dh.Table | dh.TreeTable>({
     reuseItemsOnTableResize
   );
 
+  // Store the memoized callback in a ref so that changes to `viewportData`
+  // don't invalidate the memoization of `onTableUpdated`. This prevents
+  // `useTableListener` from unnecessarily re-subscribing to the same event over
+  // and over.
+  const onTableUpdatedRef = useRef<(event: OnTableUpdatedEvent) => void>();
+  onTableUpdatedRef.current = useMemo(
+    () => createOnTableUpdatedHandler(viewportData, deserializeRow),
+    [deserializeRow, viewportData]
+  );
+
+  const onTableUpdated = useCallback((event: OnTableUpdatedEvent) => {
+    onTableUpdatedRef.current?.(event);
+  }, []);
+
   const setPaddedViewport = useSetPaddedViewportCallback(
     table,
     viewportSize,
     viewportPadding,
-    viewportSubscriptionOptions
+    viewportSubscriptionOptions,
+    onTableUpdated
   );
 
   const setViewport = useCallback(
@@ -122,24 +135,6 @@ export function useViewportData<TItem, TTable extends dh.Table | dh.TreeTable>({
     },
     [setViewport, table]
   );
-
-  const dh = useApi();
-
-  // Store the memoized callback in a ref so that changes to `viewportData`
-  // don't invalidate the memoization of `onTableUpdated`. This prevents
-  // `useTableListener` from unnecessarily re-subscribing to the same event over
-  // and over.
-  const onTableUpdatedRef = useRef<(event: OnTableUpdatedEvent) => void>();
-  onTableUpdatedRef.current = useMemo(
-    () => createOnTableUpdatedHandler(viewportData, deserializeRow),
-    [deserializeRow, viewportData]
-  );
-
-  const onTableUpdated = useCallback((event: OnTableUpdatedEvent) => {
-    onTableUpdatedRef.current?.(event);
-  }, []);
-
-  useTableListener(table, dh.Table.EVENT_UPDATED, onTableUpdated);
 
   const size = useTableSize(table);
 


### PR DESCRIPTION
https://github.com/deephaven/deephaven-core/commit/de3420a8e6dcc3986597429059be719958d20fa7#diff-162aa86fd5cbdd89292447104bd0ce09e4d45907c433bd9d10e41924e66bf4a3R848
Due to the above change, table subscriptions are severed from the table meaning that the TABLE_UPDATE event no longer fires on the table if you have a subscription.

This fix does the following:

- adds an onUpdate argument to useSetPaddedViewportCallback
- useSetPaddedViewportCallback listens for updates on either the table or the subscription depending on which is needed