### PR TITLE
fix: DH-22976: control IrisGrid sorts and filters

### DIFF
--- a/packages/iris-grid/src/FilterInputField.test.tsx
+++ b/packages/iris-grid/src/FilterInputField.test.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react';
+import FilterInputField from './FilterInputField';
+
+function renderFilterInput(value: string, onChange = jest.fn()) {
+  return render(
+    <FilterInputField value={value} onChange={onChange} debounceMs={1000} />
+  );
+}
+
+describe('FilterInputField', () => {
+  it('updates the editor when the external value changes', () => {
+    const { container, rerender } = renderFilterInput('initial');
+    const input = container.querySelector('input');
+    expect(input).not.toBeNull();
+
+    fireEvent.change(input!, { target: { value: 'draft' } });
+    rerender(
+      <FilterInputField
+        value="accepted"
+        onChange={jest.fn()}
+        debounceMs={1000}
+      />
+    );
+
+    expect(input).toHaveValue('accepted');
+  });
+
+  it('preserves in-progress text when the external value is unchanged', () => {
+    const onChange = jest.fn();
+    const { container, rerender } = renderFilterInput('initial', onChange);
+    const input = container.querySelector('input');
+    expect(input).not.toBeNull();
+
+    fireEvent.change(input!, { target: { value: 'draft' } });
+    rerender(
+      <FilterInputField value="initial" onChange={onChange} debounceMs={1000} />
+    );
+
+    expect(input).toHaveValue('draft');
+  });
+
+  it('uses the latest external value as the cancel baseline', () => {
+    const onChange = jest.fn();
+    const { container, rerender } = renderFilterInput('initial', onChange);
+    const input = container.querySelector('input');
+    expect(input).not.toBeNull();
+
+    rerender(
+      <FilterInputField
+        value="accepted"
+        onChange={onChange}
+        debounceMs={1000}
+      />
+    );
+    fireEvent.change(input!, { target: { value: 'draft' } });
+    fireEvent.keyDown(input!, { key: 'Escape' });
+
+    expect(onChange).toHaveBeenLastCalledWith('accepted');
+  });
+});

--- a/packages/iris-grid/src/FilterInputField.tsx
+++ b/packages/iris-grid/src/FilterInputField.tsx
@@ -79,7 +79,12 @@ class FilterInputField extends PureComponent<
   }
 
   componentDidUpdate(prevProps: FilterInputFieldProps): void {
-    const { debounceMs } = this.props;
+    const { debounceMs, value } = this.props;
+    if (prevProps.value !== value) {
+      this.debouncedSendUpdate.cancel();
+      this.initialValue = value;
+      this.setState({ value, isChanged: false });
+    }
     if (prevProps.debounceMs !== debounceMs) {
       this.debouncedSendUpdate.flush();
       this.debouncedSendUpdate = debounce(

--- a/packages/iris-grid/src/IrisGrid.test.tsx
+++ b/packages/iris-grid/src/IrisGrid.test.tsx
@@ -263,8 +263,12 @@ it('handles copy key handler', () => {
 
 it('handles value: undefined in setFilterMap, clears column filter', () => {
   const component = makeComponent();
-  component.setQuickFilter = jest.fn();
-  component.removeQuickFilter = jest.fn();
+  component.requestQuickFiltersChange = jest.fn();
+  act(() => {
+    component.setState({
+      quickFilters: new Map([[2, { text: 'any', filter: null }]]),
+    });
+  });
   component.setFilterMap(
     new Map([
       [
@@ -283,13 +287,14 @@ it('handles value: undefined in setFilterMap, clears column filter', () => {
       ],
     ])
   );
-  expect(component.setQuickFilter).not.toHaveBeenCalled();
-  expect(component.removeQuickFilter).toHaveBeenCalledWith(2);
+  const quickFilters = jest.mocked(component.requestQuickFiltersChange).mock
+    .calls[0][0];
+  expect(quickFilters.has(2)).toBe(false);
 });
 
 it('handles value: null in setFilterMap', () => {
   const component = makeComponent();
-  component.setQuickFilter = jest.fn();
+  component.requestQuickFiltersChange = jest.fn();
   component.setFilterMap(
     new Map([
       [
@@ -303,16 +308,17 @@ it('handles value: null in setFilterMap', () => {
       ],
     ])
   );
-  expect(component.setQuickFilter).toHaveBeenCalledWith(
-    2,
-    expect.anything(),
-    '=null'
-  );
+  const quickFilters = jest.mocked(component.requestQuickFiltersChange).mock
+    .calls[0][0];
+  expect(quickFilters.get(2)).toEqual({
+    filter: expect.anything(),
+    text: '=null',
+  });
 });
 
 it('handles undefined operator, should default to eq', () => {
   const component = makeComponent();
-  component.setQuickFilter = jest.fn();
+  component.requestQuickFiltersChange = jest.fn();
   component.setFilterMap(
     new Map([
       [
@@ -331,11 +337,12 @@ it('handles undefined operator, should default to eq', () => {
       ],
     ])
   );
-  expect(component.setQuickFilter).toHaveBeenCalledWith(
-    2,
-    expect.anything(),
-    'any'
-  );
+  const quickFilters = jest.mocked(component.requestQuickFiltersChange).mock
+    .calls[0][0];
+  expect(quickFilters.get(2)).toEqual({
+    filter: expect.anything(),
+    text: 'any',
+  });
 });
 
 it('should set gotoValueSelectedColumnName to empty string if no columns are given', () => {
@@ -888,5 +895,95 @@ describe('updateQuickFilters', () => {
     );
 
     expect(ref.current!.updateQuickFilters).not.toHaveBeenCalled();
+  });
+});
+
+describe('controlled sorts and quick filters', () => {
+  it('applies new parent sorts while controlled', () => {
+    const model = irisGridTestUtils.makeModel();
+    const ref = React.createRef<IrisGrid>();
+    const sorts = [{ column: 'A', direction: 'ASC', isAbs: false }] as const;
+    const { rerender } = render(
+      <IrisGrid
+        ref={ref}
+        model={model}
+        settings={DEFAULT_SETTINGS}
+        isSortsControlled
+        sorts={[]}
+      />
+    );
+    jest.spyOn(ref.current!, 'updateSorts');
+
+    rerender(
+      <IrisGrid
+        ref={ref}
+        model={model}
+        settings={DEFAULT_SETTINGS}
+        isSortsControlled
+        sorts={sorts}
+      />
+    );
+
+    expect(ref.current!.updateSorts).toHaveBeenCalledWith(sorts);
+  });
+
+  it('reports controlled sort changes without updating internal state', () => {
+    const onSortsChange = jest.fn();
+    const component = makeComponent(undefined, undefined, {
+      isSortsControlled: true,
+      onSortsChange,
+    });
+    const sorts = [{ column: 'A', direction: 'ASC', isAbs: false }] as const;
+    jest.spyOn(component, 'updateSorts');
+
+    act(() => component.requestSortsChange(sorts));
+
+    expect(onSortsChange).toHaveBeenCalledWith(sorts);
+    expect(component.updateSorts).not.toHaveBeenCalled();
+  });
+
+  it('updates internal sort state when uncontrolled', () => {
+    const onSortsChange = jest.fn();
+    const component = makeComponent(undefined, undefined, { onSortsChange });
+    const sorts = [{ column: 'A', direction: 'ASC', isAbs: false }] as const;
+    jest.spyOn(component, 'updateSorts');
+
+    component.requestSortsChange(sorts);
+
+    expect(onSortsChange).toHaveBeenCalledWith(sorts);
+    expect(component.updateSorts).toHaveBeenCalledWith(sorts);
+  });
+
+  it('reports controlled quick-filter changes without updating internal state', () => {
+    const onQuickFiltersChange = jest.fn();
+    const component = makeComponent(undefined, undefined, {
+      isQuickFiltersControlled: true,
+      onQuickFiltersChange,
+    });
+    const quickFilters: ReadonlyQuickFilterMap = new Map([
+      [0, { text: 'foo', filter: null }],
+    ]);
+    jest.spyOn(component, 'updateQuickFilters');
+
+    act(() => component.requestQuickFiltersChange(quickFilters));
+
+    expect(onQuickFiltersChange).toHaveBeenCalledWith(quickFilters);
+    expect(component.updateQuickFilters).not.toHaveBeenCalled();
+  });
+
+  it('updates internal quick filters when uncontrolled', () => {
+    const onQuickFiltersChange = jest.fn();
+    const component = makeComponent(undefined, undefined, {
+      onQuickFiltersChange,
+    });
+    const quickFilters: ReadonlyQuickFilterMap = new Map([
+      [0, { text: 'foo', filter: null }],
+    ]);
+    jest.spyOn(component, 'updateQuickFilters');
+
+    component.requestQuickFiltersChange(quickFilters);
+
+    expect(onQuickFiltersChange).toHaveBeenCalledWith(quickFilters);
+    expect(component.updateQuickFilters).toHaveBeenCalledWith(quickFilters);
   });
 });

--- a/packages/iris-grid/src/IrisGrid.test.tsx
+++ b/packages/iris-grid/src/IrisGrid.test.tsx
@@ -10,6 +10,7 @@ import {
 } from '@deephaven/grid';
 import IrisGrid from './IrisGrid';
 import IrisGridTestUtils from './IrisGridTestUtils';
+import IrisGridUtils from './IrisGridUtils';
 import type IrisGridProxyModel from './IrisGridProxyModel';
 import { isPartitionedGridModel } from './PartitionedGridModel';
 import { type ReadonlyQuickFilterMap } from './CommonTypes';
@@ -985,5 +986,130 @@ describe('controlled sorts and quick filters', () => {
 
     expect(onQuickFiltersChange).toHaveBeenCalledWith(quickFilters);
     expect(component.updateQuickFilters).toHaveBeenCalledWith(quickFilters);
+  });
+});
+
+describe('controlled state regression paths', () => {
+  it('synchronizes controlled values when entering controlled mode', () => {
+    const model = irisGridTestUtils.makeModel();
+    const quickFilters: ReadonlyQuickFilterMap = new Map([
+      [0, { text: 'a', filter: null }],
+    ]);
+    const sorts = [model.columns[0].sort().asc()];
+    const ref = React.createRef<IrisGrid>();
+    const { rerender } = render(
+      <IrisGrid
+        ref={ref}
+        model={model}
+        settings={DEFAULT_SETTINGS}
+        quickFilters={quickFilters}
+        sorts={sorts}
+      />
+    );
+
+    act(() => {
+      ref.current?.setState({ quickFilters: new Map(), sorts: [] });
+    });
+
+    rerender(
+      <IrisGrid
+        ref={ref}
+        model={model}
+        settings={DEFAULT_SETTINGS}
+        quickFilters={quickFilters}
+        sorts={sorts}
+        isQuickFiltersControlled
+        isSortsControlled
+      />
+    );
+
+    expect(ref.current?.state.quickFilters).toBe(quickFilters);
+    expect(ref.current?.state.sorts).toBe(sorts);
+  });
+
+  it('proposes input-filter quick-filter changes without applying them', () => {
+    const model = irisGridTestUtils.makeModel();
+    const onQuickFiltersChange = jest.fn();
+    const component = makeComponent(model, undefined, {
+      isQuickFiltersControlled: true,
+      onQuickFiltersChange,
+    });
+
+    act(() => {
+      component.applyInputFilters([
+        {
+          name: model.columns[0].name,
+          type: model.columns[0].type,
+          value: 'a',
+        },
+      ]);
+    });
+
+    expect(onQuickFiltersChange).toHaveBeenCalledWith(expect.any(Map));
+    expect(onQuickFiltersChange.mock.calls[0][0].get(0)?.text).toBe('a');
+    expect(component.state.quickFilters.size).toBe(0);
+  });
+
+  it('proposes custom-column filter and sort removals without applying them', () => {
+    const model = irisGridTestUtils.makeModel();
+    const columnName = model.columns[0].name;
+    jest
+      .spyOn(IrisGridUtils, 'getRemovedCustomColumnNames')
+      .mockReturnValue([columnName]);
+    jest
+      .spyOn(IrisGridUtils, 'removeFiltersInColumns')
+      .mockReturnValue(new Map());
+    jest.spyOn(IrisGridUtils, 'removeSortsInColumns').mockReturnValue([]);
+    const quickFilters: ReadonlyQuickFilterMap = new Map([
+      [0, { text: 'a', filter: null }],
+    ]);
+    const sorts = [model.columns[0].sort().asc()];
+    const onQuickFiltersChange = jest.fn();
+    const onSortsChange = jest.fn();
+    const component = makeComponent(model, undefined, {
+      isQuickFiltersControlled: true,
+      isSortsControlled: true,
+      onQuickFiltersChange,
+      onSortsChange,
+      quickFilters,
+      sorts,
+    });
+
+    act(() => {
+      component.handleUpdateCustomColumns([]);
+    });
+
+    expect(onQuickFiltersChange).toHaveBeenCalledWith(expect.any(Map));
+    expect(
+      onQuickFiltersChange.mock.calls.some(([filters]) => filters.size === 0)
+    ).toBe(true);
+    expect(onSortsChange).toHaveBeenCalledWith([]);
+    expect(component.state.quickFilters.get(0)?.text).toBe('a');
+    expect(component.state.sorts).toBe(sorts);
+  });
+
+  it('proposes sort clears from rollup and select-distinct changes', () => {
+    const model = irisGridTestUtils.makeModel();
+    const sorts = [model.columns[0].sort().asc()];
+    const onSortsChange = jest.fn();
+    const component = makeComponent(model, undefined, {
+      isSortsControlled: true,
+      onSortsChange,
+      sorts,
+    });
+
+    act(() => {
+      component.handleRollupChange({
+        columns: [],
+        showConstituents: true,
+        showNonAggregatedColumns: true,
+      });
+      component.handleSelectDistinctChanged([model.columns[0].name]);
+    });
+
+    expect(onSortsChange).toHaveBeenCalledTimes(2);
+    expect(onSortsChange).toHaveBeenNthCalledWith(1, []);
+    expect(onSortsChange).toHaveBeenNthCalledWith(2, []);
+    expect(component.state.sorts).toBe(sorts);
   });
 });

--- a/packages/iris-grid/src/IrisGrid.test.tsx
+++ b/packages/iris-grid/src/IrisGrid.test.tsx
@@ -679,6 +679,24 @@ describe('handleResizeAllColumns', () => {
       expect(component.setState).toBeCalled();
     });
 
+    it('does not propose unchanged empty quick filters', () => {
+      const component = makeComponent();
+      component.tableUtils.makeAdvancedFilter = jest.fn();
+      act(() => {
+        component.setState({ advancedFilters: new Map([[0, {} as never]]) });
+      });
+      const requestQuickFiltersChange = jest.spyOn(
+        component,
+        'requestQuickFiltersChange'
+      );
+
+      act(() => {
+        component.rebuildFilters();
+      });
+
+      expect(requestQuickFiltersChange).not.toHaveBeenCalled();
+    });
+
     it('does not update state for empty filters', () => {
       const component = makeComponent();
       jest.spyOn(component, 'setState');

--- a/packages/iris-grid/src/IrisGrid.tsx
+++ b/packages/iris-grid/src/IrisGrid.tsx
@@ -978,6 +978,8 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
       customFilters,
       quickFilters,
       sorts,
+      isQuickFiltersControlled,
+      isSortsControlled,
       getMetricCalculator,
     } = this.props;
 
@@ -1031,10 +1033,16 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
     if (customFilters !== prevProps.customFilters) {
       this.startLoading('Filtering...', { resetRanges: true });
     }
-    if (sorts !== prevProps.sorts) {
+    if (
+      sorts !== prevProps.sorts ||
+      (!prevProps.isSortsControlled && isSortsControlled)
+    ) {
       this.updateSorts(sorts);
     }
-    if (quickFilters !== prevProps.quickFilters) {
+    if (
+      quickFilters !== prevProps.quickFilters ||
+      (!prevProps.isQuickFiltersControlled && isQuickFiltersControlled)
+    ) {
       this.updateQuickFilters(quickFilters);
     }
     const { loadingScrimStartTime, loadingScrimFinishTime } = this;
@@ -1807,28 +1815,30 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
       : new Map(advancedFilters);
     const newQuickFilters = replaceExisting ? new Map() : new Map(quickFilters);
 
-    let isChanged = replaceExisting && advancedFilters.size > 0;
+    let didAdvancedFiltersChange = replaceExisting && advancedFilters.size > 0;
+    let didQuickFiltersChange = replaceExisting && quickFilters.size > 0;
     inputFilters.forEach(({ name, type, value }) => {
       const modelIndex = model.columns.findIndex(
         ({ name: columnName, type: columnType }) =>
           columnName === name && columnType === type
       );
       if (modelIndex >= 0) {
-        isChanged = newAdvancedFilters.delete(modelIndex) || isChanged;
-        isChanged =
+        didAdvancedFiltersChange =
+          newAdvancedFilters.delete(modelIndex) || didAdvancedFiltersChange;
+        didQuickFiltersChange =
           this.applyQuickFilter(modelIndex, value, newQuickFilters) ||
-          isChanged;
+          didQuickFiltersChange;
       } else {
         log.error('Unable to find column for inputFilter', name, type, value);
       }
     });
-    if (isChanged) {
-      this.setState({
-        quickFilters: newQuickFilters,
-        advancedFilters: newAdvancedFilters,
-      });
+    if (didQuickFiltersChange) {
+      this.requestQuickFiltersChange(newQuickFilters);
     }
-    return isChanged;
+    if (didAdvancedFiltersChange) {
+      this.setState({ advancedFilters: newAdvancedFilters });
+    }
+    return didQuickFiltersChange || didAdvancedFiltersChange;
   }
 
   /**
@@ -2103,22 +2113,16 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
         filter: this.makeQuickFilter(column, text, formatter.timeZone),
       });
     });
-    this.startLoading('Rebuilding filters...', { resetRanges: true });
-
-    this.setState({
-      quickFilters: newQuickFilters,
-      advancedFilters: newAdvancedFilters,
-    });
+    this.requestQuickFiltersChange(newQuickFilters);
+    this.setState({ advancedFilters: newAdvancedFilters });
   }
 
   setFilters({
     quickFilters,
     advancedFilters,
   }: Pick<IrisGridState, 'quickFilters' | 'advancedFilters'>): void {
-    this.setState({
-      quickFilters,
-      advancedFilters,
-    });
+    this.requestQuickFiltersChange(quickFilters);
+    this.setState({ advancedFilters });
   }
 
   updateFormatterSettings(settings?: Settings, forceUpdate = true): void {
@@ -3860,17 +3864,19 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
         );
       if (newSorts.length !== sorts.length) {
         log.debug('removing sorts from removed custom columns...');
-        this.setState({ sorts: newSorts });
+        this.requestSortsChange(newSorts);
       }
       if (
         newQuickFilters.size !== quickFilters.size ||
         newAdvancedFilters.size !== advancedFilters.size
       ) {
         log.debug(`removing filters from removed custom columns...`);
-        this.setState({
-          quickFilters: newQuickFilters,
-          advancedFilters: newAdvancedFilters,
-        });
+        if (newQuickFilters.size !== quickFilters.size) {
+          this.requestQuickFiltersChange(newQuickFilters);
+        }
+        if (newAdvancedFilters.size !== advancedFilters.size) {
+          this.setState({ advancedFilters: newAdvancedFilters });
+        }
       }
       if (!deepEqual(movedColumns, newMovedColumns)) {
         log.debug(
@@ -4132,6 +4138,8 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
       `Grouping by columns ${rollupConfig?.columns?.join(', ') ?? ''}...`
     );
 
+    this.requestSortsChange(EMPTY_ARRAY);
+
     // Have to clear select distinct since rollup uses the original columns, not the current ones.
     // IrisGridProxyModel has a check to prevent model update
     // when selectDistinctModel is cleared and the rollupConfig is set on the model.
@@ -4139,7 +4147,6 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
       rollupConfig,
       movedColumns: EMPTY_ARRAY,
       frozenColumns: EMPTY_ARRAY,
-      sorts: EMPTY_ARRAY,
       reverse: false,
       selectDistinctColumns: EMPTY_ARRAY,
     });
@@ -4160,10 +4167,11 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
       }...`
     );
 
+    this.requestSortsChange(EMPTY_ARRAY);
+
     this.setState({
       selectDistinctColumns: columnNames,
       movedColumns: [],
-      sorts: [],
       reverse: false,
     });
   }

--- a/packages/iris-grid/src/IrisGrid.tsx
+++ b/packages/iris-grid/src/IrisGrid.tsx
@@ -2114,7 +2114,9 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
       });
     });
     this.startLoading('Rebuilding filters...', { resetRanges: true });
-    this.requestQuickFiltersChange(newQuickFilters);
+    if (quickFilters.size > 0) {
+      this.requestQuickFiltersChange(newQuickFilters);
+    }
     this.setState({ advancedFilters: newAdvancedFilters });
   }
 

--- a/packages/iris-grid/src/IrisGrid.tsx
+++ b/packages/iris-grid/src/IrisGrid.tsx
@@ -2113,6 +2113,7 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
         filter: this.makeQuickFilter(column, text, formatter.timeZone),
       });
     });
+    this.startLoading('Rebuilding filters...', { resetRanges: true });
     this.requestQuickFiltersChange(newQuickFilters);
     this.setState({ advancedFilters: newAdvancedFilters });
   }

--- a/packages/iris-grid/src/IrisGrid.tsx
+++ b/packages/iris-grid/src/IrisGrid.tsx
@@ -182,7 +182,6 @@ import type AggregationOperation from './sidebar/aggregations/AggregationOperati
 import { type UIRollupConfig } from './sidebar/RollupRows';
 import {
   type Action,
-  type AdvancedFilterMap,
   type AdvancedFilterOptions,
   type ColumnName,
   type InputFilter,
@@ -302,11 +301,15 @@ export interface IrisGridProps {
   partitions?: (string | null)[];
   partitionConfig?: PartitionConfig;
   sorts: readonly SortDescriptor[];
+  isSortsControlled: boolean;
+  onSortsChange?: (sorts: readonly SortDescriptor[]) => void;
 
   /** @deprecated use `reverse` instead */
   reverseType?: ReverseType;
   reverse: boolean;
   quickFilters: ReadonlyQuickFilterMap | null;
+  isQuickFiltersControlled: boolean;
+  onQuickFiltersChange?: (quickFilters: ReadonlyQuickFilterMap) => void;
   customColumns: readonly ColumnName[];
   selectDistinctColumns: readonly ColumnName[];
   settings?: Settings;
@@ -534,8 +537,12 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
     partitions: undefined,
     partitionConfig: undefined,
     quickFilters: EMPTY_MAP,
+    isQuickFiltersControlled: false,
+    onQuickFiltersChange: undefined,
     selectDistinctColumns: EMPTY_ARRAY,
     sorts: EMPTY_ARRAY,
+    isSortsControlled: false,
+    onSortsChange: undefined,
     reverse: false,
     customColumns: EMPTY_ARRAY,
     aggregationSettings: DEFAULT_AGGREGATION_SETTINGS,
@@ -1898,13 +1905,10 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
   ): void {
     log.debug('Setting quick filter', modelIndex, filter, text);
 
-    this.startLoading('Filtering...', { resetRanges: true });
-
-    this.setState(({ quickFilters }) => {
-      const newQuickFilters = new Map(quickFilters);
-      newQuickFilters.set(modelIndex, { filter, text });
-      return { quickFilters: newQuickFilters };
-    });
+    const { quickFilters } = this.state;
+    const newQuickFilters = new Map(quickFilters);
+    newQuickFilters.set(modelIndex, { filter, text });
+    this.requestQuickFiltersChange(newQuickFilters);
   }
 
   /**
@@ -1924,6 +1928,11 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
     }
 
     const { model } = this.props;
+    const { quickFilters } = this.state;
+    const newQuickFilters: QuickFilterMap = clearFiltersOnLinkerFilterUpdate
+      ? new Map()
+      : new Map(quickFilters);
+    let didQuickFiltersChange = false;
     filterMap.forEach(({ columnType, filterList }, columnName) => {
       const column = model.columns.find(
         c => c.name === columnName && c.type === columnType
@@ -1938,67 +1947,71 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
         filterList
       );
       if (combinedText.length === 0) {
-        this.removeQuickFilter(columnIndex);
+        didQuickFiltersChange =
+          newQuickFilters.delete(columnIndex) || didQuickFiltersChange;
       } else {
         const { formatter } = model;
-        this.setQuickFilter(
-          columnIndex,
-          this.makeQuickFilter(column, combinedText, formatter.timeZone),
-          `${combinedText}`
-        );
+        newQuickFilters.set(columnIndex, {
+          filter: this.makeQuickFilter(
+            column,
+            combinedText,
+            formatter.timeZone
+          ),
+          text: `${combinedText}`,
+        });
+        didQuickFiltersChange = true;
       }
     });
+    if (didQuickFiltersChange) {
+      this.requestQuickFiltersChange(newQuickFilters);
+    }
   }
 
   removeColumnFilter(modelRange: ModelIndex | BoundedAxisRange): void {
-    this.startLoading('Filtering...', { resetRanges: true });
-
     const clearRange: BoundedAxisRange = Array.isArray(modelRange)
       ? modelRange
       : [modelRange, modelRange];
-
-    this.setState(
-      ({ advancedFilters, quickFilters }: Partial<IrisGridState>) => {
-        const newAdvancedFilters: AdvancedFilterMap = advancedFilters
-          ? new Map(advancedFilters)
-          : new Map();
-        const newQuickFilters: QuickFilterMap = quickFilters
-          ? new Map(quickFilters)
-          : new Map();
-        newAdvancedFilters.forEach((_, column) => {
-          if (column >= clearRange[0] && column <= clearRange[1]) {
-            newAdvancedFilters.delete(column);
-          }
-        });
-        newQuickFilters.forEach((_, column) => {
-          if (column >= clearRange[0] && column <= clearRange[1]) {
-            newQuickFilters.delete(column);
-          }
-        });
-
-        return {
-          quickFilters: newQuickFilters,
-          advancedFilters: newAdvancedFilters,
-        };
+    const { advancedFilters, quickFilters } = this.state;
+    const { isQuickFiltersControlled } = this.props;
+    const newAdvancedFilters = new Map(advancedFilters);
+    const newQuickFilters = new Map(quickFilters);
+    newAdvancedFilters.forEach((_, column) => {
+      if (column >= clearRange[0] && column <= clearRange[1]) {
+        newAdvancedFilters.delete(column);
       }
-    );
+    });
+    newQuickFilters.forEach((_, column) => {
+      if (column >= clearRange[0] && column <= clearRange[1]) {
+        newQuickFilters.delete(column);
+      }
+    });
+
+    const didAdvancedFiltersChange =
+      newAdvancedFilters.size !== advancedFilters.size;
+    const didQuickFiltersChange = newQuickFilters.size !== quickFilters.size;
+    if (didQuickFiltersChange) {
+      this.requestQuickFiltersChange(newQuickFilters);
+    }
+    if (didAdvancedFiltersChange) {
+      if (!didQuickFiltersChange || isQuickFiltersControlled) {
+        this.startLoading('Filtering...', { resetRanges: true });
+      }
+      this.setState({ advancedFilters: newAdvancedFilters });
+    }
   }
 
   removeQuickFilter(modelColumn: ModelIndex): void {
-    this.startLoading('Clearing Filter...', { resetRanges: true });
-
-    this.setState(({ quickFilters }) => {
-      const newQuickFilters = new Map(quickFilters);
-      newQuickFilters.delete(modelColumn);
-
-      return { quickFilters: newQuickFilters };
-    });
+    const { quickFilters } = this.state;
+    const newQuickFilters = new Map(quickFilters);
+    newQuickFilters.delete(modelColumn);
+    this.requestQuickFiltersChange(newQuickFilters);
   }
 
   clearAllFilters(): void {
     log.debug('Clearing all filters');
 
     const { advancedFilters, quickFilters, searchFilter } = this.state;
+    const { isQuickFiltersControlled } = this.props;
     if (
       quickFilters.size === 0 &&
       advancedFilters.size === 0 &&
@@ -2007,16 +2020,25 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
       return;
     }
 
-    // if there is an active quick filter input field, reset it as well
-    this.clearGridInputField();
+    if (quickFilters.size > 0) {
+      this.requestQuickFiltersChange(EMPTY_MAP);
+    }
 
-    this.startLoading('Clearing Filters...', { resetRanges: true });
-    this.setState({
-      quickFilters: new Map(),
-      advancedFilters: new Map(),
-      searchValue: '',
-      searchFilter: undefined,
-    });
+    const hasOtherFilters = advancedFilters.size > 0 || searchFilter != null;
+    if (hasOtherFilters) {
+      if (quickFilters.size === 0 || isQuickFiltersControlled) {
+        this.startLoading('Clearing Filters...', { resetRanges: true });
+      }
+      this.setState({
+        advancedFilters: new Map(),
+        searchValue: '',
+        searchFilter: undefined,
+      });
+    }
+
+    if (!isQuickFiltersControlled) {
+      this.clearGridInputField();
+    }
   }
 
   clearAllAggregations(): void {
@@ -2990,7 +3012,7 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
         addToExisting
       );
 
-      this.updateSorts(sorts);
+      this.requestSortsChange(sorts);
     } else {
       log.debug('Column type was not sortable', model.columns[columnIndex]);
     }
@@ -3000,6 +3022,14 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
     this.startLoading('Sorting...');
     this.setState({ sorts });
     this.grid?.forceUpdate();
+  }
+
+  requestSortsChange(sorts: readonly SortDescriptor[]): void {
+    const { isSortsControlled, onSortsChange } = this.props;
+    onSortsChange?.(sorts);
+    if (!isSortsControlled) {
+      this.updateSorts(sorts);
+    }
   }
 
   updateQuickFilters(quickFilters: ReadonlyQuickFilterMap | null): void {
@@ -3015,6 +3045,14 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
     this.startLoading('Filtering...', { resetRanges: true });
     this.setState({ quickFilters: quickFilters ?? EMPTY_MAP });
     this.grid?.forceUpdate();
+  }
+
+  requestQuickFiltersChange(quickFilters: ReadonlyQuickFilterMap): void {
+    const { isQuickFiltersControlled, onQuickFiltersChange } = this.props;
+    onQuickFiltersChange?.(quickFilters);
+    if (!isQuickFiltersControlled) {
+      this.updateQuickFilters(quickFilters);
+    }
   }
 
   sortColumn(
@@ -3033,9 +3071,7 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
       isAbs,
       addToExisting
     );
-    this.startLoading('Sorting...');
-    this.setState({ sorts });
-    this.grid?.forceUpdate();
+    this.requestSortsChange(sorts);
   }
 
   reverse(reverse: boolean): void {
@@ -3303,10 +3339,7 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
     );
     log.info('Setting table sorts', sorts);
 
-    this.startLoading('Sorting...');
-    this.setState({ sorts });
-
-    this.grid?.forceUpdate();
+    this.requestSortsChange(sorts);
   }
 
   handleAdvancedFilterDone(): void {
@@ -3378,17 +3411,14 @@ class IrisGrid extends Component<IrisGridProps, IrisGridState> {
   }
 
   handleFilterBarChange(value: string): void {
-    this.startLoading('Filtering...', { resetRanges: true });
-
-    this.setState(({ focusedFilterBarColumn, quickFilters }) => {
-      const newQuickFilters = new Map(quickFilters);
-      if (focusedFilterBarColumn != null) {
-        const modelIndex = this.getModelColumn(focusedFilterBarColumn);
-        assertNotNull(modelIndex);
-        this.applyQuickFilter(modelIndex, value, newQuickFilters);
-      }
-      return { quickFilters: newQuickFilters };
-    });
+    const { focusedFilterBarColumn, quickFilters } = this.state;
+    const newQuickFilters = new Map(quickFilters);
+    if (focusedFilterBarColumn != null) {
+      const modelIndex = this.getModelColumn(focusedFilterBarColumn);
+      assertNotNull(modelIndex);
+      this.applyQuickFilter(modelIndex, value, newQuickFilters);
+    }
+    this.requestQuickFiltersChange(newQuickFilters);
   }
 
   handleFilterBarDone(setGridFocus = true, defocusInput = true): void {


### PR DESCRIPTION
Adds controlled sorts and quick filters to IrisGrid. User changes are reported through callbacks without updating internal state, while uncontrolled behavior remains unchanged.

This PR should be merged and released before [deephaven-plugins#1377](https://github.com/deephaven/deephaven-plugins/pull/1377).