### PR TITLE
fix: DH-23381: Allow Legacy Plugin Menu with Zero Rows

### DIFF
--- a/packages/iris-grid/src/IrisGrid.tsx
+++ b/packages/iris-grid/src/IrisGrid.tsx
@@ -245,7 +245,7 @@ export interface IrisGridContextMenuData {
   column: DhType.Column;
   rowIndex: GridRangeIndex;
   columnIndex: GridRangeIndex;
-  modelRow: GridRangeIndex;
+  modelRow?: GridRangeIndex;
   modelColumn: GridRangeIndex;
 }
 

--- a/packages/iris-grid/src/mousehandlers/IrisGridContextMenuHandler.test.tsx
+++ b/packages/iris-grid/src/mousehandlers/IrisGridContextMenuHandler.test.tsx
@@ -1,12 +1,15 @@
+import type React from 'react';
 import { TestUtils } from '@deephaven/test-utils';
 import {
   type ExpandableColumnGridModel,
+  type Grid,
   type GridMetrics,
   type GridPoint,
+  GridSelectionMouseHandler,
   type ModelIndex,
 } from '@deephaven/grid';
 import { type dh } from '@deephaven/jsapi-types';
-import { ContextActionUtils } from '@deephaven/components';
+import { ContextActions, ContextActionUtils } from '@deephaven/components';
 import IrisGridContextMenuHandler from './IrisGridContextMenuHandler';
 import {
   type default as IrisGrid,
@@ -73,6 +76,63 @@ function makeMockIrisGrid({
     getTheme: jest.fn().mockReturnValue(theme),
   });
 }
+
+describe('onContextMenu modelRow prop', () => {
+  const mockDh = createMockProxy<typeof dh>();
+
+  beforeEach(() => {
+    jest
+      .spyOn(GridSelectionMouseHandler, 'getLatestSelection')
+      .mockReturnValue([]);
+    jest.spyOn(ContextActions, 'triggerMenu').mockImplementation(() => null);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it.each([
+    ['defined', 5 as ModelIndex],
+    ['undefined', undefined],
+    ['null', null],
+  ])('is called when modelRow is %s', (_label, modelRowValue) => {
+    const columns = makeColumns();
+    const model = makeMockModel({ columns });
+    (model.sourceForCell as jest.Mock).mockReturnValue({ column: 0, row: 0 });
+
+    const irisGrid = makeMockIrisGrid({ model });
+    const mockOnContextMenu = irisGrid.props.onContextMenu as jest.Mock;
+    mockOnContextMenu.mockReturnValue([]);
+    (irisGrid.getModelColumn as jest.Mock).mockReturnValue(0);
+    (irisGrid.getModelRow as jest.Mock).mockReturnValue(modelRowValue);
+
+    const handler = new IrisGridContextMenuHandler(irisGrid, mockDh);
+
+    const gridPoint: GridPoint = {
+      column: 0 as ModelIndex,
+      row: null,
+      x: 0,
+      y: 1000,
+      columnHeaderDepth: 0,
+    };
+
+    handler.onContextMenu(gridPoint, createMockProxy<Grid>(), {
+      clientX: 0,
+      clientY: 0,
+    } as React.MouseEvent<Element, MouseEvent>);
+
+    expect(mockOnContextMenu).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model,
+        column: columns[0],
+        rowIndex: null,
+        columnIndex: 0,
+        modelRow: modelRowValue,
+        modelColumn: 0,
+      })
+    );
+  });
+});
 
 describe('getHeaderActions', () => {
   const mockDh = createMockProxy<typeof dh>();

--- a/packages/iris-grid/src/mousehandlers/IrisGridContextMenuHandler.test.tsx
+++ b/packages/iris-grid/src/mousehandlers/IrisGridContextMenuHandler.test.tsx
@@ -68,6 +68,7 @@ function makeMockIrisGrid({
         userColumnWidths: new Map(
           model.columns.map((_col, index) => [index, 100] as [number, number])
         ),
+        gridY: 0,
       }),
       advancedFilters: new Map(),
       quickFilters: new Map(),

--- a/packages/iris-grid/src/mousehandlers/IrisGridContextMenuHandler.tsx
+++ b/packages/iris-grid/src/mousehandlers/IrisGridContextMenuHandler.tsx
@@ -942,7 +942,7 @@ class IrisGridContextMenuHandler extends GridMouseHandler {
 
     const actions: ResolvableContextAction[] = [];
 
-    if (modelColumn != null && modelRow != null) {
+    if (modelColumn != null) {
       const sourceCell = model.sourceForCell(modelColumn, modelRow ?? 0);
       const { column: sourceColumn, row: sourceRow } = sourceCell;
       const value = model.valueForCell(sourceColumn, sourceRow);
@@ -965,9 +965,7 @@ class IrisGridContextMenuHandler extends GridMouseHandler {
           })
         );
       }
-    }
 
-    if (modelColumn != null) {
       const clearFilterRange = model.getClearFilterRange(modelColumn);
       if (clearFilterRange != null && clearFilterRange.length > 0) {
         // Clear column filter should still be available after last row

--- a/packages/iris-grid/src/mousehandlers/IrisGridContextMenuHandler.tsx
+++ b/packages/iris-grid/src/mousehandlers/IrisGridContextMenuHandler.tsx
@@ -942,7 +942,7 @@ class IrisGridContextMenuHandler extends GridMouseHandler {
 
     const actions: ResolvableContextAction[] = [];
 
-    if (modelColumn != null) {
+    if (modelColumn != null && y > gridY) {
       const sourceCell = model.sourceForCell(modelColumn, modelRow ?? 0);
       const { column: sourceColumn, row: sourceRow } = sourceCell;
       const value = model.valueForCell(sourceColumn, sourceRow);
@@ -965,7 +965,9 @@ class IrisGridContextMenuHandler extends GridMouseHandler {
           })
         );
       }
+    }
 
+    if (modelColumn != null) {
       const clearFilterRange = model.getClearFilterRange(modelColumn);
       if (clearFilterRange != null && clearFilterRange.length > 0) {
         // Clear column filter should still be available after last row


### PR DESCRIPTION
Allows onContextMenu to be called with an undefined modelRow (i.e. a table with zero rows). This restores functionality where this worked in Bard and was likely broken when we update to Typescript.

There are steps to test in the PR. Currently, I have a plugin file deployed on https://dgodinez-gplus.int.illumon.com:8123/iriside/ and can test it by running npm run start-community with this branch.