### PR TITLE
ci: DH-22941: Record new e2e tests and link to the videos from the PR

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Build and Save docker image
         run: |
@@ -33,7 +33,7 @@ jobs:
           docker save e2e-ci -o e2e-ci.tar.gz
 
       - name: Store docker build for test matrix
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: image-cache
           path: e2e-ci.tar.gz
@@ -53,10 +53,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Download docker image for test matrix
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: image-cache
 
@@ -76,7 +76,7 @@ jobs:
         run: './tests/docker-scripts/run.sh e2e-ci-matrix'
 
       - name: Upload Playwright report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: ${{ !cancelled() }}
         with:
           name: playwright-report-blob-${{ matrix.config }}
@@ -89,7 +89,7 @@ jobs:
 
       - name: Upload server logs
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: server-logs-${{ matrix.config }}
           path: /tmp/server-log.txt
@@ -111,7 +111,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
@@ -132,7 +132,7 @@ jobs:
 
       - name: Download docker image
         if: steps.specs.outputs.spec-files != ''
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: image-cache
 
@@ -149,7 +149,7 @@ jobs:
       - name: Upload recordings
         id: upload
         if: ${{ steps.specs.outputs.spec-files != '' && !cancelled() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: e2e-new-test-videos
           path: test-results/e2e-video
@@ -159,7 +159,7 @@ jobs:
       - name: Comment with recordings
         # Forked PRs get a read-only token, so the comment would fail.
         if: ${{ steps.upload.outputs.artifact-url != '' && !cancelled() && github.event.pull_request.head.repo.full_name == github.repository }}
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
         with:
           header: e2e-new-test-recordings
           message: |
@@ -175,7 +175,7 @@ jobs:
 
       - name: Remove stale recordings comment
         if: ${{ steps.specs.outputs.spec-files == '' && github.event.pull_request.head.repo.full_name == github.repository }}
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
         with:
           header: e2e-new-test-recordings
           delete: true
@@ -187,7 +187,7 @@ jobs:
 
     steps:
       - name: Download blob reports from GitHub Actions Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: playwright-report-blob-*
 
@@ -201,7 +201,7 @@ jobs:
           npx playwright merge-reports --reporter html,github ./all-blob-reports
 
       - name: Upload HTML report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: playwright-report
           path: playwright-report

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -171,7 +171,7 @@ jobs:
 
             [Download the videos](${{ steps.upload.outputs.artifact-url }}) - expires in 14 days.
 
-            GitHub can't play videos straight from an artifact link. Unzip the archive and drag an `.mp4` into a comment to embed it.
+            Unzip the archive and open `index.html` to watch them.
 
       - name: Remove stale recordings comment
         if: ${{ steps.specs.outputs.spec-files == '' && github.event.pull_request.head.repo.full_name == github.repository }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -95,6 +95,91 @@ jobs:
           path: /tmp/server-log.txt
           retention-days: 14
 
+  record-new-tests:
+    if: ${{ github.event_name == 'pull_request' }}
+    runs-on: ubuntu-22.04
+    needs: build
+    # Recording is informational only - never block the PR on it.
+    continue-on-error: true
+    timeout-minutes: 45
+    permissions:
+      contents: read
+      pull-requests: write
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}-record-new-tests
+      cancel-in-progress: true
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Find added or modified e2e specs
+        id: specs
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          CHANGED=$(git diff --name-only --diff-filter=AM "$BASE_SHA...$HEAD_SHA" -- 'tests/*.spec.ts')
+          echo "Specs to record: ${CHANGED:-<none>}"
+          echo "spec-files=$(echo "$CHANGED" | tr '\n' ' ' | sed 's/ *$//')" >> "$GITHUB_OUTPUT"
+          {
+            echo 'spec-list<<SPEC_LIST_EOF'
+            echo "$CHANGED" | sed 's/^/- `/; s/$/`/'
+            echo 'SPEC_LIST_EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Download docker image
+        if: steps.specs.outputs.spec-files != ''
+        uses: actions/download-artifact@v4
+        with:
+          name: image-cache
+
+      - name: Load docker image
+        if: steps.specs.outputs.spec-files != ''
+        run: docker load -i e2e-ci.tar.gz
+
+      - name: Record specs
+        if: steps.specs.outputs.spec-files != ''
+        env:
+          SPEC_FILES: ${{ steps.specs.outputs.spec-files }}
+        run: './tests/docker-scripts/run.sh e2e-record'
+
+      - name: Upload recordings
+        id: upload
+        if: ${{ steps.specs.outputs.spec-files != '' && !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-new-test-videos
+          path: test-results/e2e-video
+          retention-days: 14
+          if-no-files-found: ignore
+
+      - name: Comment with recordings
+        # Forked PRs get a read-only token, so the comment would fail.
+        if: ${{ steps.upload.outputs.artifact-url != '' && github.event.pull_request.head.repo.full_name == github.repository }}
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: e2e-new-test-recordings
+          message: |
+            ### New e2e test recordings
+
+            Recorded the e2e specs added or modified in this PR (chromium only):
+
+            ${{ steps.specs.outputs.spec-list }}
+
+            [Download the videos](${{ steps.upload.outputs.artifact-url }}) - expires in 14 days.
+
+            GitHub can't play videos straight from an artifact link. Unzip the archive and drag an `.mp4` into a comment to embed it.
+
+      - name: Remove stale recordings comment
+        if: ${{ steps.specs.outputs.spec-files == '' && github.event.pull_request.head.repo.full_name == github.repository }}
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: e2e-new-test-recordings
+          delete: true
+
   merge-reports:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-22.04

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -158,7 +158,7 @@ jobs:
 
       - name: Comment with recordings
         # Forked PRs get a read-only token, so the comment would fail.
-        if: ${{ steps.upload.outputs.artifact-url != '' && github.event.pull_request.head.repo.full_name == github.repository }}
+        if: ${{ steps.upload.outputs.artifact-url != '' && !cancelled() && github.event.pull_request.head.repo.full_name == github.repository }}
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           header: e2e-new-test-recordings

--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
     "e2e:headed": "playwright test --project=chromium --debug --ignore-snapshots",
     "e2e:update-snapshots": "playwright test --update-snapshots=changed",
     "e2e:docker": "./tests/docker-scripts/run.sh web-ui-tests",
-    "e2e:update-ci-snapshots": "./tests/docker-scripts/run.sh web-ui-update-snapshots"
+    "e2e:update-ci-snapshots": "./tests/docker-scripts/run.sh web-ui-update-snapshots",
+    "e2e:record": "node scripts/e2e-record.mjs"
   },
   "repository": "https://github.com/deephaven/web-client-ui",
   "devDependencies": {

--- a/playwright-record-ci.config.ts
+++ b/playwright-record-ci.config.ts
@@ -1,0 +1,17 @@
+import type { PlaywrightTestConfig } from '@playwright/test';
+import CIConfig from './playwright-ci.config';
+import RecordConfig from './playwright-record.config';
+
+/**
+ * Recording config for CI, used by the `record-new-tests` job to record the
+ * e2e specs added or modified in a PR.
+ *
+ * Same single-take recording setup as `playwright-record.config.ts`, but it
+ * also starts the preview servers since CI has no dev server running.
+ */
+const config: PlaywrightTestConfig = {
+  ...RecordConfig,
+  webServer: CIConfig.webServer,
+};
+
+export default config;

--- a/playwright-record.config.ts
+++ b/playwright-record.config.ts
@@ -18,9 +18,10 @@ import DefaultConfig from './playwright.config';
  */
 
 /** Delay (ms) added before each Playwright action so the video is followable. */
+const DEFAULT_SLOW_MO_MS = 500;
 const slowMoEnv = Number(process.env.E2E_RECORD_SLOWMO);
 const SLOW_MO_MS =
-  Number.isFinite(slowMoEnv) && slowMoEnv >= 0 ? slowMoEnv : 250;
+  Number.isFinite(slowMoEnv) && slowMoEnv >= 0 ? slowMoEnv : DEFAULT_SLOW_MO_MS;
 
 const VIDEO_SIZE = { width: 1280, height: 720 };
 const OUTPUT_DIR = path.resolve(__dirname, 'test-results/e2e-video');

--- a/playwright-record.config.ts
+++ b/playwright-record.config.ts
@@ -1,0 +1,80 @@
+import path from 'path';
+import type { PlaywrightTestConfig } from '@playwright/test';
+import DefaultConfig from './playwright.config';
+
+/**
+ * Playwright config dedicated to *recording* a single e2e test as a video, e.g.
+ * to attach to a PR or Jira ticket. Use it via `npm run e2e:record`.
+ *
+ * Differences from the standard e2e config:
+ * - Video is always recorded (not just on failure) at a fixed 1280x720 size.
+ * - `slowMo` is enabled so the recording is easy to follow.
+ * - Runs chromium only, serially with a single worker and no retries, for a
+ *   clean, single take.
+ * - Artifacts (including the video) are written under the gitignored
+ *   `test-results/e2e-video` directory.
+ * - A global setup warms up the local dev server first so the video doesn't
+ *   begin with ~10s of blank white screen while Vite compiles on first request.
+ */
+
+/** Delay (ms) added before each Playwright action so the video is followable. */
+const slowMoEnv = Number(process.env.E2E_RECORD_SLOWMO);
+const SLOW_MO_MS =
+  Number.isFinite(slowMoEnv) && slowMoEnv >= 0 ? slowMoEnv : 250;
+
+const VIDEO_SIZE = { width: 1280, height: 720 };
+const OUTPUT_DIR = path.resolve(__dirname, 'test-results/e2e-video');
+
+const chromiumProject = (DefaultConfig.projects ?? []).find(
+  project => project.name === 'chromium'
+);
+
+const config: PlaywrightTestConfig = {
+  ...DefaultConfig,
+
+  // A recording is a single, deterministic take - no parallelism or retries.
+  fullyParallel: false,
+  workers: 1,
+  retries: 0,
+
+  globalSetup: require.resolve('./tests/record-globalSetup.ts'),
+
+  outputDir: OUTPUT_DIR,
+
+  // Print test results to the console; skip the html reporter since this is a
+  // local, interactive recording.
+  reporter: [['list']],
+
+  use: {
+    ...DefaultConfig.use,
+    video: {
+      mode: 'on',
+      size: VIDEO_SIZE,
+    },
+    // `video` only covers the built-in page/context fixtures. Specs that build
+    // their own context (`browser.newPage()` in `beforeAll`) need this instead.
+    contextOptions: {
+      recordVideo: {
+        dir: path.join(OUTPUT_DIR, 'manual-context'),
+        size: VIDEO_SIZE,
+      },
+    },
+  },
+
+  // Keep chromium's existing options (devices preset, launch args) and add slowMo.
+  projects: [
+    {
+      ...chromiumProject,
+      name: 'chromium',
+      use: {
+        ...chromiumProject?.use,
+        launchOptions: {
+          ...chromiumProject?.use?.launchOptions,
+          slowMo: SLOW_MO_MS,
+        },
+      },
+    },
+  ],
+};
+
+export default config;

--- a/scripts/e2e-record.mjs
+++ b/scripts/e2e-record.mjs
@@ -1,0 +1,203 @@
+#!/usr/bin/env node
+// @ts-check
+/**
+ * Records a single e2e test as a video for attaching to a PR or Jira ticket.
+ *
+ * Usage:
+ *   npm run e2e:record <file-name> [search-name]
+ *
+ *   <file-name>    A test file (or path fragment) to run, e.g.
+ *                  `table-gotorow` or `tests/table-gotorow.spec.ts`.
+ *   [search-name]  Optional test-title filter passed to Playwright's `-g`,
+ *                  e.g. "Go to row works".
+ *
+ * It runs the test using the recording Playwright config (video + slowMo),
+ * streams the test output to the console, and then prints where the video(s)
+ * were saved under the gitignored test-results/e2e-video directory.
+ */
+/* eslint-disable no-console, no-restricted-syntax */
+import { spawnSync } from 'node:child_process';
+import { existsSync, readdirSync, statSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const rootDir = path.resolve(scriptDir, '..');
+const outputDir = path.join(rootDir, 'test-results', 'e2e-video');
+const configPath = 'playwright-record.config.ts';
+
+const [fileName, searchName] = process.argv.slice(2);
+
+if (!fileName) {
+  console.error('Usage: npm run e2e:record <file-name> [search-name]');
+  console.error('  <file-name>    Test file to run, e.g. table-gotorow');
+  console.error(
+    '  [search-name]  Optional test title to filter with -g, e.g. "Go to row"'
+  );
+  process.exit(1);
+}
+
+/**
+ * Recursively collects raw Playwright video files (.webm) under a directory,
+ * newest first.
+ * @param {string} dir
+ * @returns {string[]}
+ */
+function collectVideos(dir) {
+  if (!existsSync(dir)) {
+    return [];
+  }
+
+  /** @type {{ file: string; mtimeMs: number }[]} */
+  const found = [];
+
+  /** @param {string} current */
+  function walk(current) {
+    for (const entry of readdirSync(current, { withFileTypes: true })) {
+      const full = path.join(current, entry.name);
+      if (entry.isDirectory()) {
+        walk(full);
+      } else if (/\.webm$/i.test(entry.name)) {
+        found.push({ file: full, mtimeMs: statSync(full).mtimeMs });
+      }
+    }
+  }
+
+  walk(dir);
+  return found.sort((a, b) => b.mtimeMs - a.mtimeMs).map(v => v.file);
+}
+
+/**
+ * @returns {boolean} Whether ffmpeg is available on the PATH.
+ */
+function hasFfmpeg() {
+  const probe = spawnSync('ffmpeg', ['-version'], { stdio: 'ignore' });
+  return !probe.error && probe.status === 0;
+}
+
+/**
+ * Detects how long the recording stays on a blank/white screen at the start.
+ *
+ * The app is dark-themed once loaded, so the only near-white frames are the
+ * blank page shown while the dev server loads/authenticates. We negate the
+ * video (turning white into black) and use ffmpeg's blackdetect to find that
+ * leading blank segment, returning the timestamp (seconds) where it ends.
+ *
+ * @param {string} video Path to the raw .webm recording.
+ * @returns {number} Seconds of leading blank screen (0 if none detected).
+ */
+function detectLeadingBlankEnd(video) {
+  const probe = spawnSync(
+    'ffmpeg',
+    [
+      '-hide_banner',
+      '-nostats',
+      '-i',
+      video,
+      '-vf',
+      'negate,blackdetect=d=0.2:pix_th=0.10',
+      '-an',
+      '-f',
+      'null',
+      '-',
+    ],
+    { encoding: 'utf8', maxBuffer: 10 * 1024 * 1024 }
+  );
+
+  const output = `${probe.stderr ?? ''}`;
+  const matches = [
+    ...output.matchAll(/black_start:([\d.]+)[^\n]*?black_end:([\d.]+)/g),
+  ];
+
+  // Only trim a blank segment that begins at (or very near) the start.
+  const leading = matches.find(m => Number(m[1]) < 0.5);
+  return leading ? Number(leading[2]) : 0;
+}
+
+/**
+ * Trims the leading blank screen and exports an mp4 next to the source video.
+ * mp4 is widely supported for attaching to GitHub PRs and Jira tickets.
+ *
+ * @param {string} video Path to the raw .webm recording.
+ * @param {number} startSec Seconds to skip from the start.
+ * @returns {string|null} Path to the generated mp4, or null on failure.
+ */
+function exportTrimmedMp4(video, startSec) {
+  const baseName = path.basename(video, path.extname(video));
+  const outPath = path.join(path.dirname(video), `${baseName}.mp4`);
+  const args = ['-y', '-loglevel', 'error'];
+  // Seek before -i for a fast, keyframe-aligned trim.
+  if (startSec > 0.3) {
+    args.push('-ss', startSec.toFixed(2));
+  }
+  args.push('-i', video, '-an', '-movflags', '+faststart', outPath);
+
+  const ret = spawnSync('ffmpeg', args, { stdio: 'inherit' });
+  return !ret.error && ret.status === 0 ? outPath : null;
+}
+
+// Record which videos already existed so we can highlight the new ones.
+const previousVideos = new Set(collectVideos(outputDir));
+
+const playwrightArgs = [
+  'playwright',
+  'test',
+  `--config=${configPath}`,
+  // Snapshot diffs shouldn't cut a recording short.
+  '--ignore-snapshots',
+  fileName,
+];
+if (searchName) {
+  playwrightArgs.push('-g', searchName);
+}
+
+console.log(
+  `\nRecording e2e test: ${fileName}${
+    searchName ? ` (grep: "${searchName}")` : ''
+  }\n`
+);
+
+const result = spawnSync('npx', playwrightArgs, {
+  cwd: rootDir,
+  stdio: 'inherit',
+  env: process.env,
+});
+
+const allVideos = collectVideos(outputDir);
+const newVideos = allVideos.filter(v => !previousVideos.has(v));
+const videos = newVideos.length > 0 ? newVideos : allVideos;
+
+const divider = '-'.repeat(60);
+console.log(`\n${divider}`);
+
+if (videos.length === 0) {
+  console.log(`No video files were found in ${outputDir}`);
+  console.log('(The test may not have started a browser context.)');
+} else if (!hasFfmpeg()) {
+  // No ffmpeg: just report the raw recordings (with the leading load screen).
+  console.log('Recorded video(s) (raw - includes initial load screen):');
+  for (const video of videos) {
+    console.log(`  ${path.relative(rootDir, video)}`);
+  }
+  console.log(
+    '\nInstall ffmpeg to auto-trim the leading load screen and export an mp4.'
+  );
+} else {
+  console.log('Recorded video(s):');
+  for (const video of videos) {
+    const blankEnd = detectLeadingBlankEnd(video);
+    const mp4 = exportTrimmedMp4(video, blankEnd);
+    if (mp4) {
+      const trimNote =
+        blankEnd > 0.3
+          ? ` (trimmed ${blankEnd.toFixed(1)}s of leading load screen)`
+          : '';
+      console.log(`  ${path.relative(rootDir, mp4)}${trimNote}`);
+    } else {
+      console.log(`  ${path.relative(rootDir, video)} (mp4 export failed)`);
+    }
+  }
+}
+console.log(`${divider}\n`);
+
+process.exit(result.status ?? 1);

--- a/scripts/e2e-record.mjs
+++ b/scripts/e2e-record.mjs
@@ -17,18 +17,28 @@
  *                     `playwright-record-ci.config.ts`.
  *
  * It runs the tests using the recording Playwright config (video + slowMo),
- * streams the test output to the console, and then prints where the video(s)
- * were saved under the gitignored test-results/e2e-video directory.
+ * streams the test output to the console, and then writes the video(s) plus an
+ * index.html that plays them inline to the gitignored test-results/e2e-video
+ * directory.
  */
 /* eslint-disable no-console, no-restricted-syntax */
 import { spawnSync } from 'node:child_process';
-import { existsSync, readdirSync, statSync } from 'node:fs';
+import {
+  existsSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const rootDir = path.resolve(scriptDir, '..');
 const outputDir = path.join(rootDir, 'test-results', 'e2e-video');
+const reportJsonPath = path.join(outputDir, 'report.json');
+const reportHtmlPath = path.join(outputDir, 'index.html');
 const configPath =
   process.env.E2E_RECORD_CONFIG || 'playwright-record.config.ts';
 
@@ -148,6 +158,141 @@ function exportTrimmedMp4(video, startSec) {
   return !ret.error && ret.status === 0 ? outPath : null;
 }
 
+/**
+ * Maps each recorded video back to the test that produced it, using the json
+ * reporter output. Videos from specs that build their own context aren't
+ * attached to a test and so won't appear here.
+ *
+ * @returns {Map<string, { file: string; title: string }>} Keyed by video path.
+ */
+function readVideoLabels() {
+  /** @type {Map<string, { file: string; title: string }>} */
+  const labels = new Map();
+
+  if (!existsSync(reportJsonPath)) {
+    return labels;
+  }
+
+  /** @type {any} */
+  let report;
+  try {
+    report = JSON.parse(readFileSync(reportJsonPath, 'utf8'));
+  } catch {
+    return labels;
+  }
+
+  /**
+   * @param {any} suite
+   * @param {string} file
+   * @param {string[]} titles
+   */
+  function walk(suite, file, titles) {
+    const suiteFile = suite.file ?? file;
+    for (const spec of suite.specs ?? []) {
+      const title = [...titles, spec.title].filter(Boolean).join(' > ');
+      for (const test of spec.tests ?? []) {
+        for (const testResult of test.results ?? []) {
+          for (const attachment of testResult.attachments ?? []) {
+            if (attachment.name === 'video' && attachment.path != null) {
+              labels.set(path.resolve(attachment.path), {
+                file: suiteFile,
+                title,
+              });
+            }
+          }
+        }
+      }
+    }
+    for (const child of suite.suites ?? []) {
+      // The outermost suite per file is titled with the file itself.
+      const childTitles =
+        child.file != null && child.title === child.file
+          ? titles
+          : [...titles, child.title];
+      walk(child, suiteFile, childTitles);
+    }
+  }
+
+  for (const suite of report.suites ?? []) {
+    walk(suite, suite.file ?? suite.title ?? '', []);
+  }
+
+  return labels;
+}
+
+/**
+ * @param {string} value
+ * @returns {string}
+ */
+function escapeHtml(value) {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+/**
+ * Writes a standalone page that plays every recording inline, so the artifact
+ * can be reviewed by opening one file instead of hunting through hashed names.
+ *
+ * @param {{ src: string; file: string; title: string }[]} entries
+ */
+function writeHtmlReport(entries) {
+  const sections = entries
+    .map(
+      entry => `    <section>
+      <h2>${escapeHtml(entry.title)}</h2>
+      <p>${escapeHtml(entry.file)}</p>
+      <video controls preload="metadata" src="${escapeHtml(entry.src)}"></video>
+    </section>`
+    )
+    .join('\n');
+
+  const html = `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>e2e recordings</title>
+    <style>
+      body {
+        margin: 0 auto;
+        max-width: 1000px;
+        padding: 24px;
+        background: #1a1a1a;
+        color: #f0f0f0;
+        font-family: system-ui, sans-serif;
+      }
+      section {
+        margin-bottom: 32px;
+      }
+      h2 {
+        margin-bottom: 4px;
+        font-size: 1.1rem;
+      }
+      p {
+        margin-top: 0;
+        color: #a0a0a0;
+        font-family: monospace;
+      }
+      video {
+        width: 100%;
+        border-radius: 4px;
+        background: #000;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>e2e recordings</h1>
+${sections}
+  </body>
+</html>
+`;
+
+  writeFileSync(reportHtmlPath, html);
+}
+
 // Record which videos already existed so we can highlight the new ones.
 const previousVideos = new Set(collectVideos(outputDir));
 
@@ -157,6 +302,8 @@ const playwrightArgs = [
   `--config=${configPath}`,
   // Snapshot diffs shouldn't cut a recording short.
   '--ignore-snapshots',
+  // json is used to label each video with the test that produced it.
+  '--reporter=list,json',
   ...fileNames,
 ];
 if (searchName) {
@@ -172,43 +319,72 @@ console.log(
 const result = spawnSync('npx', playwrightArgs, {
   cwd: rootDir,
   stdio: 'inherit',
-  env: process.env,
+  env: { ...process.env, PLAYWRIGHT_JSON_OUTPUT_NAME: reportJsonPath },
 });
 
 const allVideos = collectVideos(outputDir);
 const newVideos = allVideos.filter(v => !previousVideos.has(v));
 const videos = newVideos.length > 0 ? newVideos : allVideos;
 
+const labels = readVideoLabels();
+rmSync(reportJsonPath, { force: true });
+
 const divider = '-'.repeat(60);
 console.log(`\n${divider}`);
+
+/** @type {{ src: string; file: string; title: string }[]} */
+const entries = [];
+const ffmpegAvailable = hasFfmpeg();
 
 if (videos.length === 0) {
   console.log(`No video files were found in ${outputDir}`);
   console.log('(The test may not have started a browser context.)');
-} else if (!hasFfmpeg()) {
-  // No ffmpeg: just report the raw recordings (with the leading load screen).
-  console.log('Recorded video(s) (raw - includes initial load screen):');
-  for (const video of videos) {
-    console.log(`  ${path.relative(rootDir, video)}`);
-  }
-  console.log(
-    '\nInstall ffmpeg to auto-trim the leading load screen and export an mp4.'
-  );
 } else {
-  console.log('Recorded video(s):');
-  for (const video of videos) {
-    const blankEnd = detectLeadingBlankEnd(video);
-    const mp4 = exportTrimmedMp4(video, blankEnd);
-    if (mp4) {
-      const trimNote =
-        blankEnd > 0.3
-          ? ` (trimmed ${blankEnd.toFixed(1)}s of leading load screen)`
-          : '';
-      console.log(`  ${path.relative(rootDir, mp4)}${trimNote}`);
-    } else {
-      console.log(`  ${path.relative(rootDir, video)} (mp4 export failed)`);
-    }
+  if (!ffmpegAvailable) {
+    // No ffmpeg: just report the raw recordings (with the leading load screen).
+    console.log('Recorded video(s) (raw - includes initial load screen):');
+  } else {
+    console.log('Recorded video(s):');
   }
+
+  for (const video of videos) {
+    let output = video;
+    let note = '';
+
+    if (ffmpegAvailable) {
+      const blankEnd = detectLeadingBlankEnd(video);
+      const mp4 = exportTrimmedMp4(video, blankEnd);
+      if (mp4) {
+        output = mp4;
+        note =
+          blankEnd > 0.3
+            ? ` (trimmed ${blankEnd.toFixed(1)}s of leading load screen)`
+            : '';
+      } else {
+        note = ' (mp4 export failed)';
+      }
+    }
+
+    const label = labels.get(path.resolve(video));
+    entries.push({
+      src: path.relative(outputDir, output),
+      file: label?.file ?? path.relative(rootDir, output),
+      title: label?.title ?? path.basename(output),
+    });
+
+    console.log(`  ${path.relative(rootDir, output)}${note}`);
+  }
+
+  if (!ffmpegAvailable) {
+    console.log(
+      '\nInstall ffmpeg to auto-trim the leading load screen and export an mp4.'
+    );
+  }
+
+  writeHtmlReport(entries);
+  console.log(
+    `\nOpen ${path.relative(rootDir, reportHtmlPath)} to watch them.`
+  );
 }
 console.log(`${divider}\n`);
 

--- a/scripts/e2e-record.mjs
+++ b/scripts/e2e-record.mjs
@@ -1,17 +1,22 @@
 #!/usr/bin/env node
 // @ts-check
 /**
- * Records a single e2e test as a video for attaching to a PR or Jira ticket.
+ * Records e2e tests as videos for attaching to a PR or Jira ticket.
  *
  * Usage:
- *   npm run e2e:record <file-name> [search-name]
+ *   npm run e2e:record <file-name> [...file-name] [--grep=<search-name>]
  *
- *   <file-name>    A test file (or path fragment) to run, e.g.
- *                  `table-gotorow` or `tests/table-gotorow.spec.ts`.
- *   [search-name]  Optional test-title filter passed to Playwright's `-g`,
- *                  e.g. "Go to row works".
+ *   <file-name>       One or more test files (or path fragments) to run, e.g.
+ *                     `table-gotorow` or `tests/table-gotorow.spec.ts`.
+ *   --grep=<name>     Optional test-title filter passed to Playwright's `-g`,
+ *                     e.g. --grep="Go to row works".
  *
- * It runs the test using the recording Playwright config (video + slowMo),
+ * Env:
+ *   E2E_RECORD_CONFIG Playwright config to record with. Defaults to
+ *                     `playwright-record.config.ts` (local dev server). CI uses
+ *                     `playwright-record-ci.config.ts`.
+ *
+ * It runs the tests using the recording Playwright config (video + slowMo),
  * streams the test output to the console, and then prints where the video(s)
  * were saved under the gitignored test-results/e2e-video directory.
  */
@@ -24,15 +29,22 @@ import { fileURLToPath } from 'node:url';
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const rootDir = path.resolve(scriptDir, '..');
 const outputDir = path.join(rootDir, 'test-results', 'e2e-video');
-const configPath = 'playwright-record.config.ts';
+const configPath =
+  process.env.E2E_RECORD_CONFIG || 'playwright-record.config.ts';
 
-const [fileName, searchName] = process.argv.slice(2);
+const args = process.argv.slice(2);
+const searchName = args
+  .find(arg => arg.startsWith('--grep='))
+  ?.slice('--grep='.length);
+const fileNames = args.filter(arg => !arg.startsWith('--'));
 
-if (!fileName) {
-  console.error('Usage: npm run e2e:record <file-name> [search-name]');
-  console.error('  <file-name>    Test file to run, e.g. table-gotorow');
+if (fileNames.length === 0) {
   console.error(
-    '  [search-name]  Optional test title to filter with -g, e.g. "Go to row"'
+    'Usage: npm run e2e:record <file-name> [...file-name] [--grep=<search-name>]'
+  );
+  console.error('  <file-name>     Test file to run, e.g. table-gotorow');
+  console.error(
+    '  --grep=<name>   Optional test title to filter with -g, e.g. --grep="Go to row"'
   );
   process.exit(1);
 }
@@ -145,14 +157,14 @@ const playwrightArgs = [
   `--config=${configPath}`,
   // Snapshot diffs shouldn't cut a recording short.
   '--ignore-snapshots',
-  fileName,
+  ...fileNames,
 ];
 if (searchName) {
   playwrightArgs.push('-g', searchName);
 }
 
 console.log(
-  `\nRecording e2e test: ${fileName}${
+  `\nRecording e2e test(s): ${fileNames.join(', ')}${
     searchName ? ` (grep: "${searchName}")` : ''
   }\n`
 );

--- a/scripts/e2e-record.mjs
+++ b/scripts/e2e-record.mjs
@@ -103,6 +103,22 @@ const BLANK_EDGE_ENERGY = 0.3;
 const CONTENT_EDGE_RATIO = 0.25;
 /** Frames that must stay above the threshold before we call it content. */
 const CONTENT_FRAME_RUN = 3;
+/** How close a frame's energy must be to the loading screen's to match it. */
+const LOADING_LEVEL_TOLERANCE = 0.2;
+/** Cap on how far back we rewind toward the last loading-screen frame. */
+const MAX_REWIND_FRAMES = 10;
+
+/**
+ * @param {number[]} values
+ * @param {number} p Percentile in the range 0-1.
+ * @returns {number}
+ */
+function percentile(values, p) {
+  const sorted = [...values].sort((a, b) => a - b);
+  return (
+    sorted[Math.min(sorted.length - 1, Math.floor(sorted.length * p))] ?? 0
+  );
+}
 
 /**
  * Detects how long the recording sits on a blank page or the app's loading
@@ -148,18 +164,41 @@ function detectContentStart(video) {
     return 0;
   }
 
-  const sorted = [...frames].map(f => f.energy).sort((a, b) => a - b);
-  const peak = sorted[Math.floor(sorted.length * 0.95)] ?? 0;
+  const peak = percentile(
+    frames.map(f => f.energy),
+    0.95
+  );
   const threshold = Math.max(BLANK_EDGE_ENERGY, peak * CONTENT_EDGE_RATIO);
 
-  const start = frames.findIndex((_, i) =>
+  const firstContent = frames.findIndex((_, i) =>
     frames
       .slice(i, i + CONTENT_FRAME_RUN)
       .every(frame => frame.energy >= threshold)
   );
 
-  // Never trim everything - a run that never reaches content is left as-is.
-  return start > 0 ? frames[start].time : 0;
+  if (firstContent <= 0) {
+    // Never trim everything - a run that never reaches content is left as-is.
+    return 0;
+  }
+
+  // The UI paints over a few frames once the spinner goes away, so rewind past
+  // those to start on the first frame that no longer looks like the loading
+  // screen.
+  const loadingLevel = percentile(
+    frames.slice(0, firstContent).map(f => f.energy),
+    0.5
+  );
+  const tolerance = loadingLevel * LOADING_LEVEL_TOLERANCE;
+  const limit = Math.max(1, firstContent - MAX_REWIND_FRAMES);
+  let start = firstContent;
+  while (
+    start > limit &&
+    Math.abs(frames[start - 1].energy - loadingLevel) > tolerance
+  ) {
+    start -= 1;
+  }
+
+  return frames[start].time;
 }
 
 /**

--- a/scripts/e2e-record.mjs
+++ b/scripts/e2e-record.mjs
@@ -97,48 +97,74 @@ function hasFfmpeg() {
   return !probe.error && probe.status === 0;
 }
 
+/** Edge energy below this counts as a blank or loading screen. */
+const BLANK_EDGE_ENERGY = 0.3;
+/** Fraction of the recording's peak edge energy that also counts as content. */
+const CONTENT_EDGE_RATIO = 0.25;
+/** Frames that must stay above the threshold before we call it content. */
+const CONTENT_FRAME_RUN = 3;
+
 /**
- * Detects how long the recording stays on a blank/white screen at the start.
+ * Detects how long the recording sits on a blank page or the app's loading
+ * spinner before the real UI shows up.
  *
- * The app is dark-themed once loaded, so the only near-white frames are the
- * blank page shown while the dev server loads/authenticates. We negate the
- * video (turning white into black) and use ffmpeg's blackdetect to find that
- * leading blank segment, returning the timestamp (seconds) where it ends.
+ * Both of those screens are nearly featureless, so we measure per-frame "edge
+ * energy" - the mean intensity of an edge-detected, downscaled frame. A blank
+ * page scores ~0, the loading spinner ~0.15, and a rendered app screen upwards
+ * of 0.5, which separates them far more reliably than brightness does (the app
+ * is dark-themed, so the loading screen isn't white).
  *
  * @param {string} video Path to the raw .webm recording.
- * @returns {number} Seconds of leading blank screen (0 if none detected).
+ * @returns {number} Seconds of leading blank/loading screen (0 if none).
  */
-function detectLeadingBlankEnd(video) {
+function detectContentStart(video) {
   const probe = spawnSync(
     'ffmpeg',
     [
       '-hide_banner',
       '-nostats',
+      '-loglevel',
+      'error',
       '-i',
       video,
       '-vf',
-      'negate,blackdetect=d=0.2:pix_th=0.10',
+      'scale=320:-2,format=gray,edgedetect=low=0.1:high=0.4,signalstats,metadata=mode=print:key=lavfi.signalstats.YAVG:file=-',
       '-an',
       '-f',
       'null',
       '-',
     ],
-    { encoding: 'utf8', maxBuffer: 10 * 1024 * 1024 }
+    { encoding: 'utf8', maxBuffer: 50 * 1024 * 1024 }
   );
 
-  const output = `${probe.stderr ?? ''}`;
-  const matches = [
-    ...output.matchAll(/black_start:([\d.]+)[^\n]*?black_end:([\d.]+)/g),
-  ];
+  /** @type {{ time: number; energy: number }[]} */
+  const frames = [
+    ...`${probe.stdout ?? ''}`.matchAll(
+      /pts_time:([\d.]+)\s*\n\s*lavfi\.signalstats\.YAVG=([\d.]+)/g
+    ),
+  ].map(m => ({ time: Number(m[1]), energy: Number(m[2]) }));
 
-  // Only trim a blank segment that begins at (or very near) the start.
-  const leading = matches.find(m => Number(m[1]) < 0.5);
-  return leading ? Number(leading[2]) : 0;
+  if (frames.length === 0) {
+    return 0;
+  }
+
+  const sorted = [...frames].map(f => f.energy).sort((a, b) => a - b);
+  const peak = sorted[Math.floor(sorted.length * 0.95)] ?? 0;
+  const threshold = Math.max(BLANK_EDGE_ENERGY, peak * CONTENT_EDGE_RATIO);
+
+  const start = frames.findIndex((_, i) =>
+    frames
+      .slice(i, i + CONTENT_FRAME_RUN)
+      .every(frame => frame.energy >= threshold)
+  );
+
+  // Never trim everything - a run that never reaches content is left as-is.
+  return start > 0 ? frames[start].time : 0;
 }
 
 /**
- * Trims the leading blank screen and exports an mp4 next to the source video.
- * mp4 is widely supported for attaching to GitHub PRs and Jira tickets.
+ * Trims the leading blank/loading screen and exports an mp4 next to the source
+ * video. mp4 is widely supported for attaching to GitHub PRs and Jira tickets.
  *
  * @param {string} video Path to the raw .webm recording.
  * @param {number} startSec Seconds to skip from the start.
@@ -352,13 +378,13 @@ if (videos.length === 0) {
     let note = '';
 
     if (ffmpegAvailable) {
-      const blankEnd = detectLeadingBlankEnd(video);
-      const mp4 = exportTrimmedMp4(video, blankEnd);
+      const contentStart = detectContentStart(video);
+      const mp4 = exportTrimmedMp4(video, contentStart);
       if (mp4) {
         output = mp4;
         note =
-          blankEnd > 0.3
-            ? ` (trimmed ${blankEnd.toFixed(1)}s of leading load screen)`
+          contentStart > 0.3
+            ? ` (trimmed ${contentStart.toFixed(1)}s of leading load screen)`
             : '';
       } else {
         note = ' (mp4 export failed)';

--- a/tests/docker-scripts/Dockerfile
+++ b/tests/docker-scripts/Dockerfile
@@ -15,9 +15,10 @@ FROM mcr.microsoft.com/playwright:v1.56.1-noble AS playwright
 WORKDIR /work/
 
 # Update packages list and install some build tools
+# ffmpeg is used by scripts/e2e-record.mjs to trim recordings and export mp4
 RUN set -eux; \
     apt-get update; \
-    apt-get install build-essential --yes;
+    apt-get install build-essential ffmpeg --yes;
 
 # print installed fonts for debugging
 RUN fc-list : family;

--- a/tests/docker-scripts/docker-compose.yml
+++ b/tests/docker-scripts/docker-compose.yml
@@ -21,7 +21,22 @@ services:
       - ../../test-results:/work/test-results
       - ../../playwright-report:/work/playwright-report
       - ../../blob-report:/work/blob-report
-    entrypoint: 'npm run e2e -- --config=playwright-ci.config.ts --reporter=blob --project=${BROWSER:-chromium} --shard=${SHARD:-1}/${SHARD_TOTAL:-1}'
+    entrypoint: "npm run e2e -- --config=playwright-ci.config.ts --reporter=blob --project=${BROWSER:-chromium} --shard=${SHARD:-1}/${SHARD_TOTAL:-1}"
+    depends_on:
+      dhc-server:
+        condition: service_healthy
+
+  e2e-record:
+    # requires the image built by CI to be provided
+    image: e2e-ci:test
+    ipc: host
+    environment:
+      - VITE_PROXY_URL=http://dhc-server:10000
+      - E2E_RECORD_CONFIG=playwright-record-ci.config.ts
+    volumes:
+      - ../../tests:/work/tests
+      - ../../test-results:/work/test-results
+    entrypoint: "npm run e2e:record -- ${SPEC_FILES}"
     depends_on:
       dhc-server:
         condition: service_healthy
@@ -39,7 +54,7 @@ services:
       - ../../tests:/work/tests
       - ../../test-results:/work/test-results
       - ../../playwright-report:/work/playwright-report
-    entrypoint: 'npm run e2e -- --config=playwright-ci.config.ts'
+    entrypoint: "npm run e2e -- --config=playwright-ci.config.ts"
     depends_on:
       dhc-server:
         condition: service_healthy
@@ -47,7 +62,7 @@ services:
   web-ui-update-snapshots:
     extends:
       service: web-ui-tests
-    entrypoint: 'npm run e2e:update-snapshots -- --config=playwright-ci.config.ts'
+    entrypoint: "npm run e2e:update-snapshots -- --config=playwright-ci.config.ts"
     depends_on: # depends_on is not shared with extends
       dhc-server:
         condition: service_healthy

--- a/tests/record-globalSetup.ts
+++ b/tests/record-globalSetup.ts
@@ -1,0 +1,53 @@
+import { chromium, type FullConfig } from '@playwright/test';
+import baseGlobalSetup from './globalSetup';
+
+/**
+ * Global setup used only when recording a test (see playwright-record.config.ts).
+ *
+ * When running e2e tests against the local Vite dev server, the very first page
+ * load triggers an on-demand compile of the app's modules, which can leave the
+ * screen blank/white for ~10s. If we record video straight away, that blank
+ * period ends up at the start of the clip.
+ *
+ * To avoid that, we load the base URL once here so Vite compiles and caches the
+ * main app chunks *before* the recorded test runs. The recorded run then loads
+ * the already-compiled app quickly, so the video starts close to when the UI is
+ * actually visible.
+ */
+async function globalSetup(config: FullConfig): Promise<void> {
+  await baseGlobalSetup(config);
+
+  const baseURL = config.projects[0]?.use?.baseURL;
+  if (baseURL == null) {
+    return;
+  }
+
+  // Warming up only matters for a local dev server.
+  if (new URL(baseURL).hostname !== 'localhost') {
+    return;
+  }
+
+  // eslint-disable-next-line no-console
+  console.log(`[record] Warming up dev server at ${baseURL} ...`);
+
+  const browser = await chromium.launch();
+  try {
+    const page = await browser.newPage();
+    await page.goto(baseURL, {
+      waitUntil: 'domcontentloaded',
+      timeout: 120_000,
+    });
+    // Give Vite a chance to finish compiling/serving the main chunks.
+    await page.waitForLoadState('networkidle', { timeout: 120_000 });
+    // eslint-disable-next-line no-console
+    console.log('[record] Dev server warm-up complete.');
+  } catch (e) {
+    // Warm-up is only an optimization - let the test itself report real failures.
+    // eslint-disable-next-line no-console
+    console.warn(`[record] Dev server warm-up skipped: ${e}`);
+  } finally {
+    await browser.close();
+  }
+}
+
+export default globalSetup;


### PR DESCRIPTION
- Create a new action `npm run e2e:record` which records an e2e test run in slowMo of the file specified
  - Automatically trims off the starting white screen/loading spinner, so it jumps right into the test
- Add a GitHub action to add a comment to any PR with new e2e tests linking to videos of those tests
- See an example of the link generated from a PR in my fork: https://github.com/mofojed/web-client-ui/pull/23#issuecomment-5357779106