### PR TITLE
refactor: DH-23209: WidgetLoaderUtils now exported from dashboard-core-plugins

### DIFF
--- a/packages/dashboard-core-plugins/src/WidgetLoaderPlugin.tsx
+++ b/packages/dashboard-core-plugins/src/WidgetLoaderPlugin.tsx
@@ -13,28 +13,19 @@ import {
 } from '@deephaven/dashboard';
 import Log from '@deephaven/log';
 import {
-  isWidgetPlugin,
-  isWidgetMiddlewarePlugin,
   createChainedComponent,
   createChainedPanelComponent,
   usePlugins,
   type WidgetPlugin,
-  type WidgetMiddlewarePlugin,
 } from '@deephaven/plugin';
 import { WidgetPanel } from './panels';
 import { type WidgetPanelDescriptor } from './panels/WidgetPanelTypes';
+import {
+  getSupportedWidgetTypes,
+  getUniqueWidgetPluginInfos,
+} from './WidgetLoaderUtils';
 
 const log = Log.module('WidgetLoaderPlugin');
-
-/**
- * Information about a widget type including its base plugin and any middleware.
- */
-interface WidgetTypeInfo {
-  /** The base plugin that handles this widget type, or null if only middleware registered so far */
-  basePlugin: WidgetPlugin | null;
-  /** Middleware plugins to apply, in order from outermost to innermost */
-  middleware: WidgetMiddlewarePlugin[];
-}
 
 export function WrapWidgetPlugin(
   plugin: WidgetPlugin
@@ -102,87 +93,10 @@ export function WidgetLoaderPlugin(
 ): JSX.Element | null {
   const plugins = usePlugins();
 
-  /**
-   * Build a map of widget types to their plugin chain info.
-   * For each type, we have a base plugin and a list of middleware to apply.
-   */
-  const supportedTypes = useMemo(() => {
-    const typeMap = new Map<string, WidgetTypeInfo>();
-
-    plugins.forEach(plugin => {
-      const isMiddleware = isWidgetMiddlewarePlugin(plugin);
-      if (!isWidgetPlugin(plugin) && !isMiddleware) {
-        return;
-      }
-
-      [plugin.supportedTypes].flat().forEach(supportedType => {
-        if (supportedType == null || supportedType === '') {
-          return;
-        }
-
-        const existing = typeMap.get(supportedType);
-
-        if (isMiddleware) {
-          // Add middleware to existing chain or create pending chain
-          if (existing != null) {
-            existing.middleware.push(plugin);
-            log.debug(
-              `Adding middleware ${plugin.name} to chain for type ${supportedType}`
-            );
-          } else {
-            // No base plugin yet, create entry with just middleware
-            // The base plugin will be set when a non-middleware plugin is registered
-            typeMap.set(supportedType, {
-              basePlugin: null,
-              middleware: [plugin],
-            });
-            log.debug(
-              `Creating pending middleware chain for type ${supportedType} with ${plugin.name}`
-            );
-          }
-        } else {
-          // Non-middleware plugin: becomes the base plugin
-          if (existing != null) {
-            if (existing.basePlugin != null) {
-              // Already have a base plugin, warn about replacement
-              log.warn(
-                `Multiple WidgetPlugins handling type ${supportedType}. ` +
-                  `Replacing ${existing.basePlugin.name} with ${plugin.name} as base plugin`
-              );
-            }
-            // Keep existing middleware, update the base plugin
-            existing.basePlugin = plugin;
-          } else {
-            typeMap.set(supportedType, {
-              basePlugin: plugin,
-              middleware: [],
-            });
-          }
-          log.debug(`Set base plugin ${plugin.name} for type ${supportedType}`);
-        }
-      });
-    });
-
-    // Filter out entries that only have middleware (no base plugin)
-    const validEntries = new Map<
-      string,
-      WidgetTypeInfo & { basePlugin: WidgetPlugin }
-    >();
-    typeMap.forEach((info, type) => {
-      if (info.basePlugin != null) {
-        validEntries.set(
-          type,
-          info as WidgetTypeInfo & { basePlugin: WidgetPlugin }
-        );
-      } else {
-        log.warn(
-          `No base plugin found for type ${type}, middleware will not be applied`
-        );
-      }
-    });
-
-    return validEntries;
-  }, [plugins]);
+  const supportedTypes = useMemo(
+    () => getSupportedWidgetTypes(plugins),
+    [plugins]
+  );
 
   assertIsDashboardPluginProps(props);
   const { id, layout, registerComponent } = props;
@@ -225,29 +139,7 @@ export function WidgetLoaderPlugin(
 
   useEffect(() => {
     // Get unique base plugins (a plugin may handle multiple types)
-    // supportedTypes is already filtered to entries with non-null basePlugin
-    type ValidWidgetTypeInfo = WidgetTypeInfo & { basePlugin: WidgetPlugin };
-    const uniquePluginInfos = new Map<string, ValidWidgetTypeInfo>();
-    supportedTypes.forEach((info, _type) => {
-      // Use the base plugin name as the key to get unique plugins
-      if (!uniquePluginInfos.has(info.basePlugin.name)) {
-        // Clone to avoid mutating the useMemo result
-        uniquePluginInfos.set(info.basePlugin.name, {
-          basePlugin: info.basePlugin,
-          middleware: [...info.middleware],
-        });
-      } else {
-        // Merge middleware from multiple type registrations for the same base plugin
-        const existingInfo = uniquePluginInfos.get(info.basePlugin.name);
-        if (existingInfo != null) {
-          info.middleware.forEach(m => {
-            if (!existingInfo.middleware.includes(m)) {
-              existingInfo.middleware.push(m);
-            }
-          });
-        }
-      }
-    });
+    const uniquePluginInfos = getUniqueWidgetPluginInfos(supportedTypes);
 
     log.debug(
       'Registering widget components',

--- a/packages/dashboard-core-plugins/src/WidgetLoaderUtils.test.ts
+++ b/packages/dashboard-core-plugins/src/WidgetLoaderUtils.test.ts
@@ -1,0 +1,286 @@
+import {
+  PluginType,
+  type PluginModuleMap,
+  type PluginModuleExport,
+  type WidgetPlugin,
+  type WidgetMiddlewarePlugin,
+} from '@deephaven/plugin';
+import {
+  getSupportedWidgetTypes,
+  getUniqueWidgetPluginInfos,
+  type ValidWidgetTypeInfo,
+} from './WidgetLoaderUtils';
+
+function TestComponent() {
+  return null;
+}
+
+function makeWidgetPlugin(
+  name: string,
+  supportedTypes: string | string[]
+): WidgetPlugin {
+  return {
+    name,
+    type: PluginType.WIDGET_PLUGIN,
+    supportedTypes,
+    component: TestComponent,
+  };
+}
+
+function makeMiddlewarePlugin(
+  name: string,
+  supportedTypes: string | string[]
+): WidgetMiddlewarePlugin {
+  return {
+    name,
+    type: PluginType.MIDDLEWARE_PLUGIN,
+    supportedTypes,
+    component: TestComponent,
+  };
+}
+
+function makePluginMap(
+  plugins: [string, PluginModuleExport][]
+): PluginModuleMap {
+  return new Map(plugins) as PluginModuleMap;
+}
+
+describe('getSupportedWidgetTypes', () => {
+  it('returns an empty map when there are no plugins', () => {
+    expect(getSupportedWidgetTypes(makePluginMap([]))).toEqual(new Map());
+  });
+
+  it('ignores plugins that are not widget or middleware plugins', () => {
+    const themePlugin = {
+      name: 'theme',
+      type: PluginType.THEME_PLUGIN,
+      themes: [],
+    } as PluginModuleExport;
+
+    expect(
+      getSupportedWidgetTypes(makePluginMap([['theme', themePlugin]]))
+    ).toEqual(new Map());
+  });
+
+  it('maps a single supported type to its base plugin', () => {
+    const plugin = makeWidgetPlugin('widget', 'test-widget');
+
+    expect(
+      getSupportedWidgetTypes(makePluginMap([['widget', plugin]]))
+    ).toEqual(
+      new Map([['test-widget', { basePlugin: plugin, middleware: [] }]])
+    );
+  });
+
+  it('maps every type when supportedTypes is an array', () => {
+    const plugin = makeWidgetPlugin('widget', ['type-a', 'type-b']);
+
+    expect(
+      getSupportedWidgetTypes(makePluginMap([['widget', plugin]]))
+    ).toEqual(
+      new Map([
+        ['type-a', { basePlugin: plugin, middleware: [] }],
+        ['type-b', { basePlugin: plugin, middleware: [] }],
+      ])
+    );
+  });
+
+  it.each([[''], [null], [undefined]])(
+    'skips empty or nullish supported type %s',
+    supportedType => {
+      const plugin = makeWidgetPlugin('widget', [
+        supportedType as unknown as string,
+        'type-a',
+      ]);
+
+      expect(
+        getSupportedWidgetTypes(makePluginMap([['widget', plugin]]))
+      ).toEqual(new Map([['type-a', { basePlugin: plugin, middleware: [] }]]));
+    }
+  );
+
+  it('replaces the base plugin when multiple widget plugins handle the same type', () => {
+    const first = makeWidgetPlugin('first', 'test-widget');
+    const second = makeWidgetPlugin('second', 'test-widget');
+
+    expect(
+      getSupportedWidgetTypes(
+        makePluginMap([
+          ['first', first],
+          ['second', second],
+        ])
+      )
+    ).toEqual(
+      new Map([['test-widget', { basePlugin: second, middleware: [] }]])
+    );
+  });
+
+  it('adds middleware registered after the base plugin', () => {
+    const base = makeWidgetPlugin('base', 'test-widget');
+    const middleware = makeMiddlewarePlugin('middleware', 'test-widget');
+
+    expect(
+      getSupportedWidgetTypes(
+        makePluginMap([
+          ['base', base],
+          ['middleware', middleware],
+        ])
+      )
+    ).toEqual(
+      new Map([['test-widget', { basePlugin: base, middleware: [middleware] }]])
+    );
+  });
+
+  it('adds middleware registered before the base plugin', () => {
+    const middleware = makeMiddlewarePlugin('middleware', 'test-widget');
+    const base = makeWidgetPlugin('base', 'test-widget');
+
+    expect(
+      getSupportedWidgetTypes(
+        makePluginMap([
+          ['middleware', middleware],
+          ['base', base],
+        ])
+      )
+    ).toEqual(
+      new Map([['test-widget', { basePlugin: base, middleware: [middleware] }]])
+    );
+  });
+
+  it('keeps middleware in registration order', () => {
+    const base = makeWidgetPlugin('base', 'test-widget');
+    const middlewareA = makeMiddlewarePlugin('middleware-a', 'test-widget');
+    const middlewareB = makeMiddlewarePlugin('middleware-b', 'test-widget');
+
+    expect(
+      getSupportedWidgetTypes(
+        makePluginMap([
+          ['middleware-a', middlewareA],
+          ['base', base],
+          ['middleware-b', middlewareB],
+        ])
+      )
+    ).toEqual(
+      new Map([
+        [
+          'test-widget',
+          { basePlugin: base, middleware: [middlewareA, middlewareB] },
+        ],
+      ])
+    );
+  });
+
+  it('keeps existing middleware when the base plugin is replaced', () => {
+    const first = makeWidgetPlugin('first', 'test-widget');
+    const middleware = makeMiddlewarePlugin('middleware', 'test-widget');
+    const second = makeWidgetPlugin('second', 'test-widget');
+
+    expect(
+      getSupportedWidgetTypes(
+        makePluginMap([
+          ['first', first],
+          ['middleware', middleware],
+          ['second', second],
+        ])
+      )
+    ).toEqual(
+      new Map([
+        ['test-widget', { basePlugin: second, middleware: [middleware] }],
+      ])
+    );
+  });
+
+  it('omits types that only have middleware registered', () => {
+    const base = makeWidgetPlugin('base', 'type-a');
+    const middleware = makeMiddlewarePlugin('middleware', ['type-a', 'type-b']);
+
+    expect(
+      getSupportedWidgetTypes(
+        makePluginMap([
+          ['base', base],
+          ['middleware', middleware],
+        ])
+      )
+    ).toEqual(
+      new Map([['type-a', { basePlugin: base, middleware: [middleware] }]])
+    );
+  });
+});
+
+describe('getUniqueWidgetPluginInfos', () => {
+  it('returns an empty map when there are no supported types', () => {
+    expect(getUniqueWidgetPluginInfos(new Map())).toEqual(new Map());
+  });
+
+  it('keys the result by base plugin name', () => {
+    const base = makeWidgetPlugin('base', 'type-a');
+    const middleware = makeMiddlewarePlugin('middleware', 'type-a');
+    const supportedTypes = new Map<string, ValidWidgetTypeInfo>([
+      ['type-a', { basePlugin: base, middleware: [middleware] }],
+    ]);
+
+    expect(getUniqueWidgetPluginInfos(supportedTypes)).toEqual(
+      new Map([['base', { basePlugin: base, middleware: [middleware] }]])
+    );
+  });
+
+  it('does not mutate the source map when merging', () => {
+    const base = makeWidgetPlugin('base', ['type-a', 'type-b']);
+    const middlewareA = makeMiddlewarePlugin('middleware-a', 'type-a');
+    const middlewareB = makeMiddlewarePlugin('middleware-b', 'type-b');
+    const typeAInfo = { basePlugin: base, middleware: [middlewareA] };
+    const supportedTypes = new Map<string, ValidWidgetTypeInfo>([
+      ['type-a', typeAInfo],
+      ['type-b', { basePlugin: base, middleware: [middlewareB] }],
+    ]);
+
+    getUniqueWidgetPluginInfos(supportedTypes);
+
+    expect(typeAInfo.middleware).toEqual([middlewareA]);
+  });
+
+  it('merges middleware across types handled by the same base plugin', () => {
+    const base = makeWidgetPlugin('base', ['type-a', 'type-b']);
+    const middlewareA = makeMiddlewarePlugin('middleware-a', 'type-a');
+    const middlewareB = makeMiddlewarePlugin('middleware-b', 'type-b');
+    const supportedTypes = new Map<string, ValidWidgetTypeInfo>([
+      ['type-a', { basePlugin: base, middleware: [middlewareA] }],
+      ['type-b', { basePlugin: base, middleware: [middlewareB] }],
+    ]);
+
+    expect(getUniqueWidgetPluginInfos(supportedTypes)).toEqual(
+      new Map([
+        ['base', { basePlugin: base, middleware: [middlewareA, middlewareB] }],
+      ])
+    );
+  });
+
+  it('does not duplicate middleware shared across types', () => {
+    const base = makeWidgetPlugin('base', ['type-a', 'type-b']);
+    const middleware = makeMiddlewarePlugin('middleware', ['type-a', 'type-b']);
+    const supportedTypes = new Map<string, ValidWidgetTypeInfo>([
+      ['type-a', { basePlugin: base, middleware: [middleware] }],
+      ['type-b', { basePlugin: base, middleware: [middleware] }],
+    ]);
+
+    expect(getUniqueWidgetPluginInfos(supportedTypes)).toEqual(
+      new Map([['base', { basePlugin: base, middleware: [middleware] }]])
+    );
+  });
+
+  it('keeps separate entries for different base plugins', () => {
+    const baseA = makeWidgetPlugin('base-a', 'type-a');
+    const baseB = makeWidgetPlugin('base-b', 'type-b');
+    const supportedTypes = new Map<string, ValidWidgetTypeInfo>([
+      ['type-a', { basePlugin: baseA, middleware: [] }],
+      ['type-b', { basePlugin: baseB, middleware: [] }],
+    ]);
+
+    expect(getUniqueWidgetPluginInfos(supportedTypes)).toEqual(
+      new Map([
+        ['base-a', { basePlugin: baseA, middleware: [] }],
+        ['base-b', { basePlugin: baseB, middleware: [] }],
+      ])
+    );
+  });
+});

--- a/packages/dashboard-core-plugins/src/WidgetLoaderUtils.ts
+++ b/packages/dashboard-core-plugins/src/WidgetLoaderUtils.ts
@@ -1,0 +1,144 @@
+import Log from '@deephaven/log';
+import {
+  isWidgetPlugin,
+  isWidgetMiddlewarePlugin,
+  type PluginModuleMap,
+  type WidgetPlugin,
+  type WidgetMiddlewarePlugin,
+} from '@deephaven/plugin';
+
+const log = Log.module('WidgetLoaderUtils');
+
+/**
+ * Information about a widget type including its base plugin and any middleware.
+ */
+export interface WidgetTypeInfo {
+  /** The base plugin that handles this widget type, or null if only middleware registered so far */
+  basePlugin: WidgetPlugin | null;
+  /** Middleware plugins to apply, in order from outermost to innermost */
+  middleware: WidgetMiddlewarePlugin[];
+}
+
+/**
+ * Widget type info that is guaranteed to have a base plugin.
+ */
+export type ValidWidgetTypeInfo = WidgetTypeInfo & {
+  basePlugin: WidgetPlugin;
+};
+
+/**
+ * Build a map of widget types to their plugin chain info.
+ * For each type, we have a base plugin and a list of middleware to apply.
+ *
+ * Types that only have middleware registered (no base plugin) are omitted.
+ *
+ * @param plugins Map of all registered plugin modules
+ * @returns Map of widget type to the base plugin and middleware for that type
+ */
+export function getSupportedWidgetTypes(
+  plugins: PluginModuleMap
+): Map<string, ValidWidgetTypeInfo> {
+  const typeMap = new Map<string, WidgetTypeInfo>();
+
+  plugins.forEach(plugin => {
+    const isMiddleware = isWidgetMiddlewarePlugin(plugin);
+    if (!isWidgetPlugin(plugin) && !isMiddleware) {
+      return;
+    }
+
+    [plugin.supportedTypes].flat().forEach(supportedType => {
+      if (supportedType == null || supportedType === '') {
+        return;
+      }
+
+      const existing = typeMap.get(supportedType);
+
+      if (isMiddleware) {
+        // Add middleware to existing chain or create pending chain
+        if (existing != null) {
+          existing.middleware.push(plugin);
+          log.debug(
+            `Adding middleware ${plugin.name} to chain for type ${supportedType}`
+          );
+        } else {
+          // No base plugin yet, create entry with just middleware
+          // The base plugin will be set when a non-middleware plugin is registered
+          typeMap.set(supportedType, {
+            basePlugin: null,
+            middleware: [plugin],
+          });
+          log.debug(
+            `Creating pending middleware chain for type ${supportedType} with ${plugin.name}`
+          );
+        }
+      } else {
+        // Non-middleware plugin: becomes the base plugin
+        if (existing != null) {
+          if (existing.basePlugin != null) {
+            // Already have a base plugin, warn about replacement
+            log.warn(
+              `Multiple WidgetPlugins handling type ${supportedType}. ` +
+                `Replacing ${existing.basePlugin.name} with ${plugin.name} as base plugin`
+            );
+          }
+          // Keep existing middleware, update the base plugin
+          existing.basePlugin = plugin;
+        } else {
+          typeMap.set(supportedType, {
+            basePlugin: plugin,
+            middleware: [],
+          });
+        }
+        log.debug(`Set base plugin ${plugin.name} for type ${supportedType}`);
+      }
+    });
+  });
+
+  // Filter out entries that only have middleware (no base plugin)
+  const validEntries = new Map<string, ValidWidgetTypeInfo>();
+  typeMap.forEach((info, type) => {
+    if (info.basePlugin != null) {
+      validEntries.set(type, info as ValidWidgetTypeInfo);
+    } else {
+      log.warn(
+        `No base plugin found for type ${type}, middleware will not be applied`
+      );
+    }
+  });
+
+  return validEntries;
+}
+
+/**
+ * Get the unique base plugins from a supported types map, merging the middleware
+ * from each type a given base plugin handles.
+ *
+ * @param supportedTypes Map of widget type to base plugin and middleware
+ * @returns Map of base plugin name to the base plugin and its merged middleware
+ */
+export function getUniqueWidgetPluginInfos(
+  supportedTypes: Map<string, ValidWidgetTypeInfo>
+): Map<string, ValidWidgetTypeInfo> {
+  const uniquePluginInfos = new Map<string, ValidWidgetTypeInfo>();
+
+  supportedTypes.forEach(info => {
+    const existingInfo = uniquePluginInfos.get(info.basePlugin.name);
+    if (existingInfo == null) {
+      // Clone so the source map is not mutated
+      uniquePluginInfos.set(info.basePlugin.name, {
+        basePlugin: info.basePlugin,
+        middleware: [...info.middleware],
+      });
+      return;
+    }
+
+    // Merge middleware from multiple type registrations for the same base plugin
+    info.middleware.forEach(m => {
+      if (!existingInfo.middleware.includes(m)) {
+        existingInfo.middleware.push(m);
+      }
+    });
+  });
+
+  return uniquePluginInfos;
+}

--- a/packages/dashboard-core-plugins/src/index.ts
+++ b/packages/dashboard-core-plugins/src/index.ts
@@ -18,6 +18,7 @@ export { default as PandasWidgetPlugin } from './PandasWidgetPlugin';
 export { default as PandasPluginConfig } from './PandasPluginConfig';
 export { default as WidgetLoaderPlugin } from './WidgetLoaderPlugin';
 export { default as WidgetLoaderPluginConfig } from './WidgetLoaderPluginConfig';
+export * from './WidgetLoaderUtils';
 export { default as ControlType } from './controls/ControlType';
 export { default as LinkerUtils } from './linker/LinkerUtils';
 export type { Link } from './linker/LinkerUtils';


### PR DESCRIPTION
- There are other cases where we just want to get the plugin for a given widget, and don't want to use a WidgetLoaderPlugin
- Export the logic so it can be reused
