### PR TITLE
ci: Create Jira release ticket when a release is published

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -58,3 +58,36 @@ jobs:
           -H "Authorization: Bearer ${{ secrets.DEEPHAVENINTERNAL_PUBLIC_TOKEN }}" \
           -H "X-GitHub-Api-Version: 2022-11-28" \
           https://api.github.com/repos/deephaven/deephaven-core/actions/workflows/update-web.yml/dispatches --data '{"ref": "main"}'
+      - name: Create Jira release ticket
+        # Posts to a Jira Automation "Incoming webhook" rule that creates the
+        # "Update web version on G+" task and links the DH- issues in the notes
+        if: ${{ github.event_name == 'release' }}
+        continue-on-error: true
+        env:
+          RELEASE_VERSION: ${{ github.event.release.tag_name }}
+          RELEASE_URL: ${{ github.event.release.html_url }}
+          RELEASE_NOTES: ${{ github.event.release.body }}
+          # Names the thing being updated in the ticket summary
+          JIRA_COMPONENT: 'web'
+          # Bump when the target enterprise release changes
+          JIRA_FIX_VERSION: 'Grizzly Plus (2026.01, release/2026.01)'
+          JIRA_WEBHOOK_URL: ${{ secrets.JIRA_AUTOMATION_WEBHOOK_URL }}
+          JIRA_WEBHOOK_SECRET: ${{ secrets.JIRA_AUTOMATION_WEBHOOK_SECRET }}
+        run: |
+          set -euo pipefail
+          NOTES_WIKI=$(printf '%s' "$RELEASE_NOTES" \
+            | sed -E 's/^#### /h4. /; s/^### /h3. /; s/^## /h2. /; s/^- /* /; s/\[([^]]*)\]\(([^)]*)\)/[\1|\2]/g; s/\*\*([^*]+)\*\*/*\1*/g')
+          RELATED_ISSUES=$( { printf '%s' "$RELEASE_NOTES" | grep -oE 'DH-[0-9]+' || true; } \
+            | sort -u | jq -R -s -c 'split("\n") | map(select(length > 0))')
+          jq -n \
+            --arg component "$JIRA_COMPONENT" \
+            --arg version "$RELEASE_VERSION" \
+            --arg releaseUrl "$RELEASE_URL" \
+            --arg notesWiki "$NOTES_WIKI" \
+            --arg fixVersion "$JIRA_FIX_VERSION" \
+            --argjson relatedIssues "$RELATED_ISSUES" \
+            '{component: $component, version: $version, releaseUrl: $releaseUrl, notesWiki: $notesWiki, fixVersion: $fixVersion, relatedIssues: $relatedIssues}' \
+            | curl -fsS -X POST \
+              -H 'Content-Type: application/json' \
+              -H "X-Automation-Webhook-Token: $JIRA_WEBHOOK_SECRET" \
+              --data @- "$JIRA_WEBHOOK_URL"


### PR DESCRIPTION
Posts the release version, notes, and referenced DH- issue keys to a Jira Automation incoming webhook, which creates the "Update web version on G+" task and links the related issues.

Requires the Jira webhook setup, JIRA_AUTOMATION_WEBHOOK_URL and JIRA_AUTOMATION_WEBHOOK_SECRET repo secrets (already set).

Manually tested locally, see an example ticket created: https://deephaven.atlassian.net/browse/DH-23365
