### PR TITLE
fix: DH-23531: Fix subscribeToFieldUpdates is not a function error

### DIFF
--- a/packages/jsapi-utils/src/WorkerVariablesStore.test.ts
+++ b/packages/jsapi-utils/src/WorkerVariablesStore.test.ts
@@ -242,12 +242,11 @@ describe('createWorkerVariablesStore', () => {
     expect(store.snapshot('w1')).toBeNull();
   });
 
-  it('treats a connection lacking subscribeToFieldUpdates as an empty worker', async () => {
+  it('treats a connection lacking subscribeToFieldUpdates as an unresolved (null) worker', async () => {
     // Legacy Enterprise connections predate Core's field-updates API, so they
-    // expose no `subscribeToFieldUpdates`. The store must treat such a worker
-    // as resolved-but-empty (snapshot `[]`, distinct from loading's `null`),
-    // without throwing or logging the "Failed to resolve worker connection"
-    // error the missing method would otherwise trigger.
+    // expose no `subscribeToFieldUpdates`. The store must leave the snapshot
+    // null without throwing or logging the "Failed to resolve worker
+    // connection" error the missing method would otherwise trigger.
     const errorSpy = jest
       .spyOn(Log.module('@deephaven/jsapi-utils.WorkerVariablesStore'), 'error')
       .mockImplementation(() => undefined);
@@ -257,18 +256,16 @@ describe('createWorkerVariablesStore', () => {
     store.subscribe('s:legacy', listener);
     await flushPromises();
     expect(errorSpy).not.toHaveBeenCalled();
-    // Notified once so consumers re-render from `null` to the empty snapshot.
-    expect(listener).toHaveBeenCalledTimes(1);
-    expect(store.snapshot('s:legacy')).toEqual([]);
-    // Empty snapshot identity is stable across reads (no re-render churn).
-    expect(store.snapshot('s:legacy')).toBe(store.snapshot('s:legacy'));
+    // No delta is ever produced, so listeners are not notified.
+    expect(listener).not.toHaveBeenCalled();
+    expect(store.snapshot('s:legacy')).toBeNull();
     errorSpy.mockRestore();
   });
 
   describe('legacy worker without subscribeToFieldUpdates', () => {
     // Legacy Enterprise connections predate Core's field-updates API. These
-    // document that the store treats them as resolved-but-empty rather than
-    // erroring, and that the empty state participates in the normal
+    // document that the store leaves them unresolved (snapshot null) rather
+    // than erroring, while still participating in the normal
     // resolve/invalidate/teardown lifecycle.
     const makeLegacyConnection = (): dh.IdeConnection =>
       ({ close: jest.fn() }) as unknown as dh.IdeConnection;
@@ -286,36 +283,31 @@ describe('createWorkerVariablesStore', () => {
       expect(resolveConnection).toHaveBeenCalledTimes(1);
     });
 
-    it('clears to null then re-resolves back to empty on invalidate', async () => {
-      const store = createWorkerVariablesStore(async () =>
-        makeLegacyConnection()
-      );
+    it('re-resolves on invalidate and stays null', async () => {
+      const resolveConnection = jest.fn(async () => makeLegacyConnection());
+      const store = createWorkerVariablesStore(resolveConnection);
       store.subscribe('s:legacy', jest.fn());
       await flushPromises();
-      expect(store.snapshot('s:legacy')).toEqual([]);
+      expect(store.snapshot('s:legacy')).toBeNull();
 
       store.invalidate('s:legacy');
-      // Snapshot drops to null synchronously while the re-resolve is in flight.
-      expect(store.snapshot('s:legacy')).toBeNull();
       await flushPromises();
-      expect(store.snapshot('s:legacy')).toEqual([]);
+      expect(resolveConnection).toHaveBeenCalledTimes(2);
+      expect(store.snapshot('s:legacy')).toBeNull();
     });
 
-    it('tears down on last unsubscribe and re-resolves to empty on the next subscribe', async () => {
+    it('tears down on last unsubscribe and re-resolves on the next subscribe', async () => {
       const resolveConnection = jest.fn(async () => makeLegacyConnection());
       const store = createWorkerVariablesStore(resolveConnection);
       const off = store.subscribe('s:legacy', jest.fn());
       await flushPromises();
-      expect(store.snapshot('s:legacy')).toEqual([]);
-
-      off();
-      // Last listener gone: the entry is dropped and snapshot returns to null.
       expect(store.snapshot('s:legacy')).toBeNull();
 
+      off();
       store.subscribe('s:legacy', jest.fn());
       await flushPromises();
       expect(resolveConnection).toHaveBeenCalledTimes(2);
-      expect(store.snapshot('s:legacy')).toEqual([]);
+      expect(store.snapshot('s:legacy')).toBeNull();
     });
   });
 

--- a/packages/jsapi-utils/src/WorkerVariablesStore.test.ts
+++ b/packages/jsapi-utils/src/WorkerVariablesStore.test.ts
@@ -1,5 +1,6 @@
 import type { dh } from '@deephaven/jsapi-types';
 import { TestUtils } from '@deephaven/test-utils';
+import Log from '@deephaven/log';
 import {
   DEFAULT_WORKER_KEY,
   createWorkerVariablesStore,
@@ -239,6 +240,83 @@ describe('createWorkerVariablesStore', () => {
     await flushPromises();
     expect(listener).not.toHaveBeenCalled();
     expect(store.snapshot('w1')).toBeNull();
+  });
+
+  it('treats a connection lacking subscribeToFieldUpdates as an empty worker', async () => {
+    // Legacy Enterprise connections predate Core's field-updates API, so they
+    // expose no `subscribeToFieldUpdates`. The store must treat such a worker
+    // as resolved-but-empty (snapshot `[]`, distinct from loading's `null`),
+    // without throwing or logging the "Failed to resolve worker connection"
+    // error the missing method would otherwise trigger.
+    const errorSpy = jest
+      .spyOn(Log.module('@deephaven/jsapi-utils.WorkerVariablesStore'), 'error')
+      .mockImplementation(() => undefined);
+    const connection = { close: jest.fn() } as unknown as dh.IdeConnection;
+    const store = createWorkerVariablesStore(async () => connection);
+    const listener = jest.fn();
+    store.subscribe('s:legacy', listener);
+    await flushPromises();
+    expect(errorSpy).not.toHaveBeenCalled();
+    // Notified once so consumers re-render from `null` to the empty snapshot.
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(store.snapshot('s:legacy')).toEqual([]);
+    // Empty snapshot identity is stable across reads (no re-render churn).
+    expect(store.snapshot('s:legacy')).toBe(store.snapshot('s:legacy'));
+    errorSpy.mockRestore();
+  });
+
+  describe('legacy worker without subscribeToFieldUpdates', () => {
+    // Legacy Enterprise connections predate Core's field-updates API. These
+    // document that the store treats them as resolved-but-empty rather than
+    // erroring, and that the empty state participates in the normal
+    // resolve/invalidate/teardown lifecycle.
+    const makeLegacyConnection = (): dh.IdeConnection =>
+      ({ close: jest.fn() }) as unknown as dh.IdeConnection;
+
+    it('resolves the connection only once as more listeners subscribe', async () => {
+      const resolveConnection = jest.fn(async () => makeLegacyConnection());
+      const store = createWorkerVariablesStore(resolveConnection);
+      store.subscribe('s:legacy', jest.fn());
+      await flushPromises();
+      // The no-op teardown installed for a legacy worker short-circuits
+      // `start`, so extra listeners don't trigger a fresh resolve.
+      store.subscribe('s:legacy', jest.fn());
+      store.subscribe('s:legacy', jest.fn());
+      await flushPromises();
+      expect(resolveConnection).toHaveBeenCalledTimes(1);
+    });
+
+    it('clears to null then re-resolves back to empty on invalidate', async () => {
+      const store = createWorkerVariablesStore(async () =>
+        makeLegacyConnection()
+      );
+      store.subscribe('s:legacy', jest.fn());
+      await flushPromises();
+      expect(store.snapshot('s:legacy')).toEqual([]);
+
+      store.invalidate('s:legacy');
+      // Snapshot drops to null synchronously while the re-resolve is in flight.
+      expect(store.snapshot('s:legacy')).toBeNull();
+      await flushPromises();
+      expect(store.snapshot('s:legacy')).toEqual([]);
+    });
+
+    it('tears down on last unsubscribe and re-resolves to empty on the next subscribe', async () => {
+      const resolveConnection = jest.fn(async () => makeLegacyConnection());
+      const store = createWorkerVariablesStore(resolveConnection);
+      const off = store.subscribe('s:legacy', jest.fn());
+      await flushPromises();
+      expect(store.snapshot('s:legacy')).toEqual([]);
+
+      off();
+      // Last listener gone: the entry is dropped and snapshot returns to null.
+      expect(store.snapshot('s:legacy')).toBeNull();
+
+      store.subscribe('s:legacy', jest.fn());
+      await flushPromises();
+      expect(resolveConnection).toHaveBeenCalledTimes(2);
+      expect(store.snapshot('s:legacy')).toEqual([]);
+    });
   });
 
   it('isolates a throwing listener so other listeners still run', async () => {

--- a/packages/jsapi-utils/src/WorkerVariablesStore.ts
+++ b/packages/jsapi-utils/src/WorkerVariablesStore.ts
@@ -10,6 +10,16 @@ const log = Log.module('@deephaven/jsapi-utils.WorkerVariablesStore');
  */
 export type WorkerVariables = readonly dh.ide.VariableDefinition[];
 
+/**
+ * Stable empty snapshot for workers with no push-observable variables — e.g.
+ * legacy Enterprise connections that predate Core's field-updates API. Sharing
+ * one frozen instance keeps `useSyncExternalStore` snapshot identity stable so
+ * consumers don't re-render on repeated reads, and lets them distinguish
+ * "resolved but has no field-updates feed" (`[]`) from "still resolving"
+ * (`null`).
+ */
+const EMPTY_WORKER_VARIABLES: WorkerVariables = Object.freeze([]);
+
 /** Default key used when a host exposes a single connection (e.g. DHC). */
 export const DEFAULT_WORKER_KEY = 'default';
 
@@ -181,6 +191,21 @@ export function createWorkerVariablesStore(
       }
       if (connection == null) {
         log.debug('No connection available for worker', key);
+        return;
+      }
+      // Legacy Enterprise connections predate Core's field-updates API, so they
+      // have no `subscribeToFieldUpdates`. Treat such a worker as resolved with
+      // no variables (empty, not `null`) rather than throwing on the missing
+      // method, and install a no-op teardown so we don't re-resolve on every
+      // new listener.
+      if (typeof connection.subscribeToFieldUpdates !== 'function') {
+        log.debug(
+          'Connection has no field-updates support; worker is empty',
+          key
+        );
+        entry.list = EMPTY_WORKER_VARIABLES;
+        entry.unsubscribeFieldUpdates = () => undefined;
+        notify(entry);
         return;
       }
       // entry.list is replaced with a fresh array each delta so snapshot

--- a/packages/jsapi-utils/src/WorkerVariablesStore.ts
+++ b/packages/jsapi-utils/src/WorkerVariablesStore.ts
@@ -10,16 +10,6 @@ const log = Log.module('@deephaven/jsapi-utils.WorkerVariablesStore');
  */
 export type WorkerVariables = readonly dh.ide.VariableDefinition[];
 
-/**
- * Stable empty snapshot for workers with no push-observable variables — e.g.
- * legacy Enterprise connections that predate Core's field-updates API. Sharing
- * one frozen instance keeps `useSyncExternalStore` snapshot identity stable so
- * consumers don't re-render on repeated reads, and lets them distinguish
- * "resolved but has no field-updates feed" (`[]`) from "still resolving"
- * (`null`).
- */
-const EMPTY_WORKER_VARIABLES: WorkerVariables = Object.freeze([]);
-
 /** Default key used when a host exposes a single connection (e.g. DHC). */
 export const DEFAULT_WORKER_KEY = 'default';
 
@@ -193,19 +183,12 @@ export function createWorkerVariablesStore(
         log.debug('No connection available for worker', key);
         return;
       }
-      // Legacy Enterprise connections predate Core's field-updates API, so they
-      // have no `subscribeToFieldUpdates`. Treat such a worker as resolved with
-      // no variables (empty, not `null`) rather than throwing on the missing
-      // method, and install a no-op teardown so we don't re-resolve on every
-      // new listener.
+      // Legacy Enterprise connections predate Core's field-updates API. Leave
+      // the snapshot null and install a no-op teardown so we neither throw on
+      // the missing method nor re-resolve on every new listener.
       if (typeof connection.subscribeToFieldUpdates !== 'function') {
-        log.debug(
-          'Connection has no field-updates support; worker is empty',
-          key
-        );
-        entry.list = EMPTY_WORKER_VARIABLES;
+        log.debug('Connection has no field-updates support', key);
         entry.unsubscribeFieldUpdates = () => undefined;
-        notify(entry);
         return;
       }
       // entry.list is replaced with a fresh array each delta so snapshot


### PR DESCRIPTION
## Summary

`WorkerVariablesStore` called `subscribeToFieldUpdates` on every resolved connection. Legacy Enterprise sessions predate Core's field-updates API and have no such method, so resolving one threw `TypeError: subscribeToFieldUpdates is not a function` and logged `Failed to resolve worker connection`.

## Fix

Feature-detect the missing method in the store's `start()`: legacy connections leave the snapshot `null` (no throw, no error log) instead of crashing. Existing `WorkerVariablesContext` / `useWorkerVariables` contracts are unchanged.

## Tests

Added coverage for the legacy-worker lifecycle: resolves without throwing/logging (snapshot stays `null`, listeners not notified), resolves the connection only once across multiple listeners, and re-resolves on `invalidate` / re-subscribe while remaining `null`.

Tested manually using Test steps from the ticket.