### PR TITLE
fix: DH-23079: Fix Console Errors after log out and log in

### DIFF
--- a/packages/console/src/ConsoleInput.test.tsx
+++ b/packages/console/src/ConsoleInput.test.tsx
@@ -1,0 +1,131 @@
+import React from 'react';
+import dh from '@deephaven/jsapi-shim';
+import { act, render } from '@testing-library/react';
+import { ConsoleInput } from './ConsoleInput';
+import { type CommandHistoryStorage } from './command-history';
+
+/**
+ * Mock MonacoTheme so LINE_HEIGHT resolves to a real number.
+ * scss files are mocked as identity-obj-proxy by moduleNameMapper, which
+ * returns the property key as the value, making parseInt return NaN.
+ */
+jest.mock('./monaco', () => ({
+  ...jest.requireActual('./monaco'),
+  MonacoTheme: {
+    'line-height': '19px',
+  },
+}));
+
+function makeMockCommandHistoryStorage(): CommandHistoryStorage {
+  return {
+    addItem: jest.fn(),
+    getTable: jest.fn(),
+    updateItem: jest.fn(),
+    listenItem: jest.fn(),
+  };
+}
+
+function makeSession(): dh.IdeSession {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const session = new (dh as any).IdeSession('test') as dh.IdeSession;
+  jest.spyOn(session, 'openDocument');
+  jest.spyOn(session, 'closeDocument');
+  jest.spyOn(session, 'changeDocument');
+  return session;
+}
+
+function renderConsoleInput(
+  session: dh.IdeSession,
+  ref: React.RefObject<ConsoleInput>
+) {
+  return render(
+    <ConsoleInput
+      ref={ref}
+      session={session}
+      language="test"
+      commandHistoryStorage={makeMockCommandHistoryStorage()}
+      onSubmit={jest.fn()}
+    />
+  );
+}
+
+describe('ConsoleInput session transition', () => {
+  it('notifies the initial session when the document is opened', () => {
+    const session = makeSession();
+    const ref = React.createRef<ConsoleInput>();
+    renderConsoleInput(session, ref);
+
+    expect(session.openDocument).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls closeDocument on the old session and openDocument on the new session on session prop change', () => {
+    const session1 = makeSession();
+    const session2 = makeSession();
+    const ref = React.createRef<ConsoleInput>();
+
+    const { rerender } = renderConsoleInput(session1, ref);
+
+    rerender(
+      <ConsoleInput
+        ref={ref}
+        session={session2}
+        language="test"
+        commandHistoryStorage={makeMockCommandHistoryStorage()}
+        onSubmit={jest.fn()}
+      />
+    );
+
+    expect(session1.closeDocument).toHaveBeenCalledTimes(1);
+    expect(session2.openDocument).toHaveBeenCalledTimes(1);
+  });
+
+  it('routes model edits only to the current session after a session replacement', () => {
+    const session1 = makeSession();
+    const session2 = makeSession();
+    const ref = React.createRef<ConsoleInput>();
+
+    const { rerender } = renderConsoleInput(session1, ref);
+
+    rerender(
+      <ConsoleInput
+        ref={ref}
+        session={session2}
+        language="test"
+        commandHistoryStorage={makeMockCommandHistoryStorage()}
+        onSubmit={jest.fn()}
+      />
+    );
+
+    act(() => {
+      ref.current!.commandEditor!.getModel()!.setValue('hello');
+    });
+
+    expect(session2.changeDocument).toHaveBeenCalled();
+    expect(session1.changeDocument).not.toHaveBeenCalled();
+  });
+
+  it('calls closeDocument on the last active session when the component unmounts', () => {
+    const session1 = makeSession();
+    const session2 = makeSession();
+    const ref = React.createRef<ConsoleInput>();
+
+    const { unmount, rerender } = renderConsoleInput(session1, ref);
+
+    rerender(
+      <ConsoleInput
+        ref={ref}
+        session={session2}
+        language="test"
+        commandHistoryStorage={makeMockCommandHistoryStorage()}
+        onSubmit={jest.fn()}
+      />
+    );
+
+    unmount();
+
+    // session1 was closed during the session transition
+    expect(session1.closeDocument).toHaveBeenCalledTimes(1);
+    // session2 is the last active session and is closed only at unmount
+    expect(session2.closeDocument).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/console/src/ConsoleInput.tsx
+++ b/packages/console/src/ConsoleInput.tsx
@@ -86,6 +86,7 @@ export class ConsoleInput extends PureComponent<
   componentDidUpdate(prevProps: ConsoleInputProps): void {
     const { session } = this.props;
     this.layoutEditor();
+    // If the session has changed, we need to destroy the old command editor and create a new one for the new session
     if (prevProps.session !== session) {
       this.destroyCommandEditor(prevProps.session);
       this.initCommandEditor();

--- a/packages/console/src/ConsoleInput.tsx
+++ b/packages/console/src/ConsoleInput.tsx
@@ -83,8 +83,18 @@ export class ConsoleInput extends PureComponent<
     this.loadMoreHistory();
   }
 
-  componentDidUpdate(): void {
+  componentDidUpdate(prevProps: ConsoleInputProps): void {
+    const { session } = this.props;
     this.layoutEditor();
+    if (prevProps.session !== session && this.commandEditor != null) {
+      this.openDocumentCleanup?.dispose();
+      this.openDocumentCleanup = undefined;
+      MonacoUtils.closeDocument(this.commandEditor, prevProps.session);
+      this.openDocumentCleanup = MonacoUtils.openDocument(
+        this.commandEditor,
+        session
+      );
+    }
   }
 
   componentWillUnmount(): void {
@@ -98,6 +108,8 @@ export class ConsoleInput extends PureComponent<
   }
 
   cancelListener?: () => void;
+
+  openDocumentCleanup?: monaco.IDisposable;
 
   resizeObserver: ResizeObserver;
 
@@ -198,7 +210,10 @@ export class ConsoleInput extends PureComponent<
     this.commandEditor = monaco.editor.create(element, commandSettings);
 
     MonacoUtils.setEOL(this.commandEditor);
-    MonacoUtils.openDocument(this.commandEditor, session);
+    this.openDocumentCleanup = MonacoUtils.openDocument(
+      this.commandEditor,
+      session
+    );
 
     this.commandEditor.onDidChangeModelContent(() => {
       const value = this.commandEditor?.getValue();
@@ -297,6 +312,8 @@ export class ConsoleInput extends PureComponent<
   destroyCommandEditor(): void {
     const { session } = this.props;
     if (this.commandEditor) {
+      this.openDocumentCleanup?.dispose();
+      this.openDocumentCleanup = undefined;
       MonacoUtils.closeDocument(this.commandEditor, session);
       this.commandEditor.dispose();
       this.commandEditor = undefined;

--- a/packages/console/src/ConsoleInput.tsx
+++ b/packages/console/src/ConsoleInput.tsx
@@ -86,14 +86,9 @@ export class ConsoleInput extends PureComponent<
   componentDidUpdate(prevProps: ConsoleInputProps): void {
     const { session } = this.props;
     this.layoutEditor();
-    if (prevProps.session !== session && this.commandEditor != null) {
-      this.openDocumentCleanup?.dispose();
-      this.openDocumentCleanup = undefined;
-      MonacoUtils.closeDocument(this.commandEditor, prevProps.session);
-      this.openDocumentCleanup = MonacoUtils.openDocument(
-        this.commandEditor,
-        session
-      );
+    if (prevProps.session !== session) {
+      this.destroyCommandEditor(prevProps.session);
+      this.initCommandEditor();
     }
   }
 
@@ -104,7 +99,8 @@ export class ConsoleInput extends PureComponent<
       this.loadingPromise.cancel();
     }
 
-    this.destroyCommandEditor();
+    const { session } = this.props;
+    this.destroyCommandEditor(session);
   }
 
   cancelListener?: () => void;
@@ -309,8 +305,12 @@ export class ConsoleInput extends PureComponent<
     this.setState({ model: this.commandEditor.getModel() });
   }
 
-  destroyCommandEditor(): void {
-    const { session } = this.props;
+  /**
+   * Closes the monaco document, disposes the Monaco editor, and clears all associated cleanup state.
+   *
+   * @param session The session that originally received `openDocument` for this editor
+   */
+  destroyCommandEditor(session: dh.IdeSession): void {
     if (this.commandEditor) {
       this.openDocumentCleanup?.dispose();
       this.openDocumentCleanup = undefined;


### PR DESCRIPTION
After log out and log in, redux has a stale sessionWrapper. `closeDocument` and `changeDocuemnt` would fire against the wrong session causing a `KeyError`.  The fix reinitializes the editor on session change so all notifications stay on the same session.